### PR TITLE
feat(typia): new functions `llm.parse()` and `llm.coerce()`.

### DIFF
--- a/packages/core/src/programmers/llm/LlmCoerceProgrammer.ts
+++ b/packages/core/src/programmers/llm/LlmCoerceProgrammer.ts
@@ -1,0 +1,131 @@
+import { ILlmSchema } from "@typia/interface";
+import ts from "typescript";
+
+import { IProgrammerProps } from "../../context/IProgrammerProps";
+import { IdentifierFactory } from "../../factories/IdentifierFactory";
+import { LiteralFactory } from "../../factories/LiteralFactory";
+import { MetadataFactory } from "../../factories/MetadataFactory";
+import { StatementFactory } from "../../factories/StatementFactory";
+import { TypeFactory } from "../../factories/TypeFactory";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
+import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
+import { FunctionProgrammer } from "../helpers/FunctionProgrammer";
+import { FeatureProgrammer } from "../internal/FeatureProgrammer";
+import { LlmParametersProgrammer } from "./LlmParametersProgrammer";
+
+export namespace LlmCoerceProgrammer {
+  export interface IProps extends IProgrammerProps {
+    config?: Partial<ILlmSchema.IConfig>;
+  }
+
+  export const decompose = (props: {
+    context: IProps["context"];
+    config?: Partial<ILlmSchema.IConfig>;
+    modulo: ts.LeftHandSideExpression;
+    functor: FunctionProgrammer;
+    type: ts.Type;
+    name: string | undefined;
+  }): FeatureProgrammer.IDecomposed => {
+    // Generate LLM schema from type
+    const schema: ILlmSchema.IParameters = writeSchema({
+      context: props.context,
+      config: props.config,
+      type: props.type,
+    });
+
+    const typeName =
+      props.name ??
+      TypeFactory.getFullName({
+        checker: props.context.checker,
+        type: props.type,
+      });
+
+    return {
+      functions: {},
+      statements: [
+        StatementFactory.constant({
+          name: "__schema",
+          type: props.context.importer.type({
+            file: "typia",
+            name: ts.factory.createQualifiedName(
+              ts.factory.createIdentifier("ILlmSchema"),
+              ts.factory.createIdentifier("IParameters"),
+            ),
+          }),
+          value: LiteralFactory.write(schema),
+        }),
+      ],
+      arrow: ts.factory.createArrowFunction(
+        undefined,
+        undefined,
+        [
+          IdentifierFactory.parameter(
+            "input",
+            ts.factory.createTypeReferenceNode(typeName),
+          ),
+        ],
+        ts.factory.createTypeReferenceNode(typeName),
+        undefined,
+        ts.factory.createCallExpression(
+          props.context.importer.internal("coerceLlmArguments"),
+          undefined,
+          [
+            ts.factory.createIdentifier("input"),
+            ts.factory.createIdentifier("__schema"),
+          ],
+        ),
+      ),
+    };
+  };
+
+  export const write = (props: IProps): ts.CallExpression => {
+    const functor: FunctionProgrammer = new FunctionProgrammer(
+      props.modulo.getText(),
+    );
+    const result: FeatureProgrammer.IDecomposed = decompose({
+      context: props.context,
+      config: props.config,
+      modulo: props.modulo,
+      functor,
+      type: props.type,
+      name: props.name,
+    });
+    return FeatureProgrammer.writeDecomposed({
+      modulo: props.modulo,
+      functor,
+      result,
+    });
+  };
+
+  export const validate = (props: {
+    config?: Partial<ILlmSchema.IConfig>;
+    metadata: MetadataSchema;
+    explore: MetadataFactory.IExplore;
+  }): string[] => LlmParametersProgrammer.validate(props);
+
+  const writeSchema = (props: {
+    context: IProps["context"];
+    config?: Partial<ILlmSchema.IConfig>;
+    type: ts.Type;
+  }): ILlmSchema.IParameters => {
+    const result = MetadataFactory.analyze({
+      checker: props.context.checker,
+      transformer: props.context.transformer,
+      options: {
+        absorb: false,
+        escape: true,
+        constant: true,
+      },
+      components: new MetadataCollection({
+        replace: MetadataCollection.replace,
+      }),
+      type: props.type,
+    });
+    if (result.success === false)
+      throw new Error("Failed to analyze type for LLM coerce.");
+    return LlmParametersProgrammer.write({
+      metadata: result.data,
+      config: props.config,
+    });
+  };
+}

--- a/packages/core/src/programmers/llm/LlmParseProgrammer.ts
+++ b/packages/core/src/programmers/llm/LlmParseProgrammer.ts
@@ -1,0 +1,131 @@
+import { ILlmSchema } from "@typia/interface";
+import ts from "typescript";
+
+import { IProgrammerProps } from "../../context/IProgrammerProps";
+import { IdentifierFactory } from "../../factories/IdentifierFactory";
+import { LiteralFactory } from "../../factories/LiteralFactory";
+import { MetadataFactory } from "../../factories/MetadataFactory";
+import { StatementFactory } from "../../factories/StatementFactory";
+import { TypeFactory } from "../../factories/TypeFactory";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
+import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
+import { FunctionProgrammer } from "../helpers/FunctionProgrammer";
+import { FeatureProgrammer } from "../internal/FeatureProgrammer";
+import { LlmParametersProgrammer } from "./LlmParametersProgrammer";
+
+export namespace LlmParseProgrammer {
+  export interface IProps extends IProgrammerProps {
+    config?: Partial<ILlmSchema.IConfig>;
+  }
+
+  export const decompose = (props: {
+    context: IProps["context"];
+    config?: Partial<ILlmSchema.IConfig>;
+    modulo: ts.LeftHandSideExpression;
+    functor: FunctionProgrammer;
+    type: ts.Type;
+    name: string | undefined;
+  }): FeatureProgrammer.IDecomposed => {
+    // Generate LLM schema from type
+    const schema: ILlmSchema.IParameters = writeSchema({
+      context: props.context,
+      config: props.config,
+      type: props.type,
+    });
+
+    return {
+      functions: {},
+      statements: [
+        StatementFactory.constant({
+          name: "__schema",
+          type: props.context.importer.type({
+            file: "typia",
+            name: ts.factory.createQualifiedName(
+              ts.factory.createIdentifier("ILlmSchema"),
+              ts.factory.createIdentifier("IParameters"),
+            ),
+          }),
+          value: LiteralFactory.write(schema),
+        }),
+      ],
+      arrow: ts.factory.createArrowFunction(
+        undefined,
+        undefined,
+        [IdentifierFactory.parameter("input", TypeFactory.keyword("string"))],
+        props.context.importer.type({
+          file: "typia",
+          name: "IJsonParseResult",
+          arguments: [
+            ts.factory.createTypeReferenceNode(
+              props.name ??
+                TypeFactory.getFullName({
+                  checker: props.context.checker,
+                  type: props.type,
+                }),
+            ),
+          ],
+        }),
+        undefined,
+        ts.factory.createCallExpression(
+          props.context.importer.internal("parseLlmArguments"),
+          undefined,
+          [
+            ts.factory.createIdentifier("input"),
+            ts.factory.createIdentifier("__schema"),
+          ],
+        ),
+      ),
+    };
+  };
+
+  export const write = (props: IProps): ts.CallExpression => {
+    const functor: FunctionProgrammer = new FunctionProgrammer(
+      props.modulo.getText(),
+    );
+    const result: FeatureProgrammer.IDecomposed = decompose({
+      context: props.context,
+      config: props.config,
+      modulo: props.modulo,
+      functor,
+      type: props.type,
+      name: props.name,
+    });
+    return FeatureProgrammer.writeDecomposed({
+      modulo: props.modulo,
+      functor,
+      result,
+    });
+  };
+
+  export const validate = (props: {
+    config?: Partial<ILlmSchema.IConfig>;
+    metadata: MetadataSchema;
+    explore: MetadataFactory.IExplore;
+  }): string[] => LlmParametersProgrammer.validate(props);
+
+  const writeSchema = (props: {
+    context: IProps["context"];
+    config?: Partial<ILlmSchema.IConfig>;
+    type: ts.Type;
+  }): ILlmSchema.IParameters => {
+    const result = MetadataFactory.analyze({
+      checker: props.context.checker,
+      transformer: props.context.transformer,
+      options: {
+        absorb: false,
+        escape: true,
+        constant: true,
+      },
+      components: new MetadataCollection({
+        replace: MetadataCollection.replace,
+      }),
+      type: props.type,
+    });
+    if (result.success === false)
+      throw new Error("Failed to analyze type for LLM parse.");
+    return LlmParametersProgrammer.write({
+      metadata: result.data,
+      config: props.config,
+    });
+  };
+}

--- a/packages/core/src/programmers/llm/index.ts
+++ b/packages/core/src/programmers/llm/index.ts
@@ -1,4 +1,6 @@
 export * from "./LlmApplicationProgrammer";
+export * from "./LlmCoerceProgrammer";
 export * from "./LlmMetadataFactory";
 export * from "./LlmParametersProgrammer";
+export * from "./LlmParseProgrammer";
 export * from "./LlmSchemaProgrammer";

--- a/packages/transform/src/CallExpressionTransformer.ts
+++ b/packages/transform/src/CallExpressionTransformer.ts
@@ -69,8 +69,12 @@ import { JsonStringifyTransformer } from "./features/json/JsonStringifyTransform
 import { JsonValidateParseTransformer } from "./features/json/JsonValidateParseTransformer";
 import { JsonValidateStringifyTransformer } from "./features/json/JsonValidateStringifyTransformer";
 import { LlmApplicationTransformer } from "./features/llm/LlmApplicationTransformer";
+import { LlmCoerceTransformer } from "./features/llm/LlmCoerceTransformer";
 import { LlmControllerTransformer } from "./features/llm/LlmControllerTransformer";
+import { LlmCreateCoerceTransformer } from "./features/llm/LlmCreateCoerceTransformer";
+import { LlmCreateParseTransformer } from "./features/llm/LlmCreateParseTransformer";
 import { LlmParametersTransformer } from "./features/llm/LlmParametersTransformer";
+import { LlmParseTransformer } from "./features/llm/LlmParseTransformer";
 import { LlmSchemaTransformer } from "./features/llm/LlmSchemaTransformer";
 import { MiscAssertCloneTransformer } from "./features/misc/MiscAssertCloneTransformer";
 import { MiscAssertPruneTransformer } from "./features/misc/MiscAssertPruneTransformer";
@@ -421,6 +425,10 @@ const FUNCTORS: Record<string, Record<string, () => Task>> = {
     application: () => LlmApplicationTransformer.transform,
     parameters: () => LlmParametersTransformer.transform,
     schema: () => LlmSchemaTransformer.transform,
+    parse: () => LlmParseTransformer.transform,
+    createParse: () => LlmCreateParseTransformer.transform,
+    coerce: () => LlmCoerceTransformer.transform,
+    createCoerce: () => LlmCreateCoerceTransformer.transform,
   },
   json: {
     // METADATA

--- a/packages/transform/src/features/llm/LlmApplicationTransformer.ts
+++ b/packages/transform/src/features/llm/LlmApplicationTransformer.ts
@@ -17,17 +17,22 @@ export namespace LlmApplicationTransformer {
   export const transform = (props: ITransformProps): ts.Expression => {
     const dec = decompose("application", props);
     if (dec === null) return props.expression;
+
+    const typeNode: ts.ImportTypeNode = props.context.importer.type({
+      file: "typia",
+      name: "ILlmApplication.__IPrimitive",
+      arguments: [dec.node],
+    });
     return ts.factory.createCallExpression(
       props.context.importer.internal("llmApplicationFinalize"),
       [dec.node],
       [
-        ts.factory.createSatisfiesExpression(
-          LiteralFactory.write(dec.application),
-          props.context.importer.type({
-            file: "typia",
-            name: "ILlmApplication.__IPrimitive",
-            arguments: [dec.node],
-          }),
+        ts.factory.createAsExpression(
+          ts.factory.createSatisfiesExpression(
+            LiteralFactory.write(dec.application),
+            typeNode,
+          ),
+          typeNode,
         ),
         ...(props.expression.arguments?.[0] !== undefined
           ? [

--- a/packages/transform/src/features/llm/LlmCoerceTransformer.ts
+++ b/packages/transform/src/features/llm/LlmCoerceTransformer.ts
@@ -1,0 +1,88 @@
+import {
+  LlmCoerceProgrammer,
+  LlmMetadataFactory,
+  MetadataCollection,
+  MetadataFactory,
+  MetadataSchema,
+} from "@typia/core";
+import { ILlmSchema, ValidationPipe } from "@typia/interface";
+import ts from "typescript";
+
+import { ITransformProps } from "../../ITransformProps";
+import { TransformerError } from "../../TransformerError";
+
+export namespace LlmCoerceTransformer {
+  export const transform = (props: ITransformProps): ts.Expression => {
+    // CHECK PARAMETER
+    if (props.expression.arguments.length === 0)
+      throw new TransformerError({
+        code: "typia.llm.coerce",
+        message: "no input value.",
+      });
+
+    // GET GENERIC ARGUMENT
+    if (!props.expression.typeArguments?.length)
+      throw new TransformerError({
+        code: "typia.llm.coerce",
+        message: "no generic argument.",
+      });
+
+    const top: ts.Node = props.expression.typeArguments[0]!;
+    if (ts.isTypeNode(top) === false) return props.expression;
+
+    // GET TYPE AND CONFIG
+    const config: Partial<ILlmSchema.IConfig> = LlmMetadataFactory.getConfig({
+      context: props.context,
+      method: "coerce",
+      node: props.expression.typeArguments[1],
+    }) as Partial<ILlmSchema.IConfig>;
+
+    const type: ts.Type = props.context.checker.getTypeFromTypeNode(top);
+
+    if (type.isTypeParameter())
+      throw new TransformerError({
+        code: "typia.llm.coerce",
+        message: "non-specified generic argument.",
+      });
+
+    // VALIDATE TYPE
+    const result: ValidationPipe<MetadataSchema, MetadataFactory.IError> =
+      MetadataFactory.analyze({
+        checker: props.context.checker,
+        transformer: props.context.transformer,
+        options: {
+          absorb: true,
+          escape: true,
+          constant: true,
+          validate: (metadata, explore) =>
+            LlmCoerceProgrammer.validate({
+              config,
+              metadata,
+              explore,
+            }),
+        },
+        components: new MetadataCollection({
+          replace: MetadataCollection.replace,
+        }),
+        type,
+      });
+    if (result.success === false)
+      throw TransformerError.from({
+        code: "typia.llm.coerce",
+        errors: result.errors,
+      });
+
+    // GENERATE CODE
+    return ts.factory.createCallExpression(
+      LlmCoerceProgrammer.write({
+        context: props.context,
+        modulo: props.modulo,
+        type,
+        name: (top as ts.TypeNode).getFullText().trim(),
+        config,
+      }),
+      undefined,
+      props.expression.arguments,
+    );
+  };
+}

--- a/packages/transform/src/features/llm/LlmControllerTransformer.ts
+++ b/packages/transform/src/features/llm/LlmControllerTransformer.ts
@@ -20,6 +20,16 @@ export namespace LlmControllerTransformer {
         message: `no executor.`,
       });
 
+    const typeNode: ts.ImportTypeNode = props.context.importer.type({
+      file: "typia",
+      name: "ILlmController",
+      arguments: [dec.node],
+    });
+    const primitiveTypeNode: ts.ImportTypeNode = props.context.importer.type({
+      file: "typia",
+      name: "ILlmApplication.__IPrimitive",
+      arguments: [dec.node],
+    });
     const value: ts.ObjectLiteralExpression =
       ts.factory.createObjectLiteralExpression(
         [
@@ -41,13 +51,12 @@ export namespace LlmControllerTransformer {
               props.context.importer.internal("llmApplicationFinalize"),
               undefined,
               [
-                ts.factory.createSatisfiesExpression(
-                  LiteralFactory.write(dec.application),
-                  props.context.importer.type({
-                    file: "typia",
-                    name: "ILlmApplication.__IPrimitive",
-                    arguments: [dec.node],
-                  }),
+                ts.factory.createAsExpression(
+                  ts.factory.createSatisfiesExpression(
+                    LiteralFactory.write(dec.application),
+                    primitiveTypeNode,
+                  ),
+                  primitiveTypeNode,
                 ),
                 ...(props.expression.arguments?.[2] !== undefined
                   ? [
@@ -64,13 +73,9 @@ export namespace LlmControllerTransformer {
         ],
         true,
       );
-    return ts.factory.createSatisfiesExpression(
-      value,
-      props.context.importer.type({
-        file: "typia",
-        name: "ILlmController",
-        arguments: [dec.node],
-      }),
+    return ts.factory.createAsExpression(
+      ts.factory.createSatisfiesExpression(value, typeNode),
+      typeNode,
     );
   };
 }

--- a/packages/transform/src/features/llm/LlmCreateCoerceTransformer.ts
+++ b/packages/transform/src/features/llm/LlmCreateCoerceTransformer.ts
@@ -1,0 +1,77 @@
+import {
+  LlmCoerceProgrammer,
+  LlmMetadataFactory,
+  MetadataCollection,
+  MetadataFactory,
+  MetadataSchema,
+} from "@typia/core";
+import { ILlmSchema, ValidationPipe } from "@typia/interface";
+import ts from "typescript";
+
+import { ITransformProps } from "../../ITransformProps";
+import { TransformerError } from "../../TransformerError";
+
+export namespace LlmCreateCoerceTransformer {
+  export const transform = (props: ITransformProps): ts.Expression => {
+    // GET GENERIC ARGUMENT
+    if (!props.expression.typeArguments?.length)
+      throw new TransformerError({
+        code: "typia.llm.createCoerce",
+        message: "no generic argument.",
+      });
+
+    const top: ts.Node = props.expression.typeArguments[0]!;
+    if (ts.isTypeNode(top) === false) return props.expression;
+
+    // GET TYPE AND CONFIG
+    const config: Partial<ILlmSchema.IConfig> = LlmMetadataFactory.getConfig({
+      context: props.context,
+      method: "createCoerce",
+      node: props.expression.typeArguments[1],
+    }) as Partial<ILlmSchema.IConfig>;
+
+    const type: ts.Type = props.context.checker.getTypeFromTypeNode(top);
+
+    if (type.isTypeParameter())
+      throw new TransformerError({
+        code: "typia.llm.createCoerce",
+        message: "non-specified generic argument.",
+      });
+
+    // VALIDATE TYPE
+    const result: ValidationPipe<MetadataSchema, MetadataFactory.IError> =
+      MetadataFactory.analyze({
+        checker: props.context.checker,
+        transformer: props.context.transformer,
+        options: {
+          absorb: true,
+          escape: true,
+          constant: true,
+          validate: (metadata, explore) =>
+            LlmCoerceProgrammer.validate({
+              config,
+              metadata,
+              explore,
+            }),
+        },
+        components: new MetadataCollection({
+          replace: MetadataCollection.replace,
+        }),
+        type,
+      });
+    if (result.success === false)
+      throw TransformerError.from({
+        code: "typia.llm.createCoerce",
+        errors: result.errors,
+      });
+
+    // GENERATE CODE (factory returns the function directly)
+    return LlmCoerceProgrammer.write({
+      context: props.context,
+      modulo: props.modulo,
+      type,
+      name: (top as ts.TypeNode).getFullText().trim(),
+      config,
+    });
+  };
+}

--- a/packages/transform/src/features/llm/LlmCreateParseTransformer.ts
+++ b/packages/transform/src/features/llm/LlmCreateParseTransformer.ts
@@ -1,0 +1,77 @@
+import {
+  LlmMetadataFactory,
+  LlmParseProgrammer,
+  MetadataCollection,
+  MetadataFactory,
+  MetadataSchema,
+} from "@typia/core";
+import { ILlmSchema, ValidationPipe } from "@typia/interface";
+import ts from "typescript";
+
+import { ITransformProps } from "../../ITransformProps";
+import { TransformerError } from "../../TransformerError";
+
+export namespace LlmCreateParseTransformer {
+  export const transform = (props: ITransformProps): ts.Expression => {
+    // GET GENERIC ARGUMENT
+    if (!props.expression.typeArguments?.length)
+      throw new TransformerError({
+        code: "typia.llm.createParse",
+        message: "no generic argument.",
+      });
+
+    const top: ts.Node = props.expression.typeArguments[0]!;
+    if (ts.isTypeNode(top) === false) return props.expression;
+
+    // GET TYPE AND CONFIG
+    const config: Partial<ILlmSchema.IConfig> = LlmMetadataFactory.getConfig({
+      context: props.context,
+      method: "createParse",
+      node: props.expression.typeArguments[1],
+    }) as Partial<ILlmSchema.IConfig>;
+
+    const type: ts.Type = props.context.checker.getTypeFromTypeNode(top);
+
+    if (type.isTypeParameter())
+      throw new TransformerError({
+        code: "typia.llm.createParse",
+        message: "non-specified generic argument.",
+      });
+
+    // VALIDATE TYPE
+    const result: ValidationPipe<MetadataSchema, MetadataFactory.IError> =
+      MetadataFactory.analyze({
+        checker: props.context.checker,
+        transformer: props.context.transformer,
+        options: {
+          absorb: true,
+          escape: true,
+          constant: true,
+          validate: (metadata, explore) =>
+            LlmParseProgrammer.validate({
+              config,
+              metadata,
+              explore,
+            }),
+        },
+        components: new MetadataCollection({
+          replace: MetadataCollection.replace,
+        }),
+        type,
+      });
+    if (result.success === false)
+      throw TransformerError.from({
+        code: "typia.llm.createParse",
+        errors: result.errors,
+      });
+
+    // GENERATE CODE (factory returns the function directly)
+    return LlmParseProgrammer.write({
+      context: props.context,
+      modulo: props.modulo,
+      type,
+      name: (top as ts.TypeNode).getFullText().trim(),
+      config,
+    });
+  };
+}

--- a/packages/transform/src/features/llm/LlmParametersTransformer.ts
+++ b/packages/transform/src/features/llm/LlmParametersTransformer.ts
@@ -69,20 +69,25 @@ export namespace LlmParametersTransformer {
     };
     analyze(true);
 
-    // GENERATE LLM SCHEMA
-    const out: ILlmSchema.IParameters = LlmParametersProgrammer.write({
-      metadata: analyze(false),
-      config,
+    // GENERATE LLM PARAMETERS SCHEMA
+    const typeNode: ts.ImportTypeNode = props.context.importer.type({
+      file: "typia",
+      name: ts.factory.createQualifiedName(
+        ts.factory.createIdentifier("ILlmSchema"),
+        ts.factory.createIdentifier("IParameters"),
+      ),
     });
-    return ts.factory.createSatisfiesExpression(
-      LiteralFactory.write(out),
-      props.context.importer.type({
-        file: "typia",
-        name: ts.factory.createQualifiedName(
-          ts.factory.createIdentifier("ILlmSchema"),
-          ts.factory.createIdentifier("IParameters"),
+    return ts.factory.createAsExpression(
+      ts.factory.createSatisfiesExpression(
+        LiteralFactory.write(
+          LlmParametersProgrammer.write({
+            metadata: analyze(false),
+            config,
+          }),
         ),
-      }),
+        typeNode,
+      ),
+      typeNode,
     );
   };
 }

--- a/packages/transform/src/features/llm/LlmParseTransformer.ts
+++ b/packages/transform/src/features/llm/LlmParseTransformer.ts
@@ -1,0 +1,88 @@
+import {
+  LlmMetadataFactory,
+  LlmParseProgrammer,
+  MetadataCollection,
+  MetadataFactory,
+  MetadataSchema,
+} from "@typia/core";
+import { ILlmSchema, ValidationPipe } from "@typia/interface";
+import ts from "typescript";
+
+import { ITransformProps } from "../../ITransformProps";
+import { TransformerError } from "../../TransformerError";
+
+export namespace LlmParseTransformer {
+  export const transform = (props: ITransformProps): ts.Expression => {
+    // CHECK PARAMETER
+    if (props.expression.arguments.length === 0)
+      throw new TransformerError({
+        code: "typia.llm.parse",
+        message: "no input value.",
+      });
+
+    // GET GENERIC ARGUMENT
+    if (!props.expression.typeArguments?.length)
+      throw new TransformerError({
+        code: "typia.llm.parse",
+        message: "no generic argument.",
+      });
+
+    const top: ts.Node = props.expression.typeArguments[0]!;
+    if (ts.isTypeNode(top) === false) return props.expression;
+
+    // GET TYPE AND CONFIG
+    const config: Partial<ILlmSchema.IConfig> = LlmMetadataFactory.getConfig({
+      context: props.context,
+      method: "parse",
+      node: props.expression.typeArguments[1],
+    }) as Partial<ILlmSchema.IConfig>;
+
+    const type: ts.Type = props.context.checker.getTypeFromTypeNode(top);
+
+    if (type.isTypeParameter())
+      throw new TransformerError({
+        code: "typia.llm.parse",
+        message: "non-specified generic argument.",
+      });
+
+    // VALIDATE TYPE
+    const result: ValidationPipe<MetadataSchema, MetadataFactory.IError> =
+      MetadataFactory.analyze({
+        checker: props.context.checker,
+        transformer: props.context.transformer,
+        options: {
+          absorb: true,
+          escape: true,
+          constant: true,
+          validate: (metadata, explore) =>
+            LlmParseProgrammer.validate({
+              config,
+              metadata,
+              explore,
+            }),
+        },
+        components: new MetadataCollection({
+          replace: MetadataCollection.replace,
+        }),
+        type,
+      });
+    if (result.success === false)
+      throw TransformerError.from({
+        code: "typia.llm.parse",
+        errors: result.errors,
+      });
+
+    // GENERATE CODE
+    return ts.factory.createCallExpression(
+      LlmParseProgrammer.write({
+        context: props.context,
+        modulo: props.modulo,
+        type,
+        name: (top as ts.TypeNode).getFullText().trim(),
+        config,
+      }),
+      undefined,
+      props.expression.arguments,
+    );
+  };
+}

--- a/packages/transform/src/features/llm/LlmSchemaTransformer.ts
+++ b/packages/transform/src/features/llm/LlmSchemaTransformer.ts
@@ -78,8 +78,11 @@ export namespace LlmSchemaTransformer {
       file: "typia",
       name: "ILlmSchema",
     });
-    const literal = ts.factory.createSatisfiesExpression(
-      LiteralFactory.write(out.schema),
+    const literal = ts.factory.createAsExpression(
+      ts.factory.createSatisfiesExpression(
+        LiteralFactory.write(out.schema),
+        schemaTypeNode,
+      ),
       schemaTypeNode,
     );
     if (Object.keys(out.$defs).length === 0) return literal;

--- a/packages/typia/src/internal/_coerceLlmArguments.ts
+++ b/packages/typia/src/internal/_coerceLlmArguments.ts
@@ -1,0 +1,7 @@
+import { ILlmSchema } from "@typia/interface";
+import { LlmJson } from "@typia/utils";
+
+export const _coerceLlmArguments = <T>(
+  value: unknown,
+  parameters: ILlmSchema.IParameters,
+): T => LlmJson.coerce(value, parameters);

--- a/packages/typia/src/internal/_parseLlmArguments.ts
+++ b/packages/typia/src/internal/_parseLlmArguments.ts
@@ -1,0 +1,7 @@
+import { IJsonParseResult, ILlmSchema } from "@typia/interface";
+import { LlmJson } from "@typia/utils";
+
+export const _parseLlmArguments = <T>(
+  input: string,
+  parameters: ILlmSchema.IParameters,
+): IJsonParseResult<T> => LlmJson.parse(input, parameters);

--- a/packages/typia/src/llm.ts
+++ b/packages/typia/src/llm.ts
@@ -1,4 +1,9 @@
-import { ILlmApplication, ILlmController, ILlmSchema } from "@typia/interface";
+import {
+  IJsonParseResult,
+  ILlmApplication,
+  ILlmController,
+  ILlmSchema,
+} from "@typia/interface";
 
 import { NoTransformConfigurationError } from "./transformers/NoTransformConfigurationError";
 
@@ -208,4 +213,196 @@ export function schema<T, Config extends Partial<ILlmSchema.IConfig> = {}>(
 /** @internal */
 export function schema(): never {
   NoTransformConfigurationError("llm.schema");
+}
+
+/**
+ * Parse LLM response JSON with type coercion.
+ *
+ * @danger You must configure the generic argument `Parameters`
+ */
+export function parse(input: string): never;
+
+/**
+ * Parse lenient JSON with schema-based type coercion.
+ *
+ * Handles incomplete or malformed JSON commonly produced by LLMs:
+ *
+ * - Unclosed brackets, strings, trailing commas
+ * - JavaScript-style comments (`//` and multi-line)
+ * - Unquoted object keys, incomplete keywords (`tru`, `fal`, `nul`)
+ * - Markdown code block extraction, junk prefix skipping
+ *
+ * Also coerces double-stringified values based on the `Parameters` schema:
+ *
+ * - `"42"` → `42` (when schema expects number)
+ * - `"true"` → `true` (when schema expects boolean)
+ * - `"null"` → `null` (when schema expects null)
+ * - `"{...}"` → `{...}` (when schema expects object)
+ * - `"[...]"` → `[...]` (when schema expects array)
+ *
+ * Type validation is NOT performed—use {@link ILlmFunction.validate} or
+ * `typia.validate()` for that.
+ *
+ * For repeated parsing, use {@link createParse} to avoid regenerating the schema
+ * each time.
+ *
+ * Related functions:
+ *
+ * - {@link createParse} — Create reusable parser function
+ * - {@link coerce} — Type coercion for already-parsed objects
+ * - {@link parameters} — Generate parameters schema from type
+ *
+ * @template Parameters Target parameters type (object with static properties)
+ * @template Config LLM schema configuration
+ * @param input Raw JSON string (potentially incomplete or malformed)
+ * @returns Parse result with typed data on success, or partial data with errors
+ */
+export function parse<
+  Parameters extends Record<string, any>,
+  Config extends Partial<ILlmSchema.IConfig> = {},
+>(input: string): IJsonParseResult<Parameters>;
+
+/** @internal */
+export function parse(): never {
+  NoTransformConfigurationError("llm.parse");
+}
+
+/**
+ * Coerce LLM arguments to match expected schema types.
+ *
+ * LLMs often return values with incorrect types (e.g., numbers as strings).
+ * This function recursively coerces values based on the `Parameters` schema:
+ *
+ * - `"42"` → `42` (when schema expects number)
+ * - `"true"` → `true` (when schema expects boolean)
+ * - `"null"` → `null` (when schema expects null)
+ * - `"{...}"` → `{...}` (when schema expects object)
+ * - `"[...]"` → `[...]` (when schema expects array)
+ *
+ * Use this when your SDK provides already-parsed objects but values may have
+ * wrong types. For raw JSON strings, use {@link parse} instead.
+ *
+ * For repeated coercion, use {@link createCoerce} to avoid regenerating the
+ * schema each time.
+ *
+ * Type validation is NOT performed—use {@link ILlmFunction.validate} or
+ * `typia.validate()` for that.
+ *
+ * Related functions:
+ *
+ * - {@link createCoerce} — Create reusable coercer function
+ * - {@link parse} — Parse and coerce raw JSON strings
+ * - {@link parameters} — Generate parameters schema from type
+ *
+ * @template Parameters Target parameters type (object with static properties)
+ * @template Config LLM schema configuration
+ * @param input Parsed arguments object from LLM (with potentially wrong types)
+ * @returns Coerced arguments with corrected types
+ */
+export function coerce<
+  Parameters extends Record<string, any>,
+  Config extends Partial<ILlmSchema.IConfig> = {},
+>(input: Parameters): Parameters;
+
+/** @internal */
+export function coerce(): never {
+  NoTransformConfigurationError("llm.coerce");
+}
+
+/**
+ * Create reusable LLM JSON parser with type coercion.
+ *
+ * @danger You must configure the generic argument `Parameters`
+ */
+export function createParse(): never;
+
+/**
+ * Create reusable lenient JSON parser with schema-based type coercion.
+ *
+ * Returns a parser function that handles incomplete or malformed JSON commonly
+ * produced by LLMs:
+ *
+ * - Unclosed brackets, strings, trailing commas
+ * - JavaScript-style comments (`//` and multi-line)
+ * - Unquoted object keys, incomplete keywords (`tru`, `fal`, `nul`)
+ * - Markdown code block extraction, junk prefix skipping
+ *
+ * Also coerces double-stringified values based on the `Parameters` schema:
+ *
+ * - `"42"` → `42` (when schema expects number)
+ * - `"true"` → `true` (when schema expects boolean)
+ * - `"null"` → `null` (when schema expects null)
+ * - `"{...}"` → `{...}` (when schema expects object)
+ * - `"[...]"` → `[...]` (when schema expects array)
+ *
+ * Use this instead of {@link parse} when parsing multiple inputs to avoid
+ * regenerating the schema each time.
+ *
+ * Type validation is NOT performed—use {@link ILlmFunction.validate} or
+ * `typia.validate()` for that.
+ *
+ * Related functions:
+ *
+ * - {@link parse} — One-shot parsing (regenerates schema each call)
+ * - {@link createCoerce} — Create reusable coercer function
+ * - {@link parameters} — Generate parameters schema from type
+ *
+ * @template Parameters Target parameters type (object with static properties)
+ * @template Config LLM schema configuration
+ * @returns Reusable parser function
+ */
+export function createParse<
+  Parameters extends Record<string, any>,
+  Config extends Partial<ILlmSchema.IConfig> = {},
+>(): (input: string) => IJsonParseResult<Parameters>;
+
+/** @internal */
+export function createParse(): never {
+  NoTransformConfigurationError("llm.createParse");
+}
+
+/**
+ * Create reusable LLM arguments coercer.
+ *
+ * @danger You must configure the generic argument `Parameters`
+ */
+export function createCoerce(): never;
+
+/**
+ * Create reusable coercer for LLM arguments.
+ *
+ * Returns a coercer function that fixes incorrect types commonly returned by
+ * LLMs (e.g., numbers as strings). Coerces values based on the `Parameters`
+ * schema:
+ *
+ * - `"42"` → `42` (when schema expects number)
+ * - `"true"` → `true` (when schema expects boolean)
+ * - `"null"` → `null` (when schema expects null)
+ * - `"{...}"` → `{...}` (when schema expects object)
+ * - `"[...]"` → `[...]` (when schema expects array)
+ *
+ * Use this instead of {@link coerce} when coercing multiple inputs to avoid
+ * regenerating the schema each time.
+ *
+ * Type validation is NOT performed—use {@link ILlmFunction.validate} or
+ * `typia.validate()` for that.
+ *
+ * Related functions:
+ *
+ * - {@link coerce} — One-shot coercion (regenerates schema each call)
+ * - {@link createParse} — Create reusable parser function
+ * - {@link parameters} — Generate parameters schema from type
+ *
+ * @template Parameters Target parameters type (object with static properties)
+ * @template Config LLM schema configuration
+ * @returns Reusable coercer function
+ */
+export function createCoerce<
+  Parameters extends Record<string, any>,
+  Config extends Partial<ILlmSchema.IConfig> = {},
+>(): (input: Parameters) => Parameters;
+
+/** @internal */
+export function createCoerce(): never {
+  NoTransformConfigurationError("llm.createCoerce");
 }

--- a/packages/utils/src/utils/LlmJson.ts
+++ b/packages/utils/src/utils/LlmJson.ts
@@ -33,15 +33,15 @@ export namespace LlmJson {
    * - `"{...}"` → `{...}` (when schema expects object)
    * - `"[...]"` → `[...]` (when schema expects array)
    *
-   * Use this when SDK provides already-parsed objects but values may have
-   * wrong types. For raw JSON strings, use {@link parse} instead.
+   * Use this when SDK provides already-parsed objects but values may have wrong
+   * types. For raw JSON strings, use {@link parse} instead.
    *
    * @param input Parsed arguments object from LLM
    * @param parameters LLM function parameters schema for type coercion
    * @returns Coerced arguments with corrected types
    */
   export function coerce<T = unknown>(
-    input: T,
+    input: unknown,
     parameters: ILlmSchema.IParameters,
   ): T {
     return coerceLlmArguments(input, parameters);

--- a/packages/utils/src/utils/internal/coerceLlmArguments.ts
+++ b/packages/utils/src/utils/internal/coerceLlmArguments.ts
@@ -18,7 +18,7 @@ import { parseLenientJson } from "./parseLenientJson";
  * @internal
  */
 export function coerceLlmArguments<T = unknown>(
-  value: T,
+  value: unknown,
   parameters: ILlmSchema.IParameters,
 ): T {
   return coerceValue(value, parameters, parameters.$defs) as T;

--- a/packages/utils/src/utils/internal/parseLenientJson.ts
+++ b/packages/utils/src/utils/internal/parseLenientJson.ts
@@ -1,6 +1,96 @@
 import { DeepPartial, IJsonParseResult } from "@typia/interface";
 
 /**
+ * Parse lenient JSON that may be incomplete or malformed.
+ *
+ * Handles:
+ *
+ * - Unclosed brackets `{`, `[` - parses as much as possible
+ * - Trailing commas `[1, 2, ]` - ignores them
+ * - Unclosed strings `"hello` - returns partial string
+ * - Junk text before JSON (LLM often adds explanatory text)
+ * - Markdown code blocks (extracts content from `json ... `)
+ * - Incomplete keywords like `tru`, `fal`, `nul`
+ * - Unicode escape sequences including surrogate pairs (emoji)
+ * - JavaScript-style comments (single-line and multi-line)
+ * - Unquoted object keys (JavaScript identifier style)
+ *
+ * @param input Raw JSON string (potentially incomplete)
+ * @returns Parse result with data, original input, and any errors
+ * @internal
+ */
+export function parseLenientJson<T>(input: string): IJsonParseResult<T> {
+  // Try native JSON.parse first (faster for valid JSON)
+  try {
+    return {
+      success: true,
+      data: JSON.parse(input) as T,
+    };
+  } catch {
+    // Fall back to lenient parser
+  }
+
+  // Extract markdown code block if present
+  const codeBlockContent: string | null = extractMarkdownCodeBlock(input);
+  const jsonSource: string =
+    codeBlockContent !== null ? codeBlockContent : input;
+
+  // Check if input is empty or whitespace-only
+  const trimmed: string = jsonSource.trim();
+  if (trimmed.length === 0) {
+    const errors: IJsonParseResult.IError[] = [];
+    const parser: LenientJsonParser = new LenientJsonParser(jsonSource, errors);
+    const data: unknown = parser.parse();
+    if (errors.length > 0) {
+      return { success: false, data: data as DeepPartial<T>, input, errors };
+    }
+    return { success: true, data: data as T };
+  }
+
+  // Check if input starts with a primitive value (no junk prefix skipping needed)
+  if (startsWithPrimitive(trimmed)) {
+    const errors: IJsonParseResult.IError[] = [];
+    const parser: LenientJsonParser = new LenientJsonParser(jsonSource, errors);
+    const data: unknown = parser.parse();
+    if (errors.length > 0) {
+      return { success: false, data: data as DeepPartial<T>, input, errors };
+    }
+    return { success: true, data: data as T };
+  }
+
+  // Find JSON start position (skip junk prefix from LLM)
+  const jsonStart: number = findJsonStart(jsonSource);
+  if (jsonStart === -1) {
+    // No JSON found - return empty object for lenient behavior
+    return {
+      success: true,
+      data: {} as T,
+    };
+  }
+
+  // Extract JSON portion (skip junk prefix)
+  const jsonInput: string =
+    jsonStart > 0 ? jsonSource.slice(jsonStart) : jsonSource;
+
+  const errors: IJsonParseResult.IError[] = [];
+  const parser: LenientJsonParser = new LenientJsonParser(jsonInput, errors);
+  const data: unknown = parser.parse();
+
+  if (errors.length > 0) {
+    return {
+      success: false,
+      data: data as DeepPartial<T>,
+      input,
+      errors,
+    };
+  }
+  return {
+    success: true,
+    data: data as T,
+  };
+}
+
+/**
  * Maximum nesting depth to prevent stack overflow attacks.
  *
  * @internal
@@ -134,96 +224,6 @@ function startsWithPrimitive(input: string): boolean {
   )
     return true;
   return false;
-}
-
-/**
- * Parse lenient JSON that may be incomplete or malformed.
- *
- * Handles:
- *
- * - Unclosed brackets `{`, `[` - parses as much as possible
- * - Trailing commas `[1, 2, ]` - ignores them
- * - Unclosed strings `"hello` - returns partial string
- * - Junk text before JSON (LLM often adds explanatory text)
- * - Markdown code blocks (extracts content from `json ... `)
- * - Incomplete keywords like `tru`, `fal`, `nul`
- * - Unicode escape sequences including surrogate pairs (emoji)
- * - JavaScript-style comments (single-line and multi-line)
- * - Unquoted object keys (JavaScript identifier style)
- *
- * @param input Raw JSON string (potentially incomplete)
- * @returns Parse result with data, original input, and any errors
- * @internal
- */
-export function parseLenientJson<T>(input: string): IJsonParseResult<T> {
-  // Try native JSON.parse first (faster for valid JSON)
-  try {
-    return {
-      success: true,
-      data: JSON.parse(input) as T,
-    };
-  } catch {
-    // Fall back to lenient parser
-  }
-
-  // Extract markdown code block if present
-  const codeBlockContent: string | null = extractMarkdownCodeBlock(input);
-  const jsonSource: string =
-    codeBlockContent !== null ? codeBlockContent : input;
-
-  // Check if input is empty or whitespace-only
-  const trimmed: string = jsonSource.trim();
-  if (trimmed.length === 0) {
-    const errors: IJsonParseResult.IError[] = [];
-    const parser: LenientJsonParser = new LenientJsonParser(jsonSource, errors);
-    const data: unknown = parser.parse();
-    if (errors.length > 0) {
-      return { success: false, data: data as DeepPartial<T>, input, errors };
-    }
-    return { success: true, data: data as T };
-  }
-
-  // Check if input starts with a primitive value (no junk prefix skipping needed)
-  if (startsWithPrimitive(trimmed)) {
-    const errors: IJsonParseResult.IError[] = [];
-    const parser: LenientJsonParser = new LenientJsonParser(jsonSource, errors);
-    const data: unknown = parser.parse();
-    if (errors.length > 0) {
-      return { success: false, data: data as DeepPartial<T>, input, errors };
-    }
-    return { success: true, data: data as T };
-  }
-
-  // Find JSON start position (skip junk prefix from LLM)
-  const jsonStart: number = findJsonStart(jsonSource);
-  if (jsonStart === -1) {
-    // No JSON found - return empty object for lenient behavior
-    return {
-      success: true,
-      data: {} as T,
-    };
-  }
-
-  // Extract JSON portion (skip junk prefix)
-  const jsonInput: string =
-    jsonStart > 0 ? jsonSource.slice(jsonStart) : jsonSource;
-
-  const errors: IJsonParseResult.IError[] = [];
-  const parser: LenientJsonParser = new LenientJsonParser(jsonInput, errors);
-  const data: unknown = parser.parse();
-
-  if (errors.length > 0) {
-    return {
-      success: false,
-      data: data as DeepPartial<T>,
-      input,
-      errors,
-    };
-  }
-  return {
-    success: true,
-    data: data as T,
-  };
 }
 
 /**

--- a/tests/test-typia-generate/src/input/generate_llm.ts
+++ b/tests/test-typia-generate/src/input/generate_llm.ts
@@ -25,6 +25,27 @@ export const controller = typia.llm.controller<IApplication>("company", {
     props.entity.id,
 });
 
+// llm.parse and llm.coerce
+interface ISimpleParams {
+  name: string;
+  age: number;
+  alive: boolean;
+}
+
+export const parse = typia.llm.parse<ISimpleParams>(
+  JSON.stringify({ name: "John", age: "30", alive: "true" }),
+);
+
+export const createParse = typia.llm.createParse<ISimpleParams>();
+
+export const coerce = typia.llm.coerce<ISimpleParams>({
+  name: "John",
+  age: "30" as unknown as number,
+  alive: "true" as unknown as boolean,
+});
+
+export const createCoerce = typia.llm.createCoerce<ISimpleParams>();
+
 export interface IApplication {
   establishCompany(props: { company: ICompany }): ICompany;
   createDepartment(props: {

--- a/tests/test-typia-schema/src/features/llm.coerce/test_llm_coerce_object.ts
+++ b/tests/test-typia-schema/src/features/llm.coerce/test_llm_coerce_object.ts
@@ -1,0 +1,25 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_llm_coerce_object = (): void => {
+  interface IInput {
+    name: string;
+    age: number;
+    alive: boolean;
+  }
+
+  // Already parsed object with wrong types
+  const input = {
+    name: "John",
+    age: "30" as unknown as number, // string instead of number
+    alive: "true" as unknown as boolean, // string instead of boolean
+  };
+
+  const result = typia.llm.coerce<IInput>(input);
+
+  TestValidator.equals("name", result.name, "John");
+  TestValidator.equals("age", result.age, 30);
+  TestValidator.equals("age type", typeof result.age, "number");
+  TestValidator.equals("alive", result.alive, true);
+  TestValidator.equals("alive type", typeof result.alive, "boolean");
+};

--- a/tests/test-typia-schema/src/features/llm.coerce/test_llm_createCoerce_object.ts
+++ b/tests/test-typia-schema/src/features/llm.coerce/test_llm_createCoerce_object.ts
@@ -1,0 +1,33 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_llm_createCoerce_object = (): void => {
+  interface IInput {
+    name: string;
+    age: number;
+    alive: boolean;
+  }
+
+  // Create reusable coercer
+  const coerce = typia.llm.createCoerce<IInput>();
+
+  // Test with multiple inputs
+  const input1 = {
+    name: "John",
+    age: "30" as unknown as number,
+    alive: "true" as unknown as boolean,
+  };
+  const input2 = {
+    name: "Jane",
+    age: "25" as unknown as number,
+    alive: "false" as unknown as boolean,
+  };
+
+  const result1 = coerce(input1);
+  const result2 = coerce(input2);
+
+  TestValidator.equals("result1 age", result1.age, 30);
+  TestValidator.equals("result1 alive", result1.alive, true);
+  TestValidator.equals("result2 age", result2.age, 25);
+  TestValidator.equals("result2 alive", result2.alive, false);
+};

--- a/tests/test-typia-schema/src/features/llm.parse/test_llm_createParse_object.ts
+++ b/tests/test-typia-schema/src/features/llm.parse/test_llm_createParse_object.ts
@@ -1,0 +1,33 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_llm_createParse_object = (): void => {
+  interface IInput {
+    name: string;
+    age: number;
+    alive: boolean;
+  }
+
+  // Create reusable parser
+  const parse = typia.llm.createParse<IInput>();
+
+  // Test with multiple inputs
+  const input1 = JSON.stringify({ name: "John", age: 30, alive: true });
+  const input2 = JSON.stringify({ name: "Jane", age: 25, alive: false });
+
+  const result1 = parse(input1);
+  const result2 = parse(input2);
+
+  TestValidator.equals("result1 success", result1.success, true);
+  TestValidator.equals("result2 success", result2.success, true);
+
+  if (result1.success) {
+    TestValidator.equals("result1 name", result1.data.name, "John");
+    TestValidator.equals("result1 age", result1.data.age, 30);
+  }
+
+  if (result2.success) {
+    TestValidator.equals("result2 name", result2.data.name, "Jane");
+    TestValidator.equals("result2 age", result2.data.age, 25);
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parse/test_llm_parse_coercion.ts
+++ b/tests/test-typia-schema/src/features/llm.parse/test_llm_parse_coercion.ts
@@ -1,0 +1,25 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_llm_parse_coercion = (): void => {
+  interface IInput {
+    name: string;
+    age: number;
+    alive: boolean;
+  }
+
+  // Test parse with stringified values (LLM commonly returns these)
+  const malformedJson = JSON.stringify({
+    name: "John",
+    age: "30", // number as string
+    alive: "true", // boolean as string
+  });
+  const result = typia.llm.parse<IInput>(malformedJson);
+
+  TestValidator.equals("success", result.success, true);
+  if (result.success) {
+    TestValidator.equals("name", result.data.name, "John");
+    TestValidator.equals("age", result.data.age, 30);
+    TestValidator.equals("alive", result.data.alive, true);
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parse/test_llm_parse_object.ts
+++ b/tests/test-typia-schema/src/features/llm.parse/test_llm_parse_object.ts
@@ -1,0 +1,27 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_llm_parse_object = (): void => {
+  interface IInput {
+    name: string;
+    age: number;
+    alive: boolean;
+  }
+
+  const input: IInput = {
+    name: "John",
+    age: 30,
+    alive: true,
+  };
+
+  // Test parse with valid JSON
+  const json = JSON.stringify(input);
+  const result = typia.llm.parse<IInput>(json);
+
+  TestValidator.equals("success", result.success, true);
+  if (result.success) {
+    TestValidator.equals("name", result.data.name, "John");
+    TestValidator.equals("age", result.data.age, 30);
+    TestValidator.equals("alive", result.data.alive, true);
+  }
+};


### PR DESCRIPTION
This pull request introduces new functionality for handling LLM (Large Language Model) argument parsing and coercion within the codebase. It adds two new programmers (`LlmCoerceProgrammer` and `LlmParseProgrammer`) and their corresponding transformers, enabling type-safe parsing and coercion of LLM arguments. The changes also integrate these features into the transformer infrastructure and expose them through the public API.

New LLM argument parsing and coercion features:

* Added `LlmCoerceProgrammer` and `LlmParseProgrammer` for generating code to coerce and parse LLM arguments based on TypeScript types, including schema generation, validation, and code emission. [[1]](diffhunk://#diff-cd4384b24844f6e39a980c82f27015af70e217b4d5c074bd26b5e0ce842eb410R1-R131) [[2]](diffhunk://#diff-214e3861e217bed5ba453146e10a7542ce4608a8bf15db0663c0ed7aa2810f4bR1-R131)
* Implemented internal functions `_coerceLlmArguments` and `_parseLlmArguments` for runtime handling of LLM argument coercion and parsing, delegating to `LlmJson`. [[1]](diffhunk://#diff-843f7c203d5297ec955e80e2d4d031b0f353e085858d0105e7944be24daf4dd8R1-R7) [[2]](diffhunk://#diff-5ac9444f73dbb2def4c27d8b251145f343c059b7210d9220996ea01133cab4beR1-R7)

Transformer infrastructure integration:

* Added new transformers: `LlmCoerceTransformer`, `LlmCreateCoerceTransformer`, `LlmParseTransformer`, and `LlmCreateParseTransformer`, which validate types, extract configuration, and emit code using the new programmers. [[1]](diffhunk://#diff-8699e1df30adffdf2bcaf538bbb2bc57d617d6750a826273407abd057eaecf9eR1-R88) [[2]](diffhunk://#diff-e300aafe14871f2b64ba7c6182cc3c2fc70e7402e59940cc5417ff6278505a39R1-R77) [[3]](diffhunk://#diff-5f429f2a2c41186022bffef33b110bc4821c79feb159df73e3e5e62e2f6a0bb1R1-R88) [[4]](diffhunk://#diff-2a8e4769d0e82a6f49af2b38a20e696dfba9aad245f52cabadcd80703c260705R1-R77)
* Registered the new LLM transformers in the `CallExpressionTransformer` infrastructure, enabling their use via function calls in user code. [[1]](diffhunk://#diff-8a001d0eb47041ffd9d4c1d93a9737d3e7bbb257b97f1275833bb8d4ac577f60R72-R77) [[2]](diffhunk://#diff-8a001d0eb47041ffd9d4c1d93a9737d3e7bbb257b97f1275833bb8d4ac577f60R428-R431)

Public API exposure:

* Exported `LlmCoerceProgrammer` and `LlmParseProgrammer` from the LLM programmers index, making them available for external use.
* Updated imports in `llm.ts` to include `IJsonParseResult` for LLM parsing results.