### PR TITLE
feat(interface): no more `ILlmSchema.IConfig.reference` required.

### DIFF
--- a/examples/src/llm/schema.ts
+++ b/examples/src/llm/schema.ts
@@ -1,10 +1,7 @@
 import typia, { ILlmSchema, tags } from "typia";
 
 export const $defs: Record<string, ILlmSchema> = {};
-export const schema: ILlmSchema = typia.llm.schema<
-  IBbsArticle,
-  { reference: true }
->($defs);
+export const schema: ILlmSchema = typia.llm.schema<IBbsArticle>($defs);
 
 /**
  * Article entity.

--- a/packages/interface/src/schema/ILlmApplication.ts
+++ b/packages/interface/src/schema/ILlmApplication.ts
@@ -13,7 +13,6 @@ import { IValidation } from "./IValidation";
  *
  * - {@link ILlmApplication.IConfig.validate}: Custom validation per method
  * - {@link ILlmSchema.IConfig.strict}: OpenAI structured output mode
- * - {@link ILlmSchema.IConfig.reference}: Control `$ref` inlining behavior
  *
  * @author Jeongho Nam - https://github.com/samchon
  * @template Class Source class/interface type
@@ -32,7 +31,7 @@ export interface ILlmApplication<Class extends object = any> {
    * Configuration used to generate this application.
    *
    * Contains the settings that were applied during schema generation, including
-   * reference handling, strict mode, and parameter separation.
+   * strict mode, and parameter separation.
    */
   config: ILlmApplication.IConfig<Class>;
 

--- a/packages/interface/src/schema/ILlmApplication.ts
+++ b/packages/interface/src/schema/ILlmApplication.ts
@@ -31,7 +31,7 @@ export interface ILlmApplication<Class extends object = any> {
    * Configuration used to generate this application.
    *
    * Contains the settings that were applied during schema generation, including
-   * strict mode, and parameter separation.
+   * strict mode and any custom validation hooks.
    */
   config: ILlmApplication.IConfig<Class>;
 

--- a/packages/interface/src/schema/ILlmSchema.ts
+++ b/packages/interface/src/schema/ILlmSchema.ts
@@ -36,20 +36,9 @@ export namespace ILlmSchema {
    * Configuration options for LLM schema generation.
    *
    * Controls how TypeScript types are converted to LLM-compatible JSON schemas.
-   * These settings affect reference handling and OpenAI structured output
-   * compatibility.
+   * These settings affect OpenAI structured output compatibility.
    */
   export interface IConfig {
-    /**
-     * Whether to allow `$ref` references everywhere.
-     *
-     * When `false`, references are inlined except for recursive types.
-     * References reduce token cost but may cause hallucination.
-     *
-     * @default true
-     */
-    reference: boolean;
-
     /**
      * Whether to enable strict mode (OpenAI structured output).
      *

--- a/packages/utils/src/converters/LlmSchemaConverter.ts
+++ b/packages/utils/src/converters/LlmSchemaConverter.ts
@@ -29,7 +29,6 @@ import { OpenApiConstraintShifter } from "./internal/OpenApiConstraintShifter";
  *
  * Configuration options ({@link ILlmSchema.IConfig}):
  *
- * - `reference`: Allow `$ref` references (reduces tokens but may confuse LLM)
  * - `strict`: OpenAI structured output mode (all properties required)
  *
  * @author Jeongho Nam - https://github.com/samchon
@@ -44,7 +43,6 @@ export namespace LlmSchemaConverter {
   export const getConfig = (
     config?: Partial<ILlmSchema.IConfig> | undefined,
   ): ILlmSchema.IConfig => ({
-    reference: config?.reference ?? true,
     strict: config?.strict ?? false,
   });
 
@@ -238,14 +236,8 @@ export namespace LlmSchemaConverter {
         const target: OpenApi.IJsonSchema | undefined =
           props.components.schemas?.[key];
         if (target === undefined) return;
-        else if (
+        else {
           // KEEP THE REFERENCE TYPE
-          props.config.reference === true ||
-          OpenApiTypeChecker.isRecursiveReference({
-            components: props.components,
-            schema: input,
-          })
-        ) {
           const out = () => {
             union.push({
               ...input,
@@ -267,28 +259,6 @@ export namespace LlmSchemaConverter {
           if (converted.success === false) return; // UNREACHABLE
           props.$defs[key] = converted.value;
           return out();
-        } else {
-          // DISCARD THE REFERENCE TYPE
-          const length: number = union.length;
-          visit(target, accessor);
-          visitConstant(target);
-          if (length === union.length - 1)
-            union[union.length - 1] = {
-              ...union[union.length - 1]!,
-              description: JsonDescriptor.cascade({
-                prefix: "#/components/schemas/",
-                components: props.components,
-                schema: input,
-                escape: true,
-              }),
-            };
-          else
-            attribute.description = JsonDescriptor.cascade({
-              prefix: "#/components/schemas/",
-              components: props.components,
-              schema: input,
-              escape: true,
-            });
         }
       } else if (OpenApiTypeChecker.isObject(input)) {
         // OBJECT TYPE

--- a/packages/utils/src/http/HttpLlm.ts
+++ b/packages/utils/src/http/HttpLlm.ts
@@ -113,7 +113,6 @@ export namespace HttpLlm {
     return HttpLlmApplicationComposer.application({
       migrate,
       config: {
-        reference: props.config?.reference ?? true,
         strict: props.config?.strict ?? false,
         maxLength: props.config?.maxLength ?? 64,
         equals: props.config?.equals ?? false,

--- a/packages/utils/src/http/internal/HttpLlmApplicationComposer.ts
+++ b/packages/utils/src/http/internal/HttpLlmApplicationComposer.ts
@@ -36,7 +36,6 @@ export namespace HttpLlmApplicationComposer {
     const config: IHttpLlmApplication.IConfig = {
       maxLength: props.config?.maxLength ?? 64,
       equals: props.config?.equals ?? false,
-      reference: props.config?.reference ?? true,
       strict: props.config?.strict ?? false,
     };
     // seed with pre-existing migration errors, excluding human-only endpoints

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_enum.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_enum.ts
@@ -11,9 +11,7 @@ export const test_llm_schema_enum = (): void => {
       schema: collection.schemas[0] as
         | OpenApi.IJsonSchema.IObject
         | OpenApi.IJsonSchema.IReference,
-      config: {
-        reference: false,
-      },
+      config: {},
     });
   TestValidator.equals("success", result.success, true);
   if (result.success === false) return;

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_enum.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_enum.ts
@@ -11,7 +11,6 @@ export const test_llm_schema_enum = (): void => {
       schema: collection.schemas[0] as
         | OpenApi.IJsonSchema.IObject
         | OpenApi.IJsonSchema.IReference,
-      config: {},
     });
   TestValidator.equals("success", result.success, true);
   if (result.success === false) return;
@@ -22,10 +21,7 @@ export const test_llm_schema_enum = (): void => {
 };
 
 interface IBbsArticle {
-  format: IBbsArticle.Format;
+  format: "html" | "md" | "txt";
   // title: string;
   // body: string;
-}
-namespace IBbsArticle {
-  export type Format = "html" | "md" | "txt";
 }

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_enum_reference.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_enum_reference.ts
@@ -29,14 +29,12 @@ export const test_llm_schema_enum_reference = (): void => {
     ],
   };
 
+  const $defs: Record<string, ILlmSchema> = {};
   const result: IResult<ILlmSchema, IJsonSchemaTransformError> =
     LlmSchemaConverter.schema({
       components,
       schema,
-      $defs: {},
-      config: {
-        reference: false,
-      },
+      $defs,
     });
   TestValidator.equals(
     "success",
@@ -44,13 +42,16 @@ export const test_llm_schema_enum_reference = (): void => {
     true,
     (key) => key === "description",
   );
+  // const 3 is inlined as { type: "number", enum: [3] },
+  // while $ref to "named" stays as a reference
+  TestValidator.predicate("anyOf", () => {
+    if (result.success === false) return false;
+    const anyOf = (result.value as any).anyOf;
+    return Array.isArray(anyOf) && anyOf.length === 2;
+  });
   TestValidator.equals(
-    "union",
-    result.success ? result.value : {},
-    {
-      type: "number",
-      enum: [3, 4, 5],
-    },
-    (key) => key === "description",
+    "named $defs",
+    ($defs.named as any)?.enum,
+    [4, 5],
   );
 };

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_oneof.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_oneof.ts
@@ -13,17 +13,22 @@ export const test_llm_schema_oneof = (): void => {
       $defs,
       components: collection.components,
       schema: collection.schemas[0]!,
-      config: {
-        reference: false,
-      },
     });
   TestValidator.predicate("success", result.success);
+  TestValidator.predicate("anyOf length", () => {
+    const anyOf = (result as any)?.value?.anyOf;
+    return Array.isArray(anyOf) && anyOf.length === 4;
+  });
   TestValidator.equals(
-    "anyOf",
+    "types",
     ["point", "line", "triangle", "rectangle"],
-    (result as any)?.value?.anyOf?.map(
-      (e: any) => e.properties?.type?.enum?.[0],
-    ),
+    Object.values($defs)
+      .map((def: any) => def.properties?.type?.enum?.[0])
+      .filter(Boolean)
+      .sort((a: string, b: string) => {
+        const order = ["point", "line", "triangle", "rectangle"];
+        return order.indexOf(a) - order.indexOf(b);
+      }),
   );
 };
 

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_reference_escaped_description_of_name.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_reference_escaped_description_of_name.ts
@@ -15,11 +15,10 @@ export const test_llm_schema_reference_escaped_description_of_name =
       ]
     >();
     const schema: ILlmSchema.IParameters = composeSchema(collection);
-    const deep: ILlmSchema.IObject = schema.properties
-      .deep as ILlmSchema.IObject;
+    const deep: ILlmSchema = schema.properties.deep as ILlmSchema;
     TestValidator.predicate(
-      "description",
-      () => !!deep.description?.includes("Something.INested.IDeep"),
+      "$ref",
+      () => !!(deep as ILlmSchema.IReference).$ref,
     );
   };
 
@@ -46,9 +45,6 @@ const composeSchema = (
       schema: typia.assert<
         OpenApi.IJsonSchema.IObject | OpenApi.IJsonSchema.IReference
       >(collection.schemas[0]),
-      config: {
-        reference: false,
-      },
     });
   if (result.success === false) throw new Error("Invalid schema");
   return result.value;

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_reference_escaped_description_of_namespace.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_reference_escaped_description_of_namespace.ts
@@ -16,16 +16,8 @@ export const test_llm_schema_reference_escaped_description_of_namespace =
     >();
     const schema: ILlmSchema.IParameters = composeSchema(collection);
     const deep: ILlmSchema = schema.properties.deep as ILlmSchema;
-    TestValidator.predicate("description", () => {
-      const description: string | undefined = (
-        deep as OpenApi.IJsonSchema.IObject
-      ).description;
-      return (
-        !!description &&
-        description.includes("Something interface") &&
-        description.includes("Something nested interface") &&
-        description.includes("Something nested and deep interface")
-      );
+    TestValidator.predicate("$ref", () => {
+      return !!(deep as ILlmSchema.IReference).$ref;
     });
   };
 
@@ -55,9 +47,6 @@ const composeSchema = (
       schema: typia.assert<
         OpenApi.IJsonSchema.IObject | OpenApi.IJsonSchema.IReference
       >(collection.schemas[0]),
-      config: {
-        reference: false,
-      },
     });
   if (result.success === false) throw new Error("Invalid schema");
   return result.value;


### PR DESCRIPTION
This pull request removes the `reference` configuration option from the LLM schema generation process, simplifying how references are handled and streamlining related code and documentation. The change impacts schema generation, configuration interfaces, utilities, and tests.

Configuration and schema generation simplification:

* Removed the `reference` option from `ILlmSchema.IConfig`, `ILlmApplication.IConfig`, and related documentation, making reference handling implicit and reducing configuration complexity. [[1]](diffhunk://#diff-c801efea627846ada0fd5f67a57585ea45f70cb9933e565afaf271e4a585ded4L39-L52) [[2]](diffhunk://#diff-c59191eaf382c34cb8b2e729b63cfac2766545f74f2f39b1383cbb4319b268fcL16) [[3]](diffhunk://#diff-c59191eaf382c34cb8b2e729b63cfac2766545f74f2f39b1383cbb4319b268fcL35-R34) [[4]](diffhunk://#diff-ab1a86ba40808ec704e8c9d3c9a8e440d895c7e848d6cb6776b500972ac5d2afL32)
* Updated schema generation logic in `LlmSchemaConverter` to always keep reference types, eliminating conditional reference inlining and associated code branches. [[1]](diffhunk://#diff-ab1a86ba40808ec704e8c9d3c9a8e440d895c7e848d6cb6776b500972ac5d2afL47) [[2]](diffhunk://#diff-ab1a86ba40808ec704e8c9d3c9a8e440d895c7e848d6cb6776b500972ac5d2afL241-L248) [[3]](diffhunk://#diff-ab1a86ba40808ec704e8c9d3c9a8e440d895c7e848d6cb6776b500972ac5d2afL270-L291)

Code and test cleanup:

* Removed passing and handling of the `reference` option in HTTP utilities and schema generation functions, including `HttpLlm`, `HttpLlmApplicationComposer`, and example usage. [[1]](diffhunk://#diff-a896d6241f1b6f31e2855b5b6e3db30da488b25950e22280643d9d175ba4cafdL116) [[2]](diffhunk://#diff-0200f94e1c275a53e75428c1af257c00c74eb72b960d4dc734b99c9759885c28L39) [[3]](diffhunk://#diff-8872130b86cb9778ab28fb5286e2a70e711a1e3e546844e679cf165b67de00f2L4-R4)
* Refactored tests to no longer set or depend on the `reference` option, and updated test assertions to check for `$ref` presence instead of description inlining. [[1]](diffhunk://#diff-49aa99dc7663081e368faef50f7968f33caedfecc6668bde6ba344127f365111L14-R14) [[2]](diffhunk://#diff-5e0e0fa7fec2ba9189e1f6fd791d0d004a4e8316c8b1225c86c7a2d77ec37c21R32-R55) [[3]](diffhunk://#diff-f3d694ba8a041f45c46ff315ab2ecf04ca26b92e9a09120526e069b6a83aa1f6L16-R31) [[4]](diffhunk://#diff-60a1668bedcad170df101830ed0638af85b6b3188c0d14bacee263031eb8292cL18-R21) [[5]](diffhunk://#diff-60a1668bedcad170df101830ed0638af85b6b3188c0d14bacee263031eb8292cL49-L51) [[6]](diffhunk://#diff-cdb805ccba5d8be55011ffe9461637fbb8aae350bc17edc02c81250412cc4cd8L19-R20) [[7]](diffhunk://#diff-cdb805ccba5d8be55011ffe9461637fbb8aae350bc17edc02c81250412cc4cd8L58-L60)