### PR TITLE
feat(config): no more `downlevelIteration` provided.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -61,7 +61,7 @@
     "tstl": "^3.0.0",
     "uuid": "catalog:utils",
     "zod": "^3.19.1",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@typia/interface": "workspace:^",

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -56,7 +56,6 @@
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -66,7 +66,6 @@
     // "outDir": "./lib" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */

--- a/examples/package.json
+++ b/examples/package.json
@@ -25,7 +25,7 @@
     "@types/node": "catalog:utils",
     "@types/uuid": "catalog:utils",
     "rimraf": "catalog:utils",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@typia/utils": "workspace:^",

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -56,7 +56,6 @@
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */

--- a/experiments/unplugin/package.json
+++ b/experiments/unplugin/package.json
@@ -18,7 +18,7 @@
     "@typia/unplugin": "../tarballs/unplugin.tgz",
     "@typia/utils": "../tarballs/utils.tgz",
     "typia": "../tarballs/typia.tgz",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "devDependencies": {
     "@typescript/native-preview": "7.0.0-dev.20260421.2",

--- a/experiments/unplugin/package.json
+++ b/experiments/unplugin/package.json
@@ -18,7 +18,7 @@
     "@typia/unplugin": "../tarballs/unplugin.tgz",
     "@typia/utils": "../tarballs/utils.tgz",
     "typia": "../tarballs/typia.tgz",
-    "ttsc": "0.4.3-dev.20260426-2"
+    "ttsc": "0.4.3-dev.20260426-3"
   },
   "devDependencies": {
     "@typescript/native-preview": "7.0.0-dev.20260421.2",

--- a/experiments/unplugin/package.json
+++ b/experiments/unplugin/package.json
@@ -18,7 +18,7 @@
     "@typia/unplugin": "../tarballs/unplugin.tgz",
     "@typia/utils": "../tarballs/utils.tgz",
     "typia": "../tarballs/typia.tgz",
-    "ttsc": "catalog:typescript"
+    "ttsc": "0.4.3-dev.20260426-2"
   },
   "devDependencies": {
     "@typescript/native-preview": "7.0.0-dev.20260421.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "bumpp": "^10.4.1",
     "prettier": "^3.8.1",
     "prettier-plugin-jsdoc": "^1.8.0",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   }
 }

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@typescript/native-preview": "catalog:typescript",
     "rimraf": "catalog:utils",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "sideEffects": false,
   "files": [

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -39,7 +39,7 @@
     "rollup-plugin-auto-external": "catalog:rollup",
     "rollup-plugin-node-externals": "catalog:rollup",
     "tinyglobby": "^0.2.12",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "sideEffects": false,
   "files": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -41,7 +41,7 @@
     "rollup-plugin-node-externals": "catalog:rollup",
     "tinyglobby": "^0.2.12",
     "zod": "^3.25.0",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "sideEffects": false,
   "files": [

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -37,7 +37,7 @@
     "inquirer": "^8.2.5",
     "package-manager-detector": "^0.2.0",
     "randexp": "^0.5.3",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "peerDependencies": {
     "@typescript/native-preview": ">=7.0.0-dev.20260420.1"

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -61,7 +61,7 @@
     "magic-string": "^0.30.17",
     "pathe": "^2.0.3",
     "pkg-types": "^2.1.0",
-    "ttsc": "^0.4.2",
+    "ttsc": "catalog:typescript",
     "type-fest": "^4.37.0",
     "unplugin": "^2.2.2"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,7 +35,7 @@
     "rollup-plugin-auto-external": "catalog:rollup",
     "rollup-plugin-node-externals": "catalog:rollup",
     "tinyglobby": "^0.2.12",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "sideEffects": false,
   "files": [

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -40,7 +40,7 @@
     "rollup-plugin-auto-external": "catalog:rollup",
     "rollup-plugin-node-externals": "catalog:rollup",
     "tinyglobby": "^0.2.12",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "sideEffects": false,
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ catalogs:
       specifier: 7.0.0-dev.20260425.1
       version: 7.0.0-dev.20260425.1
     ttsc:
-      specifier: 0.4.3-dev.20260426-2
-      version: 0.4.3-dev.20260426-2
+      specifier: 0.4.3-dev.20260426-3
+      version: 0.4.3-dev.20260426-3
   utils:
     '@nestia/e2e':
       specifier: ^10.0.2
@@ -72,7 +72,7 @@ importers:
         version: 1.8.0(prettier@3.8.3)
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   benchmark:
     dependencies:
@@ -193,7 +193,7 @@ importers:
         version: 0.10.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
       zod:
         specifier: ^3.19.1
         version: 3.25.76
@@ -245,7 +245,7 @@ importers:
         version: 6.1.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   packages/interface:
     devDependencies:
@@ -257,7 +257,7 @@ importers:
         version: 6.1.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   packages/langchain:
     dependencies:
@@ -297,7 +297,7 @@ importers:
         version: 0.2.16
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   packages/mcp:
     dependencies:
@@ -340,7 +340,7 @@ importers:
         version: 0.2.16
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -373,7 +373,7 @@ importers:
         version: 0.5.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: catalog:rollup
@@ -494,7 +494,7 @@ importers:
         version: 5.55.4(@typescript-eslint/types@8.59.0)
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
       type-fest:
         specifier: ^4.37.0
         version: 4.41.0
@@ -562,7 +562,7 @@ importers:
         version: 0.2.16
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   packages/vercel:
     dependencies:
@@ -605,7 +605,7 @@ importers:
         version: 0.2.16
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/debug:
     dependencies:
@@ -639,7 +639,7 @@ importers:
         version: 6.1.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/template:
     dependencies:
@@ -689,7 +689,7 @@ importers:
         version: 6.1.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/test-langchain:
     dependencies:
@@ -735,7 +735,7 @@ importers:
         version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/test-mcp:
     dependencies:
@@ -772,7 +772,7 @@ importers:
         version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/test-typia-automated:
     dependencies:
@@ -818,7 +818,7 @@ importers:
         version: 6.1.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/test-typia-generate:
     dependencies:
@@ -834,7 +834,7 @@ importers:
         version: 6.1.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/test-typia-schema:
     dependencies:
@@ -877,7 +877,7 @@ importers:
         version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/test-unplugin:
     dependencies:
@@ -954,7 +954,7 @@ importers:
         version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/test-utils-automated:
     dependencies:
@@ -991,7 +991,7 @@ importers:
         version: 6.1.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   tests/test-vercel:
     dependencies:
@@ -1034,7 +1034,7 @@ importers:
         version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
   toolchain-tests/test-typia-ttsc:
     dependencies:
@@ -1056,7 +1056,7 @@ importers:
         version: 4.1.2
       ttsc:
         specifier: catalog:typescript
-        version: 0.4.3-dev.20260426-2
+        version: 0.4.3-dev.20260426-3
 
 packages:
 
@@ -2357,38 +2357,38 @@ packages:
       svelte:
         optional: true
 
-  '@ttsc/darwin-arm64@0.4.3-dev.20260426-2':
-    resolution: {integrity: sha512-vzWmLI39yTYn1z2UFRzVjdDWjY+Pg3KV51n8/TVitt8XBHToDTKfVVHJigS2O9zVXjKTCxS8Mwagv6yX0JdNTA==}
+  '@ttsc/darwin-arm64@0.4.3-dev.20260426-3':
+    resolution: {integrity: sha512-CITHiBsKP/P6SlAI3bvyuPBbdg6RaP1EjfCm52FtZCAGkYvm8JAfL2VUu4yYk5zBam+7oeQFMLS9M0MlAIJX5g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ttsc/darwin-x64@0.4.3-dev.20260426-2':
-    resolution: {integrity: sha512-txManl17JTz5Xx07QPSk4CyRdtzu5U2FpylOCQSXc/Jm0R/XY8MmZr8OPf6/x+cJnCW/Urdt2rN1BRHcKiLvbQ==}
+  '@ttsc/darwin-x64@0.4.3-dev.20260426-3':
+    resolution: {integrity: sha512-6hWDOrHyo9nsNWL5U4wZOpOCD9V9q7r+NFQrAad2s9N2/zCWdMi/xneaQjyr4NT5mfOB2fc0K41kwg+WyiUxzw==}
     cpu: [x64]
     os: [darwin]
 
-  '@ttsc/linux-arm64@0.4.3-dev.20260426-2':
-    resolution: {integrity: sha512-bmd/ZYS+NsFSb1dK026W0r1LbvB+8+zCdH1uw0mWSG6qGd5p2bYrDFprzCKDqFJOrAACoMCgNm+x7xlRSBd2ag==}
+  '@ttsc/linux-arm64@0.4.3-dev.20260426-3':
+    resolution: {integrity: sha512-frCDQKHdRjrxm8ISaOz6Ruyp2ngf5gpgH07NCh9qKXca9zVYnbqr4qddDJy1KCdDdJXQn1lq37BWt3XqrJVl0Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@ttsc/linux-arm@0.4.3-dev.20260426-2':
-    resolution: {integrity: sha512-PVDTdwD06Mnct9z2AaqZ0LvKVYQrWFMaCjs/CuqwN25owGuHe39RLl500idDl2CAlHNaW4dK+ak/kBIU8GDwiA==}
+  '@ttsc/linux-arm@0.4.3-dev.20260426-3':
+    resolution: {integrity: sha512-MZ3QyzPdZcFqkarkQBK0LGAh9fa33b8YD1VcorUctkkhUKqQKHHkU4pP5drbQJgavDElDr8hBnkBvzvZ5+vUNg==}
     cpu: [arm]
     os: [linux]
 
-  '@ttsc/linux-x64@0.4.3-dev.20260426-2':
-    resolution: {integrity: sha512-m1v6F/8hfGjSGsg/zRsUvjzocCrEBqNGa7Iqi0/ycKCwe2Flc9ERWQnOCm2msxCWqPZ8vzhXZjoYFkxtyS8hgQ==}
+  '@ttsc/linux-x64@0.4.3-dev.20260426-3':
+    resolution: {integrity: sha512-dOriE1ydr4O8Vqw/+t3HzlbFHGQa72Sryq66RO0FsNuhO0gOel32xPFx7wW5A7uYlsgoqmWN2iq4R78tDXqruQ==}
     cpu: [x64]
     os: [linux]
 
-  '@ttsc/win32-arm64@0.4.3-dev.20260426-2':
-    resolution: {integrity: sha512-75TN/+mvCW5+RN7WKDVzfpUHriPOMieHl0GsXEDQwW2RcMAciqafwWp60HnVE4Gi4GXDfWodAwfyg0992HPgWA==}
+  '@ttsc/win32-arm64@0.4.3-dev.20260426-3':
+    resolution: {integrity: sha512-R2tzwYlQBicQWlNtiIe8ijLCa2ljyTUv0x2aTeBZ+hfSzHPm/XPvKVBzmdaYYh5gTSbMVG5XWoowS/5otEea9Q==}
     cpu: [arm64]
     os: [win32]
 
-  '@ttsc/win32-x64@0.4.3-dev.20260426-2':
-    resolution: {integrity: sha512-DrEPFZ2fjHqaVPLmdbXotKWxLOpDZEBB2LuSjQz9bopgBDFLQ/bkaKBmOcKwxGOepaKm3KSi5rpXQ+4iIBWLOQ==}
+  '@ttsc/win32-x64@0.4.3-dev.20260426-3':
+    resolution: {integrity: sha512-oYjrCpDOIEDQ9wtteIrZxfhW/lkEDGnWKXVU1lpCZ8XrLQV8o4LNOBlWSv7Yj3DKCoZZXyqq1zC6Q8k8nm2bwQ==}
     cpu: [x64]
     os: [win32]
 
@@ -5106,8 +5106,8 @@ packages:
   tstl@3.0.0:
     resolution: {integrity: sha512-pR83y6/tbJx6jeGRqGJXk2t/eCUynaHEE6zsOLB0Zga8ej61LXtPfoeiROdhezpoCT15+1QMbqKB1Um5kasSKg==}
 
-  ttsc@0.4.3-dev.20260426-2:
-    resolution: {integrity: sha512-/mqwVsb+5kH+A/vhwRJNpBgheTVXjbj05fsNjP14kud4qQb758eHXrtr08Mu/0/NqV+KqBMaGo8iSfmWPiLwfw==}
+  ttsc@0.4.3-dev.20260426-3:
+    resolution: {integrity: sha512-waFb1LtUTgDFTQ6UKUa3lsn7+w9O2e8ZBRl8pb8MdaU1QSuiQ+dYBo/OppMd+Wvefx5ad7ICaQljrXwV5+c4aQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -7061,25 +7061,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ttsc/darwin-arm64@0.4.3-dev.20260426-2':
+  '@ttsc/darwin-arm64@0.4.3-dev.20260426-3':
     optional: true
 
-  '@ttsc/darwin-x64@0.4.3-dev.20260426-2':
+  '@ttsc/darwin-x64@0.4.3-dev.20260426-3':
     optional: true
 
-  '@ttsc/linux-arm64@0.4.3-dev.20260426-2':
+  '@ttsc/linux-arm64@0.4.3-dev.20260426-3':
     optional: true
 
-  '@ttsc/linux-arm@0.4.3-dev.20260426-2':
+  '@ttsc/linux-arm@0.4.3-dev.20260426-3':
     optional: true
 
-  '@ttsc/linux-x64@0.4.3-dev.20260426-2':
+  '@ttsc/linux-x64@0.4.3-dev.20260426-3':
     optional: true
 
-  '@ttsc/win32-arm64@0.4.3-dev.20260426-2':
+  '@ttsc/win32-arm64@0.4.3-dev.20260426-3':
     optional: true
 
-  '@ttsc/win32-x64@0.4.3-dev.20260426-2':
+  '@ttsc/win32-x64@0.4.3-dev.20260426-3':
     optional: true
 
   '@typegoose/typegoose@10.6.0(mongoose@6.13.9)':
@@ -10219,15 +10219,15 @@ snapshots:
 
   tstl@3.0.0: {}
 
-  ttsc@0.4.3-dev.20260426-2:
+  ttsc@0.4.3-dev.20260426-3:
     optionalDependencies:
-      '@ttsc/darwin-arm64': 0.4.3-dev.20260426-2
-      '@ttsc/darwin-x64': 0.4.3-dev.20260426-2
-      '@ttsc/linux-arm': 0.4.3-dev.20260426-2
-      '@ttsc/linux-arm64': 0.4.3-dev.20260426-2
-      '@ttsc/linux-x64': 0.4.3-dev.20260426-2
-      '@ttsc/win32-arm64': 0.4.3-dev.20260426-2
-      '@ttsc/win32-x64': 0.4.3-dev.20260426-2
+      '@ttsc/darwin-arm64': 0.4.3-dev.20260426-3
+      '@ttsc/darwin-x64': 0.4.3-dev.20260426-3
+      '@ttsc/linux-arm': 0.4.3-dev.20260426-3
+      '@ttsc/linux-arm64': 0.4.3-dev.20260426-3
+      '@ttsc/linux-x64': 0.4.3-dev.20260426-3
+      '@ttsc/win32-arm64': 0.4.3-dev.20260426-3
+      '@ttsc/win32-x64': 0.4.3-dev.20260426-3
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ catalogs:
       version: 8.1.2
   typescript:
     '@typescript/native-preview':
-      specifier: 7.0.0-dev.20260421.2
-      version: 7.0.0-dev.20260421.2
+      specifier: 7.0.0-dev.20260425.1
+      version: 7.0.0-dev.20260425.1
     ttsc:
       specifier: 0.4.3-dev.20260426-2
       version: 0.4.3-dev.20260426-2
@@ -139,7 +139,7 @@ importers:
         version: 11.0.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       ajv:
         specifier: ^8.12.0
         version: 8.18.0
@@ -251,7 +251,7 @@ importers:
     devDependencies:
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -279,7 +279,7 @@ importers:
         version: 16.0.3(rollup@4.60.2)
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -322,7 +322,7 @@ importers:
         version: 16.0.3(rollup@4.60.2)
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -395,7 +395,7 @@ importers:
         version: 8.59.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       chalk:
         specifier: ^4.0.0
         version: 4.1.2
@@ -464,7 +464,7 @@ importers:
         version: 5.3.0(rollup@4.60.2)
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       bun-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -544,7 +544,7 @@ importers:
         version: 16.0.3(rollup@4.60.2)
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -584,7 +584,7 @@ importers:
         version: 7.0.15
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       ai:
         specifier: ^6.0.116
         version: 6.0.168(zod@3.25.76)
@@ -633,7 +633,7 @@ importers:
         version: 11.0.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -673,7 +673,7 @@ importers:
         version: 11.0.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
 
   tests/test-error:
     dependencies:
@@ -683,7 +683,7 @@ importers:
     devDependencies:
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -732,7 +732,7 @@ importers:
         version: 25.6.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
         version: 0.4.3-dev.20260426-2
@@ -769,7 +769,7 @@ importers:
         version: 25.6.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
         version: 0.4.3-dev.20260426-2
@@ -812,7 +812,7 @@ importers:
         version: 11.0.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -828,7 +828,7 @@ importers:
     devDependencies:
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -874,7 +874,7 @@ importers:
         version: 11.0.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
         version: 0.4.3-dev.20260426-2
@@ -890,7 +890,7 @@ importers:
     devDependencies:
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       '@vue-macros/test-utils':
         specifier: ^1.7.1
         version: 1.7.1(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@26.1.0)(yaml@2.8.3))(yaml@2.8.3)
@@ -951,7 +951,7 @@ importers:
         version: 11.0.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
         version: 0.4.3-dev.20260426-2
@@ -985,7 +985,7 @@ importers:
         version: 11.0.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -1031,7 +1031,7 @@ importers:
         version: 25.6.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       ttsc:
         specifier: catalog:typescript
         version: 0.4.3-dev.20260426-2
@@ -1050,7 +1050,7 @@ importers:
         version: 25.6.0
       '@typescript/native-preview':
         specifier: catalog:typescript
-        version: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260425.1
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -2686,43 +2686,51 @@ packages:
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-vM7O+PlxHRUT4Dv0VkxEmU3N2uyWeSFrhu57O7s3SE9TX1ENljwQlCFG0oQdBGLBRo+SZSoedxKL5jOGlD1eiw==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-EiikklZSuEvMhZEeN0VRb0vmedhLgtKwz5p4Oz9e8hlJ4lLrslgvX7Z7JWb2YSKlhm14dUlRMvdoe+6t+56rSA==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-5KJ++prl1dscJtxnkE7Cb6rjud4T3nO4mcnKhkCfYcQaFtFrvcZhBtDobwcpSzHbfsW0MeM+QCy1UfWoK4gjUQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-9eWInaHqhfTu1Mt/1M85p5M+HlSStahAQkqYaW9rJzUWRe+AcVUKsN6I7U7iwxbkCT8gFZsMCRqABcwBUWw3kg==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-a/E/8UL2x6nWmIJwrrbEvLz938RMcrFfm5hLRKaPMjCE32bgwesBZEG5jRn8fzQes+4HICRXKEaL544jtb/Syg==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-BZ7jEnaNZHkHbq9LWuqqIgYMmMb2E2NReMybjOyl3ASFmJHYekDnytXIT3Zbp4dyPLJV55faGzLqMw2MMS81NA==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-/iwK50mO31lKr1KVDRCqW5xGyKArZuq9jQr2b/PJ3e0xEuV6hoJ4Kok11LA1lhx1uctqr3UXKmfwQF3HWqcZTQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==}
+  '@typescript/native-preview@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-qhSVDT9DsoKPBeEm777eUUkiCDjBFlF7wwjfMvcPctZFVHfD6b1O1icpfCdQHPqzjrSXWu2YaNiY0DXbljTmgw==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   '@ungap/structured-clone@1.3.0':
@@ -7454,36 +7462,36 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260421.2':
+  '@typescript/native-preview@7.0.0-dev.20260425.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260425.1
 
   '@ungap/structured-clone@1.3.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ catalogs:
     '@typescript/native-preview':
       specifier: 7.0.0-dev.20260421.2
       version: 7.0.0-dev.20260421.2
+    ttsc:
+      specifier: 0.4.3-dev.20260426-2
+      version: 0.4.3-dev.20260426-2
   utils:
     '@nestia/e2e':
       specifier: ^10.0.2
@@ -68,8 +71,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0(prettier@3.8.3)
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   benchmark:
     dependencies:
@@ -189,8 +192,8 @@ importers:
         specifier: ^0.10.0
         version: 0.10.3
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
       zod:
         specifier: ^3.19.1
         version: 3.25.76
@@ -241,8 +244,8 @@ importers:
         specifier: catalog:utils
         version: 6.1.3
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   packages/interface:
     devDependencies:
@@ -253,8 +256,8 @@ importers:
         specifier: catalog:utils
         version: 6.1.3
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   packages/langchain:
     dependencies:
@@ -293,8 +296,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.16
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   packages/mcp:
     dependencies:
@@ -336,8 +339,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.16
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -369,8 +372,8 @@ importers:
         specifier: ^0.5.3
         version: 0.5.3
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: catalog:rollup
@@ -490,8 +493,8 @@ importers:
         specifier: ^5.28.2
         version: 5.55.4(@typescript-eslint/types@8.59.0)
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
       type-fest:
         specifier: ^4.37.0
         version: 4.41.0
@@ -558,8 +561,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.16
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   packages/vercel:
     dependencies:
@@ -601,8 +604,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.16
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/debug:
     dependencies:
@@ -635,8 +638,8 @@ importers:
         specifier: catalog:utils
         version: 6.1.3
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/template:
     dependencies:
@@ -685,8 +688,8 @@ importers:
         specifier: catalog:utils
         version: 6.1.3
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/test-langchain:
     dependencies:
@@ -731,8 +734,8 @@ importers:
         specifier: catalog:typescript
         version: 7.0.0-dev.20260421.2
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/test-mcp:
     dependencies:
@@ -768,8 +771,8 @@ importers:
         specifier: catalog:typescript
         version: 7.0.0-dev.20260421.2
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/test-typia-automated:
     dependencies:
@@ -814,8 +817,8 @@ importers:
         specifier: catalog:utils
         version: 6.1.3
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/test-typia-generate:
     dependencies:
@@ -830,8 +833,8 @@ importers:
         specifier: catalog:utils
         version: 6.1.3
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/test-typia-schema:
     dependencies:
@@ -873,8 +876,8 @@ importers:
         specifier: catalog:typescript
         version: 7.0.0-dev.20260421.2
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/test-unplugin:
     dependencies:
@@ -950,8 +953,8 @@ importers:
         specifier: catalog:typescript
         version: 7.0.0-dev.20260421.2
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/test-utils-automated:
     dependencies:
@@ -987,8 +990,8 @@ importers:
         specifier: catalog:utils
         version: 6.1.3
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   tests/test-vercel:
     dependencies:
@@ -1030,8 +1033,8 @@ importers:
         specifier: catalog:typescript
         version: 7.0.0-dev.20260421.2
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
   toolchain-tests/test-typia-ttsc:
     dependencies:
@@ -1052,8 +1055,8 @@ importers:
         specifier: 4.1.2
         version: 4.1.2
       ttsc:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: catalog:typescript
+        version: 0.4.3-dev.20260426-2
 
 packages:
 
@@ -2354,38 +2357,38 @@ packages:
       svelte:
         optional: true
 
-  '@ttsc/darwin-arm64@0.4.2':
-    resolution: {integrity: sha512-sLLjOJ12lxhuO9gWNkNfKPEQFPhQeUejdIQaGLg0F1X0AK5oXhQZk3kh0VSEAQVLxsKhSuMWctyxokGj1YbWDQ==}
+  '@ttsc/darwin-arm64@0.4.3-dev.20260426-2':
+    resolution: {integrity: sha512-vzWmLI39yTYn1z2UFRzVjdDWjY+Pg3KV51n8/TVitt8XBHToDTKfVVHJigS2O9zVXjKTCxS8Mwagv6yX0JdNTA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ttsc/darwin-x64@0.4.2':
-    resolution: {integrity: sha512-BdkJ/t+qTVQRwuHdPZhaNiDYsjFVHqHTuULvqi/zaUIHNsTf+sWQqRhYOieL3wTWdq9fUllve0YNQ0rNg5OIaA==}
+  '@ttsc/darwin-x64@0.4.3-dev.20260426-2':
+    resolution: {integrity: sha512-txManl17JTz5Xx07QPSk4CyRdtzu5U2FpylOCQSXc/Jm0R/XY8MmZr8OPf6/x+cJnCW/Urdt2rN1BRHcKiLvbQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@ttsc/linux-arm64@0.4.2':
-    resolution: {integrity: sha512-9EV5Uu9P6u1bnFHK4q2TrcosiUJgjmQveSEcQ8YLCtYrsdJjQgshsTrqflYC6k044IzXzJgaYEbgtEz3IHqd1g==}
+  '@ttsc/linux-arm64@0.4.3-dev.20260426-2':
+    resolution: {integrity: sha512-bmd/ZYS+NsFSb1dK026W0r1LbvB+8+zCdH1uw0mWSG6qGd5p2bYrDFprzCKDqFJOrAACoMCgNm+x7xlRSBd2ag==}
     cpu: [arm64]
     os: [linux]
 
-  '@ttsc/linux-arm@0.4.2':
-    resolution: {integrity: sha512-BDoXTG9KrHCQG1J1ZLeqLtIGrQyTn0x3ZUq32BhthgU0RgGH+nRgR8e6pm0wwkkLZpUPYAu8m+yHEgyB37rx0Q==}
+  '@ttsc/linux-arm@0.4.3-dev.20260426-2':
+    resolution: {integrity: sha512-PVDTdwD06Mnct9z2AaqZ0LvKVYQrWFMaCjs/CuqwN25owGuHe39RLl500idDl2CAlHNaW4dK+ak/kBIU8GDwiA==}
     cpu: [arm]
     os: [linux]
 
-  '@ttsc/linux-x64@0.4.2':
-    resolution: {integrity: sha512-tvaHJG2RuXXhDo0H9JtV3pgNpjarVvJ1Hplzg78cxTDmcQugqc21zXyZOTsmb2aPDV+chJpt9eEKwa+jISJSTw==}
+  '@ttsc/linux-x64@0.4.3-dev.20260426-2':
+    resolution: {integrity: sha512-m1v6F/8hfGjSGsg/zRsUvjzocCrEBqNGa7Iqi0/ycKCwe2Flc9ERWQnOCm2msxCWqPZ8vzhXZjoYFkxtyS8hgQ==}
     cpu: [x64]
     os: [linux]
 
-  '@ttsc/win32-arm64@0.4.2':
-    resolution: {integrity: sha512-Cc8ZKGMQlbN0U5WD82u7AsDfUM08QshHYXUfjXGMLBJShUxIs4Aqzlz/wV3+w2kRktnCfOZqoZosMZUUxGk/rg==}
+  '@ttsc/win32-arm64@0.4.3-dev.20260426-2':
+    resolution: {integrity: sha512-75TN/+mvCW5+RN7WKDVzfpUHriPOMieHl0GsXEDQwW2RcMAciqafwWp60HnVE4Gi4GXDfWodAwfyg0992HPgWA==}
     cpu: [arm64]
     os: [win32]
 
-  '@ttsc/win32-x64@0.4.2':
-    resolution: {integrity: sha512-KLK3F0U+Z+d28tqmcR2witbbsY81zEB2LOfpTL2PBgrgwuSvyFM6zfbDDJhpfMrV4eBPyc2JTcEUtcW5lQ71SQ==}
+  '@ttsc/win32-x64@0.4.3-dev.20260426-2':
+    resolution: {integrity: sha512-DrEPFZ2fjHqaVPLmdbXotKWxLOpDZEBB2LuSjQz9bopgBDFLQ/bkaKBmOcKwxGOepaKm3KSi5rpXQ+4iIBWLOQ==}
     cpu: [x64]
     os: [win32]
 
@@ -5095,8 +5098,8 @@ packages:
   tstl@3.0.0:
     resolution: {integrity: sha512-pR83y6/tbJx6jeGRqGJXk2t/eCUynaHEE6zsOLB0Zga8ej61LXtPfoeiROdhezpoCT15+1QMbqKB1Um5kasSKg==}
 
-  ttsc@0.4.2:
-    resolution: {integrity: sha512-3OD3/qqtCodQI+zfgk8SxmU5b4KqcE6wYA++NXpr1HRDUbJ0hPzpAzntZ443wYeaMZORcdbr1/kigjd8w7i5Jg==}
+  ttsc@0.4.3-dev.20260426-2:
+    resolution: {integrity: sha512-/mqwVsb+5kH+A/vhwRJNpBgheTVXjbj05fsNjP14kud4qQb758eHXrtr08Mu/0/NqV+KqBMaGo8iSfmWPiLwfw==}
     hasBin: true
 
   type-check@0.4.0:
@@ -7050,25 +7053,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ttsc/darwin-arm64@0.4.2':
+  '@ttsc/darwin-arm64@0.4.3-dev.20260426-2':
     optional: true
 
-  '@ttsc/darwin-x64@0.4.2':
+  '@ttsc/darwin-x64@0.4.3-dev.20260426-2':
     optional: true
 
-  '@ttsc/linux-arm64@0.4.2':
+  '@ttsc/linux-arm64@0.4.3-dev.20260426-2':
     optional: true
 
-  '@ttsc/linux-arm@0.4.2':
+  '@ttsc/linux-arm@0.4.3-dev.20260426-2':
     optional: true
 
-  '@ttsc/linux-x64@0.4.2':
+  '@ttsc/linux-x64@0.4.3-dev.20260426-2':
     optional: true
 
-  '@ttsc/win32-arm64@0.4.2':
+  '@ttsc/win32-arm64@0.4.3-dev.20260426-2':
     optional: true
 
-  '@ttsc/win32-x64@0.4.2':
+  '@ttsc/win32-x64@0.4.3-dev.20260426-2':
     optional: true
 
   '@typegoose/typegoose@10.6.0(mongoose@6.13.9)':
@@ -10208,15 +10211,15 @@ snapshots:
 
   tstl@3.0.0: {}
 
-  ttsc@0.4.2:
+  ttsc@0.4.3-dev.20260426-2:
     optionalDependencies:
-      '@ttsc/darwin-arm64': 0.4.2
-      '@ttsc/darwin-x64': 0.4.2
-      '@ttsc/linux-arm': 0.4.2
-      '@ttsc/linux-arm64': 0.4.2
-      '@ttsc/linux-x64': 0.4.2
-      '@ttsc/win32-arm64': 0.4.2
-      '@ttsc/win32-x64': 0.4.2
+      '@ttsc/darwin-arm64': 0.4.3-dev.20260426-2
+      '@ttsc/darwin-x64': 0.4.3-dev.20260426-2
+      '@ttsc/linux-arm': 0.4.3-dev.20260426-2
+      '@ttsc/linux-arm64': 0.4.3-dev.20260426-2
+      '@ttsc/linux-x64': 0.4.3-dev.20260426-2
+      '@ttsc/win32-arm64': 0.4.3-dev.20260426-2
+      '@ttsc/win32-x64': 0.4.3-dev.20260426-2
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ packages:
 catalogs:
   typescript:
     '@typescript/native-preview': 7.0.0-dev.20260425.1
-    ttsc: 0.4.3-dev.20260426-2
+    ttsc: 0.4.3-dev.20260426-3
   rollup:
     rollup: ^4.56.0
     rollup-plugin-auto-external: ^2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
   - 'toolchain-tests/*'
 catalogs:
   typescript:
-    '@typescript/native-preview': 7.0.0-dev.20260421.2
+    '@typescript/native-preview': 7.0.0-dev.20260425.1
     ttsc: 0.4.3-dev.20260426-2
   rollup:
     rollup: ^4.56.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
 catalogs:
   typescript:
     '@typescript/native-preview': 7.0.0-dev.20260421.2
+    ttsc: 0.4.3-dev.20260426-2
   rollup:
     rollup: ^4.56.0
     rollup-plugin-auto-external: ^2.0.0

--- a/tests/config/tsconfig.json
+++ b/tests/config/tsconfig.json
@@ -59,7 +59,6 @@
     "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
-    "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -26,7 +26,7 @@
     "@types/uuid": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
     "rimraf": "catalog:utils",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@typia/interface": "workspace:^",

--- a/tests/template/tsconfig.json
+++ b/tests/template/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src"],
 }

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@typescript/native-preview": "catalog:typescript",
     "rimraf": "catalog:utils",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "typia": "workspace:^"

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/node": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@langchain/core": "^1.1.31",

--- a/tests/test-langchain/tsconfig.json
+++ b/tests/test-langchain/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src"]
 }

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/node": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/tests/test-mcp/tsconfig.json
+++ b/tests/test-mcp/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src"]
 }

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -27,7 +27,7 @@
     "@types/uuid": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
     "rimraf": "catalog:utils",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@nestia/e2e": "catalog:utils",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@typescript/native-preview": "catalog:typescript",
     "rimraf": "catalog:utils",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "typia": "workspace:^"

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -25,7 +25,7 @@
     "@types/node": "catalog:utils",
     "@types/uuid": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@nestia/e2e": "catalog:utils",

--- a/tests/test-typia-schema/tsconfig.json
+++ b/tests/test-typia-schema/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src"]
 }

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -27,7 +27,7 @@
     "@types/uuid": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
     "rimraf": "catalog:utils",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@nestia/e2e": "catalog:utils",

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -25,7 +25,7 @@
     "@types/node": "catalog:utils",
     "@types/uuid": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@nestia/e2e": "catalog:utils",

--- a/tests/test-utils/tsconfig.json
+++ b/tests/test-utils/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src"],
 }

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/node": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^2.0.35",

--- a/tests/test-vercel/tsconfig.json
+++ b/tests/test-vercel/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src"]
 }

--- a/toolchain-tests/test-typia-ttsc/package.json
+++ b/toolchain-tests/test-typia-ttsc/package.json
@@ -32,7 +32,7 @@
     "@types/node": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
     "chalk": "4.1.2",
-    "ttsc": "^0.4.2"
+    "ttsc": "catalog:typescript"
   },
   "dependencies": {
     "typia": "workspace:^"

--- a/toolchain-tests/test-typia-ttsc/src/features/test_version_banner.ts
+++ b/toolchain-tests/test-typia-ttsc/src/features/test_version_banner.ts
@@ -5,7 +5,7 @@ import { runTtsc } from "../utils/runTtsc";
 export async function test_version_banner(): Promise<void> {
   const { stdout, status } = runTtsc(["--version"]);
   assert.equal(status, 0, "ttsc --version must exit 0");
-  for (const fragment of ["ttsc ", "commit", "go"]) {
+  for (const fragment of ["ttsc ", "(Version ", ")"]) {
     assert.ok(
       stdout.includes(fragment),
       `version banner should include ${JSON.stringify(fragment)}: ${stdout}`,

--- a/website/src/compiler/COMPILER_OPTIONS.ts
+++ b/website/src/compiler/COMPILER_OPTIONS.ts
@@ -5,7 +5,6 @@ export const COMPILER_OPTIONS: ts.CompilerOptions = {
   module: ts.ModuleKind.ESNext,
   // lib: ["DOM", "ES2015"],
   esModuleInterop: true,
-  downlevelIteration: true,
   forceConsistentCasingInFileNames: true,
   moduleResolution: ts.ModuleResolutionKind.Bundler,
   strict: true,

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": [
       "dom",
       "dom.iterable",
@@ -18,7 +18,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "downlevelIteration": true,
     "plugins": [
       {
         "name": "next"

--- a/website/tsconfig.rspack.json
+++ b/website/tsconfig.rspack.json
@@ -18,7 +18,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "downlevelIteration": true,
   },
   "include": ["src/compiler"],
 }


### PR DESCRIPTION
This pull request updates the way the `ttsc` package is referenced and managed throughout the monorepo. The main change is to consistently source `ttsc` from the internal `catalog:typescript` registry instead of using a fixed version from npm. This helps ensure all packages use the same internal version and improves dependency management. Additionally, there are some minor config cleanups.

Dependency management and versioning:

* Updated all `package.json` files across the repository to reference `ttsc` as `catalog:typescript` instead of a specific npm version, ensuring consistency and alignment with internal package management. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L75-R75) [[2]](diffhunk://#diff-ebd18337ce8dc8b96a8403d2731d05bbb7502293037672a62faa622e36d2821aL64-R64) [[3]](diffhunk://#diff-393b7c6a11a71a55082b303024054ccff0a0ccdaae5932061ab069b062e95b51L28-R28) [[4]](diffhunk://#diff-2da337d23e95bb27955345ca4211b38a780046474b67f9074ae2758ff480035dL21-R21) [[5]](diffhunk://#diff-d2327fdda1c4889df8f7c8e399de581131b8df453d232fad4e976f706607e2d0L29-R29) [[6]](diffhunk://#diff-b04b890b40f07a3710d5e81a95f8c099b5dca6077f7748f19677c6039df741d7L42-R42) [[7]](diffhunk://#diff-adc96623016293ce329af7c2c6419b527d44d978a2ba059b926a85678439a3dbL44-R44) [[8]](diffhunk://#diff-534691e2a0052a711c4b7f6ea8248bf1fb2ddf2ede7c7336cdebf70306b6b311L40-R40) [[9]](diffhunk://#diff-68a8641818414cf8bbf1abd09f5941e81f69b4ce6ce7127c5c37775faec4649dL64-R64) [[10]](diffhunk://#diff-21f8eb1d7a149d42ab0454ea905d44f624ff1d0aeb6d7a88d75b42962ca6b053L38-R38) [[11]](diffhunk://#diff-2f041bb019a5d2e5340dd6b3ec14de95735ebef85a1f4cc14e4614cfd4b70303L43-R43)
* Updated the `pnpm-lock.yaml` file to reflect the new `catalog:typescript` source for `ttsc` across all importers, and set the version to `0.4.3-dev.20260426-2`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR28-R30) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL71-R75) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL192-R196) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL244-R248) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL256-R260) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL296-R300) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL339-R343) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL372-R376) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL493-R497) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL561-R565) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL604-R608) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL638-R642) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL688-R692) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL734-R738) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL771-R775) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL817-R821) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL833-R837) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL876-R880) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL953-R957) [[20]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL990-R994) [[21]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1033-R1037) [[22]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1055-R1059)

Configuration cleanups:

* Removed or commented out the `downlevelIteration` option in several `tsconfig.json` files, which is no longer needed or relevant for the current TypeScript setup. [[1]](diffhunk://#diff-2b9d1c5f21bf5d8f12627d5553857731f5de755d4972869d3f942ae870c9b326L69) [[2]](diffhunk://#diff-277539ecacea3a2046117ea705a8f89bff1c09ef418f6e4cdf83f86c59dc3da7L59) [[3]](diffhunk://#diff-5b40c06fccd9eb18613b0627b046e074fd263f1d4c3a1c131b11685fff63c15cL59)