### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
   Ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 24.x
       - uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - uses: actions/setup-node@v6
         with:
           node-version: 24.x

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - uses: crate-ci/typos@master
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -22,8 +22,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 24.x
       - uses: actions/setup-go@v5


### PR DESCRIPTION
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/spell-check.yml`
- Pinned `actions/upload-artifact` from `v4` to `ea165f8` in `.github/workflows/build.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/release.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/website.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/build.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/website.yml`
- Pinned `actions/setup-node` from `v4` to `49933ea` in `.github/workflows/website.yml`
- Pinned `actions/setup-node` from `v4` to `49933ea` in `.github/workflows/build.yml`

The changes will be tested in the CI pipeline of the pull request.

Note: Moving from #1734.