### PR TITLE
fix(cli): setup wizard not to consider `@typia/ttsc`.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/benchmark",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Benchmark program of typia performance",
   "main": "bin/index.js",
   "scripts": {

--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/config",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Shared build configuration for typia packages",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/examples",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Example codes for typia website",
   "scripts": {
     "build": "rimraf bin && ttsc && prettier --write --ignore-path /dev/null \"bin/**/*.js\"",

--- a/experiments/setup/src/internal/createContext.js
+++ b/experiments/setup/src/internal/createContext.js
@@ -183,11 +183,6 @@ function verifyWizardInstallCommands(npmLog, count) {
     count,
     commands.ttsc,
   );
-  TestValidator.equals(
-    "setup wizard does not install a separate ttsx package",
-    0,
-    commands.ttsx,
-  );
   TestValidator.predicate(
     "setup wizard does not install ts-patch",
     commands.legacy === 0,
@@ -199,7 +194,6 @@ function getWizardInstallCommandCounts(npmLog) {
   return {
     legacy: countMatches(wizardLog, "ts-patch"),
     ttsc: countMatches(wizardLog, "i -D ttsc@latest"),
-    ttsx: countMatches(wizardLog, "i -D @typia/ttsx@latest"),
     typescript: countMatches(
       wizardLog,
       "i -D @typescript/native-preview@latest",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm run build:packages",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia-darwin-arm64/package.json
+++ b/packages/typia-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/darwin-arm64",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "macOS arm64 native transform binary for typia.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/packages/typia-darwin-x64/package.json
+++ b/packages/typia-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/darwin-x64",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "macOS x64 native transform binary for typia.",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/packages/typia-linux-arm/package.json
+++ b/packages/typia-linux-arm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/linux-arm",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Linux arm native transform binary for typia.",
   "os": ["linux"],
   "cpu": ["arm"],

--- a/packages/typia-linux-arm64/package.json
+++ b/packages/typia-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/linux-arm64",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Linux arm64 native transform binary for typia.",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/packages/typia-linux-x64/package.json
+++ b/packages/typia-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/linux-x64",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Linux x64 native transform binary for typia.",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/packages/typia-win32-arm64/package.json
+++ b/packages/typia-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/win32-arm64",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Windows arm64 native transform binary for typia.",
   "os": ["win32"],
   "cpu": ["arm64"],

--- a/packages/typia-win32-x64/package.json
+++ b/packages/typia-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/win32-x64",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Windows x64 native transform binary for typia.",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/typia/src/executable/TypiaSetupWizard.ts
+++ b/packages/typia/src/executable/TypiaSetupWizard.ts
@@ -45,27 +45,11 @@ export namespace TypiaSetupWizard {
       }
       if (data.devDependencies?.["ts-patch"] !== undefined) {
         delete data.devDependencies["ts-patch"];
-      }
-      if (data.devDependencies?.["@typia/ttsc"] !== undefined) {
-        delete data.devDependencies["@typia/ttsc"];
-      }
-      if (data.devDependencies?.["@typia/ttsx"] !== undefined) {
-        delete data.devDependencies["@typia/ttsx"];
-      }
-      if (data.devDependencies !== undefined) {
         if (Object.keys(data.devDependencies).length === 0)
           delete data.devDependencies;
       }
       if (data.dependencies?.["ts-patch"] !== undefined) {
         delete data.dependencies["ts-patch"];
-      }
-      if (data.dependencies?.["@typia/ttsc"] !== undefined) {
-        delete data.dependencies["@typia/ttsc"];
-      }
-      if (data.dependencies?.["@typia/ttsx"] !== undefined) {
-        delete data.dependencies["@typia/ttsx"];
-      }
-      if (data.dependencies !== undefined) {
         if (Object.keys(data.dependencies).length === 0)
           delete data.dependencies;
       }

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typia/unplugin",
   "type": "module",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "unplugin for typia",
   "author": "ryoppippi",
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/debug",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Convenient debug program for typia",
   "scripts": {
     "dev": "ttsc --watch",

--- a/tests/template/package.json
+++ b/tests/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/template",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Template structures for typia testing.",
   "main": "src/index.ts",
   "repository": {

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-error",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Test program of typia generated error",
   "main": "index.js",
   "scripts": {

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-langchain",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Test suite for @typia/langchain package",
   "scripts": {
     "dev": "ttsc --watch",

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-mcp",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Test suite for @typia/mcp package",
   "scripts": {
     "dev": "ttsc --watch",

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-automated",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Automated test features of typia.",
   "scripts": {
     "build": "rimraf bin && ttsc",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-generate",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Test typia generation command",
   "scripts": {
     "build": "rimraf bin && ttsc build --emit --rewrite-mode none --tsconfig tsconfig.json",

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-schema",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Test features for JSON schema, LLM schema and protobuf message of typia.",
   "scripts": {
     "dev": "ttsc --watch",

--- a/tests/test-unplugin/package.json
+++ b/tests/test-unplugin/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-unplugin",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "type": "module",
   "description": "Test for @typia/unplugin package",
   "repository": {

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-openapiautomated",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Automated test features of openapi.",
   "scripts": {
     "build": "rimraf bin && ttsc",

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-utils",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Automated test features of typia.",
   "scripts": {
     "dev": "ttsc --watch",

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-vercel",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "Test suite for @typia/vercel package",
   "scripts": {
     "dev": "ttsc --watch",

--- a/toolchain-tests/test-typia-ttsc/package.json
+++ b/toolchain-tests/test-typia-ttsc/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-ttsc",
-  "version": "13.0.0-dev.20260425",
+  "version": "13.0.0-dev.20260426",
   "description": "End-to-end smoke tests for typia over the external ttsc package.",
   "scripts": {
     "dev": "ttsx src/index.ts",

--- a/toolchain-tests/test-typia-ttsc/src/features/test_setup_contract.ts
+++ b/toolchain-tests/test-typia-ttsc/src/features/test_setup_contract.ts
@@ -54,12 +54,6 @@ export async function test_setup_contract(): Promise<void> {
     "setup wizard must provision the external ttsc package",
   );
   assert.equal(
-    wizardSource.includes('const TTSC_PACKAGE = "@typia/ttsc"') ||
-      wizardSource.includes("const TTSX_PACKAGE"),
-    false,
-    "setup wizard must not provision deprecated @typia toolchain packages",
-  );
-  assert.equal(
     wizardSource.includes("@typescript/native-preview"),
     true,
     "setup wizard must provision the tsgo compiler package",


### PR DESCRIPTION
This pull request primarily updates the version numbers for all packages in the repository from `13.0.0-dev.20260425` to `13.0.0-dev.20260426`. In addition to these routine version bumps, it also makes minor adjustments to the setup wizard and related test logic to remove references to the `@typia/ttsx` package.

Most important changes:

**Version Updates:**

* Bumped the version number to `13.0.0-dev.20260426` in all `package.json` files across the repository, including core, platform-specific, and integration packages. [[1]](diffhunk://#diff-ebd18337ce8dc8b96a8403d2731d05bbb7502293037672a62faa622e36d2821aL4-R4) [[2]](diffhunk://#diff-69ef9ed564c2bb9dc3914af4bb38c5be883d8118fbf7b6414aec4ef4f8a2b1d5L4-R4) [[3]](diffhunk://#diff-393b7c6a11a71a55082b303024054ccff0a0ccdaae5932061ab069b062e95b51L4-R4) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[5]](diffhunk://#diff-d2327fdda1c4889df8f7c8e399de581131b8df453d232fad4e976f706607e2d0L3-R3) [[6]](diffhunk://#diff-b04b890b40f07a3710d5e81a95f8c099b5dca6077f7748f19677c6039df741d7L3-R3) [[7]](diffhunk://#diff-adc96623016293ce329af7c2c6419b527d44d978a2ba059b926a85678439a3dbL3-R3) [[8]](diffhunk://#diff-8ad91ecd707d714c90e99d951d183ae5e54c559d04a550d03dd6ffafbfaf1729L3-R3) [[9]](diffhunk://#diff-741c2caf951d1dfb91401379d1399ebf80a3551900eb0f6048f525b88de3996eL3-R3) [[10]](diffhunk://#diff-76d5e112571e8d6158e3a465d72dfb776e6eb0f7956212cdcb050e0258ba1431L3-R3) [[11]](diffhunk://#diff-d10fc25db895cea9f6e88ca63f7f8975a490ce30770537e5ed3eb0c9d8fd7bcfL3-R3) [[12]](diffhunk://#diff-76b90ddb31b56c95aeebdafe140f9047837b079ed4c2d9cf99a91a6331084a3bL3-R3) [[13]](diffhunk://#diff-59a99b35f156b1ec05d59d4e9030ccb4857d008a069d7fc424690552244f7086L3-R3) [[14]](diffhunk://#diff-5e0a3ba5e82b85190d61cbf3c050549ee571b43639a012b15fe2322c76b091adL3-R3) [[15]](diffhunk://#diff-534691e2a0052a711c4b7f6ea8248bf1fb2ddf2ede7c7336cdebf70306b6b311L3-R3) [[16]](diffhunk://#diff-68a8641818414cf8bbf1abd09f5941e81f69b4ce6ce7127c5c37775faec4649dL4-R4) [[17]](diffhunk://#diff-21f8eb1d7a149d42ab0454ea905d44f624ff1d0aeb6d7a88d75b42962ca6b053L3-R3) [[18]](diffhunk://#diff-2f041bb019a5d2e5340dd6b3ec14de95735ebef85a1f4cc14e4614cfd4b70303L3-R3)

**Setup Wizard and Test Adjustments:**

* Removed logic for deleting `@typia/ttsx` and `@typia/ttsc` from dependencies in the setup wizard implementation (`TypiaSetupWizard.ts`).
* Updated setup wizard test utilities to remove checks and command counts related to `@typia/ttsx`, reflecting its removal from the setup process (`createContext.js`). [[1]](diffhunk://#diff-ca4fadfc286af27eac7001fa77471498dbc2105360c95c6e60cbeb15ff34ae89L186-L190) [[2]](diffhunk://#diff-ca4fadfc286af27eac7001fa77471498dbc2105360c95c6e60cbeb15ff34ae89L202)