### PR TITLE
🐛 Fixed hot reloading in Bun

### DIFF
--- a/packages/unplugin/src/bun.ts
+++ b/packages/unplugin/src/bun.ts
@@ -128,7 +128,7 @@ function bunTypiaPlugin(bunOptions?: BunOptions): BunPlugin {
         build.onLoad({ filter }, async (args) => {
           const id = wrap<ID>(args.path);
 
-          const source = wrap<Source>(await Bun.file(id).text());
+          const source = wrap<Source>((await import(`${args.path}?`, { with: { type: 'text' } })).default);
 
           const code = await taggedTransform(id, source, unpluginRaw);
 

--- a/packages/unplugin/src/core/options.ts
+++ b/packages/unplugin/src/core/options.ts
@@ -1,5 +1,5 @@
 import type { FilterPattern } from "@rollup/pluginutils";
-import type { ITransformOptions } from "@typia/core";
+import type { ITransformOptions } from "../../../core/lib/context/ITransformOptions.js";
 import { createDefu } from "defu";
 import type { OverrideProperties, RequiredDeep } from "type-fest";
 

--- a/packages/unplugin/src/core/options.ts
+++ b/packages/unplugin/src/core/options.ts
@@ -1,5 +1,5 @@
 import type { FilterPattern } from "@rollup/pluginutils";
-import type { ITransformOptions } from "../../../core/lib/context/ITransformOptions.js";
+import type { ITransformOptions } from "@typia/core";
 import { createDefu } from "defu";
 import type { OverrideProperties, RequiredDeep } from "type-fest";
 


### PR DESCRIPTION
In this PR I have implemented the suggested workaround (https://github.com/oven-sh/bun/issues/4689#issuecomment-2888634558) to restore HMR and file watching functionalities. Currently `--watch`/`--hot` flags don't work for Bun setups that use plugins. I have tested and I confirm that this workaround does indeed fix the issue.

I also rectified the `ITransformOptions` import path in `@typia/unplugin` and restored type intellisense in plugin options.