### PR TITLE
fix(utils): explicit return type of `LlmJson.validate()`.

### DIFF
--- a/packages/utils/src/utils/LlmJson.ts
+++ b/packages/utils/src/utils/LlmJson.ts
@@ -123,7 +123,7 @@ export namespace LlmJson {
   export function validate(
     parameters: ILlmSchema.IParameters,
     equals?: boolean | undefined,
-  ) {
+  ): (input: unknown) => IValidation<unknown> {
     const components: OpenApi.IComponents = {
       schemas: {},
     };


### PR DESCRIPTION
This pull request makes a small update to the `LlmJson` utility. The `validate` function's return type is now explicitly specified as a function that takes an unknown input and returns an `IValidation<unknown>`. This improves type safety and clarity in the codebase.