### PR TITLE
feat(website): intro page's `llm` module introduction.

### DIFF
--- a/website/src/content/docs/llm/http.mdx
+++ b/website/src/content/docs/llm/http.mdx
@@ -217,7 +217,7 @@ registerMcpControllers({
 
 ## Validation Feedback
 
-When used through [MCP](./mcp), [Vercel AI SDK](./vercel), or [Agentica](./chat), `HttpLlm.controller()` embeds [`typia.validate<T>()`](/docs/validators/validate) in every tool for automatic argument validation. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
+When used through [MCP](../mcp), [Vercel AI SDK](../vercel), or [Agentica](../chat), `HttpLlm.controller()` embeds [`typia.validate<T>()`](/docs/validators/validate) in every tool for automatic argument validation. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
 
 ```json
 {
@@ -325,6 +325,6 @@ LLMs frequently return wrong types — numbers as strings, booleans as strings, 
 
 Some LLM SDKs (Anthropic, Vercel AI, LangChain, MCP) parse JSON internally and return JavaScript objects directly. In these cases, use `IHttpLlmFunction.coerce()` instead of `IHttpLlmFunction.parse()` to fix types without re-parsing.
 
-For more details, see [JSON Utilities](./json).
+For more details, see [JSON Utilities](../json).
 </Callout>
 

--- a/website/src/movies/HomeStrengthMovie.tsx
+++ b/website/src/movies/HomeStrengthMovie.tsx
@@ -67,28 +67,25 @@ const sections: HomeStrengthSectionMovie.Props[] = [
       <HomeCodeBlock
         namespace="llm"
         method="application"
-        template="App"
+        template="Class"
         color="rgb(191, 64, 191)"
         argument={false}
       />
     ),
     description: (
       <React.Fragment>
-        <p>LLM Function Calling Schema Composer</p>
+        <p>Function calling schemas from TS types.</p>
         <br />
         <p>
-          Creates LLM function call schemas from a native TypeScript class or
-          interface type.
+          Validation feedback and type coercion boost success rate from{" "}
+          <b>6.75%</b> to <b>100%</b>.
         </p>
         <br />
-        <p>
-          LLM will select proper function to call and fill arguments in the
-          conversations with human.
-        </p>
+        <p>Lenient JSON parsing recovers from every malformed LLM output.</p>
       </React.Fragment>
     ),
     image: "/images/home/openai.svg",
-    href: "/docs/llm/chat",
+    href: "/docs/llm/application",
   },
   {
     title: "Easy Protocol Buffer",


### PR DESCRIPTION
This pull request makes improvements to documentation and the `HomeStrengthMovie` component to clarify usage, improve accuracy, and update links. The most important changes are grouped below by theme.

Documentation improvements:

* Updated relative links in `website/src/content/docs/llm/http.mdx` to use the correct parent directory reference for MCP, Vercel AI SDK, Agentica, and JSON Utilities sections, improving navigation and consistency. [[1]](diffhunk://#diff-fd721d3670cc3a91986fec21ce6b794106034318129c2569717c62dcfb40fc76L220-R220) [[2]](diffhunk://#diff-fd721d3670cc3a91986fec21ce6b794106034318129c2569717c62dcfb40fc76L328-R328)

Component content and accuracy:

* Changed the `template` prop in `HomeStrengthMovie.tsx` from `"App"` to `"Class"` for the LLM section, and revised the description to emphasize function calling schemas from TypeScript types, improved validation feedback, type coercion success rates, and lenient JSON parsing. Also updated the link to point to `/docs/llm/application` instead of `/docs/llm/chat`.