### PR TITLE
fix(website): build badge to reference only master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Atest)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
+  typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
-  typia/actions?query=workflow%3Atest+branch%3Amaster)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,8 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Atest)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
+  typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,8 +5,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
-  typia/actions?query=workflow%3Atest+branch%3Amaster)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/interface/README.md
+++ b/packages/interface/README.md
@@ -5,7 +5,8 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Atest)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
+  typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/interface/README.md
+++ b/packages/interface/README.md
@@ -5,8 +5,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
-  typia/actions?query=workflow%3Atest+branch%3Amaster)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -5,7 +5,8 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Atest)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
+  typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -5,8 +5,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
-  typia/actions?query=workflow%3Atest+branch%3Amaster)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -5,7 +5,8 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Atest)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
+  typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -5,8 +5,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
-  typia/actions?query=workflow%3Atest+branch%3Amaster)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/transform/README.md
+++ b/packages/transform/README.md
@@ -5,7 +5,8 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Atest)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
+  typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/transform/README.md
+++ b/packages/transform/README.md
@@ -5,8 +5,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
-  typia/actions?query=workflow%3Atest+branch%3Amaster)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -5,7 +5,8 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Atest)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
+  typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -5,8 +5,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
-  typia/actions?query=workflow%3Atest+branch%3Amaster)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -5,7 +5,8 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Atest)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
+  typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -5,8 +5,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
-  typia/actions?query=workflow%3Atest+branch%3Amaster)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/vercel/README.md
+++ b/packages/vercel/README.md
@@ -5,7 +5,8 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Atest)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
+  typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/packages/vercel/README.md
+++ b/packages/vercel/README.md
@@ -5,8 +5,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
-[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/
-  typia/actions?query=workflow%3Atest+branch%3Amaster)
+[![Build Status](https://github.com/samchon/typia/workflows/test/badge.svg?branch=master)](https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster)
 [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -27,8 +27,8 @@ import Stack from '@mui/material/Stack';
   ],
   [
     "Build Status",
-    "https://github.com/samchon/typia/workflows/test/badge.svg",
-    "https://github.com/samchon/typia/actions?query=workflow%3Atest",
+    "https://github.com/samchon/typia/workflows/test/badge.svg?branch=master",
+    "https://github.com/samchon/typia/actions?query=workflow%3Atest+branch%3Amaster",
   ],
   [
     "Guide Documents",


### PR DESCRIPTION
This pull request updates the build status badge links across all `README.md` files and the documentation index to specifically show the status for the `master` branch, rather than for all branches. This ensures that the displayed build status accurately reflects the main branch's health.

Documentation updates:

* Updated the build status badge URLs in the root `README.md` and all package `README.md` files (`packages/core`, `packages/interface`, `packages/langchain`, `packages/mcp`, `packages/transform`, `packages/unplugin`, `packages/utils`, `packages/vercel`) to reference the `master` branch, ensuring consistency and accuracy in reporting build status. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7) [[2]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L8-R8) [[3]](diffhunk://#diff-0b91229ff9fc65385c1094136c49bb17c31cced3b169054cc6bc2df5a7f109ccL8-R8) [[4]](diffhunk://#diff-e98c5d0a5c916b83ba9366044cb3c8fd27be87ca780857e86098d521604941f5L8-R8) [[5]](diffhunk://#diff-ba5dea79fe8446f1a9461322ff9b3158efbf2e11e1bf709973a2c146fba55539L8-R8) [[6]](diffhunk://#diff-248a9916dc69dc1ab501a55752cad244bd5df592407f017d67ef78ec99dadbfeL8-R8) [[7]](diffhunk://#diff-65b334a25517d4ac3cdc84ede8dc7249f1bc36fa6ce54008d896eb1e76440475L8-R8) [[8]](diffhunk://#diff-fe99193c708bc3807bec69f753f00016179e5815584955cac2d96b100f174730L8-R8) [[9]](diffhunk://#diff-fbd81d48f7aa8d2ae5b5a42c2901f3675b17fdee6df1fc4850f6c17e1057dd4eL8-R8)

* Updated the build status badge link in the documentation index (`website/src/content/docs/index.mdx`) to match the new `master` branch-specific badge.