### PR TITLE
feat(typia): IJsonParseResult to re-exports

### DIFF
--- a/packages/typia/src/re-exports.ts
+++ b/packages/typia/src/re-exports.ts
@@ -1,6 +1,7 @@
 export {
   // validate
   AssertionGuard,
+  IJsonParseResult,
   IValidation,
   IRandomGenerator,
   // json


### PR DESCRIPTION
This pull request makes a minor update to the `packages/typia/src/re-exports.ts` file, adding a new export for `IJsonParseResult`. This allows other parts of the codebase to import and use the `IJsonParseResult` type.

- Added `IJsonParseResult` to the list of exports in `re-exports.ts` to make it available for import elsewhere.