### PR TITLE
fix(website): make playground editor knows types.

### DIFF
--- a/website/build/typia-pack.js
+++ b/website/build/typia-pack.js
@@ -7,6 +7,15 @@
 // uses. The pack is consumed at worker boot time and mounted into MemFS at
 // `/work/node_modules/...`.
 //
+// As a side effect we also patch `website/src/raw/external.json` (produced by
+// the preceding `embed-typescript external` step in build/compiler.js).
+// The local tarballs in `experiments/tarballs/` only contain placeholder
+// `package.json` files, so embed-typescript produces broken entries with no
+// `types` field and zero source files for typia and friends — that's why the
+// Monaco editor in the playground shows no autocomplete or type errors for
+// `import typia from "typia"`. We replace those entries with the same
+// source-based map we use for the wasm worker, just under `node_modules/`.
+//
 // Important: we DO NOT stage the unpacked .ts files inside `public/compiler/`.
 // Next.js's TypeScript checker would otherwise pick them up and fail with
 // "Cannot find module '@typia/interface'" because the staged tree has no
@@ -19,6 +28,12 @@ const path = require("path");
 const repoRoot = path.resolve(__dirname, "..", "..");
 const websiteRoot = path.resolve(__dirname, "..");
 const outFile = path.join(websiteRoot, "public", "compiler", "typia-pack.json");
+const externalJsonFile = path.join(
+  websiteRoot,
+  "src",
+  "raw",
+  "external.json",
+);
 
 const SOURCES = [
   {
@@ -86,6 +101,31 @@ console.log(
     1024
   ).toFixed(0)} KiB)`,
 );
+
+// Patch external.json (used by the Monaco editor) with the same source-based
+// entries under `node_modules/...`. embed-typescript runs before us in
+// build/compiler.js, so the file is already on disk; we strip its broken
+// placeholder entries for typia/@typia/interface/@typia/utils and inject the
+// real source files plus a publish-style package.json with a `types` field.
+if (fs.existsSync(externalJsonFile)) {
+  const external = JSON.parse(fs.readFileSync(externalJsonFile, "utf8"));
+  const patched = { ...external };
+  const prefixes = SOURCES.map(({ dest }) => `node_modules/${dest}/`);
+  for (const key of Object.keys(patched)) {
+    if (prefixes.some((p) => key.startsWith(p))) delete patched[key];
+  }
+  for (const [key, content] of Object.entries(pack)) {
+    patched[`node_modules/${key}`] = content;
+  }
+  fs.writeFileSync(externalJsonFile, JSON.stringify(patched));
+  console.log(
+    `build/typia-pack.js: patched ${Object.keys(pack).length} entries into ${path.relative(websiteRoot, externalJsonFile)}`,
+  );
+} else {
+  console.log(
+    `build/typia-pack.js: ${path.relative(websiteRoot, externalJsonFile)} not found; skipping Monaco patch`,
+  );
+}
 
 function walk(dir) {
   const out = [];


### PR DESCRIPTION
This pull request updates the `website/build/typia-pack.js` script to improve the integration between Typia packages and the Monaco editor in the playground. The main change is the addition of logic to patch the `external.json` file, ensuring the Monaco editor has proper type information and source files for Typia packages, which fixes issues with autocomplete and type checking.

**Monaco editor integration improvements:**

* Added code to patch `website/src/raw/external.json` by removing broken placeholder entries for Typia packages and replacing them with correct source-based entries, including a `package.json` with a `types` field. This ensures the Monaco editor in the playground provides proper autocomplete and type checking for Typia and related packages.
* Introduced a new constant `externalJsonFile` to reference the `external.json` file used by the Monaco editor.
* Updated documentation comments to explain the new patching behavior and its purpose for Monaco editor support.