### PR TITLE
feat(utils): `LlmJson.coerce` for already json parsed SDKs.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/benchmark",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Benchmark program of typia performance",
   "main": "bin/index.js",
   "scripts": {

--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/config",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Shared build configuration for typia packages",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/examples",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Example codes for typia website",
   "scripts": {
     "build": "rimraf bin && cross-env NODE_OPTIONS=\"--no-experimental-strip-types -r ts-node/register\" tsc && prettier --write bin/**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm --filter=./packages/* -r build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/core",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/interface/src/schema/ILlmFunction.ts
+++ b/packages/interface/src/schema/ILlmFunction.ts
@@ -89,6 +89,10 @@ export interface ILlmFunction {
    *
    * Type validation is NOT performed — use {@link validate} after parsing.
    *
+   * If the SDK (e.g., LangChain, Vercel AI, MCP) already parses JSON internally
+   * and provides a pre-parsed object, use `LlmJson.coerce()` from `@typia/utils`
+   * instead to apply schema-based type coercion without re-parsing.
+   *
    * @param str Raw JSON string from LLM output
    * @returns Parse result with data on success, or partial data with errors
    */

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/langchain/src/internal/LangChainToolsRegistrar.ts
+++ b/packages/langchain/src/internal/LangChainToolsRegistrar.ts
@@ -113,8 +113,9 @@ export namespace LangChainToolsRegistrar {
       description: entry.function.description ?? "",
       schema: passthroughSchema,
       func: async (args: unknown): Promise<string> => {
+        const coerced: unknown = LlmJson.coerce(args, entry.function.parameters);
         const validation: IValidation<unknown> =
-          entry.function.validate(args);
+          entry.function.validate(coerced);
         if (!validation.success) {
           return LlmJson.stringify(validation);
         }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/src/internal/McpControllerRegistrar.ts
+++ b/packages/mcp/src/internal/McpControllerRegistrar.ts
@@ -260,7 +260,8 @@ export namespace McpControllerRegistrar {
     entry: IToolEntry,
     args: unknown,
   ): Promise<CallToolResult> => {
-    const validation: IValidation<unknown> = entry.function.validate(args);
+    const coerced: unknown = LlmJson.coerce(args, entry.function.parameters);
+    const validation: IValidation<unknown> = entry.function.validate(coerced);
     if (!validation.success) {
       return {
         isError: true,

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/transform",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typia/unplugin",
   "type": "module",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "private": true,
   "description": "unplugin for typia",
   "author": "ryoppippi",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/src/utils/LlmJson.ts
+++ b/packages/utils/src/utils/LlmJson.ts
@@ -22,6 +22,32 @@ import { stringifyValidationFailure } from "./internal/stringifyValidationFailur
  */
 export namespace LlmJson {
   /**
+   * Coerce LLM arguments to match expected schema types.
+   *
+   * LLMs often return values with incorrect types (e.g., numbers as strings).
+   * This function recursively coerces values based on the schema:
+   *
+   * - `"42"` → `42` (when schema expects number)
+   * - `"true"` → `true` (when schema expects boolean)
+   * - `"null"` → `null` (when schema expects null)
+   * - `"{...}"` → `{...}` (when schema expects object)
+   * - `"[...]"` → `[...]` (when schema expects array)
+   *
+   * Use this when SDK provides already-parsed objects but values may have
+   * wrong types. For raw JSON strings, use {@link parse} instead.
+   *
+   * @param input Parsed arguments object from LLM
+   * @param parameters LLM function parameters schema for type coercion
+   * @returns Coerced arguments with corrected types
+   */
+  export function coerce<T = unknown>(
+    input: T,
+    parameters: ILlmSchema.IParameters,
+  ): T {
+    return coerceLlmArguments(input, parameters);
+  }
+
+  /**
    * Parse lenient JSON with optional schema-based coercion.
    *
    * Handles incomplete/malformed JSON commonly produced by LLMs:

--- a/packages/utils/src/utils/internal/coerceLlmArguments.ts
+++ b/packages/utils/src/utils/internal/coerceLlmArguments.ts
@@ -17,11 +17,11 @@ import { parseLenientJson } from "./parseLenientJson";
  * @returns Coerced value with double-stringified JSON parsed
  * @internal
  */
-export function coerceLlmArguments(
-  value: unknown,
+export function coerceLlmArguments<T = unknown>(
+  value: T,
   parameters: ILlmSchema.IParameters,
-): unknown {
-  return coerceValue(value, parameters, parameters.$defs);
+): T {
+  return coerceValue(value, parameters, parameters.$defs) as T;
 }
 
 function coerceValue(

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -135,8 +135,9 @@ export namespace VercelToolsRegistrar {
       ),
 
       execute: async (args: object) => {
-        // Validate using typia's built-in validator
-        const validation: IValidation<unknown> = func.validate(args);
+        // Coerce and validate using typia's built-in functions
+        const coerced: unknown = LlmJson.coerce(args, func.parameters);
+        const validation: IValidation<unknown> = func.validate(coerced);
         if (!validation.success) {
           // Return validation error in LLM-friendly format
           return {

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/debug",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Convenient debug program for typia",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/template/package.json
+++ b/tests/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/template",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Template structures for typia testing.",
   "main": "src/index.ts",
   "repository": {

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-error",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Test program of typia generated error",
   "main": "index.js",
   "scripts": {

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-langchain",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Test suite for @typia/langchain package",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-langchain/src/features/test_langchain_class_controller_validation.ts
+++ b/tests/test-langchain/src/features/test_langchain_class_controller_validation.ts
@@ -29,10 +29,11 @@ export const test_langchain_class_controller_validation =
     const invalidResult = await addTool.invoke({ x: "not a number", y: 5 });
 
     // Generate expected validation error message using typia
-    const expected: IValidation = typia.validate<Calculator.IProps>({
-      x: "not a number",
-      y: 5,
-    });
+    const coerced: unknown = LlmJson.coerce(
+      { x: "not a number", y: 5 },
+      controller.application.functions.find((f) => f.name === "add")!.parameters,
+    );
+    const expected: IValidation = typia.validate<Calculator.IProps>(coerced);
     if (expected.success === true) {
       throw new Error("Expected validation to fail, but it succeeded.");
     }

--- a/tests/test-langchain/src/features/test_langchain_http_controller_validation.ts
+++ b/tests/test-langchain/src/features/test_langchain_http_controller_validation.ts
@@ -82,6 +82,11 @@ export const test_langchain_http_controller_validation =
     const result = await addTool.invoke(invalidArgs);
 
     // 6. Verify validation matches LlmJson.stringify output
+    const func = controller.application.functions.find(
+      (f) => f.name === "calculate_add_post",
+    )!;
+    const coerced: unknown = LlmJson.coerce(invalidArgs, func.parameters);
+
     const parameterSchema: OpenApi.IJsonSchema.IObject = {
       type: "object",
       properties: {
@@ -93,7 +98,7 @@ export const test_langchain_http_controller_validation =
     const expected: IValidation = OpenApiValidator.validate({
       components: {},
       schema: parameterSchema,
-      value: invalidArgs,
+      value: coerced,
       required: true,
       equals: false,
     });

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-mcp",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Test suite for @typia/mcp package",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-mcp/src/features/test_mcp_class_controller_validation.ts
+++ b/tests/test-mcp/src/features/test_mcp_class_controller_validation.ts
@@ -54,10 +54,11 @@ export const test_mcp_class_controller_validation = async (): Promise<void> => {
     },
     { signal: new AbortController().signal },
   );
-  const expected: IValidation = typia.validate<Calculator.IProps>({
-    x: "not a number",
-    y: 5,
-  });
+  const coerced: unknown = LlmJson.coerce(
+    { x: "not a number", y: 5 },
+    controller.application.functions.find((f) => f.name === "add")!.parameters,
+  );
+  const expected: IValidation = typia.validate<Calculator.IProps>(coerced);
   if (expected.success === true)
     throw new Error("Expected validation to fail, but it succeeded.");
 

--- a/tests/test-mcp/src/features/test_mcp_http_controller_validation.ts
+++ b/tests/test-mcp/src/features/test_mcp_http_controller_validation.ts
@@ -107,6 +107,11 @@ export const test_mcp_http_controller_validation = async (): Promise<void> => {
   );
 
   // 7. Verify validation matches LlmJson.stringify output
+  const func = controller.application.functions.find(
+    (f) => f.name === "calculate_add_post",
+  )!;
+  const coerced: unknown = LlmJson.coerce(invalidArgs, func.parameters);
+
   const parameterSchema: OpenApi.IJsonSchema.IObject = {
     type: "object",
     properties: {
@@ -118,7 +123,7 @@ export const test_mcp_http_controller_validation = async (): Promise<void> => {
   const expected: IValidation = OpenApiValidator.validate({
     components: {},
     schema: parameterSchema,
-    value: invalidArgs,
+    value: coerced,
     required: true,
     equals: false,
   });

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-automated",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Automated test features of typia.",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-generate",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Test typia generation command",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=\"--no-experimental-strip-types -r ts-node/register\" tsc",

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-schema",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Test features for JSON schema, LLM schema and protobuf message of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-unplugin/package.json
+++ b/tests/test-unplugin/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-unplugin",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "type": "module",
   "description": "Test for @typia/unplugin package",
   "scripts": {

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-openapiautomated",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Automated test features of openapi.",
   "scripts": {
     "start": "node -r ts-node/register src/index.ts"

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-utils",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Automated test features of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-vercel",
-  "version": "12.0.0-dev.20260307",
+  "version": "12.0.0-dev.20260307-2",
   "description": "Test suite for @typia/vercel package",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-vercel/src/features/test_vercel_class_controller_validation.ts
+++ b/tests/test-vercel/src/features/test_vercel_class_controller_validation.ts
@@ -26,10 +26,11 @@ export const test_vercel_class_controller_validation =
     );
 
     // 4. Verify the result contains validation error
-    const expected: IValidation = typia.validate<Calculator.IProps>({
-      x: "not a number",
-      y: 5,
-    });
+    const coerced: unknown = LlmJson.coerce(
+      { x: "not a number", y: 5 },
+      controller.application.functions.find((f) => f.name === "add")!.parameters,
+    );
+    const expected: IValidation = typia.validate<Calculator.IProps>(coerced);
     if (expected.success === true)
       throw new Error("Expected validation to fail, but it succeeded.");
 


### PR DESCRIPTION
This pull request introduces schema-based type coercion for LLM function arguments across multiple SDK integrations. The main improvement is the addition and usage of `LlmJson.coerce()`, which ensures that arguments returned from LLMs are coerced to match the expected schema types before validation. This helps address common issues where LLMs return values with incorrect types (e.g., numbers as strings), improving reliability and correctness in downstream processing.

Schema-based type coercion integration:

* Added the `LlmJson.coerce()` function in `packages/utils/src/utils/LlmJson.ts` to recursively coerce argument values to match expected schema types, with detailed documentation explaining its purpose and usage.
* Updated `coerceLlmArguments` to use generics and return the coerced value as the correct type, improving type safety.

SDK integrations:

* Modified `LangChainToolsRegistrar`, `McpControllerRegistrar`, and `VercelToolsRegistrar` to use `LlmJson.coerce()` for argument coercion before validation, ensuring consistent schema enforcement across all tool registrars. [[1]](diffhunk://#diff-9346c6713f7379818c4d7f34351c765d8eafa8d8d22ccf9711fb1c8d411ac24cR116-R118) [[2]](diffhunk://#diff-674159965ec99acebbbf9c7ab9d5817f625027c76748bc49fd2c5a72a852026bL263-R264) [[3]](diffhunk://#diff-8762db14b8b1b040165b1e864442a8b490b4103cf545437274647ed8fc254fa2L138-R140)

Documentation improvements:

* Added guidance in `ILlmFunction.ts` on when to use `LlmJson.coerce()` versus parsing raw JSON, clarifying best practices for SDK integrations.