### PR TITLE
feat(website): new setup guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Typia
+
 ![Typia Logo](https://typia.io/logo.png)
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/typia/blob/master/LICENSE)
@@ -57,7 +58,28 @@ export function random<T>(g?: Partial<IRandomGenerator>): T;
 > - JSON serialization is **200x faster** than `class-transformer`
 > - LLM function calling harness turns **6.75% → 100%** accuracy
 
+## Setup
+
+Install `typia@next` with the [`ttsc`](https://github.com/samchon/ttsc) toolchain.
+
+```bash
+# install
+npm i typia@next
+npm i -D ttsc @typescript/native-preview
+
+# build
+npx ttsc
+
+# run a script directly
+npx ttsx src/index.ts
+```
+
+You **must** use `ttsc` and `ttsx`. The stock `tsc`, `ts-node`, and `tsx` cannot apply the `typia` transform, so they will not work.
+
+For bundler integration (Vite, Next.js, Webpack, Rollup, esbuild, ...), use [`@ttsc/unplugin`](https://github.com/samchon/ttsc/tree/master/packages/unplugin).
+
 ## Transformation
+
 If you call `typia` function, it would be compiled like below.
 
 This is the key concept of `typia`, transforming TypeScript type to a runtime function. The `typia.is<T>()` function is transformed to a dedicated type checker by analyzing the target type `T` in the compilation level.
@@ -80,37 +102,34 @@ export const checkString = (() => {
 })();
 ```
 
-
-
 ## Sponsors
+
 Thanks for your support.
 
 Your donation encourages `typia` development.
 
-Also, `typia` is re-distributing quarter of donations to [`nonara/ts-patch`](https://github.com/nonara/ts-patch).
-
 [![Sponsors](https://opencollective.com/typia/badge.svg?avatarHeight=75&width=600)](https://opencollective.com/typia)
 
-
-
-
 ## Playground
+
 You can experience how typia works by [playground website](https://typia.io/playground):
 
-  - 💻 https://typia.io/playground
-
-
-
+- 💻 https://typia.io/playground
 
 ## Guide Documents
+
 Check out the document in the [website](https://typia.io/docs/):
 
 ### 🏠 Home
+
 - [Introduction](https://typia.io/docs/)
 - [Setup](https://typia.io/docs/setup/)
+  - [TSGO (TypeScript v7)](https://typia.io/docs/setup/tsgo)
+  - [Legacy (TypeScript v6)](https://typia.io/docs/setup/legacy)
 - [Pure TypeScript](https://typia.io/docs/pure/)
   
 ### 📖 Features
+
 - Runtime Validators
   - [`assert()` function](https://typia.io/docs/validators/assert/)
   - [`is()` function](https://typia.io/docs/validators/is/)
@@ -134,6 +153,7 @@ Check out the document in the [website](https://typia.io/docs/):
 - [Miscellaneous](https://typia.io/docs/misc/)
 
 ### 🔗 Appendix
+
 - [API Documents](https://typia.io/api)
 - Utilization Cases
   - [MCP](https://typia.io/docs/utilization/mcp/)
@@ -144,9 +164,6 @@ Check out the document in the [website](https://typia.io/docs/):
 - [⇲ Benchmark Result](https://github.com/samchon/typia/tree/master/benchmark/results/11th%20Gen%20Intel(R)%20Core(TM)%20i5-1135G7%20%40%202.40GHz)
 - [⇲ `dev.to` Articles](https://dev.to/samchon/series/22474)
 
-
-
-
 ## Inspired By
+
 - [`typescript-is`](https://github.com/woutervh-/typescript-is)
-- [`ts-patch`](https://github.com/nonara/ts-patch)

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -148,11 +148,8 @@ Thanks for your support.
 
 Your donation encourages `typia` development.
 
-Also, `typia` is re-distributing quarter of donations to [`nonara/ts-patch`](https://github.com/nonara/ts-patch).
-
 [![Sponsors](https://opencollective.com/typia/badge.svg?avatarHeight=75&width=600)](https://opencollective.com/typia)
 
 ## References
 
   - inspired by [`typescript-is`](https://github.com/woutervh-/typescript-is)
-  - inspired by [`ts-patch`](https://github.com/nonara/ts-patch)

--- a/website/src/content/docs/setup/_meta.ts
+++ b/website/src/content/docs/setup/_meta.ts
@@ -1,0 +1,7 @@
+import { MetaRecord } from "nextra";
+
+export default {
+  index: { display: "hidden" },
+  tsgo: "TypeScript-Go",
+  legacy: "Legacy (TS v6)",
+} satisfies MetaRecord;

--- a/website/src/content/docs/setup/index.mdx
+++ b/website/src/content/docs/setup/index.mdx
@@ -1,0 +1,322 @@
+---
+title: Guide Documents > Setup
+---
+
+import { Tabs } from "nextra/components";
+
+## [TypeScript-Go](/docs/setup/tsgo)
+
+Use `typia@next` with `ttsc`.
+
+TypeScript is migrating its compiler to Go through TypeScript-Go. `ttsc` is the Go-based plugin toolchain for that compiler, and `typia@next` uses the new Go-based transform.
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+# install
+npm i typia@next
+npm i -D ttsc @typescript/native-preview
+
+# build
+npx ttsc
+
+# run without build
+npx ttsx src/index.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+# install
+pnpm i typia@next
+pnpm i -D ttsc @typescript/native-preview
+
+# build
+pnpm ttsc
+
+# run without build
+pnpm ttsx src/index.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+# install
+yarn add typia@next
+yarn add -D ttsc @typescript/native-preview
+
+# build
+yarn ttsc
+
+# run without build
+yarn ttsx src/index.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+# install
+bun add typia@next
+bun add -d ttsc @typescript/native-preview
+
+# build
+bun ttsc
+
+# run without build
+bun ttsx src/index.ts
+```
+  </Tabs.Tab>
+</Tabs>
+
+You must use `ttsc` and `ttsx`. The stock `tsc`, `ts-node`, and `tsx` cannot apply the `typia` transform, so they will not work.
+
+For bundlers, use `@ttsc/unplugin`.
+
+<Tabs
+  items={[
+    "Vite",
+    "Next.js",
+    "Rollup",
+    "Rolldown",
+    "esbuild",
+    "Webpack",
+    "Rspack",
+    "Farm",
+    "Bun",
+  ]}
+>
+  <Tabs.Tab>
+```ts filename="vite.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="next.config.mjs" showLineNumbers copy
+import withTtsc from "@ttsc/unplugin/next";
+
+/** @type {import("next").NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default withTtsc(nextConfig);
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="rollup.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/rollup";
+
+export default {
+  input: "src/index.ts",
+  output: {
+    dir: "dist",
+    format: "esm",
+  },
+  plugins: [ttsc()],
+};
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="rolldown.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/rolldown";
+import { defineConfig } from "rolldown";
+
+export default defineConfig({
+  input: "src/index.ts",
+  output: {
+    dir: "dist",
+    format: "esm",
+  },
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="esbuild.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/esbuild";
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  outdir: "dist",
+  bundle: true,
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="webpack.config.mjs" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/webpack";
+
+export default {
+  entry: "./src/index.ts",
+  output: {
+    path: new URL("./dist", import.meta.url).pathname,
+  },
+  plugins: [ttsc()],
+};
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="rspack.config.mjs" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/rspack";
+
+export default {
+  entry: "./src/index.ts",
+  plugins: [ttsc()],
+};
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="farm.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/farm";
+import { defineConfig } from "@farmfe/core";
+
+export default defineConfig({
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="build.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/bun";
+
+await Bun.build({
+  entrypoints: ["src/index.ts"],
+  outdir: "dist",
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+</Tabs>
+
+## [Legacy (TS v6)](/docs/setup/legacy)
+
+Use `typia` with `ts-patch`.
+
+This is the existing TypeScript v6 setup. It uses the JavaScript TypeScript compiler with `ts-patch`, and is still the stable path for current `typia` releases.
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+# install
+npm i typia
+npm i -D typescript ts-node ts-patch
+npx typia setup
+
+# build
+npx tsc
+
+# run without build
+npx ts-node src/index.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+# install
+pnpm i typia
+pnpm i -D typescript ts-node ts-patch
+pnpm typia setup --manager pnpm
+
+# build
+pnpm tsc
+
+# run without build
+pnpm ts-node src/index.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+# install
+# YARN BERRY IS NOT SUPPORTED
+yarn add typia
+yarn add -D typescript ts-node ts-patch
+yarn typia setup --manager yarn
+
+# build
+yarn tsc
+
+# run without build
+yarn ts-node src/index.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+# install
+bun add typia
+bun add -d typescript ts-node ts-patch
+bun typia setup
+
+# build
+bun tsc
+
+# run without build
+bun ts-node src/index.ts
+```
+  </Tabs.Tab>
+</Tabs>
+
+For bundlers, use `@typia/unplugin`.
+
+<Tabs items={["Vite", "Next.js", "esbuild", "Bun.runtime", "Bun.build"]}>
+  <Tabs.Tab>
+```ts filename="vite.config.ts" showLineNumbers copy
+import UnpluginTypia from "@typia/unplugin/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [UnpluginTypia()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="next.config.mjs" showLineNumbers copy
+import unTypiaNext from "@typia/unplugin/next";
+
+/** @type {import("next").NextConfig} */
+const config = {
+  reactStrictMode: true,
+};
+
+export default unTypiaNext(config);
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="esbuild.config.js" showLineNumbers copy
+import { build } from "esbuild";
+import UnpluginTypia from "@typia/unplugin/esbuild";
+
+build({
+  plugins: [UnpluginTypia()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="preload.ts" showLineNumbers copy
+import { plugin } from "bun";
+import UnpluginTypia from "@typia/unplugin/bun";
+
+plugin(UnpluginTypia());
+```
+
+```toml filename="bunfig.toml" showLineNumbers copy
+preload = ["./preload.ts"]
+
+[test]
+preload = ["./preload.ts"]
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="build.ts" showLineNumbers copy
+import UnpluginTypia from "@typia/unplugin/bun";
+
+await Bun.build({
+  entrypoints: ["./index.ts"],
+  outdir: "./out",
+  plugins: [UnpluginTypia()],
+});
+```
+  </Tabs.Tab>
+</Tabs>

--- a/website/src/content/docs/setup/legacy.mdx
+++ b/website/src/content/docs/setup/legacy.mdx
@@ -1,11 +1,13 @@
 ---
-title: Guide Documents > Setup
+title: Guide Documents > Setup > Legacy
 ---
 import { Callout, Tabs } from "nextra/components";
 
-import LocalSource from "../../components/LocalSource";
+import LocalSource from "../../../components/LocalSource";
 
 ## Summary
+
+This is the legacy setup path for TypeScript v6 and below. It uses [`ts-patch`](https://github.com/nonara/ts-patch) on top of the JavaScript-based TypeScript compiler, and remains the stable path for current `typia` releases.
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
@@ -78,13 +80,13 @@ This is the transform mode performing AOT (Ahead of Time) compilation.
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-npm install --save typia
+npm install typia
 npx typia setup
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-pnpm install --save typia
+pnpm install typia
 pnpm typia setup --manager pnpm
 ```
   </Tabs.Tab>
@@ -112,34 +114,34 @@ Setup wizard would be executed, and it will do everything for the transformation
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-npm install --save typia
-npm install --save-dev @typescript/native-preview ttsc
+npm install typia
+npm install -D typescript ts-patch
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-pnpm install --save typia
-pnpm install --save-dev @typescript/native-preview ttsc
+pnpm install typia
+pnpm install -D typescript ts-patch
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
 # YARN BERRY IS NOT SUPPORTED
 yarn add typia
-yarn add -D @typescript/native-preview ttsc
+yarn add -D typescript ts-patch
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
 bun add typia
-bun add -d @typescript/native-preview ttsc
+bun add -d typescript ts-patch
 ```
   </Tabs.Tab>
 </Tabs>
 
 If you want to install `typia` manually, just follow the steps.
 
-Firstly install `typia` as a dependency. And then, install `@typescript/native-preview` and `ttsc` as `devDependencies`.
+Firstly install `typia` as a dependency. And then, install `typescript` and `ts-patch` as `devDependencies`.
 
 ```json filename="tsconfig.json" copy showLineNumbers
 {
@@ -160,17 +162,48 @@ As `typia` generates optimal operation code through transformation, it must be c
 
 ```json filename="package.json" copy showLineNumbers {2-4}
 {
+  "scripts": {
+    "prepare": "ts-patch install"
+  },
   "dependencies": {
     "typia": "^6.0.6"
   },
   "devDependencies": {
-    "ttsc": "^0.4.2",
-    "@typescript/native-preview": "^7.0.0-dev"
+    "ts-patch": "^3.2.0",
+    "typescript": "^5.4.5"
   }
 }
 ```
 
-Finally run `ttsc build --emit --tsconfig tsconfig.json`. The setup wizard automates the same contract without patching the stock `tsc` compiler.
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
+  <Tabs.Tab>
+```bash filename="Terminal" copy showLineNumbers
+npm run prepare
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" copy showLineNumbers
+pnpm prepare
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" copy showLineNumbers
+# YARN BERRY IS NOT SUPPORTED
+yarn prepare
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" copy showLineNumbers
+bun prepare
+```
+  </Tabs.Tab>
+</Tabs>
+
+Finally open `package.json` file and configure `npm run prepare` command like above.
+
+Be sure to run `npm run prepare` once you have made these changes.
+
+For reference, [`ts-patch`](https://github.com/nonara/ts-patch) is an helper library of TypeScript compiler that supporting custom transformations by plugins. From now on, whenever you run `tsc` command, your `typia` function call statements would be transformed to the optimal operation codes in the compiled JavaScript files.
 
 ## Bundlers
 
@@ -192,7 +225,7 @@ Currently, `@typia/unplugin` supports the following bundlers:
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
-npm install --save typia
+npm install typia
 npx typia setup
 
 npm install -D @typia/unplugin
@@ -333,8 +366,8 @@ npm install typia
 npx typia setup
 
 # WEBPACK + TS-LOADER
-npm install --save-dev ts-loader
-npm install --save-dev webpack webpack-cli
+npm install -D ts-loader
+npm install -D webpack webpack-cli
 ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -344,8 +377,8 @@ pnpm install typia
 pnpm typia setup --manager pnpm
 
 # WEBPACK + TS-LOADER
-pnpm install --save-dev ts-loader
-pnpm install --save-dev webpack webpack-cli
+pnpm install -D ts-loader
+pnpm install -D webpack webpack-cli
 ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -453,13 +486,13 @@ Additionally, if you're using `typia` in the NodeJS project especially for the b
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-npm install --save typia
+npm install typia
 npx typia setup
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-pnpm install --save typia
+pnpm install typia
 pnpm typia setup --manager pnpm
 ```
   </Tabs.Tab>
@@ -478,7 +511,7 @@ bun typia setup --manager bun
     </Tabs.Tab>
 </Tabs>
 
-After installing `typia` like above, and ensuring `@typescript/native-preview` and `ttsc` are available, modify the `tsconfig.lib.json` on each `@nx/js` package to be similar to the below.
+After installing `typia` like above, and ensuring the `prepare` script is something similar to `ts-patch install` you have to modify the `tsconfig.lib.json` on each `@nx/js` package to be similar to the below.
 
 ```json filename="tsconfig.lib.json" showLineNumbers copy
 {
@@ -494,7 +527,7 @@ After installing `typia` like above, and ensuring `@typescript/native-preview` a
 }
 ```
 
-After this, when running `nx <package-name>:build` it _should_ now output with the Typia transforms applied. **But if Typia fails for any reason** (for example it considers some type you have to be invalid), this error is not reported back via Nx. Nx can still swallow these transform errors, and the resulting transpiled code will not have typia transformations applied. This will result in an error such as the following when running your tests that use typia (`nx <package-name>:test`), dev versions of your application (`nx <package-name>:serve`), as well as running your application after building.
+After this, when running `nx <package-name>:build` it _should_ now output with the Typia transforms applied. **But if Typia fails for any reason** (for example it considers some type you have to be invalid), this error is not reported back via Nx. Nx will silent swallow these errors from ts-patch/typia, and the resulting transpiled code will not have typia transformations applied. This will result in an error such as the following when running you tests that use typia (`nx <package-name>:test`), dev versions of your application (`nx <package-name>:serve`), as well as running your application after building.
 
 ```bash filename="Terminal"
 Error on typia.createAssert(): no transform has been configured.
@@ -518,7 +551,7 @@ To debug whether this is an issue with your setup or simply NX just silently swa
 
 Running this task will show you the errors from Typia, and allow you to correct them, meaning that using the standard `nx <package-name>:build` task should now work the way you expect.
 
-Note: While Nx has a `transformers` feature on the `@nx/js` plugin, that won't work with Typia. Nx expects a transformer to export a `before` hook, which it then plugs directly into the compiler API. Typia's default path is the `ttsc` host plus `typia/lib/transform`, so the Nx transformer slot is not the primary integration point.
+Note: While Nx has a `transformers` feature on the `@nx/js` plugin, that won't work with Typia. The reason is because Nx is expecting a transformer to export a `before` hook, which Nx then plugs directly into TypeScript via the compiler API. Typia doesn't export that kind of hook, because Typia only works with ts-patch, which abstracts the need for creating a specific before hook in the way Nx wants.
 
 ## Generation
 
@@ -526,8 +559,8 @@ Note: While Nx has a `transformers` feature on the `@nx/js` plugin, that won't w
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
 # INSTALL TYPIA
-npm install --save typia
-npm install --save-dev typescript
+npm install typia
+npm install -D typescript
 
 # GENERATE TRANSFORMED TYPESCRIPT CODES
 npx typia generate \
@@ -539,8 +572,8 @@ npx typia generate \
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
 # INSTALL TYPIA
-pnpm install --save typia
-pnpm install --save-dev typescript
+pnpm install typia
+pnpm install -D typescript
 
 # GENERATE TRANSFORMED TYPESCRIPT CODES
 pnpm typia generate \

--- a/website/src/content/docs/setup/tsgo.mdx
+++ b/website/src/content/docs/setup/tsgo.mdx
@@ -1,0 +1,501 @@
+---
+title: Guide Documents > Setup > TypeScript-Go
+---
+
+import { Tabs } from "nextra/components";
+
+## Summary
+
+`typia@next` uses the [`ttsc`](https://github.com/samchon/ttsc) toolchain.
+
+This setup targets TypeScript-Go, the Go migration of the TypeScript compiler. `ttsc` provides the Go-based plugin toolchain, and `typia@next` uses the Go-rewritten `typia` transform.
+
+- `ttsc`: build, check, and watch TypeScript projects
+- `ttsx`: execute TypeScript directly with type checking
+- `@ttsc/unplugin`: run `ttsc` plugins from bundlers
+
+> [!NOTE]
+>
+> `@typescript/native-preview` is not a stable TypeScript release yet, and `typia@next` is also an experimental release of `typia`.
+>
+> Also, you must use `ttsc` and `ttsx`. The stock `tsc`, `ts-node`, and `tsx` cannot apply the `typia` transform, so they will not work.
+
+## Setup
+
+### Install
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+npm i typia@next
+npm i -D ttsc @typescript/native-preview
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+pnpm i typia@next
+pnpm i -D ttsc @typescript/native-preview
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+yarn add typia@next
+yarn add -D ttsc @typescript/native-preview
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+bun add typia@next
+bun add -d ttsc @typescript/native-preview
+```
+  </Tabs.Tab>
+</Tabs>
+
+Keep your TypeScript project strict.
+
+```json filename="tsconfig.json" showLineNumbers copy
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}
+```
+
+### Compile
+
+Use `ttsc` to build your TypeScript project. It compiles your sources and applies the `typia` transform in one step.
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+npx ttsc
+npx ttsc --noEmit
+npx ttsc --watch
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+pnpm ttsc
+pnpm ttsc --noEmit
+pnpm ttsc --watch
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+yarn ttsc
+yarn ttsc --noEmit
+yarn ttsc --watch
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+bun ttsc
+bun ttsc --noEmit
+bun ttsc --watch
+```
+  </Tabs.Tab>
+</Tabs>
+
+### Execute
+
+Use `ttsx` to run a TypeScript file directly, without a build step.
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+npx ttsx src/index.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+pnpm ttsx src/index.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+yarn ttsx src/index.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+bun ttsx src/index.ts
+```
+  </Tabs.Tab>
+</Tabs>
+
+## Bundlers
+
+### Install
+
+Use [`@ttsc/unplugin`](https://github.com/samchon/ttsc/tree/master/packages/unplugin)
+when your project is built by a bundler.
+
+`ttsc` is enough for a normal TypeScript build, but bundlers run their own
+build pipeline. `@ttsc/unplugin` connects the `ttsc` transform to that pipeline.
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+npm i -D @ttsc/unplugin
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+pnpm i -D @ttsc/unplugin
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+yarn add -D @ttsc/unplugin
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+bun add -d @ttsc/unplugin
+```
+  </Tabs.Tab>
+</Tabs>
+
+### Configuration
+
+Currently, `@ttsc/unplugin` supports the following bundlers:
+
+- Vite
+- Next.js
+- Rollup
+- Rolldown
+- esbuild
+- Webpack
+- Rspack
+- Farm
+- Bun
+
+Then add the matching plugin to your bundler config. Import path must match the
+bundler you are using.
+
+<Tabs
+  items={[
+    "Vite",
+    "Next.js",
+    "Rollup",
+    "Rolldown",
+    "esbuild",
+    "Webpack",
+    "Rspack",
+    "Farm",
+    "Bun",
+  ]}
+>
+  <Tabs.Tab>
+```ts filename="vite.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="next.config.mjs" showLineNumbers copy
+import withTtsc from "@ttsc/unplugin/next";
+
+/** @type {import("next").NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default withTtsc(nextConfig);
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="rollup.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/rollup";
+
+export default {
+  input: "src/index.ts",
+  output: {
+    dir: "dist",
+    format: "esm",
+  },
+  plugins: [ttsc()],
+};
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="rolldown.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/rolldown";
+import { defineConfig } from "rolldown";
+
+export default defineConfig({
+  input: "src/index.ts",
+  output: {
+    dir: "dist",
+    format: "esm",
+  },
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="esbuild.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/esbuild";
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  outdir: "dist",
+  bundle: true,
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="webpack.config.mjs" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/webpack";
+
+export default {
+  entry: "./src/index.ts",
+  output: {
+    path: new URL("./dist", import.meta.url).pathname,
+  },
+  plugins: [ttsc()],
+};
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="rspack.config.mjs" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/rspack";
+
+export default {
+  entry: "./src/index.ts",
+  plugins: [ttsc()],
+};
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="farm.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/farm";
+import { defineConfig } from "@farmfe/core";
+
+export default defineConfig({
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="build.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/bun";
+
+await Bun.build({
+  entrypoints: ["src/index.ts"],
+  outdir: "dist",
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+</Tabs>
+
+Put the plugin in the same config file that already builds your application.
+For example, a Vite app uses `vite.config.ts`, a Next.js app uses
+`next.config.mjs`, and a Webpack app uses `webpack.config.mjs`.
+
+After that, run the normal build command of your framework or bundler.
+
+### Project
+
+If your bundler should read another TypeScript config file, pass `project`.
+
+<Tabs
+  items={[
+    "Vite",
+    "Next.js",
+    "Rollup",
+    "Rolldown",
+    "esbuild",
+    "Webpack",
+    "Rspack",
+    "Farm",
+    "Bun",
+  ]}
+>
+  <Tabs.Tab>
+```ts filename="vite.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    ttsc({
+      project: "tsconfig.bundle.json",
+    }),
+  ],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="next.config.mjs" showLineNumbers copy
+import withTtsc from "@ttsc/unplugin/next";
+
+/** @type {import("next").NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default withTtsc(nextConfig, {
+  project: "tsconfig.bundle.json",
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="rollup.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/rollup";
+
+export default {
+  input: "src/index.ts",
+  output: {
+    dir: "dist",
+    format: "esm",
+  },
+  plugins: [
+    ttsc({
+      project: "tsconfig.bundle.json",
+    }),
+  ],
+};
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="rolldown.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/rolldown";
+import { defineConfig } from "rolldown";
+
+export default defineConfig({
+  input: "src/index.ts",
+  output: {
+    dir: "dist",
+    format: "esm",
+  },
+  plugins: [
+    ttsc({
+      project: "tsconfig.bundle.json",
+    }),
+  ],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="esbuild.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/esbuild";
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  outdir: "dist",
+  bundle: true,
+  plugins: [
+    ttsc({
+      project: "tsconfig.bundle.json",
+    }),
+  ],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="webpack.config.mjs" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/webpack";
+
+export default {
+  entry: "./src/index.ts",
+  output: {
+    path: new URL("./dist", import.meta.url).pathname,
+  },
+  plugins: [
+    ttsc({
+      project: "tsconfig.bundle.json",
+    }),
+  ],
+};
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js filename="rspack.config.mjs" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/rspack";
+
+export default {
+  entry: "./src/index.ts",
+  plugins: [
+    ttsc({
+      project: "tsconfig.bundle.json",
+    }),
+  ],
+};
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="farm.config.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/farm";
+import { defineConfig } from "@farmfe/core";
+
+export default defineConfig({
+  plugins: [
+    ttsc({
+      project: "tsconfig.bundle.json",
+    }),
+  ],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="build.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/bun";
+
+await Bun.build({
+  entrypoints: ["src/index.ts"],
+  outdir: "dist",
+  plugins: [
+    ttsc({
+      project: "tsconfig.bundle.json",
+    }),
+  ],
+});
+```
+  </Tabs.Tab>
+</Tabs>
+
+The `project` path is resolved from the current working directory.
+
+## Transform Options
+
+Add `compilerOptions.plugins` only when you want to change transform options.
+
+```jsonc filename="tsconfig.json" showLineNumbers copy
+{
+  "compilerOptions": {
+    "strict": true,
+    "strictNullChecks": true,
+    "plugins": [
+      {
+        "transform": "typia/lib/transform",
+        "functional": true, // default: false
+        "numeric": true, // default: false
+        "finite": true, // default: false
+        "undefined": false // default: true
+      }
+    ]
+  }
+}
+```
+
+- `functional`: validate function types
+- `numeric`: reject `NaN` from `number`
+- `finite`: reject both `NaN` and `Infinity` from `number`
+- `undefined`: set `false` to skip explicit `undefined` checks
+
+> [!NOTE]
+>
+> If you use the default transform options, do not add
+> `compilerOptions.plugins` to `tsconfig.json`.
+>
+> `ttsc` automatically applies the `typia` transform. This is the difference
+> from the legacy setup.

--- a/website/src/movies/HomeSponsorMovie.tsx
+++ b/website/src/movies/HomeSponsorMovie.tsx
@@ -29,29 +29,6 @@ const HomeSponsorMovie = () => (
         >
           Thanks for your support. Your donation encourages typia development.
         </Typography>
-        <Typography
-          variant="body2"
-          sx={{
-            color: "rgba(255,255,255,0.4)",
-            fontSize: "0.9rem",
-            mt: 1.5,
-            mb: 4,
-          }}
-        >
-          Also, typia is re-distributing quarter of donations to{" "}
-          <Box
-            component="a"
-            href="https://github.com/nonara/ts-patch"
-            sx={{
-              color: "rgb(0,180,255)",
-              textDecoration: "none",
-              "&:hover": { textDecoration: "underline" },
-            }}
-          >
-            nonara/ts-patch
-          </Box>
-          .
-        </Typography>
       </Box>
       <Box sx={{ textAlign: "center" }}>
         <Box


### PR DESCRIPTION
This pull request updates the documentation for the Typia project to clarify and modernize the setup instructions, especially in light of the new TypeScript-Go (TSGO) compiler and the continued support for legacy (TypeScript v6) setups. It introduces new, clearer setup guides, splits the documentation for TSGO and legacy setups, and improves the organization and accuracy of installation and integration instructions. Additionally, it removes outdated references and cleans up sponsor and inspiration attributions.

Key documentation improvements:

**1. Modernized and Split Setup Documentation**  
- Introduces a dedicated setup guide for both TypeScript-Go (TSGO) and legacy (TS v6) workflows, with clear, tabbed instructions for different package managers and bundlers in `website/src/content/docs/setup/index.mdx`.
- Moves legacy setup instructions to `website/src/content/docs/setup/legacy.mdx` (renamed from `setup.mdx`), updating and correcting installation steps, clarifying the use of `ts-patch`, and improving explanations for Nx and bundler integrations. [[1]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL2-R11) [[2]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL81-R89) [[3]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL115-R144) [[4]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aR165-R206) [[5]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL195-R228) [[6]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL336-R370) [[7]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL347-R381) [[8]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL456-R495) [[9]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL481-R514) [[10]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL497-R530) [[11]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL521-R563)

**2. README and Website Content Updates**  
- Updates the main `README.md` to add a prominent setup section, clarify the need for `ttsc`/`ttsx` for TSGO, and reference the new setup guides and structure. Also improves the guide and appendix organization. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R82) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R132) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147-L152)
- Updates the website's main docs index to remove outdated sponsor redistribution and inspiration references, aligning with the new setup documentation.

**3. Improved Navigation and Metadata**  
- Adds `_meta.ts` to the setup documentation to control display names and ordering for TSGO and legacy guides.

**4. Clean-up and Removal of Outdated References**  
- Removes references to `ts-patch` as a sponsor redistribution and as a primary inspiration, reflecting the project's current direction. [[1]](diffhunk://#diff-123acede136fca9d51a1507da1b8839e83451b62f395411d7234e2c560692a76L151-L158) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147-L152)

These changes make the documentation clearer for both new and existing users, ensuring that the correct setup path is easy to follow for the chosen TypeScript toolchain.

---

References:  
[[1]](diffhunk://#diff-3d1b01573a8cc0dcd66dcae7ad7856c3c60eec5d56729d3e797aa4ad8997f20fR1-R322) [[2]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL2-R11) [[3]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL81-R89) [[4]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL115-R144) [[5]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aR165-R206) [[6]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL195-R228) [[7]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL336-R370) [[8]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL347-R381) [[9]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL456-R495) [[10]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL481-R514) [[11]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL497-R530) [[12]](diffhunk://#diff-3d07cfb00a8c7315b87a13d5f2f7b076f1110c3bf590a5dbc85e5b5e989bef3aL521-R563) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2) [[14]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R82) [[15]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R132) [[16]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156) [[17]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147-L152) [[18]](diffhunk://#diff-123acede136fca9d51a1507da1b8839e83451b62f395411d7234e2c560692a76L151-L158) [[19]](diffhunk://#diff-edb263874fdecff59e8586ef7d7c4e43f1887d82fb726c6757f5343fa0f9e4dbR1-R7)