### PR TITLE
fix(interface): remove internal tags from OpenAPI types.

### DIFF
--- a/packages/interface/src/openapi/OpenApiV3.ts
+++ b/packages/interface/src/openapi/OpenApiV3.ts
@@ -546,7 +546,10 @@ export namespace OpenApiV3 {
     }
 
     /** @ignore Base Attribute interface. */
-    interface __IAttribute extends Omit<IJsonSchemaAttribute, "examples"> {
+    export interface __IAttribute extends Omit<
+      IJsonSchemaAttribute,
+      "examples"
+    > {
       /** Example values. */
       examples?: any[] | Record<string, any>;
     }

--- a/packages/interface/src/openapi/OpenApiV3.ts
+++ b/packages/interface/src/openapi/OpenApiV3.ts
@@ -158,8 +158,8 @@ export namespace OpenApiV3 {
     /**
      * Non-standard HTTP method operations (extension).
      *
-     * Used when downgrading from OpenAPI v3.2 to preserve
-     * non-standard methods like `query` or custom methods.
+     * Used when downgrading from OpenAPI v3.2 to preserve non-standard methods
+     * like `query` or custom methods.
      */
     "x-additionalOperations"?: Record<string, IOperation>;
   }
@@ -545,11 +545,8 @@ export namespace OpenApiV3 {
       default?: any;
     }
 
-    /** @internal Base attribute interface. */
-    export interface __IAttribute extends Omit<
-      IJsonSchemaAttribute,
-      "examples"
-    > {
+    /** @ignore Base Attribute interface. */
+    interface __IAttribute extends Omit<IJsonSchemaAttribute, "examples"> {
       /** Example values. */
       examples?: any[] | Record<string, any>;
     }

--- a/packages/interface/src/openapi/OpenApiV3_1.ts
+++ b/packages/interface/src/openapi/OpenApiV3_1.ts
@@ -626,7 +626,10 @@ export namespace OpenApiV3_1 {
     }
 
     /** @ignore Base Attribute interface. */
-    interface __IAttribute extends Omit<IJsonSchemaAttribute, "examples"> {
+    export interface __IAttribute extends Omit<
+      IJsonSchemaAttribute,
+      "examples"
+    > {
       /** Example values. */
       examples?: any[] | Record<string, any>;
     }

--- a/packages/interface/src/openapi/OpenApiV3_1.ts
+++ b/packages/interface/src/openapi/OpenApiV3_1.ts
@@ -174,8 +174,8 @@ export namespace OpenApiV3_1 {
     /**
      * Non-standard HTTP method operations (extension).
      *
-     * Used when downgrading from OpenAPI v3.2 to preserve
-     * non-standard methods like `query` or custom methods.
+     * Used when downgrading from OpenAPI v3.2 to preserve non-standard methods
+     * like `query` or custom methods.
      */
     "x-additionalOperations"?: Record<string, IOperation>;
   }
@@ -625,11 +625,8 @@ export namespace OpenApiV3_1 {
       default?: any;
     }
 
-    /** @internal Base attribute interface. */
-    export interface __IAttribute extends Omit<
-      IJsonSchemaAttribute,
-      "examples"
-    > {
+    /** @ignore Base Attribute interface. */
+    interface __IAttribute extends Omit<IJsonSchemaAttribute, "examples"> {
       /** Example values. */
       examples?: any[] | Record<string, any>;
     }

--- a/packages/interface/src/openapi/OpenApiV3_2.ts
+++ b/packages/interface/src/openapi/OpenApiV3_2.ts
@@ -182,7 +182,10 @@ export namespace OpenApiV3_2 {
     /** Path description. */
     description?: string;
 
-    /** Additional non-standard HTTP method operations (e.g., LINK, UNLINK, PURGE). */
+    /**
+     * Additional non-standard HTTP method operations (e.g., LINK, UNLINK,
+     * PURGE).
+     */
     additionalOperations?: Record<string, IOperation>;
   }
 
@@ -634,7 +637,7 @@ export namespace OpenApiV3_2 {
       default?: any;
     }
 
-    /** @internal Base attribute interface. */
+    /** @ignore Base Attribute interface. */
     export interface __IAttribute extends Omit<
       IJsonSchemaAttribute,
       "examples"

--- a/packages/interface/src/openapi/SwaggerV2.ts
+++ b/packages/interface/src/openapi/SwaggerV2.ts
@@ -141,8 +141,8 @@ export namespace SwaggerV2 {
     /**
      * Non-standard HTTP method operations (extension).
      *
-     * Used when downgrading from OpenAPI v3.2 to preserve
-     * non-standard methods like `query` or custom methods.
+     * Used when downgrading from OpenAPI v3.2 to preserve non-standard methods
+     * like `query` or custom methods.
      */
     "x-additionalOperations"?: Record<string, IOperation>;
   }
@@ -434,7 +434,7 @@ export namespace SwaggerV2 {
       type?: undefined;
     }
 
-    /** @internal Base interface with type discriminator. */
+    /** @ignore Base Interface with type discriminator. */
     export interface __ISignificant<Type extends string> extends __IAttribute {
       /** Type discriminator. */
       type: Type;
@@ -443,7 +443,7 @@ export namespace SwaggerV2 {
       "x-nullable"?: boolean;
     }
 
-    /** @internal Base attribute interface. */
+    /** @ignore Base Attribute interface. */
     export interface __IAttribute extends Omit<
       IJsonSchemaAttribute,
       "examples" | "writeOnly"

--- a/typos.toml
+++ b/typos.toml
@@ -11,6 +11,8 @@ Nam = "Nam"
 typia = "typia"
 tru = "tru"
 fals = "fals"
+INPU = "INPU"
+INOT = "INOT"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
This pull request makes minor documentation and visibility improvements to several OpenAPI and Swagger TypeScript interfaces. The main focus is on updating comments for clarity and consistency, and adjusting visibility annotations to use `@ignore` instead of `@internal`.

Documentation and comment improvements:

* Updated comments for `x-additionalOperations` in `OpenApiV3`, `OpenApiV3_1`, and `SwaggerV2` to improve readability and consistency. [[1]](diffhunk://#diff-a8a2ffea4cf6bea6bacf89e64a2dbca043d509a417c0bc7fb718d2bf683348cbL161-R162) [[2]](diffhunk://#diff-1a8e2f9e7ce5c2a69a0b77e5a3f6736b7f5cfccd99557a5d20036b01691cfbe6L177-R178) [[3]](diffhunk://#diff-30df22db2360890145646ffbec7262d687ea054f7c12e6282cc7882932182fbcL144-R145)
* Reformatted the comment for `additionalOperations` in `OpenApiV3_2` for better clarity.

Visibility annotation changes:

* Changed `@internal` to `@ignore` for several internal interfaces (`__IAttribute`, `__ISignificant`) in `OpenApiV3`, `OpenApiV3_1`, `OpenApiV3_2`, and `SwaggerV2` to standardize visibility control and improve documentation output. [[1]](diffhunk://#diff-a8a2ffea4cf6bea6bacf89e64a2dbca043d509a417c0bc7fb718d2bf683348cbL548-R549) [[2]](diffhunk://#diff-1a8e2f9e7ce5c2a69a0b77e5a3f6736b7f5cfccd99557a5d20036b01691cfbe6L628-R629) [[3]](diffhunk://#diff-f03f4ce3ee318febaab12f27cf6f0777ea03e69a30af2dbd0107c853df6c6331L637-R640) [[4]](diffhunk://#diff-30df22db2360890145646ffbec7262d687ea054f7c12e6282cc7882932182fbcL437-R437) [[5]](diffhunk://#diff-30df22db2360890145646ffbec7262d687ea054f7c12e6282cc7882932182fbcL446-R446)