### PR TITLE
fix(unplugin): fixed hot reloading in Bun (clone of #1834 for go-lang)

### DIFF
--- a/packages/unplugin/src/bun.ts
+++ b/packages/unplugin/src/bun.ts
@@ -128,7 +128,9 @@ function bunTypiaPlugin(bunOptions?: BunOptions): BunPlugin {
         build.onLoad({ filter }, async (args) => {
           const id = wrap<ID>(args.path);
 
-          const source = wrap<Source>(await Bun.file(id).text());
+          const source = wrap<Source>(
+            (await import(`${args.path}?`, { with: { type: "text" } })).default,
+          );
 
           const code = await taggedTransform(id, source, unpluginRaw);
 


### PR DESCRIPTION
This pull request updates the way source files are loaded in the `bunTypiaPlugin` for Bun. Instead of using `Bun.file().text()`, it now loads the file as a module with a text loader, which can improve compatibility and reliability with Bun's module system.

**Build process improvements:**

* Changed the file loading mechanism in the `build.onLoad` handler of `bunTypiaPlugin` to use dynamic import with `{ with: { type: "text" } }` instead of `Bun.file().text()`, ensuring better integration with Bun's loader system.