### PR TITLE
fix(unplugin): exact import `ITransformOptions`.

### DIFF
--- a/packages/typia/src/transform.ts
+++ b/packages/typia/src/transform.ts
@@ -1,5 +1,6 @@
 import transform from "@typia/transform";
 
-export default transform;
+export { ITransformOptions } from "@typia/core";
 
+export default transform;
 export * from "@typia/transform";

--- a/packages/unplugin/src/core/options.ts
+++ b/packages/unplugin/src/core/options.ts
@@ -1,7 +1,7 @@
 import type { FilterPattern } from "@rollup/pluginutils";
-import type { ITransformOptions } from "@typia/core";
 import { createDefu } from "defu";
 import type { OverrideProperties, RequiredDeep } from "type-fest";
+import type { ITransformOptions } from "typia";
 
 /** Represents the options for the plugin. */
 export type Options = {


### PR DESCRIPTION
This pull request makes improvements to how type definitions are imported and re-exported between packages, ensuring consistency and simplifying usage. The main focus is on the `ITransformOptions` type and its import/export paths.

**Type re-exports and import path updates:**

- [`packages/typia/src/transform.ts`](diffhunk://#diff-5cec8a0bc56e3be0c86249555459fceb254d0d57d992304a7a2a2aa157f71f47L3-R5): Now explicitly re-exports the `ITransformOptions` type from `@typia/core` and ensures the default and named exports from `@typia/transform` are preserved.
- [`packages/unplugin/src/core/options.ts`](diffhunk://#diff-f6a7180e12a880806c3804df71ba561f4edf6584e9a919141607f95a4bf5e7acL2-R4): Updates the import path for `ITransformOptions` to import from `typia` instead of `@typia/core`, streamlining type access for consumers.