### PR TITLE
feat(website): hide individual blog articles from top menu.

### DIFF
--- a/website/src/content/blog/_meta.ts
+++ b/website/src/content/blog/_meta.ts
@@ -1,0 +1,7 @@
+import { MetaRecord } from "nextra";
+
+export default {
+  "*": {
+    display: "hidden",
+  },
+} satisfies MetaRecord;


### PR DESCRIPTION
This pull request introduces a new `_meta.ts` file for the blog content in the `website` directory. The file sets a default metadata configuration to hide all blog posts from display.

Metadata configuration:

* Added a new `website/src/content/blog/_meta.ts` file that hides all blog posts by default using the `display: "hidden"` setting.