### PR TITLE
feat(website): change sponsor image.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-open_collective: typia
 github: [samchon]

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ export const checkString = (() => {
 
 ## Sponsors
 
+[![Sponsors](https://raw.githubusercontent.com/samchon/sponsor-images/refs/heads/master/public/circle.svg)](https://github.com/sponsors/samchon)
+
 Thanks for your support.
 
-Your donation encourages `typia` development.
-
-[![Sponsors](https://opencollective.com/typia/badge.svg?avatarHeight=75&width=600)](https://opencollective.com/typia)
+Your [donation](https://github.com/sponsors/samchon) encourages `typia` development.
 
 ## Playground
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -144,11 +144,11 @@ export const checkString = (() => {
 
 ## Sponsors
 
+[![Sponsors](https://raw.githubusercontent.com/samchon/sponsor-images/refs/heads/master/public/circle.svg)](https://github.com/sponsors/samchon)
+
 Thanks for your support.
 
-Your donation encourages `typia` development.
-
-[![Sponsors](https://opencollective.com/typia/badge.svg?avatarHeight=75&width=600)](https://opencollective.com/typia)
+Your [donation](https://github.com/sponsors/samchon) encourages `typia` development.
 
 ## References
 

--- a/website/src/movies/HomeSponsorMovie.tsx
+++ b/website/src/movies/HomeSponsorMovie.tsx
@@ -17,6 +17,25 @@ const HomeSponsorMovie = () => (
         >
           Sponsors
         </Typography>
+      </Box>
+      <Box sx={{ textAlign: "center", mb: 4 }}>
+        <Box
+          component="a"
+          href="https://github.com/sponsors/samchon"
+          sx={{ display: "inline-block" }}
+        >
+          <Box
+            component="img"
+            src="https://raw.githubusercontent.com/samchon/sponsor-images/refs/heads/master/public/circle.svg"
+            alt="Sponsors"
+            sx={{
+              maxWidth: "100%",
+              borderRadius: 2,
+            }}
+          />
+        </Box>
+      </Box>
+      <Box sx={{ textAlign: "center" }}>
         <Typography
           variant="body1"
           sx={{
@@ -27,25 +46,19 @@ const HomeSponsorMovie = () => (
             mx: "auto",
           }}
         >
-          Thanks for your support. Your donation encourages typia development.
-        </Typography>
-      </Box>
-      <Box sx={{ textAlign: "center" }}>
-        <Box
-          component="a"
-          href="https://opencollective.com/typia"
-          sx={{ display: "inline-block" }}
-        >
+          Thanks for your support. Your{" "}
           <Box
-            component="img"
-            src="https://opencollective.com/typia/badge.svg?avatarHeight=75&width=600"
-            alt="Sponsors"
+            component="a"
+            href="https://github.com/sponsors/samchon"
             sx={{
-              maxWidth: "100%",
-              borderRadius: 2,
+              color: "rgba(255,255,255,0.75)",
+              textDecoration: "underline",
             }}
-          />
-        </Box>
+          >
+            donation
+          </Box>{" "}
+          encourages typia development.
+        </Typography>
       </Box>
     </Container>
   </Box>


### PR DESCRIPTION
This pull request updates the sponsor section across the documentation and main website to feature a new sponsor badge and update sponsor links to GitHub Sponsors instead of OpenCollective. The visual presentation and messaging around sponsorship have also been improved for clarity and consistency.

**Sponsor section updates:**

* Replaced the OpenCollective sponsor badge and links with the new GitHub Sponsors badge (`circle.svg`) and updated all related URLs to point to `https://github.com/sponsors/samchon` in `README.md`, `website/src/content/docs/index.mdx`, and `website/src/movies/HomeSponsorMovie.tsx`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R113) [[2]](diffhunk://#diff-123acede136fca9d51a1507da1b8839e83451b62f395411d7234e2c560692a76L147-R151) [[3]](diffhunk://#diff-02f540ee1ba4a88f371c8a33dec60befb348de7412a170d136e5f6fe14e43427L20-R29)
* Improved the sponsor messaging layout on the homepage: moved the thank-you message below the badge, made "donation" a clickable link, and enhanced the visual style for better emphasis in `HomeSponsorMovie.tsx`.