### PR TITLE
fix(utils): `HttpLlm` accepts `OpenApiV3_2.IDocument`.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/benchmark",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Benchmark program of typia performance",
   "main": "bin/index.js",
   "scripts": {

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/benchmark",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Benchmark program of typia performance",
   "main": "bin/index.js",
   "scripts": {

--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/config",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Shared build configuration for typia packages",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/config",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Shared build configuration for typia packages",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/examples",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Example codes for typia website",
   "scripts": {
     "build": "rimraf bin && cross-env NODE_OPTIONS=\"--no-experimental-strip-types -r ts-node/register\" tsc && prettier --write bin/**/*.js",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/examples",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Example codes for typia website",
   "scripts": {
     "build": "rimraf bin && cross-env NODE_OPTIONS=\"--no-experimental-strip-types -r ts-node/register\" tsc && prettier --write bin/**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm --filter=./packages/* -r build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm --filter=./packages/* -r build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/core",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/core",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/interface/src/schema/IJsonParseResult.ts
+++ b/packages/interface/src/schema/IJsonParseResult.ts
@@ -70,7 +70,7 @@ export namespace IJsonParseResult {
      * Contains whatever could be recovered from the malformed JSON. May be
      * incomplete or have missing properties.
      */
-    data: DeepPartial<T>;
+    data: DeepPartial<T> | undefined;
 
     /**
      * The original input string that was parsed.
@@ -129,6 +129,6 @@ export namespace IJsonParseResult {
      * @example
      *   missing opening quote for 'hello'
      */
-    value: unknown;
+    description: unknown;
   }
 }

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/transform",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/transform",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typia/unplugin",
   "type": "module",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "unplugin for typia",
   "author": "ryoppippi",
   "license": "MIT",

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typia/unplugin",
   "type": "module",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "unplugin for typia",
   "author": "ryoppippi",
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/src/http/HttpError.ts
+++ b/packages/utils/src/http/HttpError.ts
@@ -14,7 +14,14 @@
  */
 export class HttpError extends Error {
   /** HTTP method used for the request. */
-  public readonly method: "GET" | "DELETE" | "POST" | "PUT" | "PATCH" | "HEAD";
+  public readonly method:
+    | "GET"
+    | "QUERY"
+    | "DELETE"
+    | "POST"
+    | "PUT"
+    | "PATCH"
+    | "HEAD";
 
   /** Request path or URL. */
   public readonly path: string;
@@ -36,7 +43,7 @@ export class HttpError extends Error {
    * @param message Error message (response body)
    */
   public constructor(
-    method: "GET" | "DELETE" | "POST" | "PUT" | "PATCH" | "HEAD",
+    method: "GET" | "QUERY" | "DELETE" | "POST" | "PUT" | "PATCH" | "HEAD",
     path: string,
     status: number,
     headers: Record<string, string | string[]>,
@@ -87,7 +94,7 @@ export namespace HttpError {
    */
   export interface IProps<T> {
     /** HTTP method. */
-    method: "GET" | "DELETE" | "POST" | "PUT" | "PATCH" | "HEAD";
+    method: "GET" | "QUERY" | "DELETE" | "POST" | "PUT" | "PATCH" | "HEAD";
 
     /** Request path or URL. */
     path: string;

--- a/packages/utils/src/http/HttpLlm.ts
+++ b/packages/utils/src/http/HttpLlm.ts
@@ -8,6 +8,7 @@ import {
   OpenApi,
   OpenApiV3,
   OpenApiV3_1,
+  OpenApiV3_2,
   SwaggerV2,
 } from "@typia/interface";
 
@@ -62,7 +63,8 @@ export namespace HttpLlm {
       | OpenApi.IDocument
       | SwaggerV2.IDocument
       | OpenApiV3.IDocument
-      | OpenApiV3_1.IDocument;
+      | OpenApiV3_1.IDocument
+      | OpenApiV3_2.IDocument;
 
     /** Connection to the API server. */
     connection: IHttpConnection;
@@ -101,7 +103,8 @@ export namespace HttpLlm {
       | OpenApi.IDocument
       | SwaggerV2.IDocument
       | OpenApiV3.IDocument
-      | OpenApiV3_1.IDocument;
+      | OpenApiV3_1.IDocument
+      | OpenApiV3_2.IDocument;
 
     /** LLM schema conversion configuration. */
     config?: Partial<IHttpLlmApplication.IConfig>;

--- a/packages/utils/src/http/HttpMigration.ts
+++ b/packages/utils/src/http/HttpMigration.ts
@@ -6,6 +6,7 @@ import {
   OpenApi,
   OpenApiV3,
   OpenApiV3_1,
+  OpenApiV3_2,
   SwaggerV2,
 } from "@typia/interface";
 
@@ -45,7 +46,8 @@ export namespace HttpMigration {
       | OpenApi.IDocument
       | SwaggerV2.IDocument
       | OpenApiV3.IDocument
-      | OpenApiV3_1.IDocument,
+      | OpenApiV3_1.IDocument
+      | OpenApiV3_2.IDocument,
   ): IHttpMigrateApplication =>
     HttpMigrateApplicationComposer.compose(
       OpenApiConverter.upgradeDocument(document),

--- a/packages/utils/src/utils/internal/parseLenientJson.ts
+++ b/packages/utils/src/utils/internal/parseLenientJson.ts
@@ -20,16 +20,41 @@ import { DeepPartial, IJsonParseResult } from "@typia/interface";
  * @internal
  */
 export function parseLenientJson<T>(input: string): IJsonParseResult<T> {
+  // For safe guard
+  if (typeof input !== "string") input = String(input);
+
   // Try native JSON.parse first (faster for valid JSON)
+  let error: Error | null = null;
   try {
     return {
       success: true,
       data: JSON.parse(input) as T,
     };
-  } catch {
+  } catch (e) {
     // Fall back to lenient parser
+    error = e instanceof Error ? e : new Error(String(e));
   }
 
+  try {
+    return iterate(input);
+  } catch {
+    // actually unreachable, maybe?
+    return {
+      success: false,
+      data: undefined as DeepPartial<T>,
+      input,
+      errors: [
+        {
+          path: "$input",
+          expected: "valid JSON",
+          description: error.message,
+        },
+      ],
+    };
+  }
+}
+
+function iterate<T>(input: string): IJsonParseResult<T> {
   // Extract markdown code block if present
   const codeBlockContent: string | null = extractMarkdownCodeBlock(input);
   const jsonSource: string =
@@ -46,7 +71,7 @@ export function parseLenientJson<T>(input: string): IJsonParseResult<T> {
         {
           path: "$input",
           expected: "JSON value",
-          value: "empty input",
+          description: "empty input",
         },
       ],
     };
@@ -89,7 +114,7 @@ export function parseLenientJson<T>(input: string): IJsonParseResult<T> {
         {
           path: "$input",
           expected: "JSON value",
-          value: jsonSource,
+          description: jsonSource,
         },
       ],
     };
@@ -116,13 +141,6 @@ export function parseLenientJson<T>(input: string): IJsonParseResult<T> {
     data: data as T,
   };
 }
-
-/**
- * Maximum nesting depth to prevent stack overflow attacks.
- *
- * @internal
- */
-const MAX_DEPTH: number = 512;
 
 /**
  * Check if a string is a valid 4-character hexadecimal string.
@@ -404,7 +422,7 @@ class LenientJsonParser {
       this.errors.push({
         path,
         expected: "value (max depth exceeded)",
-        value: undefined,
+        description: undefined,
       });
       return undefined;
     }
@@ -431,7 +449,7 @@ class LenientJsonParser {
     this.errors.push({
       path,
       expected: "JSON value",
-      value: this.getErrorContext(),
+      description: this.getErrorContext(),
     });
     // Skip the problematic character and try to continue
     this.pos++;
@@ -487,7 +505,7 @@ class LenientJsonParser {
       this.errors.push({
         path,
         expected: "quoted string",
-        value: "missing opening quote for '" + token + "'",
+        description: "missing opening quote for '" + token + "'",
       });
       return token;
     }
@@ -496,7 +514,7 @@ class LenientJsonParser {
     this.errors.push({
       path,
       expected: "JSON value (string, number, boolean, null, object, or array)",
-      value: "unquoted string '" + token + "' - did you forget quotes?",
+      description: "unquoted string '" + token + "' - did you forget quotes?",
     });
     // Skip to next comma, closing brace/bracket for recovery
     this.skipToRecoveryPoint();
@@ -546,7 +564,7 @@ class LenientJsonParser {
         this.errors.push({
           path,
           expected: "string key",
-          value: this.input[this.pos],
+          description: this.input[this.pos],
         });
         // Try to recover by skipping to next meaningful character
         this.depth--;
@@ -568,7 +586,7 @@ class LenientJsonParser {
         this.errors.push({
           path: path + "." + key,
           expected: "':'",
-          value: this.input[this.pos],
+          description: this.input[this.pos],
         });
         this.depth--;
         return result;
@@ -892,3 +910,10 @@ class LenientJsonParser {
     }
   }
 }
+
+/**
+ * Maximum nesting depth to prevent stack overflow attacks.
+ *
+ * @internal
+ */
+const MAX_DEPTH: number = 512;

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/debug",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Convenient debug program for typia",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/debug",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Convenient debug program for typia",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/template/package.json
+++ b/tests/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/template",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Template structures for typia testing.",
   "main": "src/index.ts",
   "repository": {

--- a/tests/template/package.json
+++ b/tests/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/template",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Template structures for typia testing.",
   "main": "src/index.ts",
   "repository": {

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-error",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Test program of typia generated error",
   "main": "index.js",
   "scripts": {

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-error",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Test program of typia generated error",
   "main": "index.js",
   "scripts": {

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-langchain",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Test suite for @typia/langchain package",
   "scripts": {
     "start": "ts-node src/index.ts",

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-langchain",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Test suite for @typia/langchain package",
   "scripts": {
     "start": "ts-node src/index.ts",

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-mcp",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Test suite for @typia/mcp package",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-mcp",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Test suite for @typia/mcp package",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-automated",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Automated test features of typia.",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-automated",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Automated test features of typia.",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-generate",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Test typia generation command",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=\"--no-experimental-strip-types -r ts-node/register\" tsc",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-generate",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Test typia generation command",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=\"--no-experimental-strip-types -r ts-node/register\" tsc",

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-schema",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Test features for JSON schema, LLM schema and protobuf message of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-schema",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Test features for JSON schema, LLM schema and protobuf message of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-unplugin/package.json
+++ b/tests/test-unplugin/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-unplugin",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "type": "module",
   "description": "Test for @typia/unplugin package",
   "repository": {

--- a/tests/test-unplugin/package.json
+++ b/tests/test-unplugin/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-unplugin",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "type": "module",
   "description": "Test for @typia/unplugin package",
   "repository": {

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-openapiautomated",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Automated test features of openapi.",
   "scripts": {
     "start": "node -r ts-node/register src/index.ts"

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-openapiautomated",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Automated test features of openapi.",
   "scripts": {
     "start": "node -r ts-node/register src/index.ts"

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-utils",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Automated test features of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-utils",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Automated test features of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-utils/src/features/openapi/test_document_downgrade_v20.ts
+++ b/tests/test-utils/src/features/openapi/test_document_downgrade_v20.ts
@@ -1,4 +1,10 @@
-import { OpenApi, OpenApiV3, OpenApiV3_1, SwaggerV2 } from "@typia/interface";
+import {
+  OpenApi,
+  OpenApiV3,
+  OpenApiV3_1,
+  OpenApiV3_2,
+  SwaggerV2,
+} from "@typia/interface";
 import { OpenApiConverter } from "@typia/utils";
 import fs from "fs";
 import typia from "typia";
@@ -15,8 +21,12 @@ export const test_document_downgrade_v20 = async (): Promise<void> => {
       const swagger:
         | SwaggerV2.IDocument
         | OpenApiV3.IDocument
-        | OpenApiV3_1.IDocument = typia.assert<
-        SwaggerV2.IDocument | OpenApiV3.IDocument | OpenApiV3_1.IDocument
+        | OpenApiV3_1.IDocument
+        | OpenApiV3_2.IDocument = typia.assert<
+        | SwaggerV2.IDocument
+        | OpenApiV3.IDocument
+        | OpenApiV3_1.IDocument
+        | OpenApiV3_2.IDocument
       >(
         JSON.parse(
           await fs.promises.readFile(`${path}/${directory}/${file}`, "utf8"),

--- a/tests/test-utils/src/features/openapi/test_document_downgrade_v30.ts
+++ b/tests/test-utils/src/features/openapi/test_document_downgrade_v30.ts
@@ -1,4 +1,10 @@
-import { OpenApi, OpenApiV3, OpenApiV3_1, SwaggerV2 } from "@typia/interface";
+import {
+  OpenApi,
+  OpenApiV3,
+  OpenApiV3_1,
+  OpenApiV3_2,
+  SwaggerV2,
+} from "@typia/interface";
 import { OpenApiConverter } from "@typia/utils";
 import fs from "fs";
 import typia from "typia";
@@ -15,8 +21,12 @@ export const test_document_downgrade_v30 = async (): Promise<void> => {
       const swagger:
         | SwaggerV2.IDocument
         | OpenApiV3.IDocument
-        | OpenApiV3_1.IDocument = typia.assert<
-        SwaggerV2.IDocument | OpenApiV3.IDocument | OpenApiV3_1.IDocument
+        | OpenApiV3_1.IDocument
+        | OpenApiV3_2.IDocument = typia.assert<
+        | SwaggerV2.IDocument
+        | OpenApiV3.IDocument
+        | OpenApiV3_1.IDocument
+        | OpenApiV3_2.IDocument
       >(
         JSON.parse(
           await fs.promises.readFile(`${path}/${directory}/${file}`, "utf8"),

--- a/tests/test-utils/src/features/openapi/test_document_downgrade_v31.ts
+++ b/tests/test-utils/src/features/openapi/test_document_downgrade_v31.ts
@@ -1,4 +1,10 @@
-import { OpenApi, OpenApiV3, OpenApiV3_1, SwaggerV2 } from "@typia/interface";
+import {
+  OpenApi,
+  OpenApiV3,
+  OpenApiV3_1,
+  OpenApiV3_2,
+  SwaggerV2,
+} from "@typia/interface";
 import { OpenApiConverter } from "@typia/utils";
 import fs from "fs";
 import typia from "typia";
@@ -15,8 +21,12 @@ export const test_document_downgrade_v31 = async (): Promise<void> => {
       const swagger:
         | SwaggerV2.IDocument
         | OpenApiV3.IDocument
-        | OpenApiV3_1.IDocument = typia.assert<
-        SwaggerV2.IDocument | OpenApiV3.IDocument | OpenApiV3_1.IDocument
+        | OpenApiV3_1.IDocument
+        | OpenApiV3_2.IDocument = typia.assert<
+        | SwaggerV2.IDocument
+        | OpenApiV3.IDocument
+        | OpenApiV3_1.IDocument
+        | OpenApiV3_2.IDocument
       >(
         JSON.parse(
           await fs.promises.readFile(`${path}/${directory}/${file}`, "utf8"),

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-vercel",
-  "version": "12.0.0-dev.20260312-3",
+  "version": "12.0.0-dev.20260312-4",
   "description": "Test suite for @typia/vercel package",
   "scripts": {
     "start": "ts-node src/index.ts",

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-vercel",
-  "version": "12.0.0-dev.20260312-4",
+  "version": "12.0.0-dev.20260312-5",
   "description": "Test suite for @typia/vercel package",
   "scripts": {
     "start": "ts-node src/index.ts",


### PR DESCRIPTION
This pull request updates the supported OpenAPI specification versions in the `HttpLlm` and `HttpMigration` modules to include OpenApiV3_2. This ensures that both modules can handle documents conforming to the latest OpenAPI 3.2 standard.

OpenAPI version support enhancements:

* Added `OpenApiV3_2` to the import statements in both `HttpLlm.ts` and `HttpMigration.ts`, allowing these modules to recognize and work with OpenAPI 3.2 documents. [[1]](diffhunk://#diff-a896d6241f1b6f31e2855b5b6e3db30da488b25950e22280643d9d175ba4cafdR11) [[2]](diffhunk://#diff-503c33c444066b3b5a7e40cf955c1f91ac6c5b180eeca4763b1564f8409e452cR9)
* Updated the `HttpLlm.IDocument` and `HttpLlm.IConfig` type definitions to include `OpenApiV3_2.IDocument`, expanding compatibility with OpenAPI 3.2. [[1]](diffhunk://#diff-a896d6241f1b6f31e2855b5b6e3db30da488b25950e22280643d9d175ba4cafdL65-R67) [[2]](diffhunk://#diff-a896d6241f1b6f31e2855b5b6e3db30da488b25950e22280643d9d175ba4cafdL104-R107)
* Modified the `HttpMigration.migrate` function parameter type to accept `OpenApiV3_2.IDocument`, enabling migration operations for OpenAPI 3.2 documents.