### PR TITLE
feat(test): smoke testing with clean setup.

### DIFF
--- a/.github/workflows/experiments.yml
+++ b/.github/workflows/experiments.yml
@@ -27,10 +27,8 @@ jobs:
       - name: Build Tarballs
         run: pnpm run package:tgz
 
-      - name: Publish Smoke
+      - name: Test Smoke
         working-directory: experiments/smoke
-        env:
-          TTSC_CACHE_DIR: ${{ runner.temp }}/typia-smoke-ttsc
         run: |
-          npm install --package-lock=false --no-audit --no-fund
+          npm install
           npm start

--- a/.github/workflows/experiments.yml
+++ b/.github/workflows/experiments.yml
@@ -26,3 +26,11 @@ jobs:
 
       - name: Build Tarballs
         run: pnpm run package:tgz
+
+      - name: Publish Smoke
+        working-directory: experiments/smoke
+        env:
+          TTSC_CACHE_DIR: ${{ runner.temp }}/typia-smoke-ttsc
+        run: |
+          npm install --package-lock=false --no-audit --no-fund
+          npm start

--- a/experiments/smoke/README.md
+++ b/experiments/smoke/README.md
@@ -1,0 +1,8 @@
+# Smoke
+
+Validates the packed npm tarballs from `experiments/tarballs` in a fresh npm
+consumer project.
+
+The smoke test intentionally uses `npm`, not `pnpm`, after tarballs have been
+built. It installs the packed `typia` package and verifies that `ttsc` can build
+the published Go source plugin from `typia/native/cmd/ttsc-typia`.

--- a/experiments/smoke/package.json
+++ b/experiments/smoke/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "typia-smoke",
+  "version": "0.0.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "start": "ttsx src/index.ts"
+  },
+  "dependencies": {
+    "@typia/interface": "file:../tarballs/interface.tgz",
+    "@typia/utils": "file:../tarballs/utils.tgz",
+    "typia": "file:../tarballs/typia.tgz"
+  },
+  "devDependencies": {
+    "@typescript/native-preview": "7.0.0-dev.20260510.1",
+    "ttsc": "^0.10.0"
+  }
+}

--- a/experiments/smoke/src/index.ts
+++ b/experiments/smoke/src/index.ts
@@ -1,0 +1,17 @@
+import typia from "typia";
+
+interface Member {
+  id: string;
+  age: number;
+}
+
+const input: unknown = {
+  id: "a",
+  age: 1,
+};
+
+if (typia.is<Member>(input) === false) {
+  throw new Error("typia.is failed");
+}
+
+console.log("typia.is passed");

--- a/experiments/smoke/tsconfig.json
+++ b/experiments/smoke/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "lib",
+    "plugins": [
+      {
+        "transform": "typia/lib/transform"
+      }
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
This pull request introduces a new "smoke test" workflow to validate the integrity of the packed npm tarballs for the `typia` project. The smoke test simulates a fresh npm consumer environment, ensuring that the tarballs can be installed and used as expected, and that the `ttsc` TypeScript compiler can build a simple project using the published packages.

**New smoke test infrastructure:**

* Added a new `experiments/smoke` directory containing a minimal npm project that installs the packed tarballs and verifies `typia` functionality with a basic type check (`typia.is`). (`experiments/smoke/package.json`, `experiments/smoke/src/index.ts`, `experiments/smoke/tsconfig.json`, [[1]](diffhunk://#diff-460c43ea9db3a96434c37f1449d94013f2cd573b81993fb342b8012d449b503cR1-R18) [[2]](diffhunk://#diff-a0b74d497a55dbbac40d2dfe6efcc1df374e74f1a41fa935b97890d952aa41c5R1-R17) [[3]](diffhunk://#diff-577b67a9b5b84c99a61e124a4152059061e690cd38e1ebe1bc7d7190e4625805R1-R18)
* Created a `README.md` in `experiments/smoke` explaining the purpose and process of the smoke test.

**CI workflow enhancements:**

* Updated `.github/workflows/experiments.yml` to run the smoke test after building tarballs, using npm to install and start the test project, and setting up a cache directory for `ttsc`.