### PR TITLE
docs(website): rewrite guides for clarity and add a Tutorial track

### DIFF
--- a/website/src/content/docs/_meta.ts
+++ b/website/src/content/docs/_meta.ts
@@ -3,6 +3,7 @@ import { MetaRecord } from "nextra";
 export default {
   index: "🙋🏻‍♂️ Introduction",
   setup: "📦 Setup",
+  tutorial: "🚀 Tutorial",
   pure: "⛲ Pure TypeScript",
 
   "-- features": {

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -4,11 +4,28 @@ title: Guide Documents > Introduction
 import Alert from '@mui/material/Alert';
 import Stack from '@mui/material/Stack';
 
-## Outline
+## What is typia?
+
+**typia turns your TypeScript types into runtime code at compile time.**
+
+Other libraries make you write your types twice — once in TypeScript and once as a schema, decorators, or guards. typia reads the type you already wrote and emits the validator, JSON serializer, schema, or decoder for you. One line, pure types, no duplication.
+
+```ts copy filename="hello.ts"
+import typia from "typia";
+
+interface User {
+  id: string;
+  age: number;
+}
+
+typia.assert<User>(input); // throws TypeGuardError when the shape is wrong
+```
+
+That call expands at compile time into a hand-rolled checker for `User`. No schema file. No decorator soup. No reflection at runtime.
 
 ![Typia Logo](/logo.png)
 
-<span style={{ display: "flex", flexDirection: "row" }}>
+<span style={{ display: "flex", flexDirection: "row", flexWrap: "wrap", gap: "6px" }}>
 {[
   [
     "MIT License",
@@ -31,11 +48,6 @@ import Stack from '@mui/material/Stack';
     "https://github.com/samchon/typia/actions?query=workflow%3Atest",
   ],
   [
-    "Guide Documents",
-    "https://img.shields.io/badge/Guide-Documents-forestgreen",
-    "https://typia.io/docs/",
-  ],
-  [
     "Gurubase",
     "https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF",
     "https://gurubase.io/g/typia",
@@ -46,110 +58,99 @@ import Stack from '@mui/material/Stack';
     "https://discord.gg/E94XhzrUCZ",
   ]
 ].map(([alt, image, url]) => (
-  <a href={url} style={{ marginTop: "30px", marginRight: "6px" }}>
+  <a href={url} style={{ marginTop: "20px" }} key={alt}>
       <img src={image} alt={alt} />
   </a>
 ))}
 </span>
 
-```typescript
-// RUNTIME VALIDATORS
-export function is<T>(input: unknown): input is T; // returns boolean
-export function assert<T>(input: unknown): T; // throws TypeGuardError
-export function assertGuard<T>(input: unknown): asserts input is T;
-export function validate<T>(input: unknown): IValidation<T>; // detailed
+## What you get
 
-// JSON FUNCTIONS
-export namespace json {
-  export function schema<T>(): IJsonSchemaUnit<T>; // JSON schema
-  export function assertParse<T>(input: string): T; // type safe parser
-  export function assertStringify<T>(input: T): string; // safe and faster
-}
+```ts
+// Runtime validators — write a type, get a checker
+typia.is<T>(input);          // boolean
+typia.assert<T>(input);      // throws TypeGuardError, otherwise returns input
+typia.assertGuard<T>(input); // narrows the variable (`asserts input is T`)
+typia.validate<T>(input);    // returns IValidation<T> with every error path
 
-// AI FUNCTION CALLING HARNESS
-export namespace llm {
-  // collection of function calling schemas + validators/parsers
-  export function application<Class>(): ILlmApplication<Class>;
-  export function structuredOutput<P>(): ILlmStructuredOutput;
-  // lenient json parser + type coercion
-  export function parse<T>(str: string): T;
-}
+// JSON — same idea, plus performance
+typia.json.assertParse<T>(text);    // safe JSON.parse + assert
+typia.json.assertStringify<T>(obj); // ~10x faster JSON.stringify with type safety
+typia.json.schemas<[T]>();          // emit OpenAPI/JSON Schema
 
-// PROTOCOL BUFFER
-export namespace protobuf {
-  export function message<T>(): string; // Protocol Buffer message
-  export function assertDecode<T>(buffer: Uint8Array): T; // safe decoder
-  export function assertEncode<T>(input: T): Uint8Array; // safe encoder
-}
+// LLM function calling — turn a TypeScript class into tools
+typia.llm.application<MyService>();    // full ILlmApplication with parse/coerce/validate
+typia.llm.structuredOutput<T>();       // schema + parser + coercer + validator
+typia.llm.parameters<T>();             // just the JSON schema
 
-// RANDOM GENERATOR
-export function random<T>(g?: Partial<IRandomGenerator>): T;
+// Protocol Buffer — same again, in binary
+typia.protobuf.assertEncode<T>(obj);
+typia.protobuf.assertDecode<T>(bytes);
+typia.protobuf.message<T>();           // emit .proto schema text
+
+// Test data
+typia.random<T>();                     // generate a value that satisfies T
 ```
-
-`typia` is a transformer library supporting below features:
-
-  - Super-fast Runtime Validators
-  - Enhanced JSON functions
-  - LLM function calling harness
-  - Protocol Buffer encoder and decoder
-  - Random data generator
 
 <br/>
 <Stack spacing={1}>
   <Alert severity="warning">
-    Only **one line** required, with pure TypeScript type
+    Only **one line** required, with pure TypeScript types
   </Alert>
   <Alert severity="success">
-    Runtime validator is **20,000x** faster than `class-validator`
+    Runtime validator up to **20,000× faster** than `class-validator` ([benchmark](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics))
   </Alert>
   <Alert severity="info">
-    JSON serialization is **200x faster** than `class-transformer`
+    JSON serialization up to **200× faster** than `class-transformer` ([benchmark](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics#stringify))
   </Alert>
   <Alert severity="success">
-    LLM function calling harness turns **6.75% → 100%** accuracy
+    LLM function calling success rate: **6.75% → 100%** with the typia harness ([story](https://github.com/wrtnlabs/autobe))
   </Alert>
 </Stack>
 
-## Transformation
+## How it works
 
 <br/>
-<iframe src="https://www.youtube.com/embed/WM6LGy2UU6s?si=lZrqbILxHI22QwEE" 
-        title="Typia Tutorial Video" 
-        width="100%" 
-        height="500" 
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" 
+<iframe src="https://www.youtube.com/embed/WM6LGy2UU6s?si=lZrqbILxHI22QwEE"
+        title="Typia Tutorial Video"
+        width="100%"
+        height="500"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin"
         allowFullScreen></iframe>
 
-If you call `typia` function, it would be compiled like below.
+Every TypeScript type disappears at runtime — there is no class object to inspect, no decorator to call. So validator libraries normally ask you to re-encode the type as a schema. typia takes a different route: it ships a compile-time transform that reads the type and writes the runtime code for you.
 
-This is the key concept of `typia`, transforming TypeScript type to a runtime function. The `typia.is<T>()` function is transformed to a dedicated type checker by analyzing the target type `T` in the compilation level.
+You install the [`ttsc`](/docs/setup/tsgo) toolchain — a drop-in replacement for `tsc` that runs typia's transform — or, on stable TypeScript v5 / v6, the [`ts-patch`](/docs/setup/legacy) patcher that injects the same transform into the stock compiler. Your build becomes:
 
-This feature enables developers to ensure type safety in their applications, leveraging TypeScript's static typing while also providing runtime validation. Instead of defining additional schemas, you can simply utilize the pure TypeScript type itself.
-
-```typescript
-//----
-// examples/checkString.ts
-//----
-import typia, { tags } from "typia";
-export const checkString = typia.createIs<string>();
-
-//----
-// examples/checkString.js
-//----
+```ts copy filename="src/check.ts"
 import typia from "typia";
-export const checkString = (() => {
+export const check = typia.createIs<string>();
+```
+
+```js copy filename="dist/check.js"
+import typia from "typia";
+export const check = (() => {
   return (input) => "string" === typeof input;
 })();
 ```
+
+That's the entire trick. The TypeScript source asks for `is<string>`; the compiler emits the bare-metal check inline. No reflection, no schema, no decorator side effects. See [Pure TypeScript](/docs/pure) for the full motivation.
+
+## Where to go next
+
+- **Just getting started?** Walk through the [Tutorial](/docs/tutorial) — install, write your first validator, then add JSON and LLM in 30 minutes.
+- **Need to install it now?** See [Setup](/docs/setup) — pick TypeScript-Go (`ttsc`) or the TS v6 legacy path.
+- **Looking up an API?** Jump straight to [Validators](/docs/validators/is), [JSON](/docs/json/schema), [LLM](/docs/llm/application), [Protobuf](/docs/protobuf/message), or [Random](/docs/random).
+- **Building an agent?** Start at [LLM function calling](/docs/llm/application) and the [function calling harness](/docs/llm/json).
 
 ## Sponsors
 
 [![Backers](https://opencollective.com/typia/backers.svg?avatarHeight=75&width=600)](https://opencollective.com/typia)
 
-Thanks for your support.
-
-Your [donation](https://opencollective.com/typia) encourages `typia` development.
+If typia saves you time, please consider [donating to the project](https://opencollective.com/typia).
 
 ## References
 
-  - inspired by [`typescript-is`](https://github.com/woutervh-/typescript-is)
+- Inspired by [`typescript-is`](https://github.com/woutervh-/typescript-is)
+- Source code: [github.com/samchon/typia](https://github.com/samchon/typia)
+- Benchmarks: [benchmark/results](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics)

--- a/website/src/content/docs/json/parse.mdx
+++ b/website/src/content/docs/json/parse.mdx
@@ -1,18 +1,94 @@
 ---
-title: Guide Documents > JSON < parse() functions
+title: Guide Documents > JSON > parse() functions
 ---
 import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `parse()` functions
+# `typia.json.*Parse` — JSON.parse with built-in validation
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>Primitive.ts</code>
-]}>
+Native `JSON.parse(text)` happily returns `any`. There's no way to be sure the parsed object matches the type you expect. typia closes that gap by combining `JSON.parse` with one of the validators in a single call.
+
+```typescript copy filename="signatures"
+namespace json {
+  function isParse<T>(input: string): Primitive<T> | null;        // is + JSON.parse
+  function assertParse<T>(input: string): Primitive<T>;            // assert + JSON.parse
+  function validateParse<T>(input: string): IValidation<Primitive<T>>; // validate + JSON.parse
+}
+```
+
+Each function maps to one of the [runtime validators](/docs/validators/is):
+
+| Function | If JSON is valid AND matches `T` | If anything is wrong |
+|----------|----------------------------------|----------------------|
+| `json.isParse<T>` | returns the parsed value | returns `null` |
+| `json.assertParse<T>` | returns the parsed value | throws `TypeGuardError` |
+| `json.validateParse<T>` | returns `IValidation.ISuccess<T>` | returns `IValidation.IFailure` |
+
+## First example
+
+```typescript copy filename="hello-assertParse.ts"
+import typia, { tags } from "typia";
+
+interface User {
+  id: string & tags.Format<"uuid">;
+  name: string;
+}
+
+const text: string = await fetch("/me").then((r) => r.text());
+const user = typia.json.assertParse<User>(text);
+// → parsed User, validated. Throws if either parse or validation fails.
+```
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/json/assertParse.ts"
+      filename="examples/src/json/assertParse.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/json/assertParse.js"
+      filename="examples/bin/json/assertParse.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## `Primitive<T>` — what comes back
+
+JSON can't represent everything TypeScript can. `Primitive<T>` is the projection of `T` into the "what survives a JSON round-trip" world:
+
+| In `T` | In `Primitive<T>` |
+|--------|-------------------|
+| methods (functions) | removed |
+| `Date` | `string & tags.Format<"date-time">` (because `JSON.stringify(date)` returns an ISO string) |
+| `Set<U>`, `Map<K,V>`, `Uint8Array`, … other native classes | `never` (i.e. you'll get a compile error on use) |
+| `bigint` | `never` |
+| `class Foo { … }` | the plain object form |
+
+The error from `Primitive<T>` collapsing to `never` is the type system telling you: *this field cannot survive JSON parsing.* Choose a JSON-representable type, or use [`typia.protobuf`](/docs/protobuf/encode) for binary data, or [`typia.misc.clone`](/docs/misc) when you don't actually need JSON.
+
+For example:
+
+```typescript copy
+import typia, { Primitive } from "typia";
+
+interface Original {
+  id: string;
+  joinedAt: Date;
+  tags: Set<string>;
+}
+
+// Primitive<Original> is, conceptually:
+// {
+//   id: string;
+//   joinedAt: string & tags.Format<"date-time">;
+//   tags: never;   // → compile error if you call assertParse<Original> here
+// }
+```
+
+<Tabs items={['typia', <code>IValidation.ts</code>, <code>Primitive.ts</code>, <code>TypeGuardError.ts</code>]}>
   <Tabs.Tab>
 ```typescript copy
 export namespace json {
@@ -23,108 +99,52 @@ export namespace json {
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
+      path="packages/interface/src/schema/IValidation.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/typings/Primitive.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
       path="packages/typia/src/TypeGuardError.ts"
       filename="typia/TypeGuardError.ts"
       showLineNumbers />
   </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface/IValidation.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/typings/Primitive.ts"
-      filename="@typia/interface/Primitive.ts"
-      showLineNumbers />
-  </Tabs.Tab>
 </Tabs>
 
-Type safe JSON parser.
+## Reusable factories
 
-Unlike native `JSON.parse()` function which returns any typed instance without type checking, `typia.json.assertParse<T>()` function validates instance type after the parsing. If the parsed value is not following the promised type `T`, it throws `TypeGuardError` with the first type error info.
+If you parse the same `T` from many places, hoist the parser once:
 
-If you want to know every type error infos detaily, you can use `typia.json.validateParse<T>()` function instead. Otherwise, you just only want to know whether the parsed value is following the type `T` or not, just call `typia.json.isParse<T>()` function.
-
-  - `typia.json.isParse<T>()`: `JSON.parse()` + [`typia.is<T>()`](../validators/is)
-  - `typia.json.assertParse<T>()`: `JSON.parse()` + [`typia.assert<T>()`](../validators/assert)
-  - `typia.json.validateParse<T>()`: `JSON.parse()` + [`typia.validate<T>()`](../validators/validate)
-
-Look at the below code, then you may understand how the `typia.json.assertParse<T>()` function works.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/json/assertParse.ts"
-      filename="examples/src/json/assertParse.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/json/assertParse.js"
-      filename="examples/bin/json/assertParse.js"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## Reusable functions
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>Primitive.ts</code>
-]}>
-  <Tabs.Tab>
 ```typescript copy
-export namespace json {
-  export function createIsParse<T>(): (input: string) => Primitive<T> | null;
-  export function createAssertParse<T>(): (input: string) => Primitive<T>;
-  export function createValidateParse<T>(): (
-    input: string,
-  ) => IValidation<Primitive<T>>;
-}
+const parseUser = typia.json.createAssertParse<User>();
+const tryParseUser = typia.json.createIsParse<User>();
+const validateParseUser = typia.json.createValidateParse<User>();
 ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface/IValidation.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/typings/Primitive.ts"
-      filename="@typia/interface/Primitive.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
 
-Reusable `typia.json.isParse<T>()` function generators.
-
-If you repeat to call `typia.json.isParse<T>()` function on the same type, size of JavaScript files would be larger because of duplicated AOT compilation. To prevent it, you can generate reusable function through `typia.createIsParse<T>()` function.
-
-Just look at the code below, then you may understand how to use it.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/json/createIsParse.ts"
       filename="examples/src/json/createIsParse.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/json/createIsParse.js"
       filename="examples/bin/json/createIsParse.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
+
+## Where to go next
+
+- The matching faster stringifier → [`json.stringify*`](/docs/json/stringify)
+- Generate JSON Schema from `T` → [`json.schemas`](/docs/json/schema)
+- Underlying validators — [`is`](/docs/validators/is), [`assert`](/docs/validators/assert), [`validate`](/docs/validators/validate)

--- a/website/src/content/docs/json/schema.mdx
+++ b/website/src/content/docs/json/schema.mdx
@@ -5,14 +5,66 @@ import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `schemas()` function
+# `typia.json.schemas` — emit JSON Schema / OpenAPI from a TypeScript type
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>IJsonSchemaCollection.ts</code>, 
-  <code>OpenApi</code>,
-  <code>OpenApiV3</code>,
-]}>
+If you've ever hand-written a JSON Schema or an OpenAPI components block, you know how mechanical it is. typia generates it from the TypeScript type at compile time. Same model as the validators — no extra schema file to maintain.
+
+```typescript copy filename="signatures"
+namespace json {
+  function schema<T, Version extends "3.0" | "3.1" = "3.1">(): IJsonSchemaUnit;
+  function schemas<Schemas extends unknown[], Version = "3.1">(): IJsonSchemaCollection;
+  function application<Class extends object, Version = "3.1">(): IJsonSchemaApplication;
+}
+```
+
+| Function | Use case |
+|----------|----------|
+| `json.schema<T>()` | A single top-level schema, plus a `components` map for any `$ref`s the type pulls in |
+| `json.schemas<[T1, T2, ...]>()` | Multiple top-level types sharing one `components` map (the common case for an OpenAPI `components.schemas`) |
+| `json.application<Class>()` | Class methods → a list of `{name, parameters, output}` JSON Schemas — handy for framework-neutral tooling that wants per-method schemas without typia's LLM-specific config |
+
+For the LLM-specific shape (with `$defs`, `additionalProperties: false`, strict mode, …), use [`typia.llm.parameters`](/docs/llm/parameters) or [`typia.llm.application`](/docs/llm/application) instead.
+
+`Version` selects the JSON Schema dialect:
+
+- **`"3.1"` (default)** — OpenAPI 3.1, which is JSON Schema 2020-12. Supports tuples, pattern properties, `null` as a primitive.
+- **`"3.0"`** — OpenAPI 3.0 / Swagger compatibility. No tuples, no pattern properties.
+
+Stick with `"3.1"` unless a downstream consumer demands the older dialect.
+
+## First example
+
+```typescript copy filename="hello-schemas.ts"
+import typia, { tags } from "typia";
+
+interface User {
+  id: string & tags.Format<"uuid">;
+  age: number & tags.Type<"uint32">;
+  email?: string & tags.Format<"email">;
+}
+
+const schemas = typia.json.schemas<[User]>();
+// → an IJsonSchemaCollection with `User` under components.schemas
+```
+
+The output is a plain object — drop it into your OpenAPI spec, hand it to `ajv` if you must, or save it to disk for tooling that wants schemas at rest.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/json/schemas.ts"
+      filename="examples/src/json/schemas.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/json/schemas.js"
+      filename="examples/bin/json/schemas.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+<Tabs items={[<code>typia</code>, <code>IJsonSchemaCollection.ts</code>, <code>OpenApi</code>, <code>OpenApiV3</code>]}>
   <Tabs.Tab>
 ```typescript copy
 export namespace json {
@@ -24,9 +76,9 @@ export namespace json {
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/schema/IJsonSchemaCollection.ts"
-      filename="@typia/interface/IJsonSchemaCollection.ts"
+      filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
@@ -36,85 +88,58 @@ export namespace json {
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/openapi/OpenApiV3.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-JSON schema generator.
+## What gets included in the schema
 
-  - Definitions:
-    - [`IJsonSchemaCollection`](https://github.com/samchon/typia/blob/master/packages/interface/src/schema/IJsonSchemaCollection.ts)
-    - [OpenAPI v3.0](https://github.com/samchon/openapi/blob/master/src/OpenApiV3.ts)
-    - [OpenAPI v3.1](https://github.com/samchon/openapi/blob/master/src/OpenApi.ts)
+Anything you express in the TypeScript type carries over:
 
-When you need JSON schema, do not write it by yourself, but just call `typia.json.schemas()` function. 
+- **`tags.Format<"uuid">`** → `"format": "uuid"`
+- **`tags.MaxLength<100>`** → `"maxLength": 100`
+- **`tags.Minimum<0>`** → `"minimum": 0`
+- **JSDoc description on a property** → `"description": "..."`
 
-If you call the `typia.json.schemas()` with specialization of target `Schemas`, `typia` will analyze your `Schemas` and generate JSON schema definition in the compilation level. However, note that, JSON schema definitions of "OpenAPI v3.0" and "OpenAPI v3.1" are a little bit different. Therefore, you have to consider which value to assign in the `Version` argument.
+A few JSON-Schema-only comment tags are also recognized — they don't affect runtime validation but they show up in the emitted schema:
 
-  - Swagger can't express tuple type
-  - Swagger can't express pattern property
+| Tag | Effect |
+|-----|--------|
+| `@title Something` | Sets `title` |
+| `@deprecated` | Sets `deprecated: true` |
+| `@hidden` / `@internal` | Excludes the field from the emitted schema |
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/json/schemas.ts"
-      filename="examples/src/json/schemas.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/json/schemas.js"
-      filename="examples/bin/json/schemas.js"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## Specialization
-
-You can utilize [type tags](../validators/tags/#type-tags) (or [validator's comment tags](../validators/tags/#comment-tags)) to constructing special fields of JSON schema. 
-
-If you write any comment on a property, it would fill the `IJsonSchema.description` value. Also, there're special comment tags only for JSON schema definition that are different with [validator's comment tags](../validators/tags/#comment-tags) like below.
-
-  - `@deprecated`
-  - `@hidden`
-  - `@internal`
-  - `@title {string}`
-
-Let's see how those [type tags](../validators/tags/#type-tags), comment tags and description comments are working with example code.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/json/schemas-comment-tags.ts"
       filename="examples/src/json/schemas-comment-tags.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/json/schemas-comment-tags.js"
       filename="examples/bin/json/schemas-comment-tags.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Customization
+## Adding custom `x-…` fields
 
-If what you want is not just filling regular properties of JSON schema specification, but to adding custom properties into the JSON schema definition, you can do it through the `tags.TagBase.schema` property type or `tags.JsonSchemaPlugin` type. 
+JSON Schema reserves the `x-` prefix for non-standard extensions. To embed `x-…` properties (for vendor-specific tooling, internal flags, anything that isn't part of the standard), use `tags.TagBase.schema` or the `tags.JsonSchemaPlugin` helper:
 
-For reference, the custom property must be started with `x-` prefix. It's a rule of JSON schema.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/json/schemas-type-tags.ts"
       filename="examples/src/schema-type-tags.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/json/schemas-type-tags.js"
       filename="examples/bin/json/schemas-type-tags.js"
       showLineNumbers />
@@ -123,13 +148,13 @@ For reference, the custom property must be started with `x-` prefix. It's a rule
 
 ## Restrictions
 
-JSON schema does not support `bigint` type.
+### `bigint` is rejected
 
-So if you use `bigint` type in one of your onetarget schemas, `typia` will make compile error like below.
+JSON Schema has no `bigint`. typia refuses to compile a schema for a type that contains one:
 
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+<Tabs items={["TypeScript Source", "Console Output"]}>
   <Tabs.Tab>
-```typescript filename="json.schemas.ts" copy showLineNumbers 
+```typescript filename="json.schemas.ts" copy showLineNumbers
 import typia, { tags } from "typia";
 
 interface Something {
@@ -160,9 +185,11 @@ main.ts:12:1 - error TS(typia.json.schemas): unsupported type detected
   </Tabs.Tab>
 </Tabs>
 
-Also, if you put any type of native classes like `Map` or `Uint8Array`, it would also be error, either. By the way, only `Date` class is exceptional, and it would be considered as `string & Format<"date-time">` type like below.
+### Native classes — only `Date` is allowed
 
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+`Map`, `Set`, `Uint8Array`, … are rejected. `Date` is special-cased: it serializes as `string & tags.Format<"date-time">`, so typia accepts it.
+
+<Tabs items={["TypeScript Source", "Output JSON Schema"]}>
   <Tabs.Tab>
 ```typescript filename="json.schemas.native.ts" showLineNumbers copy
 import typia from "typia";
@@ -175,7 +202,6 @@ typia.json.schemas<[Native]>();
   </Tabs.Tab>
   <Tabs.Tab>
 ```typescript filename="json.schemas.native.js" showLineNumbers
-import typia from "typia";
 ({
   version: "3.1",
   components: {
@@ -201,3 +227,10 @@ import typia from "typia";
 ```
   </Tabs.Tab>
 </Tabs>
+
+## Where to go next
+
+- Reading JSON safely → [`json.*Parse`](/docs/json/parse)
+- Writing JSON fast → [`json.*Stringify`](/docs/json/stringify)
+- LLM-compatible schema for function calling → [`llm.parameters`](/docs/llm/parameters)
+- Constraint cheatsheet → [Special Tags](/docs/validators/tags)

--- a/website/src/content/docs/json/stringify.mdx
+++ b/website/src/content/docs/json/stringify.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guide Documents > JSON > stringify() function
+title: Guide Documents > JSON > stringify() functions
 ---
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
@@ -7,13 +7,71 @@ import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `stringify()` functions
+# `typia.json.*Stringify` — JSON.stringify, but much faster (and type-safe)
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>
-]}>
+`JSON.stringify(value)` is general-purpose: it walks the value at runtime, asking each property "are you a number? a string? an array?". typia replaces that runtime walk with a hand-written stringifier generated from the TypeScript type at compile time. The result is **up to ~10× faster** than `JSON.stringify` — and, because the stringifier only knows how to serialize `T`, you can also opt into validating `T` before serialization.
+
+```typescript copy filename="signatures"
+namespace json {
+  function stringify<T>(input: T): string;                          // dedicated stringifier
+  function isStringify<T>(input: T | unknown): string | null;       // is + stringify
+  function assertStringify<T>(input: T | unknown): string;          // assert + stringify
+  function validateStringify<T>(input: T | unknown): IValidation<string>; // validate + stringify
+}
+```
+
+## First example
+
+```typescript copy filename="hello-stringify.ts"
+import typia from "typia";
+
+interface User {
+  id: string;
+  age: number;
+  hobbies: string[];
+}
+
+const text: string = typia.json.stringify<User>({
+  id: "1",
+  age: 25,
+  hobbies: ["reading"],
+});
+// → '{"id":"1","age":25,"hobbies":["reading"]}'
+```
+
+The output is identical to `JSON.stringify({ id, age, hobbies })`. The speed comes from the compiled code: instead of "for each property, dispatch to the right encoder," the emitted JS just concatenates strings in the order your type declares.
+
+## Pick the right variant
+
+| Function | Validates input? | On failure |
+|----------|------------------|------------|
+| `json.stringify<T>` | **No** | undefined behavior (don't pass wrong-typed values) |
+| `json.isStringify<T>` | Yes ([`is`](/docs/validators/is)) | returns `null` |
+| `json.assertStringify<T>` | Yes ([`assert`](/docs/validators/assert)) | throws `TypeGuardError` |
+| `json.validateStringify<T>` | Yes ([`validate`](/docs/validators/validate)) | returns `IValidation<string>` |
+
+> [!CAUTION]
+>
+> **`json.stringify<T>` skips validation by design.**
+>
+> The generated code assumes its input already matches `T`. If you hand it a wrong-typed value, the output will be garbage (missing fields, fields with the wrong contents). Use it only when the type of the input is statically guaranteed — for example, you just built the object inside the same function. Otherwise, pick `isStringify` / `assertStringify` / `validateStringify`.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/json/isStringify.ts"
+      filename="examples/src/json/isStringify.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/json/isStringify.js"
+      filename="examples/bin/json/isStringify.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+<Tabs items={[<code>typia</code>, <code>IValidation.ts</code>, <code>TypeGuardError.ts</code>]}>
   <Tabs.Tab>
 ```typescript copy
 export namespace json {
@@ -25,102 +83,37 @@ export namespace json {
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
+      path="packages/interface/src/schema/IValidation.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
       path="packages/typia/src/TypeGuardError.ts"
       filename="typia/TypeGuardError.ts"
       showLineNumbers />
   </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface/IValidation.ts"
-      showLineNumbers />
-  </Tabs.Tab>
 </Tabs>
 
-You can boost up JSON serialization speed just by calling `typia.json.stringify<T>()` function. Also, you even can ensure type safety of JSON serialization by calling other functions like `typia.json.isStringify()` and `typia.json.assertStringify()` functions.
+## Reusable factories
 
-As `typia.json.stringify<T>()` function writes dedicated JSON serialization code only for the target type `T`, its performance is much faster than native `JSON.stringify()` function. However, because of the dedicated optimal JSON serialization code, when wrong typed data comes, unexpected error be occurred.
+Same shape as the parsers — hoist the per-type code once if you stringify the same `T` from many places:
 
-Instead, `typia` supports type safe JSON serialization functions like `typia.json.isStringify()`. The `typia.json.isStringify()` is a combination function of `typia.is<T>()` and `typia.json.stringify<T>()` function. It checks whether the input value is valid for the target type `T` or not first, and operate JSON serialization later. If the input value is not matched with the type `T`, it returns `null` value.
-
-  - `typia.json.isStringify()`: [`typia.is<T>()`](../validators/is) + `typia.json.stringify<T>()`
-  - `typia.json.assertStringify()`: [`typia.assert<T>()`](../validators/assert) + `typia.json.stringify<T>()`
-  - `typia.json.validateStringify()`: [`typia.validate<T>()`](../validators/validate) + `typia.json.stringify<T>()`
-
-<br/>
-<Alert severity="success">
-  <AlertTitle> 
-    **AOT compilation** 
-  </AlertTitle>
-
-`typia.json.isStringify()` and other similar functions are still much faster than native `JSON.stringify()` function, even though they include type checking process. This is the power of AOT compilation, writing optimal dedicated code by analyzing TypeScript type, in the compilation level.
-
-</Alert>
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/json/isStringify.ts"
-      filename="examples/src/json/isStringify.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/json/isStringify.js"
-      filename="examples/bin/json/isStringify.js"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## Reusable functions
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>
-]}>
-  <Tabs.Tab>
 ```typescript copy
-export namespace json {
-  export function createStringify<T>(): (input: T) => string;
-  export function createIsStringify<T>(): (input: unknown) => string | null;
-  export function createAssertStringify<T>(
-   errorFactory?: undefined | ((props: TypeGuardError.IProps) => Error),
-  ): (input: unknown) => string; 
-  export function createValidateStringify<T>(): (input: unknown) => IValidation<string>;
-}
+const stringifyUser = typia.json.createStringify<User>();
+const safeStringifyUser = typia.json.createAssertStringify<User>();
 ```
-  </Tabs.Tab>
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface/IValidation.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-Reusable `typia.json.stringify<T>()` function generators.
-
-If you repeat to call `typia.json.stringify<T>()` function on the same type, size of JavaScript files would be larger because of duplicated AOT compilation. To prevent it, you can generate reusable function through `typia.json.createStringify<T>()` function.
-
-Just look at the code below, then you may understand how to use it.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/json/createAssertStringify.ts"
       filename="examples/src/json/createAssertStringify.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/json/createAssertStringify.js"
       filename="examples/bin/json/createAssertStringify.js"
       showLineNumbers />
@@ -129,31 +122,26 @@ Just look at the code below, then you may understand how to use it.
 
 ## Performance
 
-Comparing JSON serialization speed with others, it is maximum 200x faster than `class-transformer`.
-
-For reference, `class-transformer` is the most famous library used in `NestJS` with `class-validator`. Also, `fast-json-stringify` is another famous one used in `fastify`. However, whether they are fast or slow, both of them require extra schema definition, that is different with TypeScript type. If you see the code below without experience of them, you may get shocked: how complicate and inefficient they are:
-
- - `fast-json-stringify` requires [JSON schema definition](https://github.com/samchon/typia/blob/master/test/schemas/json/swagger/ObjectHierarchical.json).
- - `class-validator` requires [DTO class with decorator function calls](https://github.com/samchon/typia/blob/master/benchmark/structures/class-validator/ClassValidatorObjectHierarchical.ts).
+Up to **~200× faster than `class-transformer`**, ~10× faster than native `JSON.stringify`:
 
 ![Stringify Function Benchmark](https://github.com/samchon/typia/raw/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics/images/stringify.svg)
 
 > Measured on [AMD Ryzen 9 7940HS, Rog Flow x13](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics#stringify)
 
-## Server Performance
+## Why this matters on a server
 
-Someone may ask:
+A common reaction: "isn't JSON serialization a tiny fraction of request time?"
 
-> JSON serialization speed affects on the server performance? 
->
-> I think that the JSON serialization is just a tiny thing in the server side, isn't it?
+It's not. Node.js handles most I/O asynchronously, but `JSON.stringify` is synchronous and runs on the main thread. While it's running, no other request is being routed, no socket is being read, nothing else happens. On a busy server, that synchronous time is the cost you actually pay.
 
-My answer is, "Yes, it affects on the server performance".
-
-Most operations in NodeJS server are asynchronously executed in background thread, what are called "event based non-blocking I/O model". However, JSON serialization is a synchronous operation running on the main thread. Therefore, if the JSON serialization speed is slow, it makes the entire server program slow.
-
-I'll show you the benchmark result that, how JSON serizliation speed affects on the server performance.
+`typia.json.stringify` cuts that time substantially. The end-to-end request benchmark below shows the difference at server scope (not just the serializer in isolation):
 
 ![Server Benchmark](https://raw.githubusercontent.com/samchon/typia/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics/images/server-stringify.svg)
 
 > Measured on [AMD Ryzen 9 7940HS, Rog Flow x13](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics#server-stringify)
+
+## Where to go next
+
+- Reading JSON safely → [`json.*Parse`](/docs/json/parse)
+- Emitting JSON Schema or OpenAPI from `T` → [`json.schemas`](/docs/json/schema)
+- Underlying validators — [`is`](/docs/validators/is), [`assert`](/docs/validators/assert), [`validate`](/docs/validators/validate)

--- a/website/src/content/docs/llm/application.mdx
+++ b/website/src/content/docs/llm/application.mdx
@@ -5,119 +5,115 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `application()` function
+# `typia.llm.application` — turn a TypeScript class into LLM tools
 
-<Tabs items={[
-    <code>typia</code>,
-    <code>ILlmApplication</code>,
-    <code>ILlmFunction</code>,
-    <code>ILlmSchema</code>,
-  ]}>
+> [!TIP]
+>
+> This is the **class-based** LLM tool API — for when the LLM picks one of several methods and fills its arguments. If you just want **one specific JSON shape** out of the LLM (no method selection), use [`structuredOutput`](/docs/llm/structuredOutput). If you want LLM tools generated from an **existing REST API**, use [`HttpLlm`](/docs/llm/http).
+
+Modern LLMs (OpenAI, Anthropic, Gemini, …) can decide on their own when to call a function and how to fill its arguments — provided you describe the function's signature in JSON Schema. That description is what "[function calling](https://platform.openai.com/docs/guides/function-calling)" needs.
+
+`typia.llm.application<Class>()` generates that description automatically. You write a normal TypeScript class with normal TypeScript types and JSDoc comments. typia turns each method into a tool, with parameters typed as JSON Schema and validation, parsing, and type coercion already wired up.
+
+```typescript copy filename="hello-application.ts"
+import typia from "typia";
+
+class BbsArticleService {
+  /** Create a new article. */
+  create(props: { input: { title: string; body: string } }): Promise<{ id: string }> { /* … */ }
+
+  /** List recent articles. */
+  recent(props: { limit: number }): Promise<{ items: Array<{ id: string; title: string }> }> { /* … */ }
+}
+
+const app = typia.llm.application<BbsArticleService>();
+//  app.functions[0] = { name: "create", parameters: {...JSON Schema...}, parse, coerce, validate, … }
+//  app.functions[1] = { name: "recent", ... }
+```
+
+Hand `app.functions` (or one of the framework adapters below) to your LLM SDK and the model can now invoke `create` and `recent` with arguments it composes from natural language.
+
+<Tabs items={[<code>typia</code>, <code>ILlmApplication</code>, <code>ILlmFunction</code>, <code>ILlmSchema</code>]}>
   <Tabs.Tab>
-```typescript filename="typia" showLineNumbers {2-9}
+```typescript filename="typia" showLineNumbers
 export namespace llm {
-  // LLM FUNCTION CALLING APPLICATION SCHEMA
   export function application<
     App extends Record<string, any>,
     Config extends Partial<ILlmSchema.IConfig> = {},
   >(
     config?: Partial<Pick<ILlmApplication.IConfig, "validate">>,
   ): ILlmApplication;
-
-  // STRUCTURED OUTPUT
-  export function parameters<
-    Parameters extends Record<string, any>,
-    Config extends Partial<ILlmSchema.IConfig> = {},
-  >(): ILlmSchema.IParameters;
-
-  // TYPE SCHEMA
-  export function schema<
-    T,
-    Config extends Partial<ILlmSchema.IConfig> = {},
-  >(
-    $defs: Record<string, ILlmSchema>,
-  ): ILlmSchema;
 }
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/schema/ILlmApplication.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/schema/ILlmFunction.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/schema/ILlmSchema.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-LLM function calling application schema from a native TypeScript class or interface type.
-
-`typia.llm.application<App>()` is a function composing LLM (Large Language Model) calling application schema from a native TypeScript class or interface type. The function returns an `ILlmApplication` instance, which is a data structure representing a collection of LLM function calling schemas — each with built-in `parse()`, `coerce()`, and `validate()` methods.
-
-If you put LLM function schema instances registered in the `ILlmApplication.functions` to the LLM provider like `OpenAI ChatGPT`, the LLM will select a proper function to call with parameter values of the target function in the conversations with the user. This is the "LLM Function Calling".
-
-Let's make A.I. Chatbot super-easily with `typia.llm.application<App>()` function.
-
 <Callout type="info">
-**LLM Function Calling** and **Structured Output**
+**Quick glossary — function calling vs. structured output**
 
-LLM selects proper function and fill arguments.
+- **Function calling**: the LLM picks one of several functions and fills its arguments. You execute the function and feed the result back. ([OpenAI docs](https://platform.openai.com/docs/guides/function-calling))
+- **Structured output**: the LLM doesn't pick anything — it just emits one specific JSON shape you asked for. ([OpenAI docs](https://platform.openai.com/docs/guides/structured-outputs))
 
-In nowadays, most LLM (Large Language Model) like OpenAI are supporting "function calling" feature. The "LLM function calling" means that LLM automatically selects a proper function and fills parameter values from conversation with the user (may by chatting text).
-
-Structured output is another feature of LLM. The "structured output" means that LLM automatically transforms the output conversation into a structured data format like JSON.
-
-- https://platform.openai.com/docs/guides/function-calling
-- https://platform.openai.com/docs/guides/structured-outputs
+`typia.llm.application` is for function calling. For structured output, use [`typia.llm.structuredOutput<T>()`](/docs/llm/structuredOutput).
 </Callout>
 
+## Full example
+
 <Tabs items={[
-    "TypeScript Source Code",
+    "TypeScript Source",
     "Compiled JavaScript",
     <code>BbsArticleService</code>,
     <code>IBbsArticle</code>,
   ]}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/application.ts"
       filename="example/src/llm/application.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/llm/application.js"
       filename="example/bin/llm/application.js"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/BbsArticleService.ts"
       filename="examples/src/llm/BbsArticleService.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/IBbsArticle.ts"
       filename="examples/src/llm/IBbsArticle.ts"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-> [💻 Playground Link](/playground/?script=JYWwDg9gTgLgBAbzgSQDIBsQEExncAYwEMZgIA7OAXzgDMoIQ4AiAAQGciQCALCgeghgApuSJhgzANwAoUJFhwYATwlE6DJsxVrpMuHPDR4SAEIAjdlliF0wgMrCoAN0LDqGxiwB0-C1ZsCO0cXNz0DAgp2eHEwAC4UDGxcfGJSCjgAXiVVYCJvdExvWNSSMnIAHn9rUiCHJ1cCYQA+AAoASllI8nYIOwKIAHNW2M6gA)
+> [💻 Open in Playground](/playground/?script=JYWwDg9gTgLgBAbzgSQDIBsQEExncAYwEMZgIA7OAXzgDMoIQ4AiAAQGciQCALCgeghgApuSJhgzANwAoUJFhwYATwlE6DJsxVrpMuHPDR4SAEIAjdlliF0wgMrCoAN0LDqGxiwB0-C1ZsCO0cXNz0DAgp2eHEwAC4UDGxcfGJSCjgAXiVVYCJvdExvWNSSMnIAHn9rUiCHJ1cCYQA+AAoASllI8nYIOwKIAHNW2M6gA)
 
-## Integrations
+## Plug it into your LLM SDK
 
-`typia.llm.controller<Class>()` wraps a TypeScript class into an `ILlmController` that can be plugged into any supported framework. Every class method becomes a tool — JSDoc comments become descriptions, TypeScript types become JSON schemas, and validation feedback is embedded automatically.
+`typia.llm.controller<Class>(name, instance)` wraps the schema together with an executable instance. You pass the controller to an adapter and the adapter does the wiring:
 
 <Tabs items={["Vercel AI SDK", "LangChain", "Model Context Protocol"]}>
   <Tabs.Tab>
@@ -131,10 +127,7 @@ import { BbsArticleService } from "./BbsArticleService";
 
 const tools: Record<string, Tool> = toVercelTools({
   controllers: [
-    typia.llm.controller<BbsArticleService>(
-      "bbs",
-      new BbsArticleService(),
-    ),
+    typia.llm.controller<BbsArticleService>("bbs", new BbsArticleService()),
   ],
 });
 
@@ -159,10 +152,7 @@ import { BbsArticleService } from "./BbsArticleService";
 
 const tools: DynamicStructuredTool[] = toLangChainTools({
   controllers: [
-    typia.llm.controller<BbsArticleService>(
-      "bbs",
-      new BbsArticleService(),
-    ),
+    typia.llm.controller<BbsArticleService>("bbs", new BbsArticleService()),
   ],
 });
 
@@ -197,31 +187,58 @@ const server: McpServer = new McpServer({
 registerMcpControllers({
   server,
   controllers: [
-    typia.llm.controller<BbsArticleService>(
-      "bbs",
-      new BbsArticleService(),
-    ),
+    typia.llm.controller<BbsArticleService>("bbs", new BbsArticleService()),
   ],
 });
 ```
   </Tabs.Tab>
 </Tabs>
 
-## The Function Calling Harness
+Same controller, three different transports. Pick whichever your project already uses.
 
-The **function calling harness** is typia's three-layer pipeline that turns unreliable LLM output into 100% correct structured data:
+## The function calling harness
 
-1. **Lenient JSON Parsing** — recovers broken JSON (unclosed brackets, trailing commas, markdown wrapping, etc.)
-2. **Type Coercion** — fixes wrong types (`"42"` → `42`, double-stringified objects → objects, etc.)
-3. **Validation Feedback** — pinpoints remaining value errors with inline `// ❌` annotations so the LLM can self-correct and retry
+LLM output is unreliable. Even capable models routinely:
 
-Each layer catches what the previous one didn't. Together they form a deterministic correction loop around the probabilistic LLM.
+- close a JSON object with the wrong bracket
+- wrap their answer in a ```` ```json ```` markdown block
+- return `"42"` when the schema expects a `number`
+- emit a double-stringified object: `"\"{\\\"x\\\":1}\""` instead of `{ x: 1 }`
 
-### Lenient JSON Parsing & Type Coercion
+The `ILlmFunction` typia generates carries **three methods**:
+
+1. **`parse(text)`** — lenient JSON parsing **with** type coercion based on the schema
+2. **`coerce(obj)`** — type coercion only (use when the SDK already JSON-parsed for you)
+3. **`validate(obj)`** — full schema validation; returns `IValidation<unknown>`
+
+Plus a fourth helper that lives on `@typia/utils` because it doesn't depend on a specific function's schema:
+
+4. **`LlmJson.stringify(failure)`** — format the validator's errors as annotated JSON the LLM can read
+
+Together they form a deterministic correction loop around the probabilistic LLM:
+
+```
+LLM text  ─→  parse()   ─→  coerced object
+                              │
+                              ▼
+                            validate()
+                              │
+                  ┌───────────┴────────────┐
+                  ▼                        ▼
+                success                 failure
+                  │                        │
+                  ▼                        ▼
+              execute            stringify errors back
+                                  to the LLM, retry
+```
+
+See [LLM JSON utilities](/docs/llm/json) for the full mechanics — lenient features supported, coercion rules, and the feedback-loop pattern. The same machinery powers `structuredOutput`, `parameters`, and the HTTP-based [`HttpLlm.controller`](/docs/llm/http).
+
+### Parse and coerce in practice
 
 <Tabs items={[
-    "Parsing Example",
-    "Coercing Example",
+    "Parsing (text → object)",
+    "Coercing (object → object)",
     <code>ILlmFunction</code>,
   ]}>
   <Tabs.Tab>
@@ -247,43 +264,29 @@ Each layer catches what the previous one didn't. Together they form a determinis
   </Tabs.Tab>
 </Tabs>
 
-Each `ILlmFunction` includes a `parse()` method for handling LLM JSON outputs. This parser is specifically designed for the messy reality of LLM responses:
+<Callout type="info">
+**Which one do you call — `parse` or `coerce`?**
 
-**Lenient JSON Features:**
-- Unclosed brackets `{`, `[` and strings
-- Trailing commas `[1, 2, 3, ]`
-- JavaScript-style comments (`//` and `/* */`)
-- Unquoted object keys (JavaScript identifier style)
-- Incomplete keywords (`tru`, `fal`, `nul`)
-- Markdown code block extraction (` ```json ... ``` `)
-- Junk text prefix skipping (explanatory text LLMs often add)
+- LLM gives you a raw string (OpenAI `chat.completions` content, etc.) → call `parse(text)`.
+- SDK already JSON-parsed for you (Anthropic, Vercel AI, LangChain, MCP) → call `coerce(obj)`.
 
-**Type Coercion:**
-
-LLMs frequently return wrong types — numbers as strings, booleans as strings, or even double-stringified JSON objects. `ILlmFunction.parse()` automatically coerces these based on the function's parameter schema.
+`parse` is just `coerce` with lenient JSON parsing in front. Run only one.
+</Callout>
 
 <Callout type="warning">
-**0% → 100% Success Rate on Union Types**
+**Double-stringified objects are common — and the coercion layer rescues them**
 
-`Qwen3.5` model shows 0% success rate when handling union types with double-stringified JSON objects. With `ILlmFunction.parse()` type coercion, the success rate jumps to 100%.
+Many LLMs emit a JSON-stringified value where the schema expects an object — `"{\"x\":1}"` instead of `{ x: 1 }`. Without coercion, validation rejects every one of those responses. With `parse`/`coerce` the schema-aware coercion descends through the string-wrapped layers and produces typed data. The AutoBe production data below shows the same kind of effect on much harder structures.
 </Callout>
 
-<Callout type="info">
-**For Pre-parsed Objects, Use `ILlmFunction.coerce()`**
+### Validation feedback
 
-Some LLM SDKs (Anthropic, Vercel AI, LangChain, MCP) parse JSON internally and return JavaScript objects directly. In these cases, use `ILlmFunction.coerce()` instead of `ILlmFunction.parse()` to fix types without re-parsing.
-
-For more details, see [JSON Utilities](./json).
-</Callout>
-
-### Validation Feedback
+After `parse`/`coerce`, run `validate` to verify constraints (formats, ranges, lengths). On failure, format the errors with `LlmJson.stringify` from `@typia/utils` — the output is annotated JSON the LLM can read and self-correct:
 
 <LocalSource
   path="examples/src/llm/application-validate.ts"
   filename="examples/src/llm/application-validate.ts"
   showLineNumbers />
-
-`typia.llm.application<App>()` embeds [`typia.validate<T>()`](/docs/validators/validate) in every function for automatic argument validation. When validation fails, use `LlmJson.stringify()` from `@typia/utils` to format errors with inline `// ❌` comments:
 
 ```json
 {
@@ -306,93 +309,85 @@ For more details, see [JSON Utilities](./json).
 }
 ```
 
-The LLM reads this feedback and self-corrects on the next turn. Together with lenient parsing and type coercion above, this parse → coerce → validate → feedback → retry cycle completes the harness.
+Send that block back as a system message ("you made these mistakes — fix them"). The model reads the inline annotations and corrects on the next turn. The full pattern lives at [LlmJson](/docs/llm/json#putting-it-all-together--the-validation-feedback-loop).
 
 <Callout type="info">
-**In Production**
+**Real-world numbers**
 
-In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator by [Wrtn Technologies](https://wrtn.io)), `qwen3-coder-next` showed only **6.75%** raw function calling success rate on compiler AST types. With the complete harness, it reached **100%** — across all four tested Qwen models.
+In [AutoBe](https://github.com/wrtnlabs/autobe) — an AI backend generator built by Wrtn Technologies — `qwen3-coder-next` produced **6.75%** correct function calls on compiler AST types when used naively. With the typia harness wrapping it, the success rate hit **100%** across all four tested Qwen models.
 
-AutoBe once shipped a build with the system prompt completely missing. Nobody noticed — output quality was identical. The types were the best prompt; the harness was the best orchestration.
-
-Working on compiler AST means working on any type and any use case.
+AutoBe once shipped a build with the system prompt completely empty. Nobody noticed — the types were doing the work the prompt would have done.
 
   - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
   - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
   - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
 </Callout>
 
-```typescript filename="AutoBeTest.IExpression" showLineNumbers
-// Compiler AST may be the hardest type structure possible
-//
-// Unlimited union types + unlimited depth + recursive references
+```typescript filename="AutoBeTest.IExpression — how hard a type the harness solves" showLineNumbers
+// Unlimited unions × unlimited depth × recursive references
 export type IExpression =
   | IBooleanLiteral
   | INumericLiteral
   | IStringLiteral
-  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
-  | IObjectLiteralExpression  // <- recursive (contains IExpression)
+  | IArrayLiteralExpression   // recursive (contains IExpression[])
+  | IObjectLiteralExpression  // recursive
   | INullLiteral
   | IUndefinedKeyword
   | IIdentifier
-  | IPropertyAccessExpression // <- recursive
-  | IElementAccessExpression  // <- recursive
-  | ITypeOfExpression         // <- recursive
-  | IPrefixUnaryExpression    // <- recursive
-  | IPostfixUnaryExpression   // <- recursive
-  | IBinaryExpression         // <- recursive (left & right)
-  | IArrowFunction            // <- recursive (body is IExpression)
-  | ICallExpression           // <- recursive (args are IExpression[])
-  | INewExpression            // <- recursive
-  | IConditionalPredicate     // <- recursive (then & else branches)
+  | IPropertyAccessExpression // recursive
+  | IElementAccessExpression  // recursive
+  | ITypeOfExpression         // recursive
+  | IPrefixUnaryExpression    // recursive
+  | IPostfixUnaryExpression   // recursive
+  | IBinaryExpression         // recursive (left & right)
+  | IArrowFunction            // recursive (body is IExpression)
+  | ICallExpression           // recursive (args)
+  | INewExpression            // recursive
+  | IConditionalPredicate     // recursive (then & else)
   | ... // 30+ expression types total
 ```
 
+## Strict mode — reject extra properties
+
+By default the auto-generated `ILlmFunction.validate` is lenient: arguments with extra (unexpected) properties pass validation. To reject them, set the `equals: true` config:
+
+```typescript copy
+const app = typia.llm.application<BbsArticleService, { equals: true }>();
+```
+
+`{ equals: true }` does two things:
+
+- Switches the embedded validator to `validateEquals` semantics — any property not declared on the parameter type becomes a validation error
+- Sets `additionalProperties: false` on the parameter schemas, so the LLM is told upfront which fields are allowed
+
+Same switch works on [`structuredOutput`](/docs/llm/structuredOutput#strict-mode--reject-extra-properties) and `controller`. Leave it `false` for chat-style agents (more tolerant of model variability), turn it on for production tools where extra fields would be a real bug.
+
 ## Restrictions
 
-`typia.llm.application<App>()` follows the same restrictions of below.
+The compile-time transform enforces the LLM function-calling contract on every method:
 
-About the function parameters type, it follows the restriction of both [`typia.llm.parameters<Params>()`](../parameters) and [`typia.llm.schema<T>()`](../schema) functions. Therefore, the parameters must be a keyworded object type with static keys without any dynamic keys. Also, the object type must not be nullable or optional.
+- **Each method takes exactly one keyworded-object parameter.** LLMs invoke functions with named arguments, so `add(x: number, y: number)` is rejected. Wrap the args: `add(props: { x: number; y: number })`.
+- **Each method returns a keyworded-object type** (e.g. `{ value: number }`, `{ items: T[] }`) **or `void`.** Primitives, arrays, and `T | undefined` are rejected. If you need to return one, wrap it.
+- **Object parameter and return types may not have dynamic keys.** `Record<string, number>` won't work — use `Array<{ key: string; value: number }>`.
 
-About the return value type, it also follows the restriction of [`typia.llm.parameters<Params>()`](../parameters) function. Therefore, the return type must be a keyworded object type with static keys, or `void`. Primitive types (like `number`, `string`, `boolean`), array types, and union types with `undefined` are not allowed as return types. If you need to return a primitive or array value, wrap it in an object type (e.g., `{ value: number }` or `{ items: T[] }`).
-
-  - [`typia.llm.parameters<Params>()`](../parameters)
-  - [`typia.llm.schema<T>()`](../schema)
-
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+<Tabs items={["Source That Won't Compile", "Compiler Errors"]}>
   <Tabs.Tab>
 ```typescript filename="example/src/llm/application.violation.ts" showLineNumbers
 import typia, { ILlmApplication, tags } from "typia";
 
 const app: ILlmApplication = typia.llm.application<BbsArticleController>();
 
-console.log(app);
-
 interface BbsArticleController {
-  /**
-   * Create a new article.
-   *
-   * Writes a new article and archives it into the DB.
-   *
-   * @param props Properties of create function
-   * @returns Newly created article
-   */
-  create(props: {
-    /**
-     * Information of the article to create
-     */
-    input: IBbsArticle.ICreate;
-  }): Promise<IBbsArticle | undefined>;
+  /** Create a new article and return it. */
+  create(props: { input: IBbsArticle.ICreate }): Promise<IBbsArticle | undefined>;
+  //                                            ^ return must not be union with undefined
 
-  /**
-   * Add two numbers.
-   *
-   * @param props Properties of add function
-   * @returns The sum value
-   */
+  /** Add two numbers. */
   add(props: { x: number; y: number }): number;
+  //                                    ^ return must be an object
 
   erase(id: string & tags.Format<"uuid">): Promise<void>;
+  //    ^ parameter must be a keyworded object, not a primitive
 }
 ```
   </Tabs.Tab>
@@ -408,12 +403,17 @@ src/examples/llm.application.violation.ts:4:29 - error TS(typia.llm.application)
 
 - BbsArticleController.erase: unknown
   - LLM application's function ("erase")'s parameter must be an object type.
-
-4 const app: ILlmApplication = typia.llm.application<BbsArticleController>();
-                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-Found 1 error in src/examples/llm.application.violation.ts:4
 ```
   </Tabs.Tab>
 </Tabs>
+
+For deeper type-level rules see [`llm.parameters`](/docs/llm/parameters) and [`llm.schema`](/docs/llm/schema).
+
+## Where to go next
+
+- Tutorial walkthrough → [Tutorial: LLM function calling](/docs/tutorial/llm)
+- Just need a schema for structured output → [`llm.structuredOutput`](/docs/llm/structuredOutput) or [`llm.parameters`](/docs/llm/parameters)
+- The harness mechanics in depth → [`LlmJson` utilities](/docs/llm/json)
+- Same idea from an OpenAPI document → [`HttpLlm`](/docs/llm/http)
+- Building a full chatbot on top → [Agentica](/docs/llm/chat)
+- Description, hiding, and namespacing tips → [Documentation Strategy](/docs/llm/strategy)

--- a/website/src/content/docs/llm/chat.mdx
+++ b/website/src/content/docs/llm/chat.mdx
@@ -6,30 +6,56 @@ import { Callout, Tabs } from "nextra/components";
 import LocalSource from "../../../components/LocalSource";
 import ValidatorSupportMatrixSnippet from "../../../snippets/ValidatorSupportMatrixSnippet.mdx";
 
-## Agentica
+# Building a Chatbot with Agentica
+
+`typia.llm.application<Class>()` gives you the tools an LLM can call. [Agentica](https://github.com/wrtnlabs/agentica) builds the agent loop **around** those tools — the orchestration layer that decides which function to call, when, and how to recover from mistakes.
+
+If `typia.llm.application` is "describe my service to an LLM," Agentica is "actually run a conversation in which an LLM uses that service."
+
+## Quick taste
+
+```typescript filename="src/index.ts" showLineNumbers {23-26, 37}
+import { Agentica } from "@agentica/core";
+import OpenAI from "openai";
+import typia from "typia";
+
+import { BbsArticleService } from "./BbsArticleService";
+
+const agent = new Agentica({
+  service: {
+    api: new OpenAI({ apiKey: "*****" }),
+    model: "openai/gpt-4.1-mini",
+  },
+  controllers: [
+    typia.llm.controller<BbsArticleService>(
+      "bbs",
+      new BbsArticleService(),
+    ),
+  ],
+});
+
+await agent.conversate("Hello, I want to create an article.");
+```
+
+That's a complete chatbot: it understands intent, picks the right method on `BbsArticleService`, fills the arguments from the conversation, and asks follow-up questions when arguments are missing. No prompt engineering, no agent graph definition.
+
 ![agentica-conceptual-diagram](https://github.com/user-attachments/assets/d7ebbd1f-04d3-4b0d-9e2a-234e29dd6c57)
 
-https://github.com/wrtnlabs/agentica
-
-The simplest **Agentic AI** framework, specialized in **LLM Function Calling**.
-
-With `@agentica`, you can build Agentic AI chatbot only with TypeScript class types. Complex agent workflows and graphs required in conventional AI agent develoopment are not necessary in `@agentica`. Only with TypeScript class types, `@agentica` will do everything with the function calling.
-
-Look at below demonstration, and and feel how `@agentica` is powerful. Now, you can let users to read and write articles only with conversation texts. The TypeScript class functions would be adequately called in the AI chatbot with LLM function calling.
-
 <Callout type="info">
-`@nestia/agent` had been migrated to `@agentica/*` for enhancements and separation to multiple packages extending the functionalities.
+`@nestia/agent` was renamed to `@agentica/*` to make room for additional packages built on the same idea.
 </Callout>
 
-<Tabs 
-  items={[
+## Full example
+
+<Tabs items={[
     <code>src/main.ts</code>,
-    <code>BbsArticleService.ts</code>, 
-    <code>IBbsArticle.ts</code>, 
+    <code>BbsArticleService.ts</code>,
+    <code>IBbsArticle.ts</code>,
   ]}>
   <Tabs.Tab>
-```typescript filename="src/index.tsx" showLineNumbers {23-26, 37}
+```typescript filename="src/index.ts" showLineNumbers {23-26, 37}
 import { Agentica } from "@agentica/core";
+import OpenAI from "openai";
 import typia from "typia";
 
 import { BbsArticleService } from "./BbsArticleService";
@@ -50,13 +76,13 @@ await agent.conversate("Hello, I want to create an article.");
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/BbsArticleService.ts"
       filename="examples/src/llm/BbsArticleService.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/IBbsArticle.ts"
       filename="examples/src/llm/IBbsArticle.ts"
       showLineNumbers />
@@ -64,24 +90,20 @@ await agent.conversate("Hello, I want to create an article.");
 </Tabs>
 
 <br/>
-<iframe 
-  src="https://www.youtube.com/embed/pdsplQyok8k?si=geL7DH5CWcC8qlz_" 
-  title="BBS A.I. Chatbot built with Typia" 
-  width="100%" 
-  height="600" 
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" 
-  allowFullScreen 
+<iframe
+  src="https://www.youtube.com/embed/pdsplQyok8k?si=geL7DH5CWcC8qlz_"
+  title="BBS A.I. Chatbot built with Typia"
+  width="100%"
+  height="600"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
 />
 
-  - BBS A.I. Chatbot Application: https://nestia.io/chat/bbs
+- Live demo: [nestia.io/chat/bbs](https://nestia.io/chat/bbs)
 
-## Swagger Chatbot
+## Chatting with an entire REST API
 
-You also can make the super A.I. chatbot by Swagger document too.
-
-With `@agentica`, you can build Agentic AI chatbot only with Swagger document built by [`@nestia/sdk`](https://nestia.io/docs/swagger). Complex agent workflows and graphs required in conventional AI agent development are not necessary in `@agentica`. Only with the Swagger document, `@agentica` will do everything with the function calling.
-
-Look at below demonstration, and feel how `@agentica` is powerful. Now, you can let users to search and purchase products only with conversation texts. The backend API functions would be adequately called in the AI chatbot with LLM function calling.
+You don't have to start from TypeScript code. Agentica accepts an OpenAPI document directly — every endpoint becomes a tool the LLM can call.
 
 ```typescript filename="src/main.ts" showLineNumbers
 import { Agentica, assertHttpController } from "@agentica/core";
@@ -96,17 +118,15 @@ const agent = new Agentica({
     model: "openai/gpt-4.1-mini",
   },
   controllers: [
-    // functions from TypeScript class
-    typia.llm.controller<MobileFileSystem>(
-      "filesystem",
-      MobileFileSystem(),
-    ),
-    // functions from Swagger/OpenAPI
+    // Class-based functions
+    typia.llm.controller<MobileFileSystem>("filesystem", MobileFileSystem()),
+
+    // Swagger / OpenAPI document → functions
     assertHttpController({
       name: "shopping",
       document: await fetch(
         "https://shopping-be.wrtn.ai/editor/swagger.json",
-      ).then(r => r.json()),
+      ).then((r) => r.json()),
       connection: {
         host: "https://shopping-be.wrtn.ai",
         headers: { Authorization: "Bearer ********" },
@@ -114,24 +134,23 @@ const agent = new Agentica({
     }),
   ],
 });
+
 await agent.conversate("I wanna buy MacBook Pro");
 ```
 
 <br/>
-<iframe src="https://www.youtube.com/embed/m47p4iJ90Ms?si=cvgfckN25GJhjLTB" 
-        title="Shopping A.I. Chatbot built with Nestia" 
-        width="100%" 
-        height="600" 
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" 
+<iframe src="https://www.youtube.com/embed/m47p4iJ90Ms?si=cvgfckN25GJhjLTB"
+        title="Shopping A.I. Chatbot built with Nestia"
+        width="100%"
+        height="600"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin"
         allowFullScreen></iframe>
 
-- Shopping A.I. Chatbot Application: [https://nestia.io/chat/shopping](/chat/shopping)
-- Shopping Backend Repository: https://github.com/samchon/shopping-backend
-- Shopping Swagger Document (`@nestia/editor`): [https://nestia.io/editor/?url=...](https://nestia.io/editor/?simulate=true&e2e=true&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsamchon%2Fshopping-backend%2Frefs%2Fheads%2Fmaster%2Fpackages%2Fapi%2Fswagger.json)
+- Live demo: [nestia.io/chat/shopping](/chat/shopping)
+- Backend source: [github.com/samchon/shopping-backend](https://github.com/samchon/shopping-backend)
+- Swagger UI: [open in @nestia/editor](https://nestia.io/editor/?simulate=true&e2e=true&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsamchon%2Fshopping-backend%2Frefs%2Fheads%2Fmaster%2Fpackages%2Fapi%2Fswagger.json)
 
-## Principles
-
-### Agent Strategy
+## How the loop works
 
 ```mermaid
 sequenceDiagram
@@ -181,13 +200,19 @@ loop Candidate functions exist
 end
 ```
 
-When user says, `@agentica/core` delivers the conversation text to the `selector` agent, and let the `selector` agent to find (or cancel) candidate functions from the context. If the `selector` agent could not find any candidate function to call and there is not any candidate function previously selected either, the `selector` agent will work just like a plain ChatGPT.
+Three sub-agents share the work:
 
-And `@agentica/core` enters to a loop statement until the candidate functions to be empty. In the loop statement, `caller` agent tries to LLM function calling by analyzing the user's conversation text. If context is enough to compose arguments of candidate functions, the `caller` agent actually calls the target functions, and let `decriber` agent to explain the function calling results. Otherwise the context is not enough to compose arguments, `caller` agent requests more information to user.
+- **Selector** — reads the latest user message, decides which of the registered functions are candidates this turn. If none apply, it falls back to plain conversational replies.
+- **Caller** — given the candidate functions, tries to call them. If the conversation hasn't given it enough information for the parameters, it asks the user a follow-up.
+- **Describer** — once the caller has produced results, turns them into a human-readable reply.
 
-Such LLM (Large Language Model) function calling strategy separating `selector`, `caller`, and `describer` is the key logic of `@agentica/core`.
+That separation is what keeps Agentica simple: each sub-agent does one thing and you don't have to draw a state graph to keep it on track.
 
-### Validation Feedback
+## Why validation feedback is load-bearing
+
+LLM function calling is not perfect. Models make type mistakes — for example, they fill an `Array<string>` field with just a `string`. The fix is to give the model the **structured error** and ask it to retry.
+
+Agentica relies on the same harness as [`typia.llm.application`](/docs/llm/application#the-function-calling-harness):
 
 ```typescript
 import { FunctionCall } from "pseudo";
@@ -198,68 +223,43 @@ export const correctFunctionCall = (p: {
   functions: Array<ILlmFunction<"chatgpt">>;
   retry: (reason: string, errors?: IValidation.IError[]) => Promise<unknown>;
 }): Promise<unknown> => {
-  // FIND FUNCTION
-  const func: ILlmFunction<"chatgpt"> | undefined =
-    p.functions.find((f) => f.name === p.call.name);
+  const func = p.functions.find((f) => f.name === p.call.name);
   if (func === undefined) {
-    // never happened in my experience
-    return p.retry(
-      "Unable to find the matched function name. Try it again.",
-    );
+    return p.retry("Unable to find the matched function name. Try it again.");
   }
 
-  // VALIDATE
   const result: IValidation<unknown> = func.validate(p.call.arguments);
-  if (result.success === false) {
-    // 1st trial: 50% (gpt-4o-mini in shopping mall chatbot)
-    // 2nd trial with validation feedback: 99%
-    // 3nd trial with validation feedback again: never have failed
+  if (!result.success) {
+    // 1st trial: ~50% pass (gpt-4o-mini on shopping mall demo)
+    // 2nd trial with validation feedback: ~99%
+    // 3rd trial with validation feedback again: never failed in my testing
     return p.retry(
-      "Type errors are detected. Correct it through validation errors",
-      {
-        errors: result.errors,
-      },
+      "Type errors are detected. Correct it through validation errors.",
+      { errors: result.errors },
     );
   }
   return result.data;
-}
+};
 ```
 
-Is LLM function calling perfect?
+The numbers in the comments come from running the shopping chatbot demo above. The pattern works for the same reason it works in [`application`](/docs/llm/application#validation-feedback) and at [AutoBe](https://github.com/wrtnlabs/autobe) — typia's validator gives the LLM enough detail (path, expected type, actual value) to fix its own mistakes.
 
-The answer is no, and LLM (Large Language Model) vendors like OpenAI take a lot of type level mistakes when composing the arguments of the target function to call. Even though an LLM function calling schema has defined an `Array<string>` type, LLM often fills it just by a `string` typed value. This is where the **function calling harness** comes in — a deterministic correction loop of schema generation, lenient parsing, type coercion, and validation feedback that turns unreliable LLM output into 100% correct structured data.
-
-Therefore, when developing an LLM function calling agent, the validation feedback process is essentially required. If LLM takes a type level mistake on arguments composition, the agent must feedback the most detailed validation errors, and let the LLM to retry the function calling referencing the validation errors.
-
-About the validation feedback, `@agentica/core` is utilizing [`typia.validate<T>()`](https://typia.io/docs/validators/validate) and [`typia.llm.application<Class>()`](https://typia.io/docs/llm/application/#application) functions. They construct validation logic by analyzing TypeScript source codes and types in the compilation level, so that detailed and accurate than any other validators like below.
-
-Such validation feedback strategy and combination with `typia` runtime validator, `@agentica/core` has achieved the most ideal LLM function calling through the **function calling harness** pattern. In my experience, when using OpenAI's `gpt-4o-mini` model, it tends to construct invalid function calling arguments at the first trial about 50% of the time. By the way, if you correct it through validation feedback with `typia`, success rate soars to 99%. And I've never had a failure when trying validation feedback twice.
-
-For reference, the embedded [`typia.validate<T>()`](/docs/validators/validate) function creates validation logic by analyzing TypeScript source codes and types in the compilation level. Therefore, it is accurate and detailed than any other validator libraries. This is exactly what is needed for function calling, and I can confidentelly say that `typia` is the best library for LLM function calling.
+Some LLM providers don't even honor all the JSON Schema constraint keywords (`format`, `pattern`, …). The validation feedback channel works around that too: the model doesn't have to understand "format: uuid" — it just sees `expected: "string & Format<\"uuid\">"` in the error and tries again.
 
 <ValidatorSupportMatrixSnippet />
 
-Additionally, this validation feedback strategy is useful for some LLM providers do not supporting restriction properties of JSON schema. For example, some LLM providers do not support `format` property of JSON schema, so that cannot understand the `UUID` like type. Even though `typia.llm.application<App>()` function is writing the restriction information to the `description` property of JSON schema, but LLM provider does not reflect it perfectly.
-
-In that case, if you give validation feedback from `ILlmFunction.validate()` function to the LLM agent, the LLM agent will be able to understand the restriction information exactly and fill the arguments properly.
-
-  - Restriction properties of JSON schema
-    - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
-    - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
-    - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
-
-### OpenAPI Specification
+## OpenAPI conversion under the hood
 
 ```mermaid
 flowchart
-  subgraph "OpenAPI Specification"
+  subgraph "OpenAPI specifications"
     v20("Swagger v2.0") --upgrades--> emended[["OpenAPI v3.1 (emended)"]]
     v30("OpenAPI v3.0") --upgrades--> emended
     v31("OpenAPI v3.1") --emends--> emended
   end
-  subgraph "OpenAPI Generator"
+  subgraph "OpenAPI generator"
     emended --normalizes--> migration[["Migration Schema"]]
-    migration --"Artificial Intelligence"--> lfc{{"LLM Function Calling"}}
+    migration --"AI"--> lfc{{"LLM Function Calling"}}
     lfc --"OpenAI"--> chatgpt("ChatGPT")
     lfc --"Anthropic"--> claude("Claude")
     lfc --"Google"--> gemini("Gemini")
@@ -267,16 +267,14 @@ flowchart
   end
 ```
 
-`@agentica/core` obtains LLM function calling schemas from both Swagger/OpenAPI documents and TypeScript class types. The TypeScript class type can be converted to LLM function calling schema by [`typia.llm.application<Class>()`](https://typia.io/docs/llm/application#application) function. Then how about OpenAPI document? How Swagger document can be LLM function calling schema.
+Agentica accepts Swagger 2.0 / OpenAPI 3.0 / 3.1. The conversion goes through an intermediate "emended" 3.1 representation that strips out the ambiguity and duplication of the public OpenAPI specs, then to a migration schema, and finally to whichever LLM provider's function-calling format you target.
 
-The secret is in the above diagram. 
+Why the intermediate step? Without it, you'd need *n*×*m* converters (every OpenAPI version × every LLM provider). With it, you need *n*+*m*.
 
-In the OpenAPI specification, there are three versions with different definitions. And even in the same version, there are too much ambiguous and duplicated expressions. To resolve these problems, [`@samchon/openapi`](https://github.com/samchon/openapi) is transforming every OpenAPI documents to v3.1 emended specification. The `@samchon/openapi`'s emended v3.1 specification has removed every ambiguous and duplicated expressions for clarity.
+## Where to go next
 
-With the v3.1 emended OpenAPI document, `@samchon/openapi` converts it to a migration schema that is near to the function structure. And as the last step, the migration schema will be transformed to a specific LLM vendor's function calling schema. LLM function calling schemas are composed like this way.
-
-> **Why do not directly convert, but intermediate?**
->
-> If directly convert from each version of OpenAPI specification to specific LLM's function calling schema, I have to make much more converters increased by cartesian product. In current models, number of converters would be 12 = 3 x 4.
->
-> However, if define intermediate schema, number of converters are shrunk to plus operation. In current models, I just need to develop only (7 = 3 + 4) converters, and this is the reason why I've defined intermediate specification. This way is economic.
+- The class-based tool API → [`typia.llm.application`](/docs/llm/application)
+- The OpenAPI-based tool API → [`HttpLlm`](/docs/llm/http)
+- Validation feedback mechanics → [`LlmJson`](/docs/llm/json)
+- Documentation tips for better LLM behavior → [Documentation Strategy](/docs/llm/strategy)
+- Agentica itself → [github.com/wrtnlabs/agentica](https://github.com/wrtnlabs/agentica)

--- a/website/src/content/docs/llm/http.mdx
+++ b/website/src/content/docs/llm/http.mdx
@@ -5,19 +5,62 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## HttpLlm module
+# `HttpLlm` — LLM function calling from an OpenAPI document
 
-<Tabs items={[
-    <code>HttpLlm</code>,
-    <code>IHttpLlmApplication</code>,
-    <code>IHttpLlmFunction</code>,
-    <code>IHttpLlmController</code>,
-    <code>IHttpConnection</code>,
-  ]}>
+[`typia.llm.application<Class>`](/docs/llm/application) turns a TypeScript class into LLM tools at compile time. `HttpLlm` does the same thing — but starting from an OpenAPI (Swagger) document, at **runtime**.
+
+Use it when:
+
+- You have an existing REST API (yours or someone else's) and want an LLM to be able to call it
+- The API is documented with Swagger 2.0 / OpenAPI 3.0 / 3.1 / 3.2
+- You don't necessarily own the TypeScript code for the server
+
+```typescript copy filename="signature"
+namespace HttpLlm {
+  function controller(props: {
+    name: string;
+    document: SwaggerV2.IDocument | OpenApiV3.IDocument
+            | OpenApiV3_1.IDocument | OpenApiV3_2.IDocument;
+    connection: IHttpConnection;
+    config?: Partial<IHttpLlmApplication.IConfig>;
+    execute?: IHttpLlmController["execute"];
+  }): IHttpLlmController;
+}
+```
+
+`HttpLlm` lives in `@typia/utils`. Install it alongside the framework adapter you want to wire it into (MCP, Vercel, LangChain).
+
+## First example
+
+```typescript copy filename="hello-httplm.ts"
+import { HttpLlm } from "@typia/utils";
+import { IHttpLlmController } from "@typia/interface";
+
+const controller: IHttpLlmController = HttpLlm.controller({
+  name: "shopping",
+  document: await fetch(
+    "https://shopping-be.wrtn.ai/editor/swagger.json",
+  ).then((r) => r.json()),
+  connection: {
+    host: "https://shopping-be.wrtn.ai",
+    headers: { Authorization: "Bearer ********" },
+  },
+});
+
+// controller.application.functions: one IHttpLlmFunction per API operation
+// controller.execute(funcName, args): performs the actual HTTP call
+```
+
+Each API operation becomes an `IHttpLlmFunction` carrying:
+
+- JSON Schema for parameters
+- The OpenAPI description as the tool's `description`
+- The same `parse`, `coerce`, `validate` methods you get from [`typia.llm.application`](/docs/llm/application#the-function-calling-harness) — same harness, same LLM auto-correction story
+
+<Tabs items={[<code>HttpLlm</code>, <code>IHttpLlmApplication</code>, <code>IHttpLlmFunction</code>, <code>IHttpLlmController</code>, <code>IHttpConnection</code>]}>
   <Tabs.Tab>
 ```typescript filename="@typia/utils"
 export namespace HttpLlm {
-  // Create IHttpLlmController from OpenAPI document
   export function controller(props: {
     name: string;
     document:
@@ -58,62 +101,39 @@ export namespace HttpLlm {
   </Tabs.Tab>
 </Tabs>
 
-LLM function calling from OpenAPI documents.
+### What each argument does
 
-`HttpLlm` is a utility module from `@typia/utils` that converts OpenAPI (Swagger) documents into LLM function calling schemas. While [`typia.llm.application<Class>()`](./application) generates schemas from TypeScript class types at compile time, `HttpLlm` generates them from OpenAPI documents at runtime — making any REST API instantly callable by LLMs. Every generated tool includes lenient parsing, type coercion, and validation feedback.
+| Argument | Meaning |
+|----------|---------|
+| `name` | Controller name. Becomes the prefix for tool names (`{name}_{operationId}`) |
+| `document` | The OpenAPI document — Swagger 2.0 / OpenAPI 3.0 / 3.1 / 3.2 are all accepted |
+| `connection.host` | Base URL for HTTP requests |
+| `connection.headers` | Optional headers (auth, etc.) sent with every request |
+| `config` | Optional schema-conversion tuning |
+| `execute` | Optional custom HTTP executor. Defaults to `HttpLlm.execute` |
 
-It supports all OpenAPI versions: Swagger v2.0, OpenAPI v3.0, v3.1, and v3.2.
-
-<Callout type="info">
-**OpenAPI Conversion Pipeline**
+## Inside the conversion pipeline
 
 ```mermaid
 flowchart
-  subgraph "OpenAPI Specification"
+  subgraph "OpenAPI specifications"
     v20("Swagger v2.0") --upgrades--> emended[["OpenAPI v3.2 (emended)"]]
     v30("OpenAPI v3.0") --upgrades--> emended
     v31("OpenAPI v3.1") --emends--> emended
     v32("OpenAPI v3.2") --emends--> emended
   end
-  subgraph "LLM Function Calling"
+  subgraph "LLM function calling"
     emended --normalizes--> migration[["Migration Schema"]]
     migration --converts--> app{{"IHttpLlmApplication"}}
-    app --execute--> fetch(("HTTP Request"))
+    app --execute--> fetch(("HTTP request"))
   end
 ```
 
-`HttpLlm` first upgrades any OpenAPI version to an emended OpenAPI v3.2 format, then converts each operation into an `IHttpLlmFunction` with parameter schemas, descriptions, and HTTP metadata. The resulting `IHttpLlmController` can be passed to [MCP](/docs/utilization/mcp/), [Vercel AI SDK](/docs/utilization/vercel/), or [Agentica](./chat).
-</Callout>
+`HttpLlm` first normalizes every OpenAPI dialect into one internal representation (emended OpenAPI 3.2), then converts each operation into an `IHttpLlmFunction`. The intermediate representation is what makes "any version in, any LLM provider out" possible without combinatorial conversion code.
 
-## `HttpLlm.controller()`
+## Plug it into your LLM SDK
 
-```typescript filename="@typia/utils"
-import { HttpLlm } from "@typia/utils";
-import { IHttpLlmController } from "@typia/interface";
-
-const controller: IHttpLlmController = HttpLlm.controller({
-  name: "shopping",
-  document: await fetch(
-    "https://shopping-be.wrtn.ai/editor/swagger.json",
-  ).then((r) => r.json()),
-  connection: {
-    host: "https://shopping-be.wrtn.ai",
-    headers: { Authorization: "Bearer ********" },
-  },
-});
-```
-
-`HttpLlm.controller()` creates an `IHttpLlmController` from an OpenAPI document. Every API operation is converted to an `IHttpLlmFunction` with schemas, descriptions, and HTTP metadata — bundled together with the connection info so it can be both described to and executed by LLMs.
-
-  - `name`: Controller name used as prefix for tool names
-  - `document`: Swagger/OpenAPI document (v2.0, v3.0, v3.1, or v3.2)
-  - `connection`: HTTP connection info including `host` and optional `headers`
-  - `config`: Optional LLM schema conversion configuration
-  - `execute`: Optional custom executor (defaults to `HttpLlm.execute()`)
-
-## Integrations
-
-`HttpLlm.controller()` wraps an OpenAPI document into an `IHttpLlmController` that can be plugged into any supported framework. Every API operation becomes a tool — OpenAPI descriptions become tool descriptions, request/response schemas become JSON schemas, and validation feedback is embedded automatically.
+The same controller plugs into any supported framework. Pick whichever your app already uses:
 
 <Tabs items={["Vercel AI SDK", "LangChain", "Model Context Protocol"]}>
   <Tabs.Tab>
@@ -215,70 +235,51 @@ registerMcpControllers({
   </Tabs.Tab>
 </Tabs>
 
-## The Function Calling Harness
+## Validation feedback — same harness, same payoff
 
-The **function calling harness** is typia's three-layer pipeline that turns unreliable LLM output into 100% correct structured data:
-
-1. **Lenient JSON Parsing** — recovers broken JSON (unclosed brackets, trailing commas, markdown wrapping, etc.)
-2. **Type Coercion** — fixes wrong types (`"42"` → `42`, double-stringified objects → objects, etc.)
-3. **Validation Feedback** — pinpoints remaining value errors with inline `// ❌` annotations so the LLM can self-correct and retry
-
-Each layer catches what the previous one didn't. Together they form a deterministic correction loop around the probabilistic LLM.
-
-### Validation Feedback
-
-When used through [MCP](/docs/llm/mcp), [Vercel AI SDK](/docs/llm/vercel), or [Agentica](/docs/llm/chat), `HttpLlm.controller()` embeds [`typia.validate<T>()`](/docs/validators/validate) in every tool for automatic argument validation. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
+Every `IHttpLlmFunction` carries the same `parse` / `coerce` / `validate` methods as `ILlmFunction`. When validation fails inside a framework adapter (MCP / Vercel / LangChain), the tool returns annotated error JSON the LLM can read:
 
 ```json
 {
   "name": "John",
-  "age": "twenty", // ❌ [{"path":"$input.age","expected":"number"}]
+  "age": "twenty",      // ❌ [{"path":"$input.age","expected":"number"}]
   "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
-  "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
+  "hobbies": "reading"  // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
 }
 ```
 
-The LLM reads this feedback and self-corrects on the next turn.
+Same pattern as on [`application`](/docs/llm/application#validation-feedback). Same effect — LLMs self-correct on the next turn instead of producing structured nonsense.
 
-In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator by [Wrtn Technologies](https://wrtn.io)), `qwen3-coder-next` showed only **6.75%** raw function calling success rate on compiler AST types. However, with the complete harness, it reached **100%** — across all four tested Qwen models.
+In production at [AutoBe](https://github.com/wrtnlabs/autobe), the harness took `qwen3-coder-next` from **6.75%** raw correctness to **100%** on compiler AST types — across all four tested Qwen models. AST types are the hardest realistic target (unbounded unions × unbounded depth × recursive references), so if the harness handles those, it handles your REST API.
 
-Working on compiler AST means working on any type and any use case.
-
-  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
-  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
-  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
-
-```typescript filename="AutoBeTest.IExpression"
-// Compiler AST may be the hardest type structure possible
-//
-// Unlimited union types + unlimited depth + recursive references
+```typescript filename="AutoBeTest.IExpression — the kind of type the harness handles" showLineNumbers
 export type IExpression =
   | IBooleanLiteral
   | INumericLiteral
   | IStringLiteral
-  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
-  | IObjectLiteralExpression  // <- recursive (contains IExpression)
+  | IArrayLiteralExpression   // recursive
+  | IObjectLiteralExpression  // recursive
   | INullLiteral
   | IUndefinedKeyword
   | IIdentifier
-  | IPropertyAccessExpression // <- recursive
-  | IElementAccessExpression  // <- recursive
-  | ITypeOfExpression         // <- recursive
-  | IPrefixUnaryExpression    // <- recursive
-  | IPostfixUnaryExpression   // <- recursive
-  | IBinaryExpression         // <- recursive (left & right)
-  | IArrowFunction            // <- recursive (body is IExpression)
-  | ICallExpression           // <- recursive (args are IExpression[])
-  | INewExpression            // <- recursive
-  | IConditionalPredicate     // <- recursive (then & else branches)
+  | IPropertyAccessExpression // recursive
+  | IElementAccessExpression  // recursive
+  | ITypeOfExpression         // recursive
+  | IPrefixUnaryExpression    // recursive
+  | IPostfixUnaryExpression   // recursive
+  | IBinaryExpression         // recursive
+  | IArrowFunction            // recursive
+  | ICallExpression           // recursive
+  | INewExpression            // recursive
+  | IConditionalPredicate     // recursive
   | ... // 30+ expression types total
 ```
 
-### Lenient JSON Parsing & Type Coercion
+### Parse and coerce in practice
 
 <Tabs items={[
-    "Parsing Example",
-    "Coercing Example",
+    "Parsing (text → object)",
+    "Coercing (object → object)",
     <code>ILlmFunction</code>,
   ]}>
   <Tabs.Tab>
@@ -304,37 +305,20 @@ export type IExpression =
   </Tabs.Tab>
 </Tabs>
 
-Each `IHttpLlmFunction` inherits `parse()`, `coerce()`, and `validate()` methods from `ILlmFunction`. These are specifically designed for the messy reality of LLM responses:
-
-**Lenient JSON Features:**
-- Unclosed brackets `{`, `[` and strings
-- Trailing commas `[1, 2, 3, ]`
-- JavaScript-style comments (`//` and `/* */`)
-- Unquoted object keys (JavaScript identifier style)
-- Incomplete keywords (`tru`, `fal`, `nul`)
-- Markdown code block extraction (` ```json ... ``` `)
-- Junk text prefix skipping (explanatory text LLMs often add)
-
-**Type Coercion:**
-
-LLMs frequently return wrong types — numbers as strings, booleans as strings, or even double-stringified JSON objects. `IHttpLlmFunction.parse()` automatically coerces these based on the function's parameter schema.
-
-```typescript
-// LLM returns:     { "count": "42", "active": "true", "data": "{\"x\": 1}" }
-// After coercion: { "count": 42,   "active": true,   "data": { x: 1 } }
-```
-
-<Callout type="warning">
-**0% → 100% Success Rate on Union Types**
-
-`Qwen3.5` model shows 0% success rate when handling union types with double-stringified JSON objects. With `IHttpLlmFunction.parse()` type coercion, the success rate jumps to 100%.
-</Callout>
-
 <Callout type="info">
-**For Pre-parsed Objects, Use `IHttpLlmFunction.coerce()`**
+**Same `parse` vs `coerce` rule**
 
-Some LLM SDKs (Anthropic, Vercel AI, LangChain, MCP) parse JSON internally and return JavaScript objects directly. In these cases, use `IHttpLlmFunction.coerce()` instead of `IHttpLlmFunction.parse()` to fix types without re-parsing.
+- LLM-emitted text (raw string) → `parse(text)`
+- Pre-parsed object (from the SDK) → `coerce(obj)`
 
-For more details, see [JSON Utilities](/docs/llm/json).
+Both run the same type-coercion logic; `parse` adds the lenient JSON layer in front.
 </Callout>
 
+For the full mechanics of `parse`, `coerce`, `validate`, and `stringify`, see [`LlmJson`](/docs/llm/json).
+
+## Where to go next
+
+- TypeScript class as the source instead of OpenAPI → [`typia.llm.application`](/docs/llm/application)
+- Framework adapters → [Vercel](/docs/utilization/vercel) · [LangChain](/docs/utilization/langchain) · [MCP](/docs/utilization/mcp)
+- Harness internals → [`LlmJson`](/docs/llm/json)
+- Building a chatbot on top → [Agentica](/docs/llm/chat)

--- a/website/src/content/docs/llm/json.mdx
+++ b/website/src/content/docs/llm/json.mdx
@@ -1,39 +1,60 @@
 ---
-title: Guide Documents > Large Language Model > JSON Utilities
+title: Guide Documents > Large Language Model > LlmJson module
 ---
 import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## JSON Utilities
+# `LlmJson` — the function calling harness primitives
 
-<Tabs items={[
-    <code>LlmJson</code>,
-    <code>IJsonParseResult</code>,
-  ]}>
-  <Tabs.Tab>
-```typescript filename="@typia/utils" showLineNumbers
+LLM output is messy. Even capable models routinely produce:
+
+- JSON wrapped in a markdown fence
+- Unclosed brackets, trailing commas, comments
+- Numbers as strings (`"42"`), booleans as strings (`"true"`)
+- Double-stringified objects (`"\"{\\\"x\\\":1}\""`)
+- Extra prose at the start before the JSON begins
+
+`LlmJson` is a namespace from `@typia/utils` that handles every one of these and produces typed data. It's the engine behind `ILlmFunction.parse`, `ILlmFunction.coerce`, and the `parse`/`coerce` methods on [`structuredOutput`](/docs/llm/structuredOutput) — and you can also call it directly when you're working schema-first.
+
+```typescript copy filename="@typia/utils — what's in LlmJson"
 export namespace LlmJson {
-  // STRINGIFY
-  // Format validation errors for LLM auto-correction
-  export function stringify(failure: IValidation.IFailure): string;
+  // Format a validation failure as annotated JSON for LLM auto-correction
+  function stringify(failure: IValidation.IFailure): string;
 
-  // PARSE
-  // Lenient JSON parser with optional type coercion
-  export function parse<T>(
+  // Lenient JSON parser + type coercion. Returns IJsonParseResult<T>.
+  function parse<T>(
     input: string,
     parameters?: ILlmSchema.IParameters,
   ): IJsonParseResult<T>;
 
-  // COERCE
-  // Type coercion for already-parsed objects
-  export function coerce<T>(
+  // Type coercion only, for objects already parsed by the SDK.
+  function coerce<T>(
     input: unknown,
     parameters: ILlmSchema.IParameters,
   ): T;
 
-  // VALIDATE
-  // Create validator from LLM parameters schema
+  // Build a reusable validator from an LLM parameters schema.
+  function validate(
+    parameters: ILlmSchema.IParameters,
+    equals?: boolean,
+  ): (value: unknown) => IValidation<unknown>;
+}
+```
+
+<Tabs items={[<code>LlmJson</code>, <code>IJsonParseResult</code>]}>
+  <Tabs.Tab>
+```typescript filename="@typia/utils" showLineNumbers
+export namespace LlmJson {
+  export function stringify(failure: IValidation.IFailure): string;
+  export function parse<T>(
+    input: string,
+    parameters?: ILlmSchema.IParameters,
+  ): IJsonParseResult<T>;
+  export function coerce<T>(
+    input: unknown,
+    parameters: ILlmSchema.IParameters,
+  ): T;
   export function validate(
     parameters: ILlmSchema.IParameters,
     equals?: boolean,
@@ -49,40 +70,31 @@ export namespace LlmJson {
   </Tabs.Tab>
 </Tabs>
 
-JSON utilities for LLM function calling.
-
-`LlmJson` is a utility module from `@typia/utils` package, specifically designed for LLM (Large Language Model) function calling scenarios. Together, these utilities form the **function calling harness** — handling every common failure mode of LLM responses:
-
-1. **Validation Feedback**: Format validation errors for LLM auto-correction
-2. **Lenient JSON Parsing**: LLMs often produce incomplete, malformed, or non-standard JSON
-3. **Type Coercion**: LLMs frequently return wrong types (e.g., numbers as strings `"42"`)
-
 <Callout type="info">
-**Available from `ILlmFunction`**
+**Already using `typia.llm.application` or `structuredOutput`?**
 
-When using `typia.llm.application<Class>()`, the generated `ILlmFunction` objects already include `parse()`, `coerce()`, and `validate()` methods bound to their respective parameter schemas. You can use these methods directly without importing `LlmJson`.
+The `ILlmFunction` and `ILlmStructuredOutput` objects expose `parse`, `coerce`, and `validate` *pre-bound* to their parameter schemas. You don't have to import `LlmJson` to use them:
 
 ```typescript
-const app: ILlmApplication<MyClass> = typia.llm.application<MyClass>();
-const func: ILlmFunction = app.functions[0];
+const app = typia.llm.application<MyClass>();
+const func = app.functions[0];
 
-// Use methods directly from ILlmFunction
-const parsed = func.parse(jsonString);      // LlmJson.parse with func.parameters
-const coerced = func.coerce(parsedObject);  // LlmJson.coerce with func.parameters
-const validated = func.validate(args);      // LlmJson.validate with func.parameters
+func.parse(jsonString);       // LlmJson.parse + bound schema
+func.coerce(parsedObject);    // LlmJson.coerce + bound schema
+func.validate(args);          // typia.validate + bound schema
 ```
 
-The only function exclusive to `LlmJson` is `stringify()`, which formats validation errors for LLM feedback.
+The only `LlmJson.*` function that doesn't have a built-in equivalent is `stringify` — that's what you import from `@typia/utils` for the feedback loop.
 </Callout>
 
-## `LlmJson.stringify()`
+## `LlmJson.stringify` — format errors for the LLM
+
+When `validate` reports failures, you want to tell the LLM what it did wrong in a form it understands. `LlmJson.stringify(failure)` produces annotated JSON with the original data and inline `// ❌` comments pointing at each error:
 
 <LocalSource
   path="examples/src/llm/application-validate.ts"
   filename="examples/src/llm/application-validate.ts"
   showLineNumbers />
-
-When LLM generates invalid arguments, `LlmJson.stringify()` formats the validation failure as annotated JSON with inline `// ❌` error comments. This output is wrapped in a markdown code block for optimal LLM comprehension:
 
 ```json
 {
@@ -105,30 +117,35 @@ When LLM generates invalid arguments, `LlmJson.stringify()` formats the validati
 }
 ```
 
-This format is designed for LLM auto-correction. The LLM reads this feedback and self-corrects on the next turn. Key features:
+What the format does:
 
-- **Inline error comments**: Each error is placed directly next to the problematic value with `// ❌` marker
-- **Path information**: Shows exact location like `$input.order.product.price`
-- **Expected type**: Describes what type was expected including constraints
-- **Missing properties**: Shows `undefined` for required properties that are missing
-- **Nested structures**: Properly formats nested objects and arrays with errors at any depth
-- **Unmappable errors**: If an error cannot be placed inline (e.g., root-level type mismatch), it's appended as a separate block
+- **Inline annotations** — each error sits next to the offending value, prefixed with `// ❌`
+- **Full path** — `$input.order.product.price` so the LLM knows exactly where to fix
+- **Expected type** — the same intersection syntax typia uses everywhere (`number & Minimum<0>`)
+- **Missing properties** — required properties that are absent are written as `undefined` with the same annotation
+- **Nested correctly** — works at any depth
+- **Unmappable errors** — if an error can't be placed inline (e.g. the whole root is the wrong type), it's appended as a separate block
 
-## `LlmJson.parse()`
+Drop that string into a system message ("you made these mistakes, please correct them") and the LLM will fix the problems on the next turn.
+
+## `LlmJson.parse` — lenient JSON + type coercion
+
+```typescript copy
+LlmJson.parse<T>(input: string, parameters?: ILlmSchema.IParameters)
+  : IJsonParseResult<T>
+```
+
+`parse` does two things in one call:
+
+1. **Lenient JSON parsing** — accepts JSON that `JSON.parse` would reject
+2. **Type coercion** — fixes values where the type doesn't quite match the schema
 
 <LocalSource
   path="examples/src/llm/application-parse.ts"
   filename="examples/src/llm/application-parse.ts"
   showLineNumbers />
 
-`LlmJson.parse()` is a lenient JSON parser specifically designed for LLM outputs. It combines two capabilities in a single call:
-
-1. **Lenient JSON parsing**: Handles malformed/incomplete JSON that would fail with `JSON.parse()`
-2. **Type coercion**: Fixes double-stringified values based on the expected schema
-
-### Lenient JSON Features
-
-LLMs frequently produce non-standard JSON. This parser handles:
+### Lenient JSON features
 
 | Issue | Example | Recovery |
 |-------|---------|----------|
@@ -139,79 +156,87 @@ LLMs frequently produce non-standard JSON. This parser handles:
 | Unquoted keys | `{name: "John"}` | Accepts identifier-style keys |
 | Incomplete keywords | `{"done": tru` | Completes to `true` |
 | Junk prefix | `Here is your JSON: {"a": 1}` | Skips to first `{` or `[` |
-| Markdown blocks | ` ```json\n{"a": 1}\n``` ` | Extracts content |
-| Unicode escapes | `"\uD83D\uDE00"` | Handles surrogate pairs (emoji) |
+| Markdown blocks | ` ```json\n{"a": 1}\n``` ` | Extracts the content |
+| Unicode surrogates | `"😀"` | Handles emoji correctly |
 
-### Type Coercion
+### Type coercion
 
-When `parameters` schema is provided, the parser coerces double-stringified values:
+When you pass `parameters`, the parser also fixes values based on what the schema expects:
 
 ```typescript
-// LLM returns:     { "count": "42", "active": "true", "data": "{\"x\": 1}" }
+// LLM returned: { "count": "42", "active": "true", "data": "{\"x\": 1}" }
 // After coercion: { "count": 42,   "active": true,   "data": { x: 1 } }
 ```
 
 Coercion rules:
+
 - `"42"` → `42` when schema expects `number` or `integer`
 - `"true"` / `"false"` → `true` / `false` when schema expects `boolean`
 - `"null"` → `null` when schema expects `null`
 - `"{...}"` → parsed object when schema expects `object`
 - `"[...]"` → parsed array when schema expects `array`
-- Nested coercion: Works recursively for deeply nested structures
+- Works recursively on nested objects and arrays
 
-### Discriminated Union Support
+### Discriminated unions
 
-For `anyOf` schemas with discriminators, coercion intelligently selects the correct schema variant:
+For `anyOf` schemas with a discriminator, coercion uses the discriminator to pick the right variant:
 
 ```typescript
 // Schema: anyOf [{ type: "dog", bark: boolean }, { type: "cat", meow: boolean }]
 // x-discriminator: { propertyName: "type" }
 
-// Input: { type: "dog", bark: "true" }
-// Result: { type: "dog", bark: true }  // Correctly coerced using dog schema
+// Input:  { type: "dog", bark: "true" }
+// Result: { type: "dog", bark: true }     ← coerced using the dog variant
 ```
 
 <Callout type="info">
-**Type Coercion is Optional**
+**`parameters` is optional.**
 
-If you omit the `parameters` argument, `LlmJson.parse()` still performs lenient JSON parsing but skips type coercion. This is useful when you only need to handle malformed JSON without schema-based type correction.
+If you omit the `parameters` argument, `LlmJson.parse` still does the lenient JSON parsing — you just skip type coercion. Use this if you only need the parser tolerance, not the schema-aware coercion.
 </Callout>
 
 <Callout type="warning">
-**Parse ≠ Validate**
+**`parse` does not validate.**
 
-`LlmJson.parse()` does NOT validate the data against the schema. It only coerces types. After parsing, use `typia.validate()` or `func.validate()` to check if the data actually matches the expected type constraints.
+Lenient parsing + coercion get the *shape* close. But they don't enforce things like "this number must be ≥ 0" or "this string must be a valid email". Always follow `parse` with [`typia.validate`](/docs/validators/validate) (or `func.validate` / `output.validate`).
 </Callout>
 
-## `LlmJson.coerce()`
+## `LlmJson.coerce` — type coercion only
+
+```typescript copy
+LlmJson.coerce<T>(input: unknown, parameters: ILlmSchema.IParameters): T
+```
+
+Use `coerce` when the JSON has already been parsed for you — typically because the SDK did it:
+
+| Scenario | Use |
+|----------|-----|
+| Raw JSON string from the LLM | `LlmJson.parse(text, schema)` |
+| SDK returned a JS object (Anthropic, Vercel AI, LangChain, MCP) | `LlmJson.coerce(obj, schema)` |
+| Streaming JSON assembled incrementally | `LlmJson.coerce(obj, schema)` |
+| WebSocket message already parsed | `LlmJson.coerce(obj, schema)` |
+
+`coerce` is the same logic as `parse`, minus the lenient JSON layer.
 
 <LocalSource
   path="examples/src/llm/application-coerce.ts"
   filename="examples/src/llm/application-coerce.ts"
   showLineNumbers />
 
-`LlmJson.coerce()` performs type coercion on already-parsed objects. Use it when an SDK has already parsed the JSON — this is the coercion logic from `parse()` extracted for use when you already have a JavaScript object (not a JSON string).
+What it does, step by step:
 
-### When to Use `coerce()` vs `parse()`
+1. **Resolve `$ref`** — follow schema references
+2. **`anyOf` with discriminator** — pick the right variant using `x-discriminator`
+3. **String-as-JSON** — if value is a string but schema expects a non-string, try a lenient JSON parse
+4. **Recursive descent** — coerce nested objects and arrays based on `properties` and `items`
+5. **Leave unknown extras alone** — extras pass through; validation later decides whether to accept them
 
-| Scenario | Use |
-|----------|-----|
-| Raw JSON string from LLM | `LlmJson.parse()` |
-| SDK returns parsed object (Anthropic, Vercel AI, LangChain, MCP) | `LlmJson.coerce()` |
-| Streaming response building object incrementally | `LlmJson.coerce()` |
-| WebSocket message already parsed | `LlmJson.coerce()` |
+## `LlmJson.validate` — runtime validator from a schema
 
-### Coercion Behavior
-
-The coercion algorithm:
-
-1. **Reference resolution**: Follows `$ref` to resolve schema references
-2. **anyOf handling**: Uses `x-discriminator` to select correct variant for discriminated unions
-3. **String-to-type parsing**: When value is string but schema expects non-string, attempts lenient JSON parse
-4. **Recursive descent**: Coerces nested objects and arrays based on `properties` and `items` schemas
-5. **Additional properties**: Preserves extra properties not in schema (validation handles rejection)
-
-## `LlmJson.validate()`
+```typescript copy
+LlmJson.validate(parameters: ILlmSchema.IParameters, equals?: boolean)
+  : (value: unknown) => IValidation<unknown>
+```
 
 ```typescript filename="@typia/utils - LlmJson.validate" showLineNumbers {10-17}
 import typia, { IValidation } from "typia";
@@ -224,47 +249,47 @@ interface IMember {
 
 const parameters = typia.llm.parameters<IMember>();
 
-// Create reusable validator from schema
+// Reusable validator from the schema
 const validate = LlmJson.validate(parameters);
 
 // Validate data
 const result: IValidation = validate({ name: "John", age: "thirty" });
-if (result.success === false) {
+if (!result.success) {
   console.log(LlmJson.stringify(result));
 }
 ```
 
-`LlmJson.validate()` creates a reusable validator function from an LLM parameters schema. This converts the `ILlmSchema` to OpenAPI JSON Schema internally and uses runtime validation.
+`LlmJson.validate` is the schema-first counterpart to [`typia.validate<T>`](/docs/validators/validate) — it builds a validator at runtime from an OpenAPI / LLM schema, rather than from a TypeScript type at compile time.
 
-### When to Use
+### When to use it
 
-- **Dynamic schemas**: When schema is received from external sources at runtime
-- **Generic tooling**: Building libraries that work with arbitrary LLM schemas
-- **Schema-first approach**: When you have schema but not TypeScript types
+| Scenario | Use |
+|----------|-----|
+| Schema comes from a remote registry / database | `LlmJson.validate` |
+| You're building a generic library that accepts any LLM schema | `LlmJson.validate` |
+| You have a TypeScript type at compile time | [`typia.validate<T>`](/docs/validators/validate) — it's faster and the messages are better |
 
-### Strict Mode
+### Strict mode
 
-The optional `equals` parameter enables strict validation:
+`equals = true` makes the validator reject objects with extra properties:
 
-```typescript
-// Lenient mode (default): allows extra properties
+```typescript copy
 const lenient = LlmJson.validate(parameters);
 lenient({ name: "John", age: 25, extra: "ignored" }); // success: true
 
-// Strict mode: rejects extra properties
 const strict = LlmJson.validate(parameters, true);
-strict({ name: "John", age: 25, extra: "ignored" }); // success: false
+strict({ name: "John", age: 25, extra: "ignored" });  // success: false
 ```
 
 <Callout type="info">
-**Prefer `typia.validate()` When Possible**
+**Prefer the compile-time validator when you can.**
 
-If you have TypeScript types available at compile time, prefer using `typia.validate<T>()` directly. It's faster (AOT-compiled) and provides better error messages. Use `LlmJson.validate()` only when you need runtime schema-based validation.
+`typia.validate<T>` is AOT-compiled and emits inline checks per field — significantly faster than `LlmJson.validate`, which has to interpret the schema at runtime. Reach for `LlmJson.validate` only when the TypeScript type isn't available where you need to validate.
 </Callout>
 
-## Validation Feedback Loop (The Complete Harness)
+## Putting it all together — the validation feedback loop
 
-The real power of these utilities is enabling automatic error correction by LLMs:
+The four functions form a deterministic correction loop around the probabilistic LLM:
 
 ```typescript filename="validation-feedback-loop.ts" showLineNumbers {20-21, 47, 57-58}
 import OpenAI from "openai";
@@ -287,7 +312,7 @@ class MemberService {
 }
 
 const app: ILlmApplication = typia.llm.application<MemberService>();
-const func = app.functions[0]; // register function
+const func = app.functions[0]; // register
 
 const step = async (
   client: OpenAI,
@@ -305,60 +330,46 @@ const step = async (
           "and joined to this community at 2022-01-01.",
         ].join("\n"),
       },
-      // Send validation feedback for auto-correction
+      // Feed the previous turn's mistakes back, if any.
       ...(failure
-        ? [
-            {
-              role: "system" as const,
-              content: [
-                "You A.I. agent had made a mistake that",
-                "returned wrong typed structured data.",
-                "",
-                "Here is the detailed list of type errors.",
-                "Review and correct them at the next step.",
-                "",
-                LlmJson.stringify(failure), // Only stringify needs LlmJson import
-              ].join("\n"),
-            },
-          ]
+        ? [{
+            role: "system" as const,
+            content: [
+              "You made type mistakes on the previous turn.",
+              "Here is the structured error report. Correct each one.",
+              "",
+              LlmJson.stringify(failure),
+            ].join("\n"),
+          }]
         : []),
     ],
     response_format: {
       type: "json_schema",
-      json_schema: {
-        name: "member",
-        schema: func.parameters as any,
-      },
+      json_schema: { name: "member", schema: func.parameters as any },
     },
   });
 
-  // Use ILlmFunction methods directly
   const parsed = func.parse(completion.choices[0].message.content!);
-  if (parsed.success === false) {
-    return { success: false, data: parsed.data, errors: [] };
-  }
+  if (!parsed.success) return { success: false, data: parsed.data, errors: [] };
   return func.validate(parsed.data);
 };
 
 const main = async (): Promise<void> => {
   const client = new OpenAI({ apiKey: "<YOUR_API_KEY>" });
-
   let result: IValidation<IMember> | undefined;
   for (let i = 0; i < 3; ++i) {
-    result = await step(
-      client,
-      result?.success === false ? result : undefined,
-    );
+    result = await step(client, result?.success === false ? result : undefined);
     if (result.success) break;
   }
   console.log(result);
 };
 ```
 
-This is the **function calling harness** in action — the same pattern that powers [AutoBe](https://github.com/wrtnlabs/autobe)'s 100% compilation success across all tested LLM models. It enables LLMs to automatically correct their mistakes:
+This is the same loop that powered [AutoBe](https://github.com/wrtnlabs/autobe) to 100% function calling correctness on compiler AST types — across four different Qwen models, against a raw baseline of 6.75%.
 
-1. Parse LLM response with `func.parse()` (handles malformed JSON + type coercion)
-2. Validate with `func.validate()`
-3. If validation fails, format errors with `LlmJson.stringify()`
-4. Send feedback to LLM for auto-correction
-5. Repeat until validation passes
+The recipe is the same every time:
+
+1. `parse` the LLM's response (handles malformed JSON + coerces types)
+2. `validate` to check field constraints
+3. If validation fails, format the errors with `LlmJson.stringify` and send them back
+4. Repeat until validation passes (usually one or two turns)

--- a/website/src/content/docs/llm/parameters.mdx
+++ b/website/src/content/docs/llm/parameters.mdx
@@ -5,100 +5,38 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `parameters()` function
+# `typia.llm.parameters` — JSON Schema for one type, no helpers
 
-<Tabs items={[
-    <code>typia</code>,
-    <code>ILlmApplication</code>,
-    <code>ILlmFunction</code>,
-    <code>ILlmSchema</code>,
-  ]}>
-  <Tabs.Tab>
-```typescript filename="typia" showLineNumbers {11-14}
-export namespace llm {
-  // LLM FUNCTION CALLING APPLICATION SCHEMA
-  export function application<
-    App extends Record<string, any>,
-    Config extends Partial<ILlmSchema.IConfig> = {},
-  >(
-    config?: Partial<Pick<ILlmApplication.IConfig, "validate">>,
-  ): ILlmApplication;
+If all you need is the **JSON Schema** for `T` (so you can put it in `response_format` or wherever your LLM SDK accepts a schema), `typia.llm.parameters<T>()` is the minimum tool. It returns the schema and nothing else — no `parse`, no `coerce`, no `validate`.
 
-  // STRUCTURED OUTPUT
-  export function parameters<
+```typescript copy filename="signature"
+namespace llm {
+  function parameters<
     Parameters extends Record<string, any>,
     Config extends Partial<ILlmSchema.IConfig> = {},
   >(): ILlmSchema.IParameters;
-
-  // TYPE SCHEMA
-  export function schema<
-    T,
-    Config extends Partial<ILlmSchema.IConfig> = {},
-  >(
-    $defs: Record<string, ILlmSchema>,
-  ): ILlmSchema;
 }
 ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="packages/interface/src/schema/ILlmApplication.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="packages/interface/src/schema/ILlmFunction.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="packages/interface/src/schema/ILlmSchema.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
 
-Structured output schema of LLM (Large Language Model).
+## First example
 
-`typia.llm.parameters<Parameters>()` is a function generating structured output of LLM (Large Language Model) from a TypeScript object type. It is used to LLM function calling or structured output feature provided by OpenAI like LLM providers.
+```typescript copy filename="hello-parameters.ts"
+import typia, { tags } from "typia";
 
-Return value type `ILlmSchema.IParameters` is a similar with the JSON schema definition's object type.
-  
-<Callout type="info">
-**LLM Function Calling** and **Structured Output**
+interface IMember {
+  email: string & tags.Format<"email">;
+  name: string;
+  age: number;
+  hobbies: string[];
+}
 
-LLM selects proper function and fill arguments.
+const schema = typia.llm.parameters<IMember>();
+// → ILlmSchema.IParameters (an object schema with $defs)
+```
 
-In nowadays, most LLM (Large Language Model) like OpenAI are supporting "function calling" feature. The "LLM function calling" means that LLM automatically selects a proper function and fills parameter values from conversation with the user (may by chatting text).
+You hand `schema` to your LLM SDK and the model knows the expected JSON shape. The full pattern with OpenAI:
 
-Structured output is another feature of LLM. The "structured output" means that LLM automatically transforms the output conversation into a structured data format like JSON.
-
-- https://platform.openai.com/docs/guides/function-calling
-- https://platform.openai.com/docs/guides/structured-outputs
-</Callout>
-
-<Tabs items={["TypeScript Source Code", "Compiled JavaScript"]}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/llm/parameters.ts"
-      filename="example/src/llm/parameters.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/llm/parameters.js"
-      filename="example/bin/llm/parameters.js"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-[📖 Playground Link](/playground/?script=JYWwDg9gTgLgBAbzgSQDIBsQGUDGALAUxAEM4BfOAMyghDgCIABAZ2JHwgDsB6CMAzsTDB6AbgBQoSLDgwAnsOIAaRLOIBzZuSo069eYrHi4kzjAJRKxHARQBZIgCMLiY3CLFg6AFxxmMKGBOdTgAMjVNADoAMWgSGAAeeg8vegA+CTg4QRACX39A4My4DTzsgFcQZyhivAhHR2ACZnyAoPUAbQBdYoArCCCCABMAfWIYVsKQ8JgNZhi48aSh8YJ0iTJxHC5-ODBfNExcQhJI5AAFYig2AnMoLQBeWQVgYkj0TEiwK5u75gTkA4qhY0gAKACUEm2nGYEHQBHeEHUoLAkKAA)
-
-## Structured Output
-
-```typescript filename="src/examples/llm.parameters.ts" copy showLineNumbers {4-10, 36}
+```typescript copy filename="src/examples/llm.parameters.ts" {4-10, 36}
 import OpenAI from "openai";
 import typia, { tags } from "typia";
 
@@ -112,8 +50,7 @@ interface IMember {
 
 const main = async (): Promise<void> => {
   const client: OpenAI = new OpenAI({
-    apiKey: TestGlobal.env.CHATGPT_API_KEY,
-    // apiKey: "<YOUR_OPENAI_API_KEY>",
+    apiKey: "<YOUR_OPENAI_API_KEY>",
   });
   const completion: OpenAI.ChatCompletion =
     await client.chat.completions.create({
@@ -143,7 +80,7 @@ const main = async (): Promise<void> => {
 main().catch(console.error);
 ```
 
-> ```bash filename="Terminal"
+> ```bash filename="Terminal output"
 > {
 >   email: 'john.doe@example.com',
 >   name: 'John Doe',
@@ -153,21 +90,62 @@ main().catch(console.error);
 > }
 > ```
 
-You can utilize the `typia.llm.parameters<Parameters>()` function to generate structured output like above.
+<Tabs items={[<code>typia</code>, <code>ILlmSchema</code>]}>
+  <Tabs.Tab>
+```typescript filename="typia" showLineNumbers
+export namespace llm {
+  export function parameters<
+    Parameters extends Record<string, any>,
+    Config extends Partial<ILlmSchema.IConfig> = {},
+  >(): ILlmSchema.IParameters;
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/schema/ILlmSchema.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
 
-Just configure output mode as JSON schema, and deliver the `typia.llm.parameters<Parameters>()` function returned value to the LLM provider like OpenAI (ChatGPT). Then, the LLM provider will automatically transform the output conversation into a structured data format of the `Parameters` type.
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/llm/parameters.ts"
+      filename="example/src/llm/parameters.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/llm/parameters.js"
+      filename="example/bin/llm/parameters.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
 
-## The Function Calling Harness
+[📖 Open in Playground](/playground/?script=JYWwDg9gTgLgBAbzgSQDIBsQGUDGALAUxAEM4BfOAMyghDgCIABAZ2JHwgDsB6CMAzsTDB6AbgBQoSLDgwAnsOIAaRLOIBzZuSo069eYrHi4kzjAJRKxHARQBZIgCMLiY3CLFg6AFxxmMKGBOdTgAMjVNADoAMWgSGAAeeg8vegA+CTg4QRACX39A4My4DTzsgFcQZyhivAhHR2ACZnyAoPUAbQBdYoArCCCCABMAfWIYVsKQ8JgNZhi48aSh8YJ0iTJxHC5-ODBfNExcQhJI5AAFYig2AnMoLQBeWQVgYkj0TEiwK5u75gTkA4qhY0gAKACUEm2nGYEHQBHeEHUoLAkKAA)
 
-The **function calling harness** is typia's three-layer pipeline that turns unreliable LLM output into 100% correct structured data:
+## When to use `parameters` instead of `structuredOutput`
 
-1. **Lenient JSON Parsing** — recovers broken JSON (unclosed brackets, trailing commas, markdown wrapping, etc.)
-2. **Type Coercion** — fixes wrong types (`"42"` → `42`, double-stringified objects → objects, etc.)
-3. **Validation Feedback** — pinpoints remaining value errors with inline `// ❌` annotations so the LLM can self-correct and retry
+| What you need | Use |
+|---------------|-----|
+| Just the schema (your code does the parsing) | `parameters<T>()` |
+| Schema **plus** parse/coerce/validate helpers | [`structuredOutput<T>()`](/docs/llm/structuredOutput) |
+| Multiple functions, LLM picks one to call | [`application<Class>()`](/docs/llm/application) |
 
-Each layer catches what the previous one didn't. Together they form a deterministic correction loop around the probabilistic LLM.
+`structuredOutput<T>()` is essentially `parameters<T>()` + the parse/coerce/validate methods bundled together. If you don't need those methods (or you'll wire them up yourself from [`LlmJson`](/docs/llm/json)), `parameters` is the leaner choice.
 
-### Lenient JSON Parsing & Type Coercion
+## The function calling harness (when used with `parameters`)
+
+`parameters` is schema-only by design, but you can still get the parse/coerce/validate behavior by composing manually:
+
+| Goal | Use |
+|------|-----|
+| Parse messy LLM JSON text + coerce types | [`LlmJson.parse<T>(text, schema)`](/docs/llm/json#llmjsonparse--lenient-json--type-coercion) |
+| Coerce types on an already-parsed object | [`LlmJson.coerce<T>(obj, schema)`](/docs/llm/json#llmjsoncoerce--type-coercion-only) |
+| Validate against the type | [`typia.validate<T>(obj)`](/docs/validators/validate) |
+| Format errors back to the LLM | [`LlmJson.stringify(failure)`](/docs/llm/json#llmjsonstringify--format-errors-for-the-llm) |
 
 <Tabs items={[
     "Parsing Example",
@@ -197,43 +175,20 @@ Each layer catches what the previous one didn't. Together they form a determinis
   </Tabs.Tab>
 </Tabs>
 
-Use `LlmJson.parse()` from `@typia/utils` to handle LLM JSON outputs with the parameter schema from `typia.llm.parameters<T>()`. This parser is specifically designed for the messy reality of LLM responses:
-
-**Lenient JSON Features:**
-- Unclosed brackets `{`, `[` and strings
-- Trailing commas `[1, 2, 3, ]`
-- JavaScript-style comments (`//` and `/* */`)
-- Unquoted object keys (JavaScript identifier style)
-- Incomplete keywords (`tru`, `fal`, `nul`)
-- Markdown code block extraction (` ```json ... ``` `)
-- Junk text prefix skipping (explanatory text LLMs often add)
-
-**Type Coercion:**
-
-LLMs frequently return wrong types — numbers as strings, booleans as strings, or even double-stringified JSON objects. `LlmJson.parse()` automatically coerces these based on the parameter schema.
-
 <Callout type="warning">
-**0% → 100% Success Rate on Union Types**
+**Double-stringified objects fail every time without coercion**
 
-`Qwen3.5` model shows 0% success rate when handling union types with double-stringified JSON objects. With `LlmJson.parse()` type coercion, the success rate jumps to 100%.
+LLMs frequently emit `"{\"x\":1}"` (a JSON-stringified value) where the schema expects an object. Without coercion, validation rejects those responses outright. With `parse`/`coerce` it descends through the string-wrapped layers and produces typed data. See [`application`](/docs/llm/application#the-function-calling-harness) for the full picture.
 </Callout>
 
-<Callout type="info">
-**For Pre-parsed Objects, Use `LlmJson.coerce()`**
-
-Some LLM SDKs (Anthropic, Vercel AI, LangChain, MCP) parse JSON internally and return JavaScript objects directly. In these cases, use `LlmJson.coerce()` instead of `LlmJson.parse()` to fix types without re-parsing.
-
-For more details, see [JSON Utilities](./json).
-</Callout>
-
-### Validation Feedback
+### Validation feedback
 
 <LocalSource
   path="examples/src/llm/parameters-validate.ts"
   filename="examples/src/llm/parameters-validate.ts"
   showLineNumbers />
 
-Use [`typia.validate<T>()`](/docs/validators/validate) for validation feedback on structured output. When validation fails, use `LlmJson.stringify()` from `@typia/utils` to format errors with inline `// ❌` comments:
+When validation fails, format the errors with `LlmJson.stringify` and send them back to the LLM. The formatted output:
 
 ```json
 {
@@ -249,51 +204,40 @@ Use [`typia.validate<T>()`](/docs/validators/validate) for validation feedback o
 }
 ```
 
-The LLM reads this feedback and self-corrects on the next turn.
-
-In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator by [Wrtn Technologies](https://wrtn.io)), `qwen3-coder-next` showed only **6.75%** raw function calling success rate on compiler AST types. However, with the complete harness, it reached **100%** — across all four tested Qwen models.
-
-Working on compiler AST means working on any type and any use case.
-
-  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
-  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
-  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
+In [AutoBe](https://github.com/wrtnlabs/autobe), the same pattern took `qwen3-coder-next` from **6.75% → 100%** correct on compiler AST types. Compiler ASTs are the hardest possible target — unlimited unions, unlimited depth, recursive references — so if the harness works there, it works on anything realistic.
 
 ```typescript filename="AutoBeTest.IExpression" showLineNumbers
-// Compiler AST may be the hardest type structure possible
-//
-// Unlimited union types + unlimited depth + recursive references
 export type IExpression =
   | IBooleanLiteral
   | INumericLiteral
   | IStringLiteral
-  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
-  | IObjectLiteralExpression  // <- recursive (contains IExpression)
+  | IArrayLiteralExpression   // recursive
+  | IObjectLiteralExpression  // recursive
   | INullLiteral
   | IUndefinedKeyword
   | IIdentifier
-  | IPropertyAccessExpression // <- recursive
-  | IElementAccessExpression  // <- recursive
-  | ITypeOfExpression         // <- recursive
-  | IPrefixUnaryExpression    // <- recursive
-  | IPostfixUnaryExpression   // <- recursive
-  | IBinaryExpression         // <- recursive (left & right)
-  | IArrowFunction            // <- recursive (body is IExpression)
-  | ICallExpression           // <- recursive (args are IExpression[])
-  | INewExpression            // <- recursive
-  | IConditionalPredicate     // <- recursive (then & else branches)
+  | IPropertyAccessExpression // recursive
+  | IElementAccessExpression  // recursive
+  | ITypeOfExpression         // recursive
+  | IPrefixUnaryExpression    // recursive
+  | IPostfixUnaryExpression   // recursive
+  | IBinaryExpression         // recursive
+  | IArrowFunction            // recursive
+  | ICallExpression           // recursive
+  | INewExpression            // recursive
+  | IConditionalPredicate     // recursive
   | ... // 30+ expression types total
 ```
 
 ## Restrictions
 
-`typia.llm.parameters<Parameters>()` follows the same restrictions [`typia.llm.schema<T>()`](../schema) function. Also, it has only one additional restriction; the keyworded argument.
+LLMs use keyworded arguments. typia enforces this at compile time:
 
-In the LLM function calling and structured output, the parameters must be a keyworded object type with static keys without any dynamic keys. Also, the object type must not be nullable or optional.
+- `T` must be an **object type** with **static keys**
+- No dynamic keys (`Record<string, V>`)
+- `T` may not be nullable or optional
 
-If you don't follow the LLM's keyworded arguments rule, `typia.llm.parameters<Parameters>()` will throw compilation error like below.
-
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+<Tabs items={["Source That Won't Compile", "Compiler Errors"]}>
   <Tabs.Tab>
 ```typescript filename="src/examples/llm.parameters.violation.ts" showLineNumbers
 import typia from "typia";
@@ -313,17 +257,10 @@ src/examples/llm.parameters.violation.ts:3:1 - error TS(typia.llm.parameters): u
 3 typia.llm.parameters<string>();
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-src/examples/llm.parameters.violation.ts:3:22 - error TS2344: Type 'string' does not satisfy the constraint 'Record<string, any>'.
-
-3 typia.llm.parameters<string>();
-                       ~~~~~~
-
 src/examples/llm.parameters.violation.ts:4:1 - error TS(typia.llm.parameters): unsupported type detected
 
 - Recordstringboolean
   - LLM parameters must be an object type.
-
-- Recordstringboolean
   - LLM parameters must not have dynamic keys.
 
 4 typia.llm.parameters<Record<string, boolean>>();
@@ -336,9 +273,15 @@ src/examples/llm.parameters.violation.ts:5:1 - error TS(typia.llm.parameters): u
 
 5 typia.llm.parameters<Array<number>>();
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-Found 4 errors in the same file, starting at: src/examples/llm.parameters.violation.ts
 ```
   </Tabs.Tab>
 </Tabs>
+
+For deeper type-level rules (recursion handling, anyOf/$ref behavior) see [`llm.schema`](/docs/llm/schema).
+
+## Where to go next
+
+- All-in-one helper bundle → [`structuredOutput`](/docs/llm/structuredOutput)
+- Multiple methods on a class → [`application`](/docs/llm/application)
+- Inner-type schemas with `$defs` → [`schema`](/docs/llm/schema)
+- Parsing / coercion / validation utilities → [`LlmJson`](/docs/llm/json)

--- a/website/src/content/docs/llm/schema.mdx
+++ b/website/src/content/docs/llm/schema.mdx
@@ -5,32 +5,46 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `schema()` function
+# `typia.llm.schema` — schema for a single inner type
 
-<Tabs items={[
-    <code>typia</code>,
-    <code>ILlmApplication</code>,
-    <code>ILlmFunction</code>,
-    <code>ILlmSchema</code>,
-  ]}>
-  <Tabs.Tab>
-```typescript filename="typia" showLineNumbers {17-21}
-export namespace llm {
-  // LLM FUNCTION CALLING APPLICATION SCHEMA
-  export function application<
-    App extends Record<string, any>,
+```typescript copy filename="signature"
+namespace llm {
+  function schema<
+    T,
     Config extends Partial<ILlmSchema.IConfig> = {},
   >(
-    config?: Partial<Pick<ILlmApplication.IConfig, "validate">>,
-  ): ILlmApplication;
+    $defs: Record<string, ILlmSchema>,
+  ): ILlmSchema;
+}
+```
 
-  // STRUCTURED OUTPUT
-  export function parameters<
-    Parameters extends Record<string, any>,
-    Config extends Partial<ILlmSchema.IConfig> = {},
-  >(): ILlmSchema.IParameters;
+`typia.llm.schema<T>` generates an `ILlmSchema` for `T` — useful when you're composing schemas by hand instead of letting [`parameters`](/docs/llm/parameters) or [`application`](/docs/llm/application) do the whole thing.
 
-  // TYPE SCHEMA
+You pass a `$defs` object as the runtime argument. Any named types referenced in `T` will be added to `$defs` and surfaced through `$ref`. So you can call `llm.schema` multiple times against the same `$defs` and the referenced sub-schemas will be deduplicated.
+
+> Most users want [`parameters`](/docs/llm/parameters), [`structuredOutput`](/docs/llm/structuredOutput), or [`application`](/docs/llm/application) — they all generate full top-level schemas for you. `schema` is the building block.
+
+## First example
+
+```typescript copy filename="hello-schema.ts"
+import typia from "typia";
+import { ILlmSchema } from "typia";
+
+interface Animal {
+  name: string;
+  legs: number;
+}
+
+const $defs: Record<string, ILlmSchema> = {};
+const s = typia.llm.schema<Animal>($defs);
+// s is `{ "$ref": "#/$defs/Animal" }`
+// $defs.Animal = { type: "object", properties: { name: ..., legs: ... }, ... }
+```
+
+<Tabs items={[<code>typia</code>, <code>ILlmSchema</code>]}>
+  <Tabs.Tab>
+```typescript filename="typia" showLineNumbers
+export namespace llm {
   export function schema<
     T,
     Config extends Partial<ILlmSchema.IConfig> = {},
@@ -42,102 +56,72 @@ export namespace llm {
   </Tabs.Tab>
   <Tabs.Tab>
     <LocalSource
-      path="packages/interface/src/schema/ILlmApplication.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="packages/interface/src/schema/ILlmFunction.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
       path="packages/interface/src/schema/ILlmSchema.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Type schema in the LLM function calling application.
-
-`typia.llm.schema<T>()` is a function generating type schema which is used in the LLM (Large Language Model) function calling application schema or structured output, especially composed by the [`typia.llm.parameters<Parameters>()`](../parameters) and [`typia.llm.application<App>()`](../application) functions.
-
-Return value type `ILlmSchema` is similar with the JSON schema definition.
-
-<Callout type="info">
-**LLM Function Calling** and **Structured Output**
-
-LLM selects proper function and fill arguments.
-
-In nowadays, most LLM (Large Language Model) like OpenAI are supporting "function calling" feature. The "LLM function calling" means that LLM automatically selects a proper function and fills parameter values from conversation with the user (may by chatting text).
-
-Structured output is another feature of LLM. The "structured output" means that LLM automatically transforms the output conversation into a structured data format like JSON.
-
-- https://platform.openai.com/docs/guides/function-calling
-- https://platform.openai.com/docs/guides/structured-outputs
-</Callout>
-
-<Tabs items={["TypeScript Source Code", "Compiled JavaScript"]}>
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/schema.ts"
       filename="example/src/llm/schema.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/llm/schema.js"
       filename="example/bin/llm/schema.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Specialization
+## Special fields — description, title, deprecated
 
-You can utilize [type tags](../validators/tags/#type-tags) (or [validator's comment tags](../validators/tags/#comment-tags)) to constructing special fields of JSON schema. 
+[Type tags](/docs/validators/tags) carry over to the JSON Schema:
 
-If you write any comment on a property, it would fill the `IJsonSchema.description` value. Also, there're special comment tags only for JSON schema definition that are different with [validator's comment tags](../validators/tags/#comment-tags) like below.
+- `tags.MaxLength<100>` → `"maxLength": 100`
+- `tags.Format<"email">` → `"format": "email"`
+- `tags.Minimum<0>` → `"minimum": 0`
 
-  - `@deprecated`
-  - `@hidden`
-  - `@internal`
-  - `@title {string}`
+JSDoc comments on properties become `"description"`. Two extra comment tags only affect the emitted schema (not runtime validation):
 
-Let's see how those [type tags](../validators/tags/#type-tags), comment tags and description comments are working with example code.
+| Tag | Effect |
+|-----|--------|
+| `@title Something` | Sets `"title"` separately from the description |
+| `@deprecated` | Sets `"deprecated": true` |
+| `@hidden` / `@internal` | Excludes the field from the emitted schema |
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/schema-special.ts"
       filename="example/src/llm/schema-special.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/llm/schema-special.js"
       filename="example/bin/llm/schema-special.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Customization
+## Custom `x-…` properties
 
-If what you want is not just filling regular properties of LLM schema specification, but to adding custom properties into the JSON schema definition, you can do it through the `tags.TagBase.schema` property type or `tags.JsonSchemaPlugin` type. 
+JSON Schema lets you add `x-…` extensions. typia surfaces them through `tags.TagBase.schema` (and the `tags.JsonSchemaPlugin` shortcut):
 
-For reference, the custom property must be started with `x-` prefix. It's a rule of LLM schema.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/schema-custom.ts"
       filename="example/src/llm/schema-custom.ts"
       showLineNumbers
       highlight="12-14, 18, 22-23" />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/llm/schema-custom.js"
       filename="example/bin/llm/schema-custom.js"
       showLineNumbers
@@ -147,13 +131,17 @@ For reference, the custom property must be started with `x-` prefix. It's a rule
 
 ## Restrictions
 
-LLM schema does not support `bigint` type.
+LLM schemas are OpenAPI 3.0-style JSON Schema. A few things don't survive the conversion:
 
-LLM schema is based on the JSON schema definition of the OpenAPI v3.0 specification. Therefore, limitations of the JSON schema is also applied to the LLM schema, and the `bigint` type is not supported in the LLM function calling schema composition.
+### No `bigint`
 
-Also, LLM schema does not support the tuple type, which is represented by the `OpenApi.IJsonSchema.ITuple` type. It's no LLM providers are supporting the tuple type, and such tuple type harms the separation option of the [`typia.llm.application<App>()`](../application) function. If you need a tuple type, just change the tuple type to a regular object type instead.
+Same as standard JSON Schema. `bigint` properties cause a compile error.
 
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+### No tuples
+
+`[number, string]` is not allowed — no LLM provider supports tuples, and they confuse `application`'s function-grouping logic. Replace tuples with a plain object: `{ count: number; name: string }`.
+
+<Tabs items={["Source That Won't Compile", "Compiler Errors"]}>
   <Tabs.Tab>
 ```typescript filename="src/examples/llm.schema.bigint-and-tuple.ts" showLineNumbers
 import typia from "typia";
@@ -182,31 +170,19 @@ src/examples/llm.schema.bigint-and-tuple.ts:4:1 - error TS(typia.llm.schema): fa
   </Tabs.Tab>
 </Tabs>
 
-For reference, if recursive type comes from the array type, it would be repeated 3 times, and at the fourth step the recursive type would be removed. If the recursive type comes from a property and the property is optional, the 4th property would be removed from the object type. At last, if the recursive type is combined as an `oneOf` type, the type would be removed from there.
+### No dynamic object keys
 
-<Tabs items={["TypeScript Source Code", "Compiled JavaScript File"]}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/llm/schema-recursive-gemini.ts"
-      filename="example/src/llm/schema-recursive-gemini.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/llm/schema-recursive-gemini.js"
-      filename="example/bin/llm/schema-recursive-gemini.js"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
+`Record<string, T>` is not allowed. Convert it to an array of `{ key, value }` pairs:
 
-Also, `typia.llm.schema<T>()` does not support the `OpenApi.IJsonSchema.IObject.additionalProperties` type, which represent the dynamic key typed object like `Record<string, T>` type in the TypeScript. Therefore, if you put the dynamic `Record<string, T>` type like below, `typia.llm.schema<T>()` function throw the compilation error like below.
+```typescript
+// not allowed
+typia.llm.schema<Record<string, number>>({});
 
-Therefore, you have to change the `Record<string, T>` type to an array of regular object type like below. Note that, as LLM providers do not support the `tuple` type, you don't have to define the array type containing the tuple type.
+// recommended
+typia.llm.schema<Array<{ key: string; value: number }>>({});
+```
 
-  - recommended: `Array<{ key: string, value: T }>`
-  - not recommended: `Array<[string, T]>`
-
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+<Tabs items={["Source That Won't Compile", "Compiler Errors"]}>
   <Tabs.Tab>
 ```typescript filename="src/examples/llm.schema.additionalProperties.ts" showLineNumbers
 import typia from "typia";
@@ -229,3 +205,33 @@ src/examples/llm.schema.additionalProperties.ts:3:1 - error TS(typia.llm.schema)
 ```
   </Tabs.Tab>
 </Tabs>
+
+### Recursion is bounded
+
+LLM providers have limits on how deep a recursive schema can go. typia handles recursion as follows:
+
+- A type that recurses through an **array** is expanded 3 times; the 4th level is removed from the array.
+- A type that recurses through an **optional property** is expanded 3 times; the 4th level drops the property.
+- A type that recurses through a `oneOf` is removed from that branch.
+
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/llm/schema-recursive-gemini.ts"
+      filename="example/src/llm/schema-recursive-gemini.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/llm/schema-recursive-gemini.js"
+      filename="example/bin/llm/schema-recursive-gemini.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## Where to go next
+
+- Schema for whole `Parameters` object → [`parameters`](/docs/llm/parameters)
+- All-in-one helper bundle → [`structuredOutput`](/docs/llm/structuredOutput)
+- Multiple functions on a class → [`application`](/docs/llm/application)
+- Constraint tags → [Special Tags](/docs/validators/tags)

--- a/website/src/content/docs/llm/strategy.mdx
+++ b/website/src/content/docs/llm/strategy.mdx
@@ -5,22 +5,67 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## Description Comment
+# Documentation Strategy
+
+LLMs decide which function to call by reading its description. Good descriptions are not optional — they are the prompt. This page covers three practical patterns that make the LLM behave better without changing any TypeScript types:
+
+1. **[Description comments](#description-comments)** — JSDoc on the method and on the parameter type
+2. **[Namespace inheritance](#namespace-inheritance)** — description on the parent type cascades into children
+3. **[Hiding methods](#hiding-methods)** — exclude internal helpers from the schema
+
+Plus two carry-overs from the schema layer for reference:
+
+4. **[Specialization](#specialization)** — `@title`, `@deprecated`, `@hidden`, `@internal`
+5. **[Custom `x-…` fields](#customization)** — vendor extensions in JSON Schema
+
+## Description comments
+
+The LLM reads:
+
+- The **method JSDoc comment** as the function's `description`
+- **Property JSDoc comments** as each property's `description`
+- The **`@title`** comment tag (if present) as the property's `title`
+
+```typescript copy filename="example/src/llm/BbsArticleController.ts" {11, 15-17}
+class BbsArticleController {
+  /**
+   * Create a new article.
+   *
+   * Writes a new article and archives it into the DB.
+   */
+  async create(props: {
+    /**
+     * Information of the article to create.
+     */
+    input: IBbsArticle.ICreate;
+  }): Promise<IBbsArticle> { /* … */ }
+}
+```
+
+Console output of what the LLM sees for `create`:
+
+```
+Create a new article.
+
+Writes a new article and archives it into the DB.
+```
+
+The more the description tells the LLM about *when* to call the function (not just what it returns), the more reliably it picks the right one.
 
 <Tabs items={[
-  "TypeScript Source Code", 
-  "Compiled JavaScript File",
+  "TypeScript Source",
+  "Compiled JavaScript",
   "Console Output"
 ]}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/application-description.ts"
       filename="example/src/llm/application-description.ts"
       showLineNumbers
       highlight="11, 15-17" />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/llm/application-description.js"
       filename="example/bin/llm/application-description.js"
       showLineNumbers />
@@ -34,33 +79,37 @@ Writes a new article and archives it into the DB.
   </Tabs.Tab>
 </Tabs>
 
-Here is the example code utilizing the `typia.llm.application<App, Model>()` function.
+### `description` vs `title`
 
-As you can see, above example code is writing detailed descriptions for every functions and their parameter/return types. Such detailed descriptions are very important to teach the purpose of the function to the LLM (Language Large Model), and LLM actually determines which function to call by the description. Therefore, don't forget to writing detailed descriptions. It's very import feature for the LLM function calling.
+`ILlmFunction` has one `description`. `ILlmSchema` has both `description` and `title`. Use `@title` to add a short heading on a property without it being repeated in the description:
 
-Also, `ILlmFunction` type which has only `description` property about the comment, but `ILlmSchema` has two descriptive properties; `description` and `title`. The `title` property of the `ILlmSchema` can be filled by writing `@title {string}` comment tag. In that case, the `title` value would not be contained in the `description` value. For reference, it is possible to fill the `description` property of the `ILlmSchema` by the comment tag `@description`, but you have to take care of the indentation like below.
-
-<LocalSource 
+<LocalSource
   path="examples/src/llm/IMember.ts"
   filename="examples/src/llm/IMember.ts"
   showLineNumbers />
 
-## Namespace Strategy
+> [!NOTE]
+>
+> You can also fill `description` with `@description ...`, but watch indentation — the parser is sensitive to leading whitespace in multi-line `@description` blocks.
+
+## Namespace inheritance
+
+CRUD-style controllers tend to have parent types (`IBbsArticle`) and child variants (`IBbsArticle.ICreate`, `IBbsArticle.IUpdate`). Repeating the same long description on every variant is tedious. typia copies the parent's description **into** the children automatically:
 
 <Tabs items={[
-  "TypeScript Source Code", 
-  "Compiled JavaScript File",
+  "TypeScript Source",
+  "Compiled JavaScript",
   "Console Output"
 ]}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/application-namespace.ts"
       filename="example/src/llm/application-namespace.ts"
       showLineNumbers
       highlight="11, 13-18, 35-38, 65-70" />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/llm/application-namespace.js"
       filename="example/bin/llm/application-namespace.js"
       showLineNumbers />
@@ -76,48 +125,56 @@ Description of the current {@link IBbsArticle.ICreate} type:
 Information of the article to create.
 
 > Description of the parent {@link IBbsArticle} type: Article entity.
-> 
+>
 > `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).
 ```
   </Tabs.Tab>
 </Tabs>
 
-`typia.llm.application<App, Model>()` copies the parent namespaced type description comment to the children types. `typia` calls this comment writing strategy as namespace documentation, and it is recommended for the efficient documentation.
+Write the parent's description once, give each child a short variant-specific note, and the LLM sees both — the variant note **and** the inherited parent context.
 
-As you can see from the above example, `BbsArticleController` has many CRUD functions about the `IBbsArticle` namespaced type. By the way, the above `IBbsArticle.ICreate` and `IBbsArticle.IUpdate` types are not repeating same description comments about the `IBbsArticle` type. Instead, just writing the short description comment about them, and just compose the LLM function calling application schema.
+## Hiding methods
 
-In that case, the `IBbsArticle` type's description comment would be copied to the `IBbsArticle.ICreate` and `IBbsArticle.IUpdate` types like above "Console Output" case. It's a good strategy to avoid repeating same description comments, and also to deliver enough information to the LLM function calling.
+Sometimes you want a method on the class but not on the LLM's tool list — an internal helper, a sensitive admin action, anything the LLM shouldn't be calling. Use one of these JSDoc tags on the method:
 
-## Function Hiding
+| Tag | Means |
+|-----|-------|
+| `@hidden` | Excluded from the LLM application |
+| `@internal` | Excluded (TypeScript convention for "not part of the public API") |
+| `@human` | Excluded (typia convention for "only humans, not LLMs, should call this") |
 
 <Tabs items={[
-    "TypeScript Source Code",
-    "Compiled JavaScript File",
+    "TypeScript Source",
+    "Compiled JavaScript",
   ]}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/application-hidden.ts"
       filename="example/src/llm/application-hidden.ts"
       showLineNumbers
       highlight="36, 52, 72" />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/llm/application-hidden.js"
       filename="example/bin/llm/application-hidden.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Hiding some functions by comment tag.
-
-If you write `@hidden`, `@human` or `@internal` tag onto a function description comment, the function would not participate in the LLM (Large Language Model) function calling application composition. `ILlmFunction` schema does not be generated in the `ILlmApplication.functions` collection.
-
-It's a good feature to hide some internal functions, so that avoiding the LLM function calling.
+Hidden methods don't appear in `ILlmApplication.functions`, so the LLM never sees them. They still exist on the class instance and you can call them normally from your own code.
 
 ## Specialization
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+The same comment tags work for properties on the parameter and return types:
+
+| Tag | Effect |
+|-----|--------|
+| `@title Something` | Short title shown alongside description |
+| `@deprecated` | Marks the property as deprecated in the schema |
+| `@hidden` / `@internal` | Excludes the property from the emitted schema |
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
     <LocalSource
       path="examples/src/llm/schema-special.ts"
@@ -132,36 +189,32 @@ It's a good feature to hide some internal functions, so that avoiding the LLM fu
   </Tabs.Tab>
 </Tabs>
 
-You can utilize [type tags](../validators/tags/#type-tags) (or [validator's comment tags](../validators/tags/#comment-tags)) to constructing special fields of JSON schema. 
-
-If you write any comment on a property, it would fill the `IJsonSchema.description` value. Also, there're special comment tags only for JSON schema definition that are different with [validator's comment tags](../validators/tags/#comment-tags) like below.
-
-  - `@deprecated`
-  - `@hidden`
-  - `@internal`
-  - `@title {string}`
-
-Let's see how those [type tags](../validators/tags/#type-tags), comment tags and description comments are working with example code.
+Also see [type tags](/docs/validators/tags) — the same `Format`, `Minimum`, `MaxLength`, etc. that drive runtime validation also flow into the emitted JSON Schema as `format`, `minimum`, `maxLength`.
 
 ## Customization
 
-If what you want is not just filling regular properties of LLM schema specification, but to adding custom properties into the JSON schema definition, you can do it through the `tags.TagBase.schema` property type or `tags.JsonSchemaPlugin` type. 
+JSON Schema reserves the `x-` prefix for non-standard extensions. To add `x-…` keys, use `tags.TagBase.schema` or the `tags.JsonSchemaPlugin` shortcut:
 
-For reference, the custom property must be started with `x-` prefix. It's a rule of LLM schema.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/llm/schema-custom.ts"
       filename="example/src/llm/schema-custom.ts"
       showLineNumbers
       highlight="12-14, 18, 22-23" />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/llm/schema-custom.js"
       filename="example/bin/llm/schema-custom.js"
       showLineNumbers
       highlight="7, 11" />
   </Tabs.Tab>
 </Tabs>
+
+## Where to go next
+
+- The class-based tool API → [`typia.llm.application`](/docs/llm/application)
+- Schema for one structured output → [`structuredOutput`](/docs/llm/structuredOutput) · [`parameters`](/docs/llm/parameters)
+- The validation feedback channel → [`LlmJson`](/docs/llm/json)
+- Constraint tags → [Special Tags](/docs/validators/tags)

--- a/website/src/content/docs/llm/structuredOutput.mdx
+++ b/website/src/content/docs/llm/structuredOutput.mdx
@@ -5,27 +5,66 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `structuredOutput()` function
+# `typia.llm.structuredOutput` — schema + parse + coerce + validate, in one shot
 
-<Tabs items={[
-    <code>typia</code>,
-    <code>ILlmStructuredOutput</code>,
-    <code>ILlmSchema</code>,
-  ]}>
-  <Tabs.Tab>
-```typescript filename="typia" showLineNumbers {3-10}
+When you ask an LLM for **structured output** (one specific JSON shape, no function selection involved), you typically need four things:
+
+1. The **schema** to put in `response_format` / `json_schema`
+2. A **parser** that copes with messy LLM output
+3. A **coercer** for SDKs that already JSON-parsed
+4. A **validator** to confirm the result actually matches your type
+
+`typia.llm.structuredOutput<T>()` returns all four bundled together for a single TypeScript type `T`.
+
+```typescript copy filename="signature"
 export namespace llm {
-  // STRUCTURED OUTPUT
+  function structuredOutput<
+    T extends Record<string, any>,
+    Config extends Partial<ILlmSchema.IConfig & { equals: boolean }> = {},
+  >(): ILlmStructuredOutput<T>;
+}
+```
+
+```typescript copy filename="what-you-get"
+interface ILlmStructuredOutput<T> {
+  parameters: ILlmSchema.IParameters;             // hand this to the LLM
+  parse: (input: string) => IJsonParseResult<T>;  // raw string in
+  coerce: (input: unknown) => T;                  // pre-parsed object in
+  validate: (input: unknown) => IValidation<T>;   // check constraints
+}
+```
+
+## First example
+
+```typescript copy filename="hello-structured.ts"
+import typia from "typia";
+
+interface IMember {
+  email: string;
+  name: string;
+  age: number;
+  hobbies: string[];
+}
+
+const output = typia.llm.structuredOutput<IMember>();
+
+// hand `output.parameters` to your LLM SDK as JSON schema
+// then:
+const parsed = output.parse(rawLlmText);
+if (parsed.success) {
+  const v = output.validate(parsed.data);
+  if (v.success) doSomething(v.data);
+}
+```
+
+<Tabs items={[<code>typia</code>, <code>ILlmStructuredOutput</code>, <code>ILlmSchema</code>]}>
+  <Tabs.Tab>
+```typescript filename="typia" showLineNumbers
+export namespace llm {
   export function structuredOutput<
     T extends Record<string, any>,
     Config extends Partial<ILlmSchema.IConfig & { equals: boolean }> = {},
   >(): ILlmStructuredOutput<T>;
-
-  // SCHEMA ONLY (use structuredOutput() for full interface)
-  export function parameters<
-    Parameters extends Record<string, any>,
-    Config extends Partial<ILlmSchema.IConfig> = {},
-  >(): ILlmSchema.IParameters;
 }
 ```
   </Tabs.Tab>
@@ -43,38 +82,7 @@ export namespace llm {
   </Tabs.Tab>
 </Tabs>
 
-All-in-one interface for LLM structured output.
-
-`typia.llm.structuredOutput<T>()` is a function generating `ILlmStructuredOutput<T>` containing everything needed for handling LLM structured outputs: the JSON schema for prompting, and functions for parsing, coercing, and validating responses.
-
-- **`parameters`**: JSON schema to pass to LLM providers
-- **`parse`**: Lenient JSON parser with type coercion
-- **`coerce`**: Type coercion for pre-parsed objects
-- **`validate`**: Schema validation with error details
-
-<Callout type="info">
-**LLM Function Calling** and **Structured Output**
-
-LLM selects proper function and fill arguments.
-
-In nowadays, most LLM (Large Language Model) like OpenAI are supporting "function calling" feature. The "LLM function calling" means that LLM automatically selects a proper function and fills parameter values from conversation with the user (may by chatting text).
-
-Structured output is another feature of LLM. The "structured output" means that LLM automatically transforms the output conversation into a structured data format like JSON.
-
-- https://platform.openai.com/docs/guides/function-calling
-- https://platform.openai.com/docs/guides/structured-outputs
-</Callout>
-
-<Callout type="info">
-**When to use `structuredOutput()` vs `parameters()`**
-
-- Use `structuredOutput()` when you need parsing, coercion, and validation together
-- Use `parameters()` when you only need the schema (e.g., passing to `response_format`)
-
-`structuredOutput()` is essentially `parameters()` + `parse()` + `coerce()` + `validate()` bundled together.
-</Callout>
-
-<Tabs items={["TypeScript Source Code", "Compiled JavaScript"]}>
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>
     <LocalSource
       path="examples/src/llm/structuredOutput.ts"
@@ -89,47 +97,44 @@ Structured output is another feature of LLM. The "structured output" means that 
   </Tabs.Tab>
 </Tabs>
 
-## The Function Calling Harness
+## `structuredOutput` vs `parameters` vs `application`
 
-The **function calling harness** is typia's three-layer pipeline that turns unreliable LLM output into 100% correct structured data:
+| If you need… | Use |
+|--------------|-----|
+| **One JSON shape** with parse + coerce + validate | `structuredOutput<T>()` |
+| **One JSON shape**, schema only (no helpers) | [`parameters<T>()`](/docs/llm/parameters) |
+| **Multiple functions** the LLM picks between | [`application<Class>()`](/docs/llm/application) |
+| Schema of an inner sub-type (advanced) | [`schema<T>()`](/docs/llm/schema) |
 
-1. **Lenient JSON Parsing** — recovers broken JSON (unclosed brackets, trailing commas, markdown wrapping, etc.)
-2. **Type Coercion** — fixes wrong types (`"42"` → `42`, double-stringified objects → objects, etc.)
-3. **Validation Feedback** — pinpoints remaining value errors with inline `// ❌` annotations so the LLM can self-correct and retry
+## Parse and coerce
 
-Each layer catches what the previous one didn't. Together they form a deterministic correction loop around the probabilistic LLM.
-
-### Parse & Coerce
+The same parse / coerce / validate / stringify harness as [`application`](/docs/llm/application#the-function-calling-harness):
 
 <Tabs items={[
-    "Parsing Example",
-    "Coercing Example",
+    "Parsing (string → T)",
+    "Coercing (object → T)",
     <code>ILlmStructuredOutput</code>,
   ]}>
   <Tabs.Tab>
-```typescript filename="Using parse() for raw JSON strings" showLineNumbers
+```typescript filename="raw JSON string from the LLM" showLineNumbers
 const output = typia.llm.structuredOutput<IMember>();
 
-// LLM returns raw JSON string
 const jsonString = '{"name": "John", "age": "25"}';
 
-// parse() handles lenient JSON + type coercion
 const result = output.parse(jsonString);
 if (result.success) {
-  console.log(result.data.age); // 25 (number, not string)
+  console.log(result.data.age); // 25 — coerced to number
 }
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="Using coerce() for pre-parsed objects" showLineNumbers
+```typescript filename="pre-parsed object from the SDK" showLineNumbers
 const output = typia.llm.structuredOutput<IMember>();
 
-// SDK already parsed JSON (Vercel AI, LangChain, MCP, etc.)
-const preParsedObject = { name: "John", age: "25" };
+const preParsed = { name: "John", age: "25" };
 
-// coerce() fixes types without re-parsing
-const coerced = output.coerce(preParsedObject);
-console.log(coerced.age); // 25 (number, not string)
+const coerced = output.coerce(preParsed);
+console.log(coerced.age); // 25 — coerced to number
 ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -141,51 +146,44 @@ console.log(coerced.age); // 25 (number, not string)
   </Tabs.Tab>
 </Tabs>
 
-**Type Coercion:**
+**Type coercion handles** (full list in [LlmJson](/docs/llm/json#type-coercion)):
 
-LLMs frequently return wrong types. Both `parse()` and `coerce()` automatically fix these based on the schema:
-
-- `"42"` → `42` (when schema expects number)
-- `"true"` → `true` (when schema expects boolean)
-- `"null"` → `null` (when schema expects null)
-- `"{...}"` → `{...}` (double-stringified objects)
-- `"[...]"` → `[...]` (double-stringified arrays)
-
-<Callout type="warning">
-**0% → 100% Success Rate on Union Types**
-
-`Qwen3.5` model shows 0% success rate when handling union types with double-stringified JSON objects. With type coercion, the success rate jumps to 100%.
-</Callout>
+- `"42"` → `42` for number/integer fields
+- `"true"` / `"false"` → `true` / `false` for boolean fields
+- `"null"` → `null` for nullable fields
+- `"{...}"` → object (double-stringified objects)
+- `"[...]"` → array (double-stringified arrays)
+- Nested coercion descends into properties recursively
 
 <Callout type="info">
-**For Pre-parsed Objects, Use `coerce()`**
+**`parse` vs `coerce` — same rule as in [`application`](/docs/llm/application).**
 
-Some LLM SDKs (Anthropic, Vercel AI, LangChain, MCP) parse JSON internally and return JavaScript objects directly. In these cases, use `coerce()` instead of `parse()` to fix types without re-parsing.
+- Raw string from the LLM → `parse(text)`
+- Already-parsed object from the SDK → `coerce(obj)`
 
-For more details, see [JSON Utilities](./json).
+`parse` is `coerce` with a lenient JSON parser in front.
 </Callout>
 
-### Validation Feedback
+## Validation feedback
 
-```typescript filename="Validation with LLM feedback" showLineNumbers
+```typescript filename="feedback-loop.ts" showLineNumbers
 import { LlmJson } from "@typia/utils";
 
 const output = typia.llm.structuredOutput<IMember>();
 const parsed = output.parse(llmResponse);
 
 if (parsed.success) {
-  const validated = output.validate(parsed.data);
+  const v = output.validate(parsed.data);
 
-  if (!validated.success) {
-    // Format errors for LLM to understand and self-correct
-    const feedback = LlmJson.stringify(validated);
-    console.log(feedback);
-    // Send feedback back to LLM for retry
+  if (!v.success) {
+    // Annotated JSON the LLM can read and self-correct from
+    const feedback = LlmJson.stringify(v);
+    // Send `feedback` back to the model in the next turn
   }
 }
 ```
 
-**Formatted Error Output:**
+The formatted output:
 
 ```json
 {
@@ -195,21 +193,14 @@ if (parsed.success) {
 }
 ```
 
-The LLM reads this feedback and self-corrects on the next turn.
+Same pattern, same payoff as in [`application`](/docs/llm/application#validation-feedback) — `qwen3-coder-next` jumps from 6.75% raw success to 100% with the harness around it.
 
-In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator by [Wrtn Technologies](https://wrtn.io)), `qwen3-coder-next` showed only **6.75%** raw function calling success rate on compiler AST types. However, with the complete harness, it reached **100%** — across all four tested Qwen models.
+## Strict mode — reject extra properties
 
-## Config Options
+```typescript copy
+const strict = typia.llm.structuredOutput<IMember, { equals: true }>();
 
-```typescript showLineNumbers
-// Use validateEquals (strict mode - reject extra properties)
-const strictOutput = typia.llm.structuredOutput<
-  IMember,
-  { equals: true }
->();
-
-// Strict validation rejects objects with extra properties
-const result = strictOutput.validate({
+strict.validate({
   name: "John",
   age: 25,
   email: "john@example.com",
@@ -218,27 +209,17 @@ const result = strictOutput.validate({
 });
 ```
 
-## Comparison
-
-| Feature | `parameters()` | `structuredOutput()` |
-|---------|---------------|---------------------|
-| Schema generation | ✅ | ✅ |
-| `parse()` function | ❌ | ✅ |
-| `coerce()` function | ❌ | ✅ |
-| `validate()` function | ❌ | ✅ |
-| Use case | Schema only | Full workflow |
-
-For schema-only needs, use [`parameters()`](./parameters). For the complete structured output workflow, use `structuredOutput()`.
+`{ equals: true }` switches the validator to `validateEquals` semantics. The schema also gets `additionalProperties: false` so the LLM is told upfront which properties are allowed.
 
 ## Restrictions
 
-`typia.llm.structuredOutput<T>()` follows the same restrictions as [`typia.llm.parameters<T>()`](./parameters) and [`typia.llm.schema<T>()`](./schema) functions.
+Same as [`parameters`](/docs/llm/parameters) and [`schema`](/docs/llm/schema):
 
-The type `T` must be a keyworded object type with static keys without any dynamic keys. Also, the object type must not be nullable or optional.
+- `T` must be a keyworded object type with static keys
+- No dynamic keys (`Record<string, V>`)
+- `T` may not be nullable or optional
 
-If you don't follow the LLM's keyworded arguments rule, `typia.llm.structuredOutput<T>()` will throw a compilation error.
-
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+<Tabs items={["Source That Won't Compile", "Compiler Errors"]}>
   <Tabs.Tab>
 ```typescript filename="src/examples/llm.structuredOutput.violation.ts" showLineNumbers
 import typia from "typia";
@@ -262,8 +243,6 @@ src/examples/llm.structuredOutput.violation.ts:4:1 - error TS(typia.llm.structur
 
 - Recordstringboolean
   - LLM parameters must be an object type.
-
-- Recordstringboolean
   - LLM parameters must not have dynamic keys.
 
 4 typia.llm.structuredOutput<Record<string, boolean>>();
@@ -279,3 +258,10 @@ src/examples/llm.structuredOutput.violation.ts:5:1 - error TS(typia.llm.structur
 ```
   </Tabs.Tab>
 </Tabs>
+
+## Where to go next
+
+- Multiple functions, LLM picks → [`application`](/docs/llm/application)
+- Just the schema, no helpers → [`parameters`](/docs/llm/parameters)
+- Harness internals (`parse`, `coerce`, `validate`, `stringify`) → [`LlmJson`](/docs/llm/json)
+- Tutorial walkthrough → [Tutorial: LLM function calling](/docs/tutorial/llm)

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -7,170 +7,194 @@ import AlertTitle from '@mui/material/AlertTitle';
 
 import LocalSource from '../../components/LocalSource';
 
-## `misc` module
+# Miscellaneous
 
-### `clone()` functions
+Three small modules that share the typia transform but don't fit anywhere else: `misc` (clone / prune / literals), `notations` (case conversion), and `http` (form data / query / headers / route parameters).
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>Resolved.ts</code>
-]}>
+## `misc.clone` — deep copy
+
+```typescript copy filename="signatures"
+namespace misc {
+  function clone<T>(input: T): Resolved<T>;
+  function assertClone<T>(input: unknown): Resolved<T>;  // + assert
+  function isClone<T>(input: unknown): Resolved<T> | null;  // + is
+  function validateClone<T>(input: unknown): IValidation<Resolved<T>>;  // + validate
+}
+```
+
+Same family pattern as the validators — `clone` trusts you, the others wrap the copy with type checking.
+
+```typescript copy
+const copy = typia.misc.clone<User>(user);
+
+// Type-safe variants
+const maybe = typia.misc.isClone<User>(input);        // null if `input` isn't a User
+const result = typia.misc.validateClone<User>(input); // IValidation<User>
+const checked = typia.misc.assertClone<User>(input);  // throws if invalid
+```
+
+The pairing rule is the same as elsewhere:
+
+- `misc.isClone<T>` = [`is<T>`](/docs/validators/is) + `clone<T>`
+- `misc.assertClone<T>` = [`assert<T>`](/docs/validators/assert) + `clone<T>`
+- `misc.validateClone<T>` = [`validate<T>`](/docs/validators/validate) + `clone<T>`
+
+<Tabs items={[<code>typia</code>, <code>TypeGuardError.ts</code>, <code>IValidation.ts</code>, <code>Resolved.ts</code>]}>
   <Tabs.Tab>
 ```typescript
 export namespace misc {
-  export function clone<T>(input: T): T;
+  export function clone<T>(input: T): Resolved<T>;
   export function assertClone<T>(input: T | unknown): Resolved<T>;
   export function isClone<T>(input: T | unknown): Resolved<T> | null;
   export function validateClone<T>(input: T | unknown): IValidation<Resolved<T>>;
 
+  // Factories (Resolved<T> = T projected for the JS runtime)
   export function createClone<T>(): (input: T) => Resolved<T>;
   export function createAssertClone<T>(): (input: T | unknown) => Resolved<T>;
   export function createIsClone<T>(): (input: T | unknown) => Resolved<T> | null;
-  export function createValidateClone<T>(): (
-      input: T | unknown
-  ) => IValidation<Resolved<T>>;
+  export function createValidateClone<T>(): (input: T | unknown) => IValidation<Resolved<T>>;
 }
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/typia/src/TypeGuardError.ts"
       filename="typia/TypeGuardError.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/schema/IValidation.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/typings/Resolved.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Deep copy functions.
-
-When you want to copy an instance, just call `typia.misc.clone()` function. It would perform deep copy including nested objects, so you can get a new instance with same values. Also, if you want type safe deep copy function, you can use `typia.misc.isClone()`, `typia.misc.assertClone()` or `typia.misc.validateClone()` functions instead.
-
-  - `typia.misc.assertClone()`: [`typia.assert<T>()`](../validators/assert) + `typia.misc.clone<T>()`
-  - `typia.misc.isClone()`: [`typia.is<T>()`](../validators/is) + `typia.misc.clone<T>()`
-  - `typia.misc.validateClone()`: [`typia.validate<T>()`](../validators/validate) + `typia.misc.clone<T>()`
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/misc/assertClone.ts"
       filename="examples/src/misc/assertClone.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/misc/assertClone.js"
       filename="examples/bin/misc/assertClone.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-### `prune()` functions
+## `misc.prune` — remove extra properties
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>
-]}>
-  <Tabs.Tab>
-```typescript
-export function prune<T>(input: T): void;
-export function assertPrune<T>(input: T | unknown): T;
-export function isPrune<T>(input: T | unknown): T | null;
-export function validatePrune<T>(input: T | unknown): IValidation<T>;
-
-export function createPrune<T>(): (input: T) => void;
-export function createAssertPrune<T>(): (input: T | unknown) => T;
-export function createIsPrune<T>(): (input: T | unknown) => T | null;
-export function createValidatePrune<T>(): (input: T | unknown) => IValidation<T>;
+```typescript copy filename="signatures"
+namespace misc {
+  function prune<T>(input: T): void;                          // mutates input
+  function assertPrune<T>(input: unknown): T;                 // + assert, then mutates
+  function isPrune<T>(input: unknown): input is T;            // + is; returns false instead of mutating
+  function validatePrune<T>(input: unknown): IValidation<T>;  // + validate
+}
 ```
-  </Tabs.Tab>
+
+**`prune` and `assertPrune` walk the input object and delete any property not declared on `T` — they mutate `input` in place.** `prune` returns `void`; `assertPrune` returns the now-mutated `input` typed as `T`. The `isPrune` and `validatePrune` variants only mutate once they're sure the input matches `T`, so they're safe on values you weren't expecting.
+
+> [!CAUTION]
+>
+> If you need a non-mutating version, clone first: `typia.misc.prune<T>(typia.misc.clone<T>(value))`.
+
+```typescript copy
+typia.misc.prune<User>(input);
+// input is now narrowed in place — extra properties removed.
+
+const cleaned = typia.misc.assertPrune<User>(input);
+// Same, but throws if input doesn't match User. Returns input.
+
+if (typia.misc.isPrune<User>(input)) {
+  // input is User and has been pruned. `input` is now typed as User.
+}
+
+const r = typia.misc.validatePrune<User>(input);
+// r.success === true means input was a User and is now pruned.
+```
+
+Useful when you receive a JSON document with extra fields you'd rather not pass around (e.g. logging, persisting to a DB that's strict about schema).
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface/IValidation.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-Deep prune functions.
-
-When you want to remove every extra properties that are not defined in the type including nested objects, you can use `typia.misc.prune<T>()` function. Also, if you want to perform type safe pruning, you can use `typia.misc.isPrune<T>()`, `typia.misc.assertPrune<T>()` or `typia.misc.validatePrune<T>()` functions instead.
-
-  - `typia.misc.isPrune()`: [`typia.is<T>()`](../validators/is) + `typia.misc.prune<T>()`
-  - `typia.misc.assertPrune()`: [`typia.assert<T>()`](../validators/assert) + `typia.misc.prune<T>()`
-  - `typia.misc.validatePrune()`: [`typia.validate<T>()`](../validators/validate) + `typia.misc.prune<T>()`
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/misc/assertPrune.ts"
       filename="examples/src/misc/assertPrune.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/misc/assertPrune.js"
       filename="examples/bin/misc/assertPrune.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-### `literals()` function
-```typescript
-export namespace misc {
-  export function literals<
-    T extends boolean | number | string | bigint | null,
-  >(): T[];
+## `misc.literals` — union literal type → array
+
+```typescript copy filename="signature"
+namespace misc {
+  function literals<T extends boolean | number | string | bigint | null>(): T[];
 }
 ```
 
-Union literal type to array.
+If you have a string-literal union (`"red" | "green" | "blue"`) and you want the runtime array `["red", "green", "blue"]` to iterate over, `misc.literals` reads the union from the TS type and emits the array.
 
-When you call `typia.misc.literals<T>()` function with union literal type, it returns an array of literal values listed in the generic `T` argument. This `typia.misc.literals<T>` function is useful when you are developing test program, especially handling some discriminated union types.
+Handy for select-box options, discriminated-union test matrices, etc.
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/misc/literals.ts"
       filename="examples/src/misc/literals.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/misc/literals.js"
       filename="examples/bin/misc/literals.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## `notations` module
+## `notations` — case conversion
 
-### `camel()` functions
+Three case converters: `camel`, `pascal`, `snake`. Each one walks the object and rewrites property names to that case. Same four-variant family as everywhere else:
+
+```typescript copy filename="signatures — example for camelCase"
+namespace notations {
+  function camel<T>(input: T): CamelCase<T>;
+  function assertCamel<T>(input: unknown): CamelCase<T>;
+  function isCamel<T>(input: unknown): CamelCase<T> | null;
+  function validateCamel<T>(input: unknown): IValidation<CamelCase<T>>;
+}
+```
+
+`PascalCase` and `SnakeCase` swap in for `CamelCase` in the type. The output type is computed at the type level so the rest of your code knows about the new property names.
+
+```typescript copy
+typia.notations.snake<{ userId: string; userName: string }>({
+  userId: "1",
+  userName: "John",
+});
+// → { user_id: "1", user_name: "John" }
+```
 
 <Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
+  <code>typia</code>,
+  <code>TypeGuardError.ts</code>,
   <code>IValidation.ts</code>,
-  <code>CamelCase.ts</code>
+  <code>CamelCase.ts</code>,
 ]}>
   <Tabs.Tab>
 ```typescript
@@ -178,470 +202,189 @@ export namespace notations {
   export function camel<T>(input: T): CamelCase<T>;
   export function assertCamel<T>(input: T | unknown): CamelCase<T>;
   export function isCamel<T>(input: T | unknown): CamelCase<T> | null;
-  export function validateCamel<T>(
-    input: T | unknown,
-  ): IValidation<CamelCase<T>>;
+  export function validateCamel<T>(input: T | unknown): IValidation<CamelCase<T>>;
 
-  export function createCamel<T>(): (input: T) => CamelCase<T>;
-  export function createAssertCamel<T>(): (input: T | unknown) => CamelCase<T>;
-  export function createIsCamel<T>(): (
-    input: T | unknown,
-  ) => CamelCase<T> | null;
-  export function createValidateCamel<T>(): (
-    input: T | unknown,
-  ) => IValidation<CamelCase<T>>;
+  // Same surface for pascal / Pascal and snake / Snake.
+  // Each has create* factories too.
 }
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/typia/src/TypeGuardError.ts"
       filename="typia/TypeGuardError.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface/IValidation.ts"
+      filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/typings/CamelCase.ts"
-      filename="typia/CamelCase.ts"
+      filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Camel case converters.
-
-Convert every property names of nested objects to be camel case notation.
-
-When you need type safe functions, you can utilize below them.
-
-  - `typia.notations.assertCamel<T>()`: [`typia.assert<T>()`](../validators/assert) + `typia.notations.camel<T>()`
-  - `typia.notations.isCamel<T>`: [`typia.is<T>()`](../validators/is) + `typia.notations.camel<T>()`
-  - `typia.notations.validateCamel<T>`: [`typia.validate<T>()`](../validators/validate) + `typia.notations.camel<T>()`
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['camel example', 'pascal example', 'snake example']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/notations/camel.ts"
       filename="examples/src/notations/camel.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/notations/camel.js"
-      filename="examples/bin/notations/camel.js"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-### `pascal()` functions
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>PascalCase.ts</code>
-]}>
-  <Tabs.Tab>
-```typescript
-export namespace notations {
-  export function pascal<T>(input: T): PascalCase<T>;
-  export function assertPascal<T>(input: T | unknown): PascalCase<T>;
-  export function isPascal<T>(input: T | unknown): PascalCase<T> | null;
-  export function validatePascal<T>(
-    input: T | unknown,
-  ): IValidation<PascalCase<T>>;
-
-  export function createPascal<T>(): (input: T) => PascalCase<T>;
-  export function createAssertPascal<T>(): (
-    input: T | unknown,
-  ) => PascalCase<T>;
-  export function createIsPascal<T>(): (
-    input: T | unknown,
-  ) => PascalCase<T> | null;
-  export function createValidatePascal<T>(): (
-    input: T | unknown,
-  ) => IValidation<PascalCase<T>>;
-}
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface/IValidation.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-
-      path="packages/interface/src/typings/PascalCase.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-Pascal case converters.
-
-Convert every property names of nested objects to be pascal case notation.
-
-When you need type safe functions, you can utilize below them.
-
-  - `typia.notations.assertPascal<T>()`: [`typia.assert<T>()`](../validators/assert) + `typia.notations.pascal<T>()`
-  - `typia.notations.isPascal<T>`: [`typia.is<T>()`](../validators/is) + `typia.notations.pascal<T>()`
-  - `typia.notations.validatePascal<T>`: [`typia.validate<T>()`](../validators/validate) + `typia.notations.pascal<T>()`
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/notations/pascal.ts"
       filename="examples/src/notations/pascal.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/notations/pascal.js"
-      filename="examples/bin/notations/pascal.js"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-### `snake()` functions
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>SnakeCase.ts</code>
-]}>
-  <Tabs.Tab>
-```typescript
-export namespace notations {
-  export function snake<T>(input: T): SnakeCase<T>;
-  export function assertSnake<T>(input: T | unknown): SnakeCase<T>;
-  export function isSnake<T>(input: T | unknown): SnakeCase<T> | null;
-  export function validateSnake<T>(
-    input: T | unknown,
-  ): IValidation<SnakeCase<T>>;
-
-  export function createSnake<T>(): (input: T) => SnakeCase<T>;
-  export function createAssertSnake<T>(): (input: T | unknown) => SnakeCase<T>;
-  export function createIsSnake<T>(): (
-    input: T | unknown,
-  ) => SnakeCase<T> | null;
-  export function createValidateSnake<T>(): (
-    input: T | unknown,
-  ) => IValidation<SnakeCase<T>>;
-}
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface/IValidation.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/typings/SnakeCase.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-Snake case converters.
-
-Convert every property names of nested objects to be snake case notation.
-
-When you need type safe functions, you can utilize below them.
-
-  - `typia.notations.assertSnake<T>()`: [`typia.assert<T>()`](../validators/assert) + `typia.notations.snake<T>()`
-  - `typia.notations.isSnake<T>`: [`typia.is<T>()`](../validators/is) + `typia.notations.snake<T>()`
-  - `typia.notations.validateSnake<T>`: [`typia.validate<T>()`](../validators/validate) + `typia.notations.snake<T>()`
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/notations/snake.ts"
       filename="examples/src/notations/snake.ts"
       showLineNumbers />
   </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/notations/snake.js"
-      filename="examples/bin/notations/snake.js"
-      showLineNumbers />
-  </Tabs.Tab>
 </Tabs>
 
-## `http` module
+## `http` — decode form data, query strings, headers, route params
 
-<br/>
+The `http` module turns HTTP-shaped inputs (`URLSearchParams`, headers object, route parameter strings, `FormData`) into typed objects, with automatic string-to-number / string-to-boolean coercion.
+
 <Alert severity="success">
-  <AlertTitle> 
-    **Nestia Supporting** 
+  <AlertTitle>
+    **Designed for Nestia**
   </AlertTitle>
 
-`http` module has been designed to support the [nestia](https://github.com/samchon/nestia) project.
-
-  - `query()` functions -> [`@TypedQuery()`](https://nestia.io/docs/core/TypedQuery/)
-  - `headers()` functions -> [`@TypedHeaders()`](https://nestia.io/docs/core/TypedHeaders/)
-  - `parameter()` function -> [`@TypedParam()`](https://nestia.io/docs/core/TypedParam/)
+These functions back [Nestia](https://nestia.io)'s HTTP decorators — [`@TypedQuery()`](https://nestia.io/docs/core/TypedQuery/), [`@TypedHeaders()`](https://nestia.io/docs/core/TypedHeaders/), [`@TypedParam()`](https://nestia.io/docs/core/TypedParam/), and friends. They also work standalone for hand-rolled Express / Fastify / Hono handlers.
 
 </Alert>
 
-### `query()` functions
+### `http.query` — URL query strings
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>Resolved.ts</code>
-]}>
-  <Tabs.Tab>
-```typescript
-export namespace http {
-  export function query<T extends object>(input: Query): Resolved<T>;
-  export function assertQuery<T extends object>(input: Query): Resolved<T>;
-  export function isQuery<T extends object>(input: Query): Resolved<T> | null;
-  export function validateQuery<T extends object>(
-    input: Query,
-  ): IValidation<Resolved<T>>;
-
-  export function createQuery<T extends object>(): (
-    input: Query,
-  ) => Resolved<T>;
-  export function createAssertQuery<T extends object>(): (
-    input: Query,
-  ) => Resolved<T>;
-  export function createIsQuery<T extends object>(): (
-    input: Query,
-  ) => Resolved<T> | null;
-  export function createValidateQuery<T extends object>(): (
-    input: Query,
-  ) => IValidation<Resolved<T>>;
+```typescript copy filename="signatures"
+namespace http {
+  function query<T extends object>(input: string | URLSearchParams): Resolved<T>;
+  function assertQuery<T extends object>(input: string | URLSearchParams): Resolved<T>;
+  function isQuery<T extends object>(input: string | URLSearchParams): Resolved<T> | null;
+  function validateQuery<T extends object>(input: string | URLSearchParams): IValidation<Resolved<T>>;
 }
-type Query = string | URLSearchParams;
 ```
-  </Tabs.Tab>
+
+`http.query` decodes a query string (or a `URLSearchParams`) into a typed object. Numeric and boolean properties are coerced from their string form automatically.
+
+**Restrictions** (typia rejects at compile time):
+
+1. `T` must be an object type
+2. No dynamic keys
+3. Only `boolean | bigint | number | string` or arrays of those
+4. No unions
+
+`http.query` itself doesn't validate constraint tags (`Format`, `Minimum`, …). The `assertQuery` / `isQuery` / `validateQuery` variants do.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/typings/Resolved.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-URL query decoder functions.
-
-`typia.http.query<T>()` is a function decoding a query string or an `URLSearchParams` instance, with automatic type casting to the expected type. When property type be defined as boolean or number type, `typia.http.query<T>()` will cast the value to the expected type when decoding.
-
-By the way, as URL query is not enough to express complex data structures, `typia.http.query<T>()` function has some limitations. If target type `T` is not following those restrictions, compilation errors would be occurred.
-
-  1. Type T must be an object type
-  2. Do not allow dynamic property
-  3. Only boolean, bigint, number, string or their array types are allowed
-  4. By the way, union type never be not allowed
-
-Also, `typia.http.query<T>()` function does not perform validation about the decoded value. Therefore, if you can't sure that input data is following the `T` type, it would better to call one of below functions instead.
-
-  - `typia.http.assertQuery<T>()`: [`typia.assert<T>()`](../validators/assert) + `typia.http.query<T>()`
-  - `typia.http.isQuery<T>()`: [`typia.is<T>()`](../validators/is) + `typia.http.query<T>()`
-  - `typia.http.validateQuery<T>()`: [`typia.validate<T>()`](../validators/validate) + `typia.http.query<T>()`
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/http/query.ts"
       filename="examples/src/http/query.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/http/query.js"
       filename="examples/bin/query.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-### `headers()` functions
+### `http.headers` — HTTP request headers
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>Resolved.ts</code>
-]}>
-  <Tabs.Tab>
-```typescript
-export namespace http {
-  export function headers<T extends object>(input: Headers): Resolved<T>;
-  export function assertHeaders<T extends object>(input: Headers): Resolved<T>;
-  export function isHeaders<T extends object>(
-    input: Headers,
-  ): Resolved<T> | null;
-  export function validateHeaders<T extends object>(
-    input: Headers,
-  ): IValidation<Resolved<T>>;
-
-  export function createHeaders<T extends object>(): (
-    input: Headers,
-  ) => Resolved<T>;
-  export function createAssertHeaders<T extends object>(): (
-    input: Headers,
-  ) => Resolved<T>;
-  export function createIsHeaders<T extends object>(): (
-    input: Headers,
-  ) => Resolved<T> | null;
-  export function createValidateHeaders<T extends object>(): (
-    input: Headers,
-  ) => IValidation<Resolved<T>>;
+```typescript copy filename="signatures"
+namespace http {
+  function headers<T extends object>(
+    input: Record<string, string | string[] | undefined>,
+  ): Resolved<T>;
+  // …assert / is / validate variants
 }
-type Headers = Record<string, string | string[] | undefined>;
 ```
-  </Tabs.Tab>
+
+`http.headers` decodes an Express/Fastify-style headers object. Same coercion as `query`, plus a stricter set of restrictions specific to HTTP:
+
+1. `T` must be an object type
+2. No dynamic keys
+3. **Property keys must be lowercase** (HTTP headers are case-insensitive; typia normalizes to lowercase)
+4. Property values may be `undefined` but not `null`
+5. Only `boolean | bigint | number | string` or arrays of those
+6. No unions
+7. `set-cookie` must be an array
+8. **These headers cannot be array-typed** (the HTTP spec collapses them to a single value):
+
+   `age, authorization, content-length, content-type, etag, expires, from, host, if-modified-since, if-unmodified-since, last-modified, location, max-forwards, proxy-authorization, referer, retry-after, server, user-agent`
+
+If you trip one of these rules, typia rejects the call at compile time with a clear error.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/typings/Resolved.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-Headers decoder (for express and fastify).
-
-`typia.http.headers<t>()` is a function decoding an header instance, with automatic type casting to the expected type. When property type be defined as boolean or number type, `typia.http.headers<t>()` will cast the value to the expected type.
-
-By the way, as HTTP headers are not enough to express complex data structures, `typia.http.headers<t>()` function has some limitations. If target type `T` is not following those restrictions, compilation errors would be occurred.
-
-  1. Type T must be an object type
-  2. Do not allow dynamic property
-  3. Property key must be lower case
-  4. Property value cannot be null, but undefined is possible
-  5. Only boolean, bigint, number, string or their array types are allowed
-  6. By the way, union type never be not allowed
-  7. Property set-cookie must be array type
-  8. Those properties cannot be array type
-     - age
-     - authorization
-     - content-length
-     - content-type
-     - etag
-     - expires
-     - from
-     - host
-     - if-modified-since
-     - if-unmodified-since
-     - last-modified
-     - location
-     - max-forwards
-     - proxy-authorization
-     - referer
-     - retry-after
-     - server
-     - user-agent
-
-Also, `typia.http.headers<t>()` function does not perform validation about the decoded value. Therefore, if you can't sure that input data is following the `T` type, it would better to call one of below functions instead.
-
-  - `typia.http.assertHeaders<T>()`: [`typia.assert<T>()`](../validators/assert) + `typia.http.headers<T>()`
-  - `typia.http.isHeaders<T>()`: [`typia.is<T>()`](../validators/is) + `typia.http.headers<T>()`
-  - `typia.http.validateHeaders<T>()`: [`typia.validate<T>()`](../validators/validate) + `typia.http.headers<T>()`
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/http/headers.ts"
       filename="examples/src/http/headers.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/http/headers.js"
       filename="examples/bin/http/headers.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-### `parameter()` functions
+### `http.parameter` — URL path parameters
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-]}>
-  <Tabs.Tab>
-```typescript
-export namespace http {
-  export function parameter<T extends Atomic.Type | null>(input: string): T;
-  export function createParameter<T extends Atomic.Type | null>(): (
-    input: string,
-  ) => T;
+```typescript copy filename="signature"
+namespace http {
+  function parameter<T extends boolean | bigint | number | string | null>(input: string): T;
 }
 ```
-  </Tabs.Tab>
+
+`http.parameter` decodes a single URL path parameter (a string from `:id` in your route) into the expected primitive type, **and always asserts**. Unlike `query` / `headers`, there's no `isParameter` or `validateParameter` — if the value doesn't match `T`, it throws `TypeGuardError`.
+
+```typescript copy
+const id: number = typia.http.parameter<number>(request.params.id);
+// throws if `request.params.id` isn't a valid number string
+```
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-URL path parameter decoder.
-
-`typia.http.parameter<T>()` is a function decoding a path parameter, with automatic type casting to the expected type. When type T has been defined as boolean or number `type, typia.http.parameter<T>()` will cast the value to the expected type.
-
-Also, `typia.http.parameter<T>()` performs type assertion to the decoded value by combining with assert function. Therefore, when the decoded value is not following the `T` type, `TypeGuardError` would be thrown.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/http/parameter.ts"
       filename="examples/src/http/parameter.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/http/parameter.js"
       filename="examples/bin/http/parameter.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
+
+### `http.formData` — multipart form data
+
+```typescript copy filename="signature"
+namespace http {
+  function formData<T extends object>(input: FormData): Resolved<T>;
+  // …assert / is / validate variants
+}
+```
+
+`http.formData` decodes a `FormData` instance into a typed object. Allowed property types: `boolean | bigint | number | string | Blob | File` or arrays of those.
+
+## Where to go next
+
+- The full validator family → [`is`](/docs/validators/is) · [`assert`](/docs/validators/assert) · [`validate`](/docs/validators/validate)
+- Constraint tags on `query`/`headers`/`parameter` values → [Special Tags](/docs/validators/tags)
+- Random data for tests → [`random`](/docs/random)
+- NestJS integration that builds on `http.*` → [Nestia](https://nestia.io)

--- a/website/src/content/docs/protobuf/decode.mdx
+++ b/website/src/content/docs/protobuf/decode.mdx
@@ -7,14 +7,64 @@ import AlertTitle from '@mui/material/AlertTitle';
 
 import LocalSource from '../../../components/LocalSource';
 
-## `decode()` functions
+# `typia.protobuf.*Decode` — Protocol Buffer bytes → TypeScript object
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>Resolved.ts</code>,
-]}>
+```typescript copy filename="signatures"
+namespace protobuf {
+  function decode<T>(buffer: Uint8Array): Resolved<T>;
+  function isDecode<T>(buffer: Uint8Array): Resolved<T> | null;
+  function assertDecode<T>(buffer: Uint8Array): Resolved<T>;
+  function validateDecode<T>(buffer: Uint8Array): IValidation<Resolved<T>>;
+}
+```
+
+The decoder reads `T` at compile time and emits a hand-rolled binary reader for that shape — same model as the encoder, in reverse.
+
+## First example
+
+```typescript copy filename="hello-decode.ts"
+import typia from "typia";
+
+interface User { id: string; age: number; hobbies: string[] }
+
+const bytes: Uint8Array = await fetchBytesSomehow();
+const user = typia.protobuf.assertDecode<User>(bytes);
+// → User, with type tag constraints validated. Throws on mismatch.
+```
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/protobuf/decode.ts"
+      filename="examples/src/protobuf/decode.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/protobuf/decode.js"
+      filename="examples/bin/protobuf/decode.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## Pick the right variant
+
+| Function | Validates result? | On failure |
+|----------|-------------------|------------|
+| `protobuf.decode<T>` | **No** | output is whatever fell out of the binary reader |
+| `protobuf.isDecode<T>` | Yes ([`is`](/docs/validators/is)) | returns `null` |
+| `protobuf.assertDecode<T>` | Yes ([`assert`](/docs/validators/assert)) | throws `TypeGuardError` |
+| `protobuf.validateDecode<T>` | Yes ([`validate`](/docs/validators/validate)) | returns `IValidation<Resolved<T>>` |
+
+> [!IMPORTANT]
+>
+> **What the `*Decode` validators actually verify.**
+>
+> They check **custom tag constraints** — `tags.Format<"uuid">`, `tags.Minimum<0>`, etc. They do **not** re-verify that the bytes were structurally valid Protocol Buffer for `T` — the decoder already did that decoding work. So you can rely on these to catch "the producer encoded a UUID that's actually not a UUID" but not "someone fed me random bytes."
+>
+> The safe pattern is: producer uses `protobuf.assertEncode` (or `validateEncode`), consumer uses `protobuf.assertDecode` (or `validateDecode`). Then both ends of the wire are checked.
+
+<Tabs items={[<code>typia</code>, <code>IValidation.ts</code>, <code>TypeGuardError.ts</code>, <code>Resolved.ts</code>]}>
   <Tabs.Tab>
 ```typescript
 export namespace protobuf {
@@ -28,136 +78,52 @@ export namespace protobuf {
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
     <LocalSource
       path="packages/interface/src/schema/IValidation.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/typings/Resolved.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-Protocol Buffer Decoder.
-
-You can easily convert a Protocol Buffer's binary data to a JavaScript object, without any extra Protocol Buffer [Message Schema](../message) definition. `typia.protobuf.decode<T>()` function analyzes your type `T`, and generates a Protocol Buffer Message Schema internally.And then, it converts the binary data to a JavaScript object.
-
-By the way, as Protocol Buffer handles binary data directly, there's no way when `input` binary data was not encoded from the `T` typed value. In that case, unexpected behavior or internal error would be occurred. Therefore, I recommend you to encode binary data of Protocol Buffer from type safe encode functions like below, Use `typia.protobuf.encode<T>()` function only when you can trust it.
-
-  - [`typia.protobuf.isEncode<T>()`](../encode)
-  - [`typia.protobuf.assertEncode<T>()`](../encode)
-  - [`typia.protobuf.validateEncode<T>()`](../encode)
-
-For reference, `typia` provides type safe decorators like below, but they are just for additional type validation like `number & Minimum<7>` or `string & Format<"uuid">` cases, that are represented by [Special Tags](../validators/tags). Thus, I repeat that, you've to ensure type safety when using decoder function.
-
-  - `typia.protobuf.isDecode<T>()`: [`typia.is<T>()`](../validators/is) + `typia.protobuf.decode<T>()`
-  - `typia.protobuf.assertDecode<T>()`: [`typia.assert<T>()`](../validators/assert) + `typia.protobuf.decode<T>()`
-  - `typia.protobuf.validateDecode<T>()`: [`typia.validate<T>()`](../validators/validate) + `typia.protobuf.decode<T>()`
-
-
-<br/>
-<Alert severity="success">
-  <AlertTitle> 
-    **AOT compilation** 
-  </AlertTitle>
-
-`typia.protobuf.decode<T>()` and other similar functions are still much faster than any other competitive libraries, even though they include type checking process. This is the power of AOT compilation, writing optimal dedicated code by analyzing TypeScript type, in the compilation level.
-
-</Alert>
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/protobuf/decode.ts"
-      filename="examples/src/protobuf/decode.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/protobuf/decode.js"
-      filename="examples/bin/protobuf/decode.js"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## Reusable functions
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>Resolved.ts</code>,
-]}>
-  <Tabs.Tab>
-```typescript
-export namespace protobuf {
-  export function createDecode<T>(): (buffer: Uint8Array) => Resolved<T>;
-  export function createIsDecode<T>: (buffer: Uint8Array) => Resolved<T> | null;
-  export function createAssertDecode<T>(): (buffer: Uint8Array) => Resolved<T>;
-  export function createValidateDecode<T>(): (
-      buffer: Uint8Array
-  ) => IValidation<Resolved<T>>;
-}
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/typia/src/TypeGuardError.ts"
       filename="typia/TypeGuardError.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/typings/Resolved.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Reusable `typia.protobuf.decode<T>()` function generators.
+## Reusable factories
 
-If you repeat to call `typia.protobuf.decode<T>()` function on the same type, size of JavaScript files would be larger because of duplicated AOT compilation. To prevent it, you can generate reusable function through `typia.protobuf.createDecode<T>()` function.
+```typescript copy
+const decodeUser = typia.protobuf.createAssertDecode<User>();
+```
 
-Just look at the code below, then you may understand how to use it.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/protobuf/createDecode.ts"
       filename="examples/src/protobuf/createDecode.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/protobuf/createDecode.js"
       filename="examples/bin/protobuf/createDecode.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## References
+## Restrictions
 
-Protocol Buffer supports special numeric types like `int32` or `uint64` that are not supported in TypeScript. Also, types of Protocol Buffer cannot fully meet TypeScript type specs either, as expression power of TypeScript types are much stronger than Protocol Buffer.
+Same as the rest of the protobuf surface — see [`protobuf.message`](/docs/protobuf/message#restrictions).
 
-To know how to define special numeric types like `uint64`, and to understand which TypeScript types are not supported in Protocol Buffer specs, it would better to read below documents. I recommend you to read them before using `typia.protobuf.decode<T>()` related functions.
+## Where to go next
 
-  - [Typia Guide Documents > Protocol Buffer > Message Schema](../message)
-    - [`message()` function](../message#message-function)
-    - [Type Tags](../message#type-tags)
-    - [Comment Tags](../message#comment-tags)
-    - [Restrictions](../message#restrictions)
+- Encoding values → [`protobuf.encode`](/docs/protobuf/encode)
+- Sharing the schema with other services → [`protobuf.message`](/docs/protobuf/message)
+- Numeric and string tags → [Special Tags](/docs/validators/tags)

--- a/website/src/content/docs/protobuf/encode.mdx
+++ b/website/src/content/docs/protobuf/encode.mdx
@@ -7,14 +7,64 @@ import AlertTitle from '@mui/material/AlertTitle';
 
 import LocalSource from '../../../components/LocalSource';
 
-## `encode()` functions
+# `typia.protobuf.*Encode` — TypeScript object → Protocol Buffer bytes
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>Resolved.ts</code>
-]}>
+```typescript copy filename="signatures"
+namespace protobuf {
+  function encode<T>(input: T): Uint8Array;                          // no validation
+  function isEncode<T>(input: T): Uint8Array | null;                 // is + encode
+  function assertEncode<T>(input: T): Uint8Array;                    // assert + encode
+  function validateEncode<T>(input: T): IValidation<Uint8Array>;     // validate + encode
+}
+```
+
+The encoder reads your type at compile time and emits a hand-rolled binary writer for that exact shape — no separate `.proto` schema is needed. You only need [`protobuf.message`](/docs/protobuf/message) when another service has to read the schema.
+
+## First example
+
+```typescript copy filename="hello-encode.ts"
+import typia from "typia";
+
+interface User { id: string; age: number; hobbies: string[] }
+
+const bytes: Uint8Array = typia.protobuf.assertEncode<User>({
+  id: "1",
+  age: 25,
+  hobbies: ["reading"],
+});
+```
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/protobuf/encode.ts"
+      filename="examples/src/protobuf/encode.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/protobuf/encode.js"
+      filename="examples/bin/protobuf/encode.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## Pick the right variant
+
+| Function | Validates input? | On failure |
+|----------|------------------|------------|
+| `protobuf.encode<T>` | **No** | output is undefined — typically the bytes will not decode |
+| `protobuf.isEncode<T>` | Yes ([`is`](/docs/validators/is)) | returns `null` |
+| `protobuf.assertEncode<T>` | Yes ([`assert`](/docs/validators/assert)) | throws `TypeGuardError` |
+| `protobuf.validateEncode<T>` | Yes ([`validate`](/docs/validators/validate)) | returns `IValidation<Uint8Array>` |
+
+> [!CAUTION]
+>
+> **`protobuf.encode<T>` trusts you completely.**
+>
+> If `input` doesn't actually match `T`, the encoder writes whatever bytes its emitted code happens to produce — and the decoder on the other end will likely fail or produce garbage. Use it only when the input was constructed inside the same call frame from typed values. Otherwise, pick `assertEncode` or `validateEncode`.
+
+<Tabs items={[<code>typia</code>, <code>IValidation.ts</code>, <code>TypeGuardError.ts</code>, <code>Resolved.ts</code>]}>
   <Tabs.Tab>
 ```typescript showLineNumbers
 export namespace protobuf {
@@ -26,127 +76,63 @@ export namespace protobuf {
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
     <LocalSource
       path="packages/interface/src/schema/IValidation.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/typings/Resolved.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-Protocol Buffer Encoder.
-
-You can easily convert a JavaScript object to a binary data of Protocol Buffer, without any extra Protocol Buffer [Message Schema](../message) definition. `typia.protobuf.encode<T>()` function analyzes your type `T`, and generates a Protocol Buffer Message Schema internally. And then, it converts the `input` instance to the binary data of Protocol Buffer format.
-
-By the way, `typia.protobuf.encode<T>()` function does not validate the `input` value. It just believes user and `input` value, and converts to the Protocol Buffer binary data directly without any validation. By the way, if the `input` value was not validate, the encoded binary data never can be decoded. So, if you can't sure the `input` value type, you should use below functions instead.
-
-  - `typia.protobuf.isEncode<T>()`: [`typia.is<T>()`](../validators/is) + `typia.protobuf.encode<T>()`
-  - `typia.protobuf.assertEncode<T>()`: [`typia.assert<T>()`](../validators/assert) + `typia.protobuf.encode<T>()`
-  - `typia.protobuf.validateEncode<T>()`: [`typia.validate<T>()`](../validators/validate) + `typia.protobuf.encode<T>()`
-
-<br/>
-<Alert severity="success">
-    <AlertTitle> 
-        **AOT compilation** 
-    </AlertTitle>
-
-`typia.protobuf.encode<T>()` and other similar functions are still much faster than any other competitive libraries, even though they include type checking process. This is the power of AOT compilation, writing optimal dedicated code by analyzing TypeScript type, in the compilation level.
-
-</Alert>
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/protobuf/encode.ts"
-      filename="examples/src/protobuf/encode.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/protobuf/encode.js"
-      filename="examples/bin/protobuf/encode.js"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## Reusable Functions
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>, 
-  <code>IValidation.ts</code>,
-  <code>Resolved.ts</code>
-]}>
-  <Tabs.Tab>
-```typescript showLineNumbers
-export namespace protobuf {
-  export function encode<T>(): (input: T) => Uint8Array;
-  export function isEncode<T>(): (input: T) => Uint8Array | null;
-  export function assertEncode<T>(): (input: T) => Uint8Array;
-  export function validateEncode<T>(): (input: T) => IValidation<Uint8Array>;
-}
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/typia/src/TypeGuardError.ts"
       filename="typia/TypeGuardError.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="packages/interface/src/typings/Resolved.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Reusable `typia.protobuf.encode<T>()` function generators.
+## Reusable factories
 
-If you repeat to call `typia.protobuf.encode<T>()` function on the same type, size of JavaScript files would be larger because of duplicated AOT compilation. To prevent it, you can generate reusable function through `typia.protobuf.createEncode<T>()` function.
+Same pattern as the other namespaces — hoist the per-type code once:
 
-Just look at the code below, then you may understand how to use it.
+```typescript copy
+const encodeUser = typia.protobuf.createAssertEncode<User>();
+```
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/protobuf/createEncode.ts"
       filename="examples/src/protobuf/createEncode.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/protobuf/createEncode.js"
       filename="examples/bin/protobuf/createEncode.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## References
+## Restrictions
 
-Protocol Buffer supports special numeric types like `int32` or `uint64` that are not supported in TypeScript. Also, types of Protocol Buffer cannot fully meet TypeScript type specs either, as expression power of TypeScript types are much stronger than Protocol Buffer.
+The encoder follows the same type restrictions as [`protobuf.message`](/docs/protobuf/message#restrictions): top-level type must be a single static object, no two-dimensional containers, no `any`/`Date`/`Set`/etc.
 
-To know how to define special numeric types like `uint64`, and to understand which TypeScript types are not supported in Protocol Buffer specs, it would better to read below documents. I recommend you to read them before using `typia.protobuf.encode<T>()` related functions.
+If you need numeric types Protocol Buffer specifies but TypeScript doesn't (e.g. `uint32`, `int64`), pick them with [type tags](/docs/validators/tags) on the property:
 
-  - [Typia Guide Documents > Protocol Buffer > Message Schema](../message)
-    - [`message()` function](../message#message-function)
-    - [Type Tags](../message#type-tags)
-    - [Comment Tags](../message#comment-tags)
-    - [Restrictions](../message#restrictions)
+```typescript
+interface Pricing {
+  cents: number & tags.Type<"uint32">;
+  customerCount: bigint & tags.Type<"uint64">;
+}
+```
+
+## Where to go next
+
+- Decoding the bytes back into a value → [`protobuf.decode`](/docs/protobuf/decode)
+- Sharing the schema with another language → [`protobuf.message`](/docs/protobuf/message)
+- Numeric tags → [Special Tags](/docs/validators/tags)

--- a/website/src/content/docs/protobuf/message.mdx
+++ b/website/src/content/docs/protobuf/message.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guide Documents > Protobuf > Schema
+title: Guide Documents > Protobuf > Message Schema
 ---
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
@@ -7,100 +7,108 @@ import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `message()` function
+# `typia.protobuf.message` — emit a `.proto` schema from a TypeScript type
 
-<Tabs items={[
-  <code>typia</code>
-]}>
-  <Tabs.Tab>
-```typescript
-export namespace protobuf {
-  export function message<T>(): string;
+If you only encode and decode within TypeScript, you don't need this — the [`encode`](/docs/protobuf/encode) and [`decode`](/docs/protobuf/decode) functions analyze your type internally and produce a wire-compatible binary form.
+
+`typia.protobuf.message<T>()` is for the other case: when you need to **share** the schema with a service written in another language (Go, Python, …). It returns the `.proto` text that any Protocol Buffer compiler can consume.
+
+```typescript copy filename="signature"
+namespace protobuf {
+  function message<T>(): string;  // returns .proto schema text
 }
 ```
-  </Tabs.Tab>
-</Tabs>
 
-`typia.protobuf.message()` function returns a Protocol Buffer message (structure) as a string value.
+## First example
 
-With this `message()` function, you can share `*.proto` files with other languages. If you want to customize byte order or define specific type (that is not supported in the TypeScript) like `uint32`, use comment tags by following [comment tags](#comment-tags) section.
+```typescript copy filename="hello-message.ts"
+import typia, { tags } from "typia";
 
-<Tabs items={["TypeScript Source Code", "Compiled JavaScript File"]}>
+interface User {
+  id: string;
+  age: number & tags.Type<"uint32">;
+  hobbies: string[];
+}
+
+const proto: string = typia.protobuf.message<User>();
+console.log(proto);
+//
+// syntax = "proto3";
+// message User {
+//   required string id = 1;
+//   required uint32 age = 2;
+//   repeated string hobbies = 3;
+// }
+```
+
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/protobuf/message.ts"
       filename="examples/src/protobuf/message.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/protobuf/message.js"
       filename="examples/bin/protobuf.message.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Type Tags
+## Picking the wire type — type tags
 
-By using type tags, you can use special numeric types that are not supported in the TypeScript.
+Protocol Buffer has narrower numeric types than TypeScript (`int32`, `uint32`, `int64`, `uint64`, `float`, `double`). Use [type tags](/docs/validators/tags) to pick the wire type explicitly:
 
-Just import `Type` (or `typia.tags.Type`) type, and combine it with `number` or `bigint` type through intersection symbol `number & typia.tagsType<"float">` case. If you want to declare an union numeric type, combine `|` and bracket (`()`) symbols properly like below.
+```typescript copy
+type Score = number & tags.Type<"float">;
+type Population = bigint & tags.Type<"uint64">;
+type Mixed = (number & tags.Type<"int32">) | (bigint & tags.Type<"uint64">);
+```
 
-When you take a mistake that choosing different target type, TypeScript compiler would block it with compilation error message. Therefore, have a confidence when using the `Type` tag. For such type safety reason, I recommend to use `Type` tag instead of using [comment tags](#comment-tags) as much as possible.
+If you don't tag a `number`, typia treats it as `double`. If you don't tag a `bigint`, typia treats it as `int64`.
 
-  - `number & (Type<"uint32"> | Type<"double">)`
-    - `number` type can be both `uint32` and `double`
-  - `(number & Type<"int32">) | (bigint & Type<"uint64">)`
-    - `number` is `int32`
-    - `bigint` is `uint64`
-  - `(number & (Type<"int32">)| Type<"float">) | (bigint & Type<"uint64">)`
-    - `number` can be both `int32` and `float`
-    - `bigint` is `uint64`
+> The TypeScript compiler will block invalid combinations — you can't put `tags.Type<"uint32">` on a `bigint`, for example.
 
-<Tabs items={["TypeScript Source Code", "Compiled JavaScript File"]}>
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/protobuf/message-type-tag.ts"
       filename="examples/src/protobuf/message-type-tag.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/protobuf/message-type-tag.js"
       filename="examples/bin/protobuf/message-type-tag.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Comment Tags
+## Comment tags — for older codebases
 
-By using `@type {target}` comment tag, you also can use special numeric types.
+Same wire types are also expressible as `@type` comments:
 
-However, this way is not recommended, because it can't perform union numeric types, and cannot be used in `Array` and `Map` types. When you declare `@type int32` statement, target `number` type be fixed as `int32` type, and never can have another numeric type by declaring union statements.
+```typescript copy
+interface User {
+  /** @type uint32 */
+  age: number;
+}
+```
 
-Also, those comment tags are not type safe. If you take a mistake when writing a comment tag, it will not be detected by the compiler, and will cause an error at runtime. For example, if you write a miss-spelled keyword like `@type unit32`, the target `number` type would be `double` type, and you can identify it just by running the program (or visiting playground website).
+> [!CAUTION]
+>
+> Same caveats as [`validators/tags`](/docs/validators/tags#comment-tags--for-older-codebases): comment tags are not type-checked (a typo silently falls back to `double`), they only work on object properties, and they can't express union numeric types. Prefer type tags unless you're maintaining a JSDoc-style codebase.
 
-<br/>
-<Alert severity="warning">
-  <AlertTitle>
-    **Why supports comment tags?**
-  </AlertTitle>
-
-Despite these disadvantages, comment tags are still maintained for compatibility with legacy JSDoc-style projects.
-
-If your codebase already describes numeric constraints in comments, you can keep that style and migrate incrementally instead of rewriting everything to type tags at once.
-
-</Alert>
-
-<Tabs items={["TypeScript Source Code", "Compiled JavaScript File"]}>
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/src/protobuf/message-comment-tag.ts"
       filename="examples/src/protobuf/message-comment-tag.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
       path="examples/bin/protobuf/message-comment-tag.js"
       filename="examples/bin/protobuf.message-comment-tag.js"
       showLineNumbers />
@@ -109,31 +117,19 @@ If your codebase already describes numeric constraints in comments, you can keep
 
 ## Restrictions
 
-You know what? Expression power of Protocol Buffer is extremely narrower than type system of TypeScript. For example, Protocol Buffer can't express complicate union type containing array. Also, Protocol Buffer can't express multi dimensional array type, either.
+Protocol Buffer's type system is much narrower than TypeScript's. The following are not representable:
 
-In such reason, when converting TypeScript type to Protocol buffer message schema, lots of restrictions are exist. Let's study which types of TypeScript are not supported in Protocol Buffer. For reference, if you try to call `typia.protobuf.message<T>()` function with unsupported type, `typia` will generate compile errors like below example cases.
+### Top-level type must be a single static object
 
----------------
+`number`, `Array<T>`, `Cat | Dog`, `Record<string, T>` — none of these are valid top-level shapes. Wrap them in an object.
 
-At first, top level type must be a sole and static object. 
-
-If you try to use `number` or `Array<T>` type as a top level type, `typia` will generate compile error like below. Dynamic object types like `Record<string, T>`, or `Map<string, T>` types are not allowed either. For reference, the sole object means that, union of object types is not allowed, either.
-
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+<Tabs items={["TypeScript Source", "Console Output"]}>
   <Tabs.Tab>
 ```typescript showLineNumbers copy
 import typia from "typia";
 
-interface Cat {
-    type: "cat";
-    name: string;
-    ribbon: boolean;
-}
-interface Dog {
-    type: "dog";
-    name: string;
-    hunt: boolean;
-}
+interface Cat { type: "cat";  name: string; ribbon: boolean }
+interface Dog { type: "dog";  name: string; hunt: boolean }
 
 typia.protobuf.message<bigint>();
 typia.protobuf.createDecode<Record<string, number>>();
@@ -144,30 +140,27 @@ typia.protobuf.createEncode<Cat | Dog>();
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash
-main.ts:14:1 - error TS(typia.protobuf.message): unsupported type detected
+main.ts:6:1 - error TS(typia.protobuf.message): unsupported type detected
 
 - bigint
   - target type must be a sole and static object type
 
-main.ts:15:1 - error TS(typia.protobuf.typia.protobuf.createDecode): unsupported type detected
+main.ts:7:1 - error TS(typia.protobuf.createDecode): unsupported type detected
 
 - Record<string, number>
   - target type must be a sole and static object type
 
-main.ts:16:1 - error TS(typia.protobuf.typia.protobuf.createDecode): unsupported type detected
+main.ts:8:1 - error TS(typia.protobuf.createDecode): unsupported type detected
 
 - Map<(number & Type<"float">), Dog>
   - target type must be a sole and static object type
 
-- (number & Type<"float">)
-  - target type must be a sole and static object type
-
-main.ts:17:1 - error TS(typia.protobuf.typia.protobuf.createEncode): unsupported type detected
+main.ts:9:1 - error TS(typia.protobuf.createEncode): unsupported type detected
 
 - Array<boolean>
   - target type must be a sole and static object type
 
-main.ts:18:1 - error TS(typia.protobuf.typia.protobuf.createEncode): unsupported type detected
+main.ts:10:1 - error TS(typia.protobuf.createEncode): unsupported type detected
 
 - (Cat | Dog)
   - target type must be a sole and static object type
@@ -175,66 +168,53 @@ main.ts:18:1 - error TS(typia.protobuf.typia.protobuf.createEncode): unsupported
   </Tabs.Tab>
 </Tabs>
 
-At next, in Protocol Buffer, those types are categorized as container types.
+### Container nesting is limited
 
-  - `Array<T>`
-  - `Map<Key, T>`
-  - `Record<string, T>` (dynamic object)
+`Array<T>`, `Map<K, V>`, and `Record<string, T>` are containers. The rules:
 
-Also, those container types does not allow over two-dimensional stacking. Therefore, it is not possible to declaring two dimensional array like `number[][]`, or `Array` type in `Map` like `Map<string, number[]>`. Besides, value type of those container also do not support union type either.
+- **No two-dimensional containers.** `number[][]` is not allowed. Neither is `Map<string, number[]>`.
+- **No unions inside container values.** `Map<string, Cat | Dog>` is not allowed.
+- **`Map` keys must be atomic and non-union.** `Map<Cat, string>` and `Map<string | number, Dog>` are not allowed.
 
-Additionally, about `Map<Key, T>` type, key type must be an atomic type. It means that, only `boolean`, `number`, `bigint` and `string` types are allowed. Also, key type cannot be union type, either.
-
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+<Tabs items={["TypeScript Source", "Console Output"]}>
   <Tabs.Tab>
 ```typescript showLineNumbers copy
 import typia from "typia";
 
-interface IPointer<T> {
-  value: T;
-}
-interface Cat {
-  type: "cat";
-  name: string;
-  ribbon: boolean;
-}
-interface Dog {
-  type: "dog";
-  name: string;
-  hunt: boolean;
-}
+interface IPointer<T> { value: T }
+interface Cat { type: "cat"; name: string; ribbon: boolean }
+interface Dog { type: "dog"; name: string; hunt: boolean }
 
 typia.protobuf.message<IPointer<number[][]>>();
 typia.protobuf.createEncode<IPointer<Record<string, string[]>>>();
 typia.protobuf.createDecode<IPointer<Map<string, Cat | Dog>>>();
-
 typia.protobuf.message<IPointer<Map<Cat, string>>>();
 typia.protobuf.message<IPointer<Map<number | string, Dog>>>();
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash
-main.ts:17:1 - error TS(typia.protobuf.message): unsupported type detected
+main.ts:7:1 - error TS(typia.protobuf.message): unsupported type detected
 
 - IPointer<Array<Array<number>>>[key]: Array<Array<number>>
   - does not support over two dimensional array type
 
-main.ts:18:1 - error TS(typia.protobuf.typia.protobuf.createEncode): unsupported type detected
+main.ts:8:1 - error TS(typia.protobuf.createEncode): unsupported type detected
 
 - IPointer<Record<string, Array<string>>>[key]: Record<string, Array<string>>
   - does not support dynamic object with array value type
 
-main.ts:19:1 - error TS(typia.protobuf.typia.protobuf.createDecode): unsupported type detected
+main.ts:9:1 - error TS(typia.protobuf.createDecode): unsupported type detected
 
 - IPointer<Map<string, Cat | Dog>>[key]: Map<string, (Cat | Dog)>
   - does not support union type in map value type
 
-main.ts:21:1 - error TS(typia.protobuf.message): unsupported type detected
+main.ts:10:1 - error TS(typia.protobuf.message): unsupported type detected
 
 - IPointer<Map<Cat, string>>[key]: Map<Cat, string>
   - does not support non-atomic key typed map
 
-main.ts:22:1 - error TS(typia.protobuf.message): unsupported type detected
+main.ts:11:1 - error TS(typia.protobuf.message): unsupported type detected
 
 - IPointer<Map<string | number, Dog>>[key]: Map<(number | string), Dog>
   - does not support union key typed map
@@ -243,18 +223,17 @@ main.ts:22:1 - error TS(typia.protobuf.message): unsupported type detected
   </Tabs.Tab>
 </Tabs>
 
-At last, those types are all not allowed.
+### Types with no Protocol Buffer counterpart
 
-  - `any`
-  - `functional type`
-  - `Set<T>`, `WeakSet<T>` and `WeakMap<T>`
-  - `Date`, `Boolean`, `BigInt`, `Number`, `String`
-  - Binary classes except `Uint8Array`
-    - `Uint8ClampedArray`, `Uint16Array`, `Uint32Array`, `BigUint64Array`
-    - `Int8Array`, `Int16Array`, `Int32Array`, `BigInt64Array`
-    - `ArrayBuffer`, `SharedArrayBuffer` and `DataView`
+These are rejected outright:
 
-<Tabs items={["TypeScript Source Code", "Console Output"]}>
+- `any` / `unknown` (you don't know how to encode an unknown value)
+- function types
+- `Set<T>`, `WeakSet<T>`, `WeakMap<K, V>` — use `Array<T>` / `Map<K, V>` instead
+- `Date`, `Boolean`, `BigInt`, `Number`, `String` — use the primitive (`string`, `boolean`, …) instead
+- Typed arrays except `Uint8Array` — use `Uint8Array` for binary data
+
+<Tabs items={["TypeScript Source", "Console Output"]}>
   <Tabs.Tab>
 ```typescript showLineNumbers copy
 import typia from "typia";
@@ -301,3 +280,9 @@ main.ts:13:1 - error TS(typia.protobuf.message): unsupported type detected
 ```
   </Tabs.Tab>
 </Tabs>
+
+## Where to go next
+
+- Encoding a value → [`protobuf.encode`](/docs/protobuf/encode)
+- Decoding bytes → [`protobuf.decode`](/docs/protobuf/decode)
+- Numeric constraints in tags → [Special Tags](/docs/validators/tags)

--- a/website/src/content/docs/pure.mdx
+++ b/website/src/content/docs/pure.mdx
@@ -4,46 +4,43 @@ title: Guide Documents > Pure TypeScript Type
 import { Tabs } from 'nextra/components'
 
 # Pure TypeScript
-## Outline
-```typescript filename="assertArticle.ts" showLineNumbers
+
+## One line. Pure types. Done.
+
+```ts copy filename="check.ts"
 typia.assert<IBbsArticle>(article);
 ```
 
-`typia` needs only one line with pure TypeScript type.
+Every other validator library in the JavaScript ecosystem makes you describe your data twice. typia doesn't. The single line above is the entire validator definition. The type `IBbsArticle` is everything typia needs to know.
 
-You know what? Every other validator libraries need extra schema definition, that is different with pure TypeScript type. For an example, `class-validator` is the most famous validator due to used in `NestJS`. However, `NestJS` and `class-validator` force you to define triple duplicated DTO schema.
+## Why this matters
 
-  1. TypeScript Type
-  2. `class-validator` decorators
-  3. `@nestjs/swagger` decorators
+Most validator libraries can't see TypeScript types — at runtime, types are gone. So they ask you to re-encode the type in a form they *can* see:
 
-Another famous validator library `ajv` requires JSON schema definition. Move to the [#Demonstration](#demonstration), and click the `ajv (JSON Schema)` tab, then you may understand how it terrible. It requires hundreds of lines of JSON schema definition even just for a simple DTO.
+- **`class-validator`** wants a class with stacked decorators. For NestJS apps, you usually maintain a *third* parallel definition for `@nestjs/swagger`. A typical request DTO ends up triple-duplicated.
+- **`ajv`** wants a JSON Schema object. Hundreds of lines of `{ "type": "...", "properties": {...} }` for what's a 30-line TypeScript interface.
+- **`zod`** wants you to build the schema with its own builder API (`z.object({...})`). The TypeScript type comes from `z.infer`, so the schema is the source of truth — your TypeScript types are downstream.
 
-Those duplicated schema definitions are not only annoying, but also error-prone. If you take any mistake on the extra schema definition, such mistake can't be detected by TypeScript compiler. It will be detected only at runtime, therefore become a critical runtime error. Another words, it is not type safe.
+All three approaches share two problems:
 
-Besides, `typia` only needs pure TypeScript type. You don't need to define any extra schema like `class-validator` or `ajv`. Just define pure TypeScript type only (especially recommend to use `interface` type), then `typia` will do all the rest.
+1. **Drift.** When you change a field on the TS side, nothing forces you to update the schema. The compiler can't catch it. The mistake shows up only when production traffic hits.
+2. **Effort.** Mechanical, joyless typing of the same thing in two notations.
 
+typia removes both. It is a **compile-time transformer**: it reads your TypeScript type at build time and writes the runtime code for you. The TypeScript type is the only source of truth.
 
+## Compare three approaches side by side
 
-
-## Demonstration
-If you're confusing how `typia` is different with others, just see example codes below.
-
-At first, look at the first (*`class-validator`*) tab, and find the `BbsArticle.files` property, enhanced by blue colored blocks. Looking at the `files` property, how do you feel? Just defining an array object type, you've to call 7 decorator functions. If you take any mistake when using the decorator like omitting `isArray` property, it would be a critical runtime error.
-
-Besides, `typia` needs only one line. Click the third (*`typia`*) tab, and find the `IAttachmentFile.files` property. Only one line being used, and they are even not class, but just interface types. Comparing it to the first and second tabs, how do you feel? Isn't it more simple and readable?
-
-This is the power of `typia`, with pure TypeScript type.
+The example below is the same data model — a BBS article with files — written for `class-validator`, `ajv`, and typia. Look at the highlighted `files` property in each.
 
 <Tabs items={[
   <span>
-    <code>class-validator</code> <sub>(Triple duplicated)</sub>
+    <code>class-validator</code> <sub>(triple definition)</sub>
   </span>,
   <span>
     <code>ajv</code> <sub>(JSON Schema)</sub>
   </span>,
   <span>
-    <code>typia</code> <sub>(Pure TypeScript)</sub>
+    <code>typia</code> <sub>(pure type)</sub>
   </span>
 ]}>
   <Tabs.Tab>
@@ -55,7 +52,7 @@ import {
   IsObject,
   IsOptional,
   IsString,
-  Match,
+  Matches,
   MaxLength,
   Type,
   ValidateNested,
@@ -68,9 +65,9 @@ export class BbsArticle {
   @IsString()
   id!: string;
 
-  // DUPLICATED SCHEMA DEFINITION
-  // - duplicated function call + property type
-  // - have to specify `isArray` and `nullable` props by yourself
+  // Seven decorator calls just to say
+  // "files is either null or an array of AttachmentFile."
+  // Forget any one of them and you'll find out at runtime.
   @ApiProperty({
     type: () => AttachmentFile,
     nullable: true,
@@ -289,75 +286,54 @@ export interface IAttachmentFile {
   </Tabs.Tab>
 </Tabs>
 
+Same data. Same constraints. Three very different costs to maintain.
 
+The typia version is a normal TypeScript interface. The validation rules live in [type tags](/docs/validators/tags) like `tags.Format<"uuid">` and `tags.MaxLength<255>` that intersect with the base type. Rename `files` and TypeScript drags every reference along with it. Forget a constraint and you change the type once.
 
+## "But TypeScript types disappear at runtime..."
 
-## AOT Compilation
-Someone may be suspicious of the phrase "Pure TypeScript Type".
+That's a fair objection. If types don't exist at runtime, how does typia validate anything?
 
-> "As you know, TypeScript types do not have any tangible instance when compiled to JS. 
->
-> However, with only these fictitious TypeScript types, how can `typia` validates types at runtime? How `typia` builds much faster JSON serializer only with these types? Are these things really possible without extra schema definition like `class-validator` or `ajv`?"
+**At compile time, typia rewrites your code.** The `typia.assert<T>` call site is replaced inline with a hand-written validator specialized to `T`. There is no schema object at runtime because there is no general-purpose validator at runtime — only the specific check your code needs.
 
-My answer is: "Yes, it is possible due to `typia` analyzes your server code, and performs AOT compilation".
+This is called AOT (Ahead-of-Time) compilation. Look at what the compiler actually produces:
 
-Such compile time optimization is called AOT (Ahead of Time) compilation. And this is the secret why `typia` can do everything with only pure TypeScript type. Read below example codes, and just look how JavaScript file being compiled. Then you may understand why `typia` is much easier, and furthermore much faster.
-
-  - Runtime validator is **20,000x** faster than `class-validator`
-  - JSON serialization is **200x faster** than `class-transformer`
-
-<Tabs 
+<Tabs
   items={[
     <code>IBbsArticle.ts</code>,
     <code>assertArticle.ts</code>,
-    'Compiled JavaScript File'
+    'Compiled JavaScript'
   ]}
   defaultIndex={1}>
   <Tabs.Tab>
-```typescript copy filenam="IBbsArticle.ts" showLineNumbers
+```typescript copy filename="IBbsArticle.ts" showLineNumbers
 import typia, { tags } from "typia";
 
 export interface IBbsArticle {
-  /**
-   * Primary Key.
-   */
+  /** Primary Key. */
   id: string & tags.Format<"uuid">;
 
-  /**
-   * List of attached files.
-   */
+  /** List of attached files. */
   files: null | IAttachmentFile[];
 
-  /**
-   * Title of the article.
-   */
+  /** Title of the article. */
   title: null | (string & tags.MinLength<5> & tags.MaxLength<100>);
 
-  /**
-   * Main content body of the article.
-   */
+  /** Main content body of the article. */
   body: string;
 
-  /**
-   * Creation time of article.
-   */
+  /** Creation time of article. */
   created_at: string & tags.Format<"date-time">;
 }
 
 export interface IAttachmentFile {
-  /**
-   * File name.
-   */
+  /** File name. */
   name: string & tags.Pattern<"^[a-z0-9]+$"> & tags.MaxLength<255>;
 
-  /**
-   * File extension.
-   */
+  /** File extension. */
   extension: null | (string & tags.Pattern<"^[a-z0-9]+$"> & tags.MaxLength<8>);
 
-  /**
-   * URL of the file.
-   */
+  /** URL of the file. */
   url: string;
 }
 ```
@@ -402,265 +378,33 @@ export const assertArticle = (() => {
         RegExp("^[a-z0-9]+$").test(input.extension) &&
         input.extension.length <= 8)) &&
     "string" === typeof input.url;
-  const _ao0 = (input, _path, _exceptionable = true) =>
-    (("string" === typeof input.id &&
-      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.createAssert",
-            path: _path + ".id",
-            expected: 'string & Format<"uuid">',
-            value: input.id,
-          },
-          _errorFactory,
-        ))) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.createAssert",
-          path: _path + ".id",
-          expected: '(string & Format<"uuid">)',
-          value: input.id,
-        },
-        _errorFactory,
-      )) &&
-    (null === input.files ||
-      ((Array.isArray(input.files) ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.createAssert",
-            path: _path + ".files",
-            expected: "(Array<IAttachmentFile> | null)",
-            value: input.files,
-          },
-          _errorFactory,
-        )) &&
-        input.files.every(
-          (elem, _index2) =>
-            ((("object" === typeof elem && null !== elem) ||
-              __typia_transform__assertGuard._assertGuard(
-                _exceptionable,
-                {
-                  method: "typia.createAssert",
-                  path: _path + ".files[" + _index2 + "]",
-                  expected: "IAttachmentFile",
-                  value: elem,
-                },
-                _errorFactory,
-              )) &&
-              _ao1(
-                elem,
-                _path + ".files[" + _index2 + "]",
-                true && _exceptionable,
-              )) ||
-            __typia_transform__assertGuard._assertGuard(
-              _exceptionable,
-              {
-                method: "typia.createAssert",
-                path: _path + ".files[" + _index2 + "]",
-                expected: "IAttachmentFile",
-                value: elem,
-              },
-              _errorFactory,
-            ),
-        )) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.createAssert",
-          path: _path + ".files",
-          expected: "(Array<IAttachmentFile> | null)",
-          value: input.files,
-        },
-        _errorFactory,
-      )) &&
-    (null === input.title ||
-      ("string" === typeof input.title &&
-        (5 <= input.title.length ||
-          __typia_transform__assertGuard._assertGuard(
-            _exceptionable,
-            {
-              method: "typia.createAssert",
-              path: _path + ".title",
-              expected: "string & MinLength<5>",
-              value: input.title,
-            },
-            _errorFactory,
-          )) &&
-        (input.title.length <= 100 ||
-          __typia_transform__assertGuard._assertGuard(
-            _exceptionable,
-            {
-              method: "typia.createAssert",
-              path: _path + ".title",
-              expected: "string & MaxLength<100>",
-              value: input.title,
-            },
-            _errorFactory,
-          ))) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.createAssert",
-          path: _path + ".title",
-          expected: "((string & MinLength<5> & MaxLength<100>) | null)",
-          value: input.title,
-        },
-        _errorFactory,
-      )) &&
-    ("string" === typeof input.body ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.createAssert",
-          path: _path + ".body",
-          expected: "string",
-          value: input.body,
-        },
-        _errorFactory,
-      )) &&
-    (("string" === typeof input.created_at &&
-      (__typia_transform__isFormatDateTime._isFormatDateTime(
-        input.created_at,
-      ) ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.createAssert",
-            path: _path + ".created_at",
-            expected: 'string & Format<"date-time">',
-            value: input.created_at,
-          },
-          _errorFactory,
-        ))) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.createAssert",
-          path: _path + ".created_at",
-          expected: '(string & Format<"date-time">)',
-          value: input.created_at,
-        },
-        _errorFactory,
-      ));
-  const _ao1 = (input, _path, _exceptionable = true) =>
-    (("string" === typeof input.name &&
-      (RegExp("^[a-z0-9]+$").test(input.name) ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.createAssert",
-            path: _path + ".name",
-            expected: 'string & Pattern<"^[a-z0-9]+$">',
-            value: input.name,
-          },
-          _errorFactory,
-        )) &&
-      (input.name.length <= 255 ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.createAssert",
-            path: _path + ".name",
-            expected: "string & MaxLength<255>",
-            value: input.name,
-          },
-          _errorFactory,
-        ))) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.createAssert",
-          path: _path + ".name",
-          expected: '(string & Pattern<"^[a-z0-9]+$"> & MaxLength<255>)',
-          value: input.name,
-        },
-        _errorFactory,
-      )) &&
-    (null === input.extension ||
-      ("string" === typeof input.extension &&
-        (RegExp("^[a-z0-9]+$").test(input.extension) ||
-          __typia_transform__assertGuard._assertGuard(
-            _exceptionable,
-            {
-              method: "typia.createAssert",
-              path: _path + ".extension",
-              expected: 'string & Pattern<"^[a-z0-9]+$">',
-              value: input.extension,
-            },
-            _errorFactory,
-          )) &&
-        (input.extension.length <= 8 ||
-          __typia_transform__assertGuard._assertGuard(
-            _exceptionable,
-            {
-              method: "typia.createAssert",
-              path: _path + ".extension",
-              expected: "string & MaxLength<8>",
-              value: input.extension,
-            },
-            _errorFactory,
-          ))) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.createAssert",
-          path: _path + ".extension",
-          expected: '((string & Pattern<"^[a-z0-9]+$"> & MaxLength<8>) | null)',
-          value: input.extension,
-        },
-        _errorFactory,
-      )) &&
-    ("string" === typeof input.url ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.createAssert",
-          path: _path + ".url",
-          expected: "string",
-          value: input.url,
-        },
-        _errorFactory,
-      ));
-  const __is = (input) =>
-    "object" === typeof input && null !== input && _io0(input);
-  let _errorFactory;
-  return (input, errorFactory) => {
-    if (false === __is(input)) {
-      _errorFactory = errorFactory;
-      ((input, _path, _exceptionable = true) =>
-        ((("object" === typeof input && null !== input) ||
-          __typia_transform__assertGuard._assertGuard(
-            true,
-            {
-              method: "typia.createAssert",
-              path: _path + "",
-              expected: "IBbsArticle",
-              value: input,
-            },
-            _errorFactory,
-          )) &&
-          _ao0(input, _path + "", true)) ||
-        __typia_transform__assertGuard._assertGuard(
-          true,
-          {
-            method: "typia.createAssert",
-            path: _path + "",
-            expected: "IBbsArticle",
-            value: input,
-          },
-          _errorFactory,
-        ))(input, "$input", true);
-    }
-    return input;
-  };
+  /* …assertion variant that adds error paths, abbreviated… */
 })();
 ```
   </Tabs.Tab>
 </Tabs>
 
+That's hand-rolled JavaScript with no dynamic dispatch and no schema interpretation. Just a sequence of `typeof` checks and string comparisons that the V8 JIT loves.
+
+**That's why typia is fast.**
+
+- Runtime validation: up to **20,000× faster** than `class-validator`
+- JSON serialization: up to **200× faster** than `class-transformer`
+
 ![Assert Function Benchmark](https://github.com/samchon/typia/raw/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics/images/assert.svg)
 
 > Measured on [AMD Ryzen 9 7940HS, Rog Flow x13](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics#assert)
+
+## What this means for you
+
+- **No schema files.** You will not check a `*.schema.ts` file into your repo.
+- **No drift.** Rename a field — every validator updates automatically because the type is the validator.
+- **No reflection.** The runtime cost is whatever your compiled JavaScript already costs. Bundle it for the browser. Run it on the edge. It just works.
+- **Tags are real types.** `tags.MaxLength<100>` lives in the TypeScript type system. The compiler will flag you if you intersect it with the wrong base type.
+
+## Where to go next
+
+- [Setup](/docs/setup) — install `ttsc` (or `ts-patch` for TypeScript v6) and you can paste the code above into a fresh project right now.
+- [Validators](/docs/validators/is) — `is`, `assert`, `validate`, and when to pick which.
+- [Type Tags](/docs/validators/tags) — the full list of constraints you can intersect into a type.
+- [Tutorial](/docs/tutorial) — a 30-minute walkthrough from "I just installed it" to "I have a working LLM agent".

--- a/website/src/content/docs/random.mdx
+++ b/website/src/content/docs/random.mdx
@@ -5,37 +5,40 @@ import { Tabs } from "nextra/components";
 
 import LocalSource from "../../components/LocalSource";
 
-## `random()` function
+# `typia.random` — make up a value that satisfies the type
 
-<Tabs items={[
-  <code>typia</code>,
-  <code>IRandomGenerator.ts</code>,
-  <code>Resolved.ts</code>
-]}>
-  <Tabs.Tab>
-```typescript copy
-export function random<T>(g?: IRandomGenerator): Resolved<T>;
+```typescript copy filename="signatures"
+function random<T>(generator?: Partial<IRandomGenerator>): Resolved<T>;
+function createRandom<T>(): (generator?: Partial<IRandomGenerator>) => Resolved<T>;
 ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="packages/interface/src/utils/IRandomGenerator.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="packages/interface/src/typings/Resolved.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
 
-You can make every random data just by calling `typia.random<T>()` function.
+`typia.random<T>` returns a value that satisfies `T`. Use it for test fixtures, seeding databases, or building demos without writing factory functions by hand.
 
-When you call the `typia.random<T>()` function, `typia` will analyze your type `T`, and writes optimal random generation code for the type `T`, in the compilation level. This is called AOT (Ahead of Time) compilation, and you may understand what it is just by reading below example code.
+It honors every [type tag](/docs/validators/tags) you put on the type: `tags.Format<"email">` will produce an email, `tags.Minimum<0> & tags.Maximum<100>` will pick a number in that range, `tags.MaxLength<8>` will cap a string's length.
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+## First example
+
+```typescript copy filename="hello-random.ts"
+import typia, { tags } from "typia";
+
+interface User {
+  id: string & tags.Format<"uuid">;
+  email: string & tags.Format<"email">;
+  age: number & tags.Type<"uint32"> & tags.Minimum<19> & tags.Maximum<99>;
+  hobbies: string[];
+}
+
+const user = typia.random<User>();
+// e.g.
+// {
+//   id: "b6e0…",
+//   email: "abc@example.com",
+//   age: 47,
+//   hobbies: ["wzPwLvO", "u_a-mqQ"],
+// }
+```
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
     <LocalSource
       path="examples/src/random/random.ts"
@@ -50,16 +53,10 @@ When you call the `typia.random<T>()` function, `typia` will analyze your type `
   </Tabs.Tab>
 </Tabs>
 
-## Reusable function
-
-<Tabs items={[
-  <code>typia</code>,
-  <code>IRandomGenerator.ts</code>,
-  <code>Resolved.ts</code>,
-]}>
+<Tabs items={[<code>typia</code>, <code>IRandomGenerator.ts</code>, <code>Resolved.ts</code>]}>
   <Tabs.Tab>
 ```typescript copy
-export function createRandom<T>(): (g?: IRandomGenerator) => Resolved<T>;
+export function random<T>(g?: Partial<IRandomGenerator>): Resolved<T>;
 ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -76,16 +73,43 @@ export function createRandom<T>(): (g?: IRandomGenerator) => Resolved<T>;
   </Tabs.Tab>
 </Tabs>
 
-## Special Tags
+## Reusable factory
 
-Runtime validators of `typia` provides additional type checking logic through [Type Tags](../validators/tags#type-tags) and [Comment Tags](../validators/tags#comment-tags). `typia.random<T>()` function also like that. `typia.random<T>()` function can utilize those tags to specialize the behavior of random data generation.
+```typescript copy
+const randomUser = typia.createRandom<User>();
 
-For reference, whether you choose [Type Tags](../validators/tags#type-tags) or [Comment Tags](../validators/tags#comment-tags). `typia.random<T>()`, it is not a matter for `typia.random<T>()` function. Below two TypeScript codes are generating exactly same JavaScript code. Therefore, you can choose whatever you want considering your preference.
+const a = randomUser();
+const b = randomUser({ /* custom generator overrides */ });
+```
+
+<Tabs items={[<code>typia</code>, <code>IRandomGenerator.ts</code>, <code>Resolved.ts</code>]}>
+  <Tabs.Tab>
+```typescript copy
+export function createRandom<T>(): (g?: Partial<IRandomGenerator>) => Resolved<T>;
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/utils/IRandomGenerator.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/typings/Resolved.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## Tags in action
+
+The constraints you'd normally use for runtime validation also pin down what `random` produces. Type tags and comment tags compile to the same code, so either style works:
 
 <Tabs items={[
   'TypeScript (Type Tags)',
   'TypeScript (Comment Tags)',
-  'Compiled JavaScript File'
+  'Compiled JavaScript'
 ]}>
   <Tabs.Tab>
     <LocalSource
@@ -107,41 +131,13 @@ For reference, whether you choose [Type Tags](../validators/tags#type-tags) or [
   </Tabs.Tab>
 </Tabs>
 
-## Customization
+> For long-running test suites and especially anything that goes into a real database, prefer type tags — typos in comment tags fall back to defaults silently. See [Special Tags](/docs/validators/tags#comment-tags--for-older-codebases) for the trade-off.
 
-<Tabs items={[
-  <code>typia</code>,
-  <code>IRandomGenerator.ts</code>,
-  <code>Resolved.ts</code>,
-]}>
-  <Tabs.Tab>
-```typescript copy
-export function random<T>(g?: IRandomGenerator): Resolved<T>;
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="packages/interface/src/utils/IRandomGenerator.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="packages/interface/src/typings/Resolved.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
+## Custom tags — custom generators
 
-You can add custom type tags for random data generation.
+Defining a custom [type tag](/docs/validators/tags#customization) for validation also gives you a hook for random generation. When you write `validate` on the tag, typia uses it for `assert`/`is`/`validate` — and uses the tag's `kind` to look up a generator on the runtime `IRandomGenerator`.
 
-As above `IRandomGenerator.CustomMap` has a little bit complicate type, it may hard to understand for newcomers. However, such newcomers may easily understand, how to customize the random generation, just by reading the following example.
-
-Just define custom type tags like below, then everything would be done.
-
-For reference, when defining custom type tag, `typia` enforces user to define `validate` function literal for type safety. Never forget it when you define custom type tags for random generation. Such validation logic definition may enhance your random data generator logic when combining with [`typia.assert<T>()`](../validators/assert) function.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
     <LocalSource
       path="examples/src/random/random-custom.ts"
@@ -155,3 +151,11 @@ For reference, when defining custom type tag, `typia` enforces user to define `v
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
+
+A custom tag without a `validate` is fine for documentation purposes, but if you want `random` to actually produce values that satisfy it, define the validation logic. The same `validate` then doubles as the check used by `typia.assert<T>`.
+
+## Where to go next
+
+- The full tag catalogue → [Special Tags](/docs/validators/tags)
+- Validating randomly-generated data round-trips → [`assert`](/docs/validators/assert)
+- Cloning / pruning random values → [Miscellaneous module](/docs/misc)

--- a/website/src/content/docs/setup/index.mdx
+++ b/website/src/content/docs/setup/index.mdx
@@ -4,11 +4,20 @@ title: Guide Documents > Setup
 
 import { Tabs } from "nextra/components";
 
-## [TypeScript-Go](/docs/setup/tsgo)
+## Pick your setup path
 
-Use `typia@next` with `ttsc`.
+typia is a compile-time transformer, so it has to plug into your TypeScript build. There are two supported paths — pick the one that matches your TypeScript version.
 
-TypeScript is migrating its compiler to Go through TypeScript-Go. `ttsc` is the Go-based plugin toolchain for that compiler, and `typia@next` uses the new Go-based transform.
+| Path | When to use | Package |
+|------|-------------|---------|
+| [**TypeScript-Go (`ttsc`)**](/docs/setup/tsgo) | TypeScript-Go preview (`@typescript/native-preview`) — experimental | `typia@next` |
+| [**Legacy (`ts-patch`)**](/docs/setup/legacy) | Stable TypeScript v5 or v6 (the standard `typescript` npm package) | `typia` |
+
+If you don't know which to pick, choose **Legacy** — it's the stable release used in production today.
+
+## [TypeScript-Go](/docs/setup/tsgo) — `typia@next`
+
+TypeScript is migrating its compiler from JavaScript to Go (the "TypeScript-Go" project). `ttsc` is the Go-native plugin toolchain for that compiler, and `typia@next` ships a Go-rewritten transform that plugs into it.
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
@@ -20,7 +29,7 @@ npm i -D ttsc @typescript/native-preview
 # build
 npx ttsc
 
-# run without build
+# run without building first
 npx ttsx src/index.ts
 ```
   </Tabs.Tab>
@@ -33,7 +42,7 @@ pnpm i -D ttsc @typescript/native-preview
 # build
 pnpm ttsc
 
-# run without build
+# run without building first
 pnpm ttsx src/index.ts
 ```
   </Tabs.Tab>
@@ -46,7 +55,7 @@ yarn add -D ttsc @typescript/native-preview
 # build
 yarn ttsc
 
-# run without build
+# run without building first
 yarn ttsx src/index.ts
 ```
   </Tabs.Tab>
@@ -59,15 +68,17 @@ bun add -d ttsc @typescript/native-preview
 # build
 bun ttsc
 
-# run without build
+# run without building first
 bun ttsx src/index.ts
 ```
   </Tabs.Tab>
 </Tabs>
 
-You must use `ttsc` and `ttsx`. The stock `tsc`, `ts-node`, and `tsx` cannot apply the `typia` transform, so they will not work.
+> [!IMPORTANT]
+>
+> You must use `ttsc` and `ttsx`. The stock `tsc`, `ts-node`, and `tsx` cannot apply the typia transform, so they will silently produce a build with no validators.
 
-For bundlers, use `@ttsc/unplugin`.
+For bundlers, use `@ttsc/unplugin`:
 
 <Tabs
   items={[
@@ -192,11 +203,11 @@ await Bun.build({
   </Tabs.Tab>
 </Tabs>
 
-## [Legacy (TS v6)](/docs/setup/legacy)
+Continue to [TypeScript-Go setup](/docs/setup/tsgo) for the full configuration reference.
 
-Use `typia` with `ts-patch`.
+## [Legacy (TypeScript v6)](/docs/setup/legacy) — `typia`
 
-This is the existing TypeScript v6 setup. It uses the JavaScript TypeScript compiler with `ts-patch`, and is still the stable path for current `typia` releases.
+The legacy path uses [`ts-patch`](https://github.com/nonara/ts-patch) on top of the JavaScript-based TypeScript compiler. This is the stable release path used in production today.
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
@@ -209,7 +220,7 @@ npx typia setup
 # build
 npx tsc
 
-# run without build
+# run without building first
 npx ts-node src/index.ts
 ```
   </Tabs.Tab>
@@ -223,14 +234,14 @@ pnpm typia setup --manager pnpm
 # build
 pnpm tsc
 
-# run without build
+# run without building first
 pnpm ts-node src/index.ts
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
 # install
-# YARN BERRY IS NOT SUPPORTED
+# Yarn Berry is NOT supported
 yarn add typia
 yarn add -D typescript ts-node ts-patch
 yarn typia setup --manager yarn
@@ -238,7 +249,7 @@ yarn typia setup --manager yarn
 # build
 yarn tsc
 
-# run without build
+# run without building first
 yarn ts-node src/index.ts
 ```
   </Tabs.Tab>
@@ -252,13 +263,15 @@ bun typia setup
 # build
 bun tsc
 
-# run without build
+# run without building first
 bun ts-node src/index.ts
 ```
   </Tabs.Tab>
 </Tabs>
 
-For bundlers, use `@typia/unplugin`.
+`npx typia setup` runs a one-shot wizard that installs the right `ts-patch` plugin entry into your `tsconfig.json` and wires up a `prepare` script.
+
+For bundlers, use `@typia/unplugin`:
 
 <Tabs items={["Vite", "Next.js", "esbuild", "Bun.runtime", "Bun.build"]}>
   <Tabs.Tab>
@@ -320,3 +333,18 @@ await Bun.build({
 ```
   </Tabs.Tab>
 </Tabs>
+
+Continue to [Legacy setup](/docs/setup/legacy) for `tsconfig.json` details, NX, Webpack notes, and the [generation](/docs/setup/legacy#generation) fallback for projects that can't run a transformer (Babel, SWC).
+
+## Verifying your setup
+
+Drop this into your project and run it:
+
+```ts copy filename="src/check-setup.ts"
+import typia from "typia";
+
+console.log(typia.is<{ id: string }>({ id: "ok" }));
+// → true
+```
+
+If you see `true`, the transformer ran. If you see an error like `typia transformer has not been configured`, the build is using stock `tsc` / `tsx` instead of `ttsc` / `ttsx` or `ts-patch`. Re-check the build command and `tsconfig.json` plugin entry.

--- a/website/src/content/docs/setup/legacy.mdx
+++ b/website/src/content/docs/setup/legacy.mdx
@@ -5,9 +5,11 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## Summary
+## Legacy (TypeScript v6)
 
-This is the legacy setup path for TypeScript v6 and below. It uses [`ts-patch`](https://github.com/nonara/ts-patch) on top of the JavaScript-based TypeScript compiler, and remains the stable path for current `typia` releases.
+This is the production-stable path. It uses [`ts-patch`](https://github.com/nonara/ts-patch) on top of the JavaScript TypeScript compiler and is what current published `typia` releases (v6 line) plug into.
+
+The fastest way to install: run the wizard.
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
@@ -24,7 +26,7 @@ pnpm typia setup --manager pnpm
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
-# YARN BERRY IS NOT SUPPORTED
+# Yarn Berry is NOT supported
 yarn add typia
 yarn typia setup --manager yarn
 ```
@@ -37,45 +39,41 @@ bun typia setup --manager bun
   </Tabs.Tab>
 </Tabs>
 
-Just run `npx typia setup` command if you're using `tsc`. The setup wizard will do everything. 
+`npx typia setup` installs `typescript` and `ts-patch`, adds the `typia/lib/transform` plugin entry to your `tsconfig.json`, and wires up a `prepare` script so `ts-patch install` runs after every `npm install`. After it finishes, plain `tsc` builds your project with the typia transform applied.
 
-By the way, if you use `typia` with bundlers(`vite`, `rollup`, `webpack`, etc), [`@typia/unplugin`](#typiaunplugin) is recommended.
+If your build pipeline uses a bundler (Vite, Next.js, Webpack, esbuild, …), you'll also want [`@typia/unplugin`](#typiaunplugin).
 
-Otherwise non-standard compiler case, only the [generation](#generation) mode is available.
+If your build pipeline uses Babel, SWC, or another tool that doesn't run TypeScript-compatible transformers, you have to fall back to the [generation mode](#generation) — typia writes the transformed `*.ts` files for you ahead of time.
 
-  - Standard Compiler
-    - [Microsoft/TypeScript](https://github.com/microsoft/typescript) (`tsc`)
-  - Non-standard Compilers
-    - [babel](https://babeljs.io/)
-    - [esbuild](https://esbuild.github.io/) -> covered by [`@typia/unplugin`](#typiaunplugin)
-    - [SWC](https://swc.rs)
+## How the transformer works
 
-## Transformation
+This is *Ahead-of-Time* (AOT) compilation.
 
-### Concepts
+When you write `typia.createIs<IMember>()` and compile with `tsc`, the `ts-patch`-patched compiler replaces that call site with a hand-written checker specialized to `IMember`. There is no runtime schema — only the JavaScript that does exactly the comparisons your `IMember` type implies.
 
-AOT (Ahead of Time) compilation mode.
-
-When you write a TypeScript code calling `typia.createIs<IMember>()` function and compile it through `tsc` command, `typia` will replace the `typia.createIs<IMember>()` statement to optimal validation code in the compiled JavaScript file, for the `IMember` type. 
-
-This is the transform mode performing AOT (Ahead of Time) compilation.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/is.ts" 
-      filename="examples/src/validators/is.ts" 
+    <LocalSource
+      path="examples/src/validators/is.ts"
+      filename="examples/src/validators/is.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/is.js" 
-      filename="examples/bin/validators/is.js" 
+    <LocalSource
+      path="examples/bin/validators/is.js"
+      filename="examples/bin/validators/is.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-### Setup Wizard
+Two requirements follow from this:
+
+1. **The build has to run TypeScript-with-transformers.** That means stock `tsc` patched by `ts-patch`, or a bundler plugin that wraps the same machinery. Babel and SWC strip types before any transformer can see them, so they're not supported in this mode — use [generation mode](#generation) instead.
+2. **`strict` (or at least `strictNullChecks`) has to be on.** Without strict null checking, your types lie about which fields can be `null`/`undefined`, and the emitted validator will lie with them.
+
+## Wizard setup
+
+The recommended way.
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
@@ -92,7 +90,7 @@ pnpm typia setup --manager pnpm
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY IS NOT SUPPORTED
+# Yarn Berry is NOT supported
 yarn add typia
 yarn typia setup --manager yarn
 ```
@@ -105,11 +103,17 @@ bun typia setup --manager bun
   </Tabs.Tab>
 </Tabs>
 
-You can turn on transformation mode just by running `npx typia setup` command.
+The wizard does three things:
 
-Setup wizard would be executed, and it will do everything for the transformation.
+1. Installs `typescript` and `ts-patch` if they aren't already devDependencies.
+2. Adds `{ "transform": "typia/lib/transform" }` to `compilerOptions.plugins` in `tsconfig.json`.
+3. Adds `"prepare": "ts-patch install"` to `package.json`'s `scripts`.
 
-### Manual Setup
+That's everything. Run `npm run prepare` once (or let it run automatically on the next `npm install`) and `tsc` will apply the typia transform from then on.
+
+## Manual setup
+
+If you'd rather configure it by hand, here's what the wizard does:
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
@@ -126,7 +130,6 @@ pnpm install -D typescript ts-patch
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY IS NOT SUPPORTED
 yarn add typia
 yarn add -D typescript ts-patch
 ```
@@ -139,15 +142,13 @@ bun add -d typescript ts-patch
   </Tabs.Tab>
 </Tabs>
 
-If you want to install `typia` manually, just follow the steps.
-
-Firstly install `typia` as a dependency. And then, install `typescript` and `ts-patch` as `devDependencies`.
+Add the transform plugin to `tsconfig.json`:
 
 ```json filename="tsconfig.json" copy showLineNumbers
 {
   "compilerOptions": {
     "strict": true,
-    "strictNullChecks": true, 
+    "strictNullChecks": true,
     "skipLibCheck": true,
     "plugins": [
       { "transform": "typia/lib/transform" }
@@ -156,9 +157,7 @@ Firstly install `typia` as a dependency. And then, install `typescript` and `ts-
 }
 ```
 
-Secondly open your `tsconfig.json` file as shown above.
-
-As `typia` generates optimal operation code through transformation, it must be configured as a `plugin`. Also, never forget to configure `strict` (or `strictNullChecks`) to be `true` within your tsconfig.json `compilerOptions`. It is essential option for modern TypeScript development.
+Add the `prepare` script to `package.json`:
 
 ```json filename="package.json" copy showLineNumbers {2-4}
 {
@@ -175,6 +174,8 @@ As `typia` generates optimal operation code through transformation, it must be c
 }
 ```
 
+Run `prepare` once so `ts-patch` patches your local `typescript`:
+
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
@@ -188,7 +189,6 @@ pnpm prepare
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY IS NOT SUPPORTED
 yarn prepare
 ```
   </Tabs.Tab>
@@ -199,28 +199,25 @@ bun prepare
   </Tabs.Tab>
 </Tabs>
 
-Finally open `package.json` file and configure `npm run prepare` command like above.
-
-Be sure to run `npm run prepare` once you have made these changes.
-
-For reference, [`ts-patch`](https://github.com/nonara/ts-patch) is an helper library of TypeScript compiler that supporting custom transformations by plugins. From now on, whenever you run `tsc` command, your `typia` function call statements would be transformed to the optimal operation codes in the compiled JavaScript files.
+After that, plain `tsc` applies the transform.
 
 ## Bundlers
 
 ### `@typia/unplugin`
 
-[`@typia/unplugin`](https://github.com/samchon/typia/tree/master/packages/unplugin) is a plugin to integrate `typia` into your bundlers seamlessly.
+[`@typia/unplugin`](https://github.com/samchon/typia/tree/master/packages/unplugin) integrates the typia transform into bundlers. It supports:
 
-Currently, `@typia/unplugin` supports the following bundlers:
-  - [Bun](https://github.com/samchon/typia/blob/master/packages/unplugin/src/bun.ts)
-  - [Esbuild](https://github.com/samchon/typia/blob/master/packages/unplugin/src/esbuild.ts)
-  - [Farm](https://github.com/samchon/typia/blob/master/packages/unplugin/src/farm.ts)
-  - [Next.js](https://github.com/samchon/typia/blob/master/packages/unplugin/src/next.ts)
-  - [Rolldown](https://github.com/samchon/typia/blob/master/packages/unplugin/src/rolldown.ts)
-  - [Rollup](https://github.com/samchon/typia/blob/master/packages/unplugin/src/rollup.ts)
-  - [Rspack](https://github.com/samchon/typia/blob/master/packages/unplugin/src/rspack.ts)
-  - [Vite](https://github.com/samchon/typia/blob/master/packages/unplugin/src/vite.ts)
-  - [Webpack](https://webpack.js.org/)
+- [Vite](https://github.com/samchon/typia/blob/master/packages/unplugin/src/vite.ts)
+- [Next.js](https://github.com/samchon/typia/blob/master/packages/unplugin/src/next.ts)
+- [esbuild](https://github.com/samchon/typia/blob/master/packages/unplugin/src/esbuild.ts)
+- [Rollup](https://github.com/samchon/typia/blob/master/packages/unplugin/src/rollup.ts)
+- [Rolldown](https://github.com/samchon/typia/blob/master/packages/unplugin/src/rolldown.ts)
+- [Rspack](https://github.com/samchon/typia/blob/master/packages/unplugin/src/rspack.ts)
+- [Farm](https://github.com/samchon/typia/blob/master/packages/unplugin/src/farm.ts)
+- [Bun](https://github.com/samchon/typia/blob/master/packages/unplugin/src/bun.ts)
+- [Webpack](https://webpack.js.org/)
+
+Install it alongside typia:
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
@@ -241,7 +238,7 @@ pnpm install -D @typia/unplugin
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
-# YARN BERRY IS NOT SUPPORTED
+# Yarn Berry is NOT supported
 yarn add typia
 yarn typia setup --manager yarn
 
@@ -258,18 +255,12 @@ bun add -D @typia/unplugin
   </Tabs.Tab>
 </Tabs>
 
-At first, install both `@typia/unplugin` and `typia`, with `npx typia setup` command.
-
-After that, follow the next section steps to integrate `@typia/unplugin` into your bundlers.
-
-For reference, there are a couple of ways to integrate `@typia/unplugin` into your bundlers. For the full integration guide, please refer to the [`@typia/unplugin` documentation](https://github.com/samchon/typia/tree/master/packages/unplugin).  
+Then add the matching plugin import to your bundler config:
 
 <Tabs items={['Vite', 'Next.js', 'esbuild', 'Bun.runtime', 'Bun.build']}>
   <Tabs.Tab>
 <Callout type="info">
-You can use any plugins with [`@typia/unplugin`](#typiaunplugin) in Vite (including [`@vitejs/plugin-react-swc`](https://github.com/vitejs/vite-plugin-react-swc)).
-
-`@typia/unplugin` processes the TypeScript code before transforming it to JavaScript, so it can be used with any plugins.
+You can run any other plugin alongside `@typia/unplugin` in Vite — including [`@vitejs/plugin-react-swc`](https://github.com/vitejs/vite-plugin-react-swc). `@typia/unplugin` rewrites the TypeScript source before the next plugin sees it, so they don't conflict.
 </Callout>
 
 ```typescript filename="vite.config.ts" copy showLineNumbers
@@ -288,7 +279,7 @@ import unTypiaNext from "@typia/unplugin/next";
 
 /** @type {import('next').NextConfig} */
 const config = {
-  // your next.js config
+  // your existing Next.js config
 };
 export default unTypiaNext(
   config,
@@ -309,7 +300,7 @@ build({
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-First, create a `preload.ts` file and add the following code.
+Make a `preload.ts`:
 
 ```typescript filename="preload.ts" copy showLineNumbers
 import { plugin } from 'bun';
@@ -318,116 +309,98 @@ import UnpluginTypia from '@typia/unplugin/bun'
 plugin(UnpluginTypia({ /* options */ }))
 ```
 
-Then, add the `preload` option to your `bunfig.toml` file.
+Then point `bunfig.toml` at it:
 
-```typescript filename="bunfig.toml" copy showLineNumbers {1, 4}
+```toml filename="bunfig.toml" copy showLineNumbers {1, 4}
 preload = ["./preload.ts"]
 
 [test]
 preload = ["./preload.ts"]
 ```
 
-And, run the `bun run` command.
-
+Now `bun run` and `bun test` both apply the transform:
 
 ```bash filename="Terminal" showLineNumbers copy
 bun run index.ts
 ```
-
-For more details, please refer to the [`@typia/unplugin` documentation](https://github.com/samchon/typia/tree/master/packages/unplugin).
   </Tabs.Tab>
   <Tabs.Tab>
-
 ```typescript filename="Build.ts" copy showLineNumbers
 import UnpluginTypia from '@typia/unplugin/bun'
 
 await Bun.build({
-	entrypoints: ["./index.ts"],
-	outdir: "./out",
-	plugins: [UnpluginTypia(/* options */)]
+  entrypoints: ["./index.ts"],
+  outdir: "./out",
+  plugins: [UnpluginTypia(/* options */)]
 });
 ```
-
-For more details, please refer to the [`@typia/unplugin` documentation](https://github.com/samchon/typia/tree/master/packages/unplugin).
   </Tabs.Tab>
 </Tabs>
+
+Full options reference lives in the [`@typia/unplugin` README](https://github.com/samchon/typia/tree/master/packages/unplugin).
 
 ### Webpack
 
 <Callout type="info">
-  [`@typia/unplugin`](#typiaunplugin) also supports `webpack` as well.
+[`@typia/unplugin`](#typiaunplugin) supports Webpack out of the box. The instructions below are the manual `ts-loader` route for projects that prefer to wire it themselves.
 </Callout>
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# TYPIA
+# typia
 npm install typia
 npx typia setup
 
-# WEBPACK + TS-LOADER
-npm install -D ts-loader
-npm install -D webpack webpack-cli
+# webpack + ts-loader
+npm install -D ts-loader webpack webpack-cli
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# TYPIA
+# typia
 pnpm install typia
 pnpm typia setup --manager pnpm
 
-# WEBPACK + TS-LOADER
-pnpm install -D ts-loader
-pnpm install -D webpack webpack-cli
+# webpack + ts-loader
+pnpm install -D ts-loader webpack webpack-cli
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-###########################################
-# YARN BERRY IS NOT SUPPORTED
-###########################################
-# TYPIA
+# Yarn Berry is NOT supported
+# typia
 yarn add typia
 yarn typia setup --manager yarn
 
-# WEBPACK + TS-LOADER
-yarn add -D ts-loader
-yarn add -D webpack webpack-cli
+# webpack + ts-loader
+yarn add -D ts-loader webpack webpack-cli
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-    ```bash filename="Terminal" copy showLineNumbers
-# TYPIA
+```bash filename="Terminal" copy showLineNumbers
+# typia
 bun add typia
 bun typia setup
 
-# WEBPACK + TS-LOADER
-bun add -d ts-loader
-bun add -d webpack webpack-cli
+# webpack + ts-loader
+bun add -d ts-loader webpack webpack-cli
 ```
   </Tabs.Tab>
 </Tabs>
 
-When you're using `webpack` as a bundler, you can still utilize the [transformation](#transformation) mode.
+`ts-loader` runs the patched `tsc`, so the typia transform applies automatically. Configure as usual:
 
-Just install `ts-loader` as well as `webpack`, and configure `webpack.config.js` file like below.
-
-```javascript filename="webpack.config.js" copy showLineNumbers {20-24}
+```javascript filename="webpack.config.js" copy showLineNumbers
 const path = require("path");
-const nodeExternals = require("webpack-node-externals");
 
 module.exports = {
-  // CUSTOMIZE HERE
   entry: ["./src/index.tsx"],
   output: {
     path: path.join(__dirname, "dist"),
     filename: "index.js",
   },
-  optimization: {
-    minimize: false,
-  },
-
-  // JUST KEEP THEM
+  optimization: { minimize: false },
   mode: "development",
   target: "node",
   module: {
@@ -445,7 +418,7 @@ module.exports = {
 };
 ```
 
-From now on, you can build the single JS file just by running the `npx webpack` command. By the way, when removing `devDependencies` for `--production` install, never forget to add the `--ignore-scripts` option to prevent the `prepare` script.
+Build with `npx webpack`. When you strip dev dependencies for production, **also pass `--ignore-scripts`** to skip `ts-patch install` (which would fail because `typescript` is no longer present):
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
@@ -475,11 +448,7 @@ bun install --production --ignore-scripts
   </Tabs.Tab>
 </Tabs>
 
-Additionally, if you're using `typia` in the NodeJS project especially for the backend development, *Setup Guide Documents* of [`nestia`](https://github.com/samchon/nestia) would be helpful. Even though you're not using NestJS, you can still utilize below documents, and "Single JS file only" mode would be especially helpful for you.
-
-  - [Nestia > Setup > Webpack](https://nestia.io/docs/setup/#webpack)
-    - [With `node_modules`](https://nestia.io/docs/setup/#with-node_modules)
-    - [Single JS file only](https://nestia.io/docs/setup/#single-js-file-only)
+For Node.js backend bundling — including the popular "single bundled JS file with no `node_modules`" pattern — see the [Nestia setup guide](https://nestia.io/docs/setup/#webpack).
 
 ### NX
 
@@ -498,7 +467,7 @@ pnpm typia setup --manager pnpm
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY IS NOT SUPPORTED
+# Yarn Berry is NOT supported
 yarn add typia
 yarn typia setup --manager yarn
 ```
@@ -511,7 +480,7 @@ bun typia setup --manager bun
     </Tabs.Tab>
 </Tabs>
 
-After installing `typia` like above, and ensuring the `prepare` script is something similar to `ts-patch install` you have to modify the `tsconfig.lib.json` on each `@nx/js` package to be similar to the below.
+After installation, make sure the `prepare` script runs `ts-patch install`, then add the typia plugin to each `@nx/js` package's `tsconfig.lib.json`:
 
 ```json filename="tsconfig.lib.json" showLineNumbers copy
 {
@@ -527,42 +496,41 @@ After installing `typia` like above, and ensuring the `prepare` script is someth
 }
 ```
 
-After this, when running `nx <package-name>:build` it _should_ now output with the Typia transforms applied. **But if Typia fails for any reason** (for example it considers some type you have to be invalid), this error is not reported back via Nx. Nx will silent swallow these errors from ts-patch/typia, and the resulting transpiled code will not have typia transformations applied. This will result in an error such as the following when running you tests that use typia (`nx <package-name>:test`), dev versions of your application (`nx <package-name>:serve`), as well as running your application after building.
-
-```bash filename="Terminal"
-Error on typia.createAssert(): no transform has been configured.
-```
-
-To debug whether this is an issue with your setup or simply NX just silently swallowing typia errors, you can create a new task in your `project.json` file similar to the one below.
-
-```json filename="project.json" showLineNumbers copy
- "targets": {
-    "build:validate:typia": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "tsc --project packages/<package-name>/tsconfig.lib.json --outDir dist/packages/typiaTest"
-        ],
-      }
-    },
-    ...
- }
-```
-
-Running this task will show you the errors from Typia, and allow you to correct them, meaning that using the standard `nx <package-name>:build` task should now work the way you expect.
-
-Note: While Nx has a `transformers` feature on the `@nx/js` plugin, that won't work with Typia. The reason is because Nx is expecting a transformer to export a `before` hook, which Nx then plugs directly into TypeScript via the compiler API. Typia doesn't export that kind of hook, because Typia only works with ts-patch, which abstracts the need for creating a specific before hook in the way Nx wants.
+> [!WARNING]
+>
+> **Nx swallows transformer errors.** If typia detects an unsupported type (or anything else), `nx <package>:build` will succeed but emit JavaScript without the typia transform applied. At runtime you'll see:
+>
+> ```
+> Error on typia.createAssert(): no transform has been configured.
+> ```
+>
+> To get the actual error, run `tsc` directly:
+>
+> ```json filename="project.json" showLineNumbers copy
+> "targets": {
+>   "build:validate:typia": {
+>     "executor": "nx:run-commands",
+>     "options": {
+>       "commands": [
+>         "tsc --project packages/<package-name>/tsconfig.lib.json --outDir dist/packages/typiaTest"
+>       ]
+>     }
+>   }
+> }
+> ```
+>
+> Nx's own `transformers` option on `@nx/js` does not work with typia — it expects a `before` hook that typia doesn't expose, because typia operates through `ts-patch` instead.
 
 ## Generation
+
+`npx typia generate` is the fallback for build pipelines where a TypeScript transformer can't run — Babel in Create-React-App, raw SWC, and so on. typia reads the input directory, expands every `typia.*<T>()` call site, and writes the transformed `.ts` files to the output directory. Your bundler then compiles those transformed files normally.
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# INSTALL TYPIA
 npm install typia
 npm install -D typescript
 
-# GENERATE TRANSFORMED TYPESCRIPT CODES
 npx typia generate \
   --input src/templates \
   --output src/generated \
@@ -571,11 +539,9 @@ npx typia generate \
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# INSTALL TYPIA
 pnpm install typia
 pnpm install -D typescript
 
-# GENERATE TRANSFORMED TYPESCRIPT CODES
 pnpm typia generate \
   --input src/templates \
   --output src/generated \
@@ -584,11 +550,9 @@ pnpm typia generate \
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# INSTALL TYPIA
 yarn add typia
 yarn add -D typescript
 
-# GENERATE TRANSFORMED TYPESCRIPT CODES
 yarn typia generate \
   --input src/templates \
   --output src/generated \
@@ -597,9 +561,9 @@ yarn typia generate \
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# INSTALL TYPIA
 bun add typia
 bun add -d typescript
+
 bun typia generate \
   --input src/templates \
   --output src/generated \
@@ -608,24 +572,18 @@ bun typia generate \
   </Tabs.Tab>
 </Tabs>
 
-For frontend projects.
+When to use it:
 
-If you are using a non-standard TypeScript compiler such as the following, you will need to fall back to [generation](#generation) mode
+| Build tool | Use this instead |
+|------------|------------------|
+| Create-React-App / Babel | `typia generate` |
+| Vite / esbuild | [`@typia/unplugin`](#typiaunplugin) |
+| SWC alone | `typia generate` |
+| Bundlers with SWC inside (Next.js, Vite, …) | [`@typia/unplugin`](#typiaunplugin) |
 
-  - Non-standard TypeScript compilers:
-    - [Babel](https://babeljs.io/) in Create-React-App
-    - [esbuild](https://esbuild.github.io/) in Vite -> covered by [`@typia/unplugin`](#typiaunplugin)
-    - [SWC](https://swc.rs/) -> use [`@typia/unplugin`](#typiaunplugin) with your bundlers ( including `next.js`, `vite`, `webpack`, `rollup`, etc )
+The `--input` directory contains `.ts` files that import typia and re-export validators. typia reads each file, applies the transform, and writes the result to `--output`:
 
-Instead you should utilize the generation mode. 
-
-Install `typia` through `npm install` command, and run `typia generate` command. Then, generator of `typia` reads your TypeScript codes of `--input`, and writes transformed TypeScript files into the `--output` directory, like below.
-
-For clarification, the input directory should contain one or more TypeScript files which define how you want to verify your associated type assertions. Commonly you will import your TypeScript type, then export a function which validates that type. See below.
-
-If you want to specify other TypeScript project file instead of `tsconfig.json`, you can use `--project` option.
-
-<Tabs items={['TypeScript Source Code', 'Generated TypeScript File']}>
+<Tabs items={['TypeScript Input', 'Generated TypeScript']}>
   <Tabs.Tab>
 ```typescript copy filename="examples/src/templates/check.ts" showLineNumbers {5}
 import typia from "typia";
@@ -658,8 +616,8 @@ export const check = (input: any): input is IMember => {
   </Tabs.Tab>
 </Tabs>
 
-<Callout type="error">
-**Why not support non-standard compilers?**
-
-Non-standard TypeScript compilers are removing every type information, and skipping type checks for rapid compilation. By the way, without those type information, `typia` can't do anything. This is the reason why `typia` doesn't support non-standard TypeScript compilers.
-</Callout>
+> [!CAUTION]
+>
+> **Why non-standard compilers aren't supported directly.**
+>
+> Babel and SWC strip type annotations before any transformer runs. typia needs the type information, so it can't operate inside those toolchains. Generation mode works around the limitation by running typia ahead of time, producing plain `.ts` files that any tool can then compile.

--- a/website/src/content/docs/setup/tsgo.mdx
+++ b/website/src/content/docs/setup/tsgo.mdx
@@ -4,25 +4,23 @@ title: Guide Documents > Setup > TypeScript-Go
 
 import { Tabs } from "nextra/components";
 
-## Summary
+## TypeScript-Go (`ttsc`)
 
-`typia@next` uses the [`ttsc`](https://github.com/samchon/ttsc) toolchain.
+This setup targets **TypeScript-Go** — the Go rewrite of the TypeScript compiler that ships under `@typescript/native-preview`. `typia@next` ships a Go-rewritten transform that plugs into it through the [`ttsc`](https://github.com/samchon/ttsc) toolchain.
 
-This setup targets TypeScript-Go, the Go migration of the TypeScript compiler. `ttsc` provides the Go-based plugin toolchain, and `typia@next` uses the Go-rewritten `typia` transform.
+You need three commands:
 
-- `ttsc`: build, check, and watch TypeScript projects
-- `ttsx`: execute TypeScript directly with type checking
-- `@ttsc/unplugin`: run `ttsc` plugins from bundlers
+- `ttsc` — build, check, and watch a TypeScript project
+- `ttsx` — execute a TypeScript file directly, with type checking
+- `@ttsc/unplugin` — connect `ttsc` to a bundler (Vite, Next.js, Webpack, …)
 
 > [!NOTE]
 >
-> `@typescript/native-preview` is not a stable TypeScript release yet, and `typia@next` is also an experimental release of `typia`.
+> `@typescript/native-preview` is **not yet a stable TypeScript release**, and `typia@next` is the matching experimental release of typia. For production today, use the [Legacy (TS v6) setup](/docs/setup/legacy).
 >
-> Also, you must use `ttsc` and `ttsx`. The stock `tsc`, `ts-node`, and `tsx` cannot apply the `typia` transform, so they will not work.
+> The stock `tsc`, `ts-node`, and `tsx` cannot apply the typia transform — you must use `ttsc` and `ttsx`.
 
-## Setup
-
-### Install
+## Install
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
@@ -51,7 +49,7 @@ bun add -d ttsc @typescript/native-preview
   </Tabs.Tab>
 </Tabs>
 
-Keep your TypeScript project strict.
+Then keep your TypeScript project strict:
 
 ```json filename="tsconfig.json" showLineNumbers copy
 {
@@ -61,16 +59,18 @@ Keep your TypeScript project strict.
 }
 ```
 
-### Compile
+That's it. Unlike the legacy setup, you do **not** add `compilerOptions.plugins` for typia — `ttsc` discovers the transform from the `ttsc` field in `typia/package.json` automatically.
 
-Use `ttsc` to build your TypeScript project. It compiles your sources and applies the `typia` transform in one step.
+## Build
+
+Use `ttsc` exactly the way you would use `tsc`:
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
-npx ttsc
-npx ttsc --noEmit
-npx ttsc --watch
+npx ttsc            # build
+npx ttsc --noEmit   # type-check only
+npx ttsc --watch    # rebuild on change
 ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -96,9 +96,9 @@ bun ttsc --watch
   </Tabs.Tab>
 </Tabs>
 
-### Execute
+## Execute without building
 
-Use `ttsx` to run a TypeScript file directly, without a build step.
+Use `ttsx` instead of `ts-node` or `tsx`:
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
@@ -125,13 +125,9 @@ bun ttsx src/index.ts
 
 ## Bundlers
 
+Bundlers (Vite, Next.js, Webpack, …) run their own TypeScript pipeline that bypasses `ttsc`. To plug typia in, install [`@ttsc/unplugin`](https://github.com/samchon/ttsc/tree/master/packages/unplugin) and add its plugin to your bundler config.
+
 ### Install
-
-Use [`@ttsc/unplugin`](https://github.com/samchon/ttsc/tree/master/packages/unplugin)
-when your project is built by a bundler.
-
-`ttsc` is enough for a normal TypeScript build, but bundlers run their own
-build pipeline. `@ttsc/unplugin` connects the `ttsc` transform to that pipeline.
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
@@ -156,22 +152,9 @@ bun add -d @ttsc/unplugin
   </Tabs.Tab>
 </Tabs>
 
-### Configuration
+### Configure
 
-Currently, `@ttsc/unplugin` supports the following bundlers:
-
-- Vite
-- Next.js
-- Rollup
-- Rolldown
-- esbuild
-- Webpack
-- Rspack
-- Farm
-- Bun
-
-Then add the matching plugin to your bundler config. Import path must match the
-bundler you are using.
+`@ttsc/unplugin` exposes one entry per bundler — import the matching path:
 
 <Tabs
   items={[
@@ -296,15 +279,11 @@ await Bun.build({
   </Tabs.Tab>
 </Tabs>
 
-Put the plugin in the same config file that already builds your application.
-For example, a Vite app uses `vite.config.ts`, a Next.js app uses
-`next.config.mjs`, and a Webpack app uses `webpack.config.mjs`.
+Drop the plugin into the same config file that already builds your app (`vite.config.ts`, `next.config.mjs`, `webpack.config.mjs`, …). After that, run your normal build command — no other change.
 
-After that, run the normal build command of your framework or bundler.
+### Pointing at a different `tsconfig.json`
 
-### Project
-
-If your bundler should read another TypeScript config file, pass `project`.
+If your bundler should use a config other than the default `tsconfig.json`, pass `project`:
 
 <Tabs
   items={[
@@ -465,9 +444,9 @@ await Bun.build({
 
 The `project` path is resolved from the current working directory.
 
-## Transform Options
+## Tuning the transform
 
-Add `compilerOptions.plugins` only when you want to change transform options.
+Most projects don't need to touch this. Add `compilerOptions.plugins` only when you want to flip one of the optional transform flags:
 
 ```jsonc filename="tsconfig.json" showLineNumbers copy
 {
@@ -478,24 +457,22 @@ Add `compilerOptions.plugins` only when you want to change transform options.
       {
         "transform": "typia/lib/transform",
         "functional": true, // default: false
-        "numeric": true, // default: false
-        "finite": true, // default: false
-        "undefined": false // default: true
+        "numeric": true,    // default: false
+        "finite": true,     // default: false
+        "undefined": false  // default: true
       }
     ]
   }
 }
 ```
 
-- `functional`: validate function types
-- `numeric`: reject `NaN` from `number`
-- `finite`: reject both `NaN` and `Infinity` from `number`
-- `undefined`: set `false` to skip explicit `undefined` checks
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `functional` | `false` | Validate `function` types — needed for `typia.functional.*` |
+| `numeric` | `false` | Reject `NaN` when a property is typed as `number` |
+| `finite` | `false` | Reject `NaN` and `±Infinity` when a property is typed as `number` |
+| `undefined` | `true`  | When `false`, skip explicit `undefined` checks on required properties |
 
 > [!NOTE]
 >
-> If you use the default transform options, do not add
-> `compilerOptions.plugins` to `tsconfig.json`.
->
-> `ttsc` automatically applies the `typia` transform. This is the difference
-> from the legacy setup.
+> With the default flags you do **not** need `compilerOptions.plugins`. `ttsc` will pick up the transform from `typia/package.json` on its own.

--- a/website/src/content/docs/tutorial/_meta.ts
+++ b/website/src/content/docs/tutorial/_meta.ts
@@ -1,0 +1,12 @@
+import { MetaRecord } from "nextra";
+
+export default {
+  index: "Welcome",
+  install: "1. Install",
+  "first-validator": "2. First validator",
+  "refining-types": "3. Refining types",
+  json: "4. JSON parse & stringify",
+  llm: "5. LLM function calling",
+  integrations: "6. Plug into a framework",
+  "next-steps": "7. Next steps",
+} satisfies MetaRecord;

--- a/website/src/content/docs/tutorial/first-validator.mdx
+++ b/website/src/content/docs/tutorial/first-validator.mdx
@@ -1,0 +1,183 @@
+---
+title: Tutorial > 2. First validator
+---
+
+# Step 2 — Your first validator
+
+We'll define the `Bookmark` interface — the data model we'll use through the rest of the tutorial — and write three different validators against it: `is`, `assert`, and `validate`. They look almost identical to call, but each one is the right pick for a different situation. We'll see all three.
+
+## The `Bookmark` interface
+
+Make a new file:
+
+```typescript copy filename="src/bookmark.ts"
+export interface Bookmark {
+  /** Stable identifier. */
+  id: string;
+
+  /** The URL we're saving. */
+  url: string;
+
+  /** Human-readable title for the link. */
+  title: string;
+
+  /** Optional one-paragraph description. */
+  description?: string;
+
+  /** Tags for filtering / grouping. */
+  tags: string[];
+
+  /** When the bookmark was created (ISO-8601 string). */
+  createdAt: string;
+}
+```
+
+That's just TypeScript — no decorators, no schema builder. typia will read this interface directly.
+
+## `typia.is` — "does this look like a Bookmark?"
+
+```typescript copy filename="src/02-is.ts"
+import typia from "typia";
+
+import { Bookmark } from "./bookmark";
+
+const good: unknown = {
+  id: "b1",
+  url: "https://typia.io",
+  title: "typia",
+  tags: ["docs", "validation"],
+  createdAt: "2026-05-16T09:00:00.000Z",
+};
+
+const bad: unknown = {
+  id: "b2",
+  // url missing
+  title: "broken",
+  tags: ["broken"],
+  createdAt: "2026-05-16T09:00:00.000Z",
+};
+
+console.log(typia.is<Bookmark>(good)); // true
+console.log(typia.is<Bookmark>(bad));  // false
+```
+
+Run it:
+
+```bash filename="Terminal"
+npx ttsx src/02-is.ts
+```
+
+You'll see `true` then `false`. The compiled JavaScript expanded `typia.is<Bookmark>` into a hand-rolled checker for the shape of `Bookmark` — no schema lookup at runtime. Curious what it looks like? Run `npx ttsc` and read `dist/02-is.js`.
+
+`is` is a *type guard*: TypeScript narrows the variable on the `true` branch. So this is also legal:
+
+```typescript copy
+function describe(input: unknown) {
+  if (typia.is<Bookmark>(input)) {
+    // input is now typed as Bookmark
+    console.log(`${input.title} → ${input.url}`);
+  }
+}
+```
+
+## `typia.assert` — throw the first error
+
+`is` only tells you yes or no. When you actually want the program to stop on a bad input — for example, when an HTTP request body arrives and you need to refuse to handle it — use `assert`:
+
+```typescript copy filename="src/02-assert.ts"
+import typia from "typia";
+
+import { Bookmark } from "./bookmark";
+
+const bad: unknown = {
+  id: "b3",
+  url: 42, // wrong type
+  title: "broken",
+  tags: ["broken"],
+  createdAt: "2026-05-16T09:00:00.000Z",
+};
+
+try {
+  typia.assert<Bookmark>(bad);
+} catch (err) {
+  console.log(err);
+}
+```
+
+Run it. You'll see a `TypeGuardError` with structured fields:
+
+```
+TypeGuardError {
+  method: 'typia.assert',
+  path: '$input.url',
+  expected: 'string',
+  value: 42,
+  ...
+}
+```
+
+That `path` is the killer feature. You can drop it into a UI message ("the field `url` should be a string"), pipe it to logs, or attach it to an HTTP 400 response. No string parsing required.
+
+`assert` returns the input on success, so you can wrap it inline:
+
+```typescript copy
+const safe: Bookmark = typia.assert<Bookmark>(rawInput);
+// the next line is statically typed as Bookmark
+console.log(safe.title);
+```
+
+## `typia.validate` — collect *every* error
+
+For forms or any UI that wants to highlight every bad field at once, `assert` stops too early — it throws on the first one. Use `validate` instead:
+
+```typescript copy filename="src/02-validate.ts"
+import typia from "typia";
+
+import { Bookmark } from "./bookmark";
+
+const messy: unknown = {
+  id: 42,             // wrong: should be string
+  url: 9999,          // wrong: should be string
+  title: "broken",
+  tags: "not an array", // wrong: should be string[]
+  createdAt: "2026-05-16T09:00:00.000Z",
+};
+
+const result = typia.validate<Bookmark>(messy);
+if (result.success) {
+  console.log("OK:", result.data);
+} else {
+  for (const err of result.errors) {
+    console.log(`${err.path}: expected ${err.expected}, got`, err.value);
+  }
+}
+```
+
+Run it and you'll get all three errors in one pass:
+
+```
+$input.id: expected string, got 42
+$input.url: expected string, got 9999
+$input.tags: expected Array<string>, got 'not an array'
+```
+
+`result.success` is the discriminator. On the `true` branch `result.data` is typed as `Bookmark`. On the `false` branch `result.errors` is an array of `{ path, expected, value }` records.
+
+## How to choose
+
+| Question | Use |
+|----------|-----|
+| Just a yes/no answer? | [`is`](/docs/validators/is) |
+| Want an exception to propagate? | [`assert`](/docs/validators/assert) |
+| Need to render every error at once? | [`validate`](/docs/validators/validate) |
+| Want to also reject extra properties? | append `Equals`: `assertEquals`, `validateEquals`, `equals` |
+
+## What you've done
+
+- Defined the `Bookmark` interface as plain TypeScript
+- Validated three different ways, with the validator generated from the interface itself
+- Seen the structured error path that typia produces for free
+
+Next we'll tighten the type so the validator catches more than just "is this a string?" — it'll also check URL format, minimum length, max length, and so on.
+
+→ [Step 3: Refining types](/docs/tutorial/refining-types)

--- a/website/src/content/docs/tutorial/index.mdx
+++ b/website/src/content/docs/tutorial/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Tutorial > Welcome
+---
+
+# Welcome to the typia tutorial
+
+This tutorial walks you from "I just heard of typia" to "I have a small typia-powered service that an LLM can drive." It's seven short steps. The full project takes about 30 minutes if you copy-paste, an hour or so if you experiment along the way.
+
+## What you'll build
+
+A tiny **Bookmark service**:
+
+- A `Bookmark` interface with constraints (URL format, max-length tags, an optional description)
+- A validator that rejects bad inputs with helpful error paths
+- A JSON loader that reads `bookmarks.json` from disk and refuses to start if the data is corrupt
+- An HTTP endpoint (via [Hono](https://hono.dev)) that accepts new bookmarks
+- An LLM tool that turns a user message like "save https://typia.io for me, tag it as docs" into a real bookmark, with self-correction when the LLM gets the schema wrong
+
+Every piece of typia we cover is something you'd actually reach for in a production project. We won't touch features just to mention them.
+
+## What you should already know
+
+- TypeScript basics — interfaces, type intersections, generics
+- npm / pnpm / bun, whichever you prefer
+- A terminal you can run commands in
+
+You **don't** need to know about JSON Schema, OpenAPI, LLM function calling, or the typia internals. We'll introduce them as they come up.
+
+> [!TIP]
+>
+> If you'd rather try typia before setting up a project locally, head to the [browser playground](/playground). It compiles in-browser and shows the emitted JavaScript next to your TypeScript — useful for the "should I bother installing this?" decision.
+
+## The seven steps
+
+1. **[Install](/docs/tutorial/install)** — set up `ttsc` and write a one-line smoke test
+2. **[First validator](/docs/tutorial/first-validator)** — the `Bookmark` interface and `typia.assert`
+3. **[Refining types](/docs/tutorial/refining-types)** — `tags.Format`, `tags.MaxLength`, and friends
+4. **[JSON parse & stringify](/docs/tutorial/json)** — `assertParse` and `assertStringify`
+5. **[LLM function calling](/docs/tutorial/llm)** — turn a TypeScript class into LLM tools
+6. **[Plug into a framework](/docs/tutorial/integrations)** — a real Hono endpoint
+7. **[Next steps](/docs/tutorial/next-steps)** — what to read next
+
+Each step is a separate page. You can read straight through, or skip ahead — but the running code example is the same across all of them, so it's easier the first time if you do them in order.
+
+> [!TIP]
+>
+> If something doesn't behave the way the tutorial says, the most common cause is a build tool that doesn't run the typia transform. See [the verification step at the end of Install](/docs/tutorial/install#verify-your-setup). It catches 95% of "why isn't this working?" moments.
+
+Ready? → [Step 1: Install](/docs/tutorial/install)

--- a/website/src/content/docs/tutorial/install.mdx
+++ b/website/src/content/docs/tutorial/install.mdx
@@ -1,0 +1,147 @@
+---
+title: Tutorial > 1. Install
+---
+import { Tabs } from "nextra/components";
+
+# Step 1 — Install
+
+We'll set up a fresh project that compiles with `ttsc` (the Go-rewritten TypeScript compiler that knows how to run the typia transform). If you already have a TypeScript project, you can install into that — just make sure your build command runs `ttsc` instead of `tsc`.
+
+The legacy `ts-patch` setup also works ([setup/legacy](/docs/setup/legacy)). The tutorial uses the modern `ttsc` path because it's the simpler experience.
+
+## Create the project
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
+```bash filename="Terminal" copy
+mkdir typia-tutorial && cd typia-tutorial
+npm init -y
+
+npm i typia@next
+npm i -D ttsc @typescript/native-preview @types/node
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" copy
+mkdir typia-tutorial && cd typia-tutorial
+pnpm init
+
+pnpm i typia@next
+pnpm i -D ttsc @typescript/native-preview @types/node
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" copy
+mkdir typia-tutorial && cd typia-tutorial
+yarn init -y
+
+yarn add typia@next
+yarn add -D ttsc @typescript/native-preview @types/node
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" copy
+mkdir typia-tutorial && cd typia-tutorial
+bun init -y
+
+bun add typia@next
+bun add -d ttsc @typescript/native-preview @types/node
+```
+  </Tabs.Tab>
+</Tabs>
+
+## Configure TypeScript
+
+Drop this into `tsconfig.json`:
+
+```json filename="tsconfig.json" copy
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+```
+
+`target: ES2022` is needed by the later tutorial steps (top-level `await` in step 5). `module: Preserve` + `moduleResolution: Bundler` lets `ttsx` handle module loading for you — you can write `import { Bookmark } from "./bookmark"` without the `.js` extension that raw Node ESM would otherwise require.
+
+That's it — `ttsc` discovers the typia transform from `typia/package.json` automatically. You do **not** add `compilerOptions.plugins` here. (That step is only for the legacy `ts-patch` path.)
+
+`"strict": true` matters: without strict null checks your interfaces lie about which fields can be `null` or `undefined`, and the emitted validator will lie with them.
+
+## Verify your setup
+
+Create the `src` directory and write a one-line smoke test:
+
+```bash filename="Terminal" copy
+mkdir -p src
+```
+
+```typescript copy filename="src/check-setup.ts"
+import typia from "typia";
+
+console.log(typia.is<{ id: string }>({ id: "ok" }));
+//                                  ^---- transform turns this into an inline checker
+```
+
+Then run it without building first — `ttsx` is the typia-aware counterpart of `ts-node` / `tsx`:
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
+```bash filename="Terminal" copy
+npx ttsx src/check-setup.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" copy
+pnpm ttsx src/check-setup.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" copy
+yarn ttsx src/check-setup.ts
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" copy
+bun ttsx src/check-setup.ts
+```
+  </Tabs.Tab>
+</Tabs>
+
+You should see:
+
+```
+true
+```
+
+If you see this instead:
+
+```
+Error on typia.is(): no transform has been configured
+```
+
+…you're running stock `tsc` / `tsx` / `ts-node` somewhere — those compilers don't know about typia's transform. The fix is always to use `ttsc` for building and `ttsx` for running. Double-check the command you ran and the scripts in `package.json`.
+
+## Build script (for later)
+
+You'll want a quick `build` script for later steps. Add this to `package.json`:
+
+```json filename="package.json (scripts only)" copy
+{
+  "scripts": {
+    "build": "ttsc",
+    "check": "ttsc --noEmit"
+  }
+}
+```
+
+Now `npm run build` compiles and `npm run check` type-checks without emitting. The rest of the tutorial uses `npx ttsx <file>` (or `pnpm ttsx <file>`, etc.) directly for ad-hoc runs.
+
+→ [Step 2: First validator](/docs/tutorial/first-validator)

--- a/website/src/content/docs/tutorial/integrations.mdx
+++ b/website/src/content/docs/tutorial/integrations.mdx
@@ -1,0 +1,138 @@
+---
+title: Tutorial > 6. Plug into a framework
+---
+
+# Step 6 — Plug into a framework
+
+The bookmark service is now usable from typia, from a CLI script, and from an LLM. The last missing piece is a normal HTTP endpoint so any client can hit it. We'll use [Hono](https://hono.dev) — small, fast, runs on Node / Bun / edge — but the typia parts of this step transfer to NestJS, tRPC, or Express directly.
+
+The point is *not* "how to write HTTP routes." The point is: **the same `Bookmark` type drives validation in every layer.** No DTO duplication, no separate request schema, no manual `if (!body.url) throw …`.
+
+## Install
+
+```bash filename="Terminal"
+npm i hono @hono/typia-validator
+```
+
+`@hono/typia-validator` is the Hono integration. It accepts a validator built with [`typia.createValidate`](/docs/validators/validate#reusable-factories--and-standard-schema-support) and runs it on the request body before your handler sees it.
+
+## A typed request payload
+
+We don't want clients to send us `id` or `createdAt` — those are server-generated. Let's express that as a derived type:
+
+```typescript copy filename="src/bookmark.ts (add to the bottom)"
+/** What a client sends when creating a new bookmark. */
+export type BookmarkCreate = Omit<Bookmark, "id" | "createdAt">;
+```
+
+`Omit` is plain TypeScript — typia reads it and produces a validator for exactly the right shape.
+
+## The HTTP server
+
+```typescript copy filename="src/06-server.ts"
+import { Hono } from "hono";
+import { typiaValidator } from "@hono/typia-validator";
+import typia from "typia";
+
+import { BookmarkCreate } from "./bookmark";
+import { BookmarkService } from "./BookmarkService";
+
+const service = new BookmarkService();
+const validateCreate = typia.createValidate<BookmarkCreate>();
+
+const app = new Hono();
+
+// POST /bookmarks  — create a new bookmark
+app.post(
+  "/bookmarks",
+  typiaValidator("json", validateCreate),
+  async (c) => {
+    const input = c.req.valid("json"); // typed as BookmarkCreate
+    const { id } = await service.add(input);
+    return c.json({ id }, 201);
+  },
+);
+
+// GET /bookmarks?tag=docs
+app.get("/bookmarks", async (c) => {
+  const tag = c.req.query("tag") ?? "";
+  const result = await service.list({ tag });
+  return c.json(result);
+});
+
+export default app;
+```
+
+Three things to notice:
+
+1. **`typia.createValidate<BookmarkCreate>()`** generates a reusable validator that also implements the [Standard Schema](https://standardschema.dev/) interface. `@hono/typia-validator` consumes it directly.
+2. **`c.req.valid("json")`** returns the typed input. TypeScript knows it's `BookmarkCreate` because the middleware narrowed it — there's no `as BookmarkCreate` cast in your handler.
+3. **The validator runs before your handler**, so by the time `service.add(input)` is called, every constraint on `BookmarkCreate` (URL format, tag count, lengths, …) has already passed. If anything's wrong, Hono returns a structured error response automatically.
+
+## Run it
+
+For Node:
+
+```bash filename="Terminal"
+npm i @hono/node-server
+```
+
+```typescript copy filename="src/06-run.ts"
+import { serve } from "@hono/node-server";
+import app from "./06-server";
+
+const PORT = 3000;
+serve({ fetch: app.fetch, port: PORT });
+console.log(`Listening on http://localhost:${PORT}`);
+```
+
+```bash filename="Terminal"
+npx ttsx src/06-run.ts
+```
+
+Then in another terminal:
+
+```bash filename="Terminal"
+curl -s -X POST http://localhost:3000/bookmarks \
+  -H 'content-type: application/json' \
+  -d '{ "url": "https://typia.io", "title": "typia", "tags": ["docs"] }'
+# → {"id":"…uuid…"}
+
+curl -s http://localhost:3000/bookmarks?tag=docs
+# → {"items":[…]}
+```
+
+Try a bad payload:
+
+```bash filename="Terminal"
+curl -s -X POST http://localhost:3000/bookmarks \
+  -H 'content-type: application/json' \
+  -d '{ "url": "lol", "title": "", "tags": [] }'
+```
+
+You get a 400 carrying the structured errors — `$input.url`, `$input.title`, `$input.tags` — with the same `expected` strings you saw in step 3. The HTTP layer never gets a chance to insert a malformed bookmark.
+
+## What other frameworks look like
+
+The patterns are short — see the dedicated pages for full examples:
+
+| Framework | Integration | What you write |
+|-----------|------------|----------------|
+| **NestJS** | [`@nestia/core`](/docs/utilization/nestjs) | `@TypedBody() input: BookmarkCreate` instead of a DTO class |
+| **tRPC** | [Direct typia](/docs/utilization/trpc) | `.input(typia.createAssert<BookmarkCreate>())` on the procedure |
+| **MCP server** | [`@typia/mcp`](/docs/utilization/mcp) | `registerMcpControllers({ server, controllers: [typia.llm.controller<BookmarkService>("bm", service)] })` |
+| **Vercel AI** | [`@typia/vercel`](/docs/utilization/vercel) | `toVercelTools({ controllers: [...] })` |
+| **LangChain** | [`@typia/langchain`](/docs/utilization/langchain) | `toLangChainTools({ controllers: [...] })` |
+
+The same `BookmarkService` class plugs into all five LLM-shaped surfaces; the same `BookmarkCreate` type plugs into all the HTTP-shaped ones.
+
+## What you've done
+
+- Stood up a real HTTP server backed by `BookmarkService`
+- Reused the `Bookmark` type for HTTP request validation — no DTO class
+- Returned structured 400 errors for bad input, for free
+- Seen the same service work from CLI, from HTTP, and from an LLM
+
+That's the whole loop. One TypeScript type — `Bookmark` — drives validation, JSON parsing, schema generation, HTTP middleware, and LLM tool descriptions.
+
+→ [Step 7: Next steps](/docs/tutorial/next-steps)

--- a/website/src/content/docs/tutorial/json.mdx
+++ b/website/src/content/docs/tutorial/json.mdx
@@ -1,0 +1,136 @@
+---
+title: Tutorial > 4. JSON parse & stringify
+---
+
+# Step 4 — JSON parse & stringify
+
+We have a `Bookmark` type and a way to validate one. Now let's give the service some state: persist a list of bookmarks to `bookmarks.json` on disk, and load it back on startup.
+
+This is where two of typia's most pragmatic functions earn their keep:
+
+- [`typia.json.assertParse`](/docs/json/parse) — `JSON.parse` + validation in one call. Refuses to start the program if the file on disk has been hand-edited into nonsense.
+- [`typia.json.assertStringify`](/docs/json/stringify) — `JSON.stringify`, but much faster (typia emits a hand-rolled stringifier for your type), with a quick "is this actually a Bookmark?" check up front.
+
+## The store
+
+Make a new file:
+
+```typescript copy filename="src/store.ts"
+import { promises as fs } from "node:fs";
+import typia from "typia";
+
+import { Bookmark } from "./bookmark";
+
+const FILE = "bookmarks.json";
+
+/** Load and validate the bookmarks file. */
+export async function loadAll(): Promise<Bookmark[]> {
+  try {
+    const text = await fs.readFile(FILE, "utf8");
+    return typia.json.assertParse<Bookmark[]>(text);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err; // bad JSON or schema mismatch → surface it
+  }
+}
+
+/** Atomically write all bookmarks back to disk. */
+export async function saveAll(items: Bookmark[]): Promise<void> {
+  const text = typia.json.assertStringify<Bookmark[]>(items);
+  await fs.writeFile(FILE, text, "utf8");
+}
+```
+
+Two things worth pointing out:
+
+1. **`assertParse<Bookmark[]>`** doesn't only validate the array — it also checks every constraint on every field (URL format, max length, …). Edit `bookmarks.json` by hand and put `"createdAt": "yesterday"` in one entry, the next `loadAll()` throws on that field's path. You get to choose whether to surface the error or fall back to an empty list, but you never get a half-corrupt in-memory model.
+2. **`assertStringify<Bookmark[]>`** is the validating sibling of `JSON.stringify`. It runs your data through a quick `assert` first (so you don't accidentally serialize garbage), then runs typia's bespoke serializer — which is several times faster than the native one because it knows exactly which fields exist on `Bookmark`.
+
+> Use `typia.json.stringify<T>` (no `assert`) when you've just *constructed* the value yourself and there's no way for it to be wrong. Otherwise, `assertStringify` is the safe default.
+
+## Use it
+
+```typescript copy filename="src/04-store.ts"
+import typia from "typia";
+
+import { Bookmark } from "./bookmark";
+import { loadAll, saveAll } from "./store";
+
+const main = async () => {
+  const existing = await loadAll();
+  console.log(`Loaded ${existing.length} bookmark(s).`);
+
+  // Add one
+  const fresh: Bookmark = typia.random<Bookmark>();
+  await saveAll([...existing, fresh]);
+
+  // Read again to verify the round-trip
+  const after = await loadAll();
+  console.log(`Now ${after.length}.`);
+};
+
+main().catch(console.error);
+```
+
+Run it twice. The first time it creates `bookmarks.json` with one bookmark. The second time it loads that one, appends another, and writes both back — so the file grows by one entry per run.
+
+```bash filename="Terminal"
+npx ttsx src/04-store.ts
+npx ttsx src/04-store.ts
+```
+
+## Corrupt the file on purpose
+
+To see the safety net in action, open `bookmarks.json` and break one entry — for example, change the `createdAt` value to `"yesterday"` so the file looks like:
+
+```jsonc filename="bookmarks.json" copy
+[
+  {
+    "id": "...",
+    "url": "https://...",
+    "title": "...",
+    "tags": ["..."],
+    "createdAt": "yesterday"
+  }
+]
+```
+
+Then re-run:
+
+```bash filename="Terminal"
+npx ttsx src/04-store.ts
+```
+
+```
+TypeGuardError: invalid type on $input[0].createdAt, expect to be string & Format<"date-time">
+```
+
+`assertParse` refused to hand back a half-valid array. You can decide to fall back to `[]`, log the corrupt record, prompt the user — but you never silently load broken data.
+
+## The variants you didn't need today
+
+| Function | When |
+|----------|------|
+| `typia.json.isParse<T>` | "Try to parse, give me `null` if anything's wrong" |
+| `typia.json.validateParse<T>` | "Give me every error in `bookmarks.json` so I can report all of them at once" |
+| `typia.json.isStringify<T>` | Like `assertStringify` but returns `null` instead of throwing |
+| `typia.json.validateStringify<T>` | Validate, then serialize, returning `IValidation<string>` |
+| `typia.json.stringify<T>` | Fastest. Skips validation. Trust the caller. |
+
+See [json.parse](/docs/json/parse) and [json.stringify](/docs/json/stringify) for full signatures.
+
+## A note on `Primitive<T>`
+
+If you look at the return type of `assertParse<Bookmark[]>`, it's `Primitive<Bookmark[]>`. That's typia's "what survives a JSON round-trip" projection. For `Bookmark` it's identical to `Bookmark` (nothing in it is `Date` or `bigint` or `Set`), so you can ignore the distinction.
+
+If your type *does* contain a `Date`, `Primitive<T>` rewrites that property to `string & tags.Format<"date-time">` — because that's what `JSON.stringify(date)` produces and what `JSON.parse` gives you back. Same for `Map`, `Set`, and friends collapsing to plain objects. The `Primitive` type tells you about a few classes of "this won't survive JSON" mistakes at compile time. See [json.parse > Primitive](/docs/json/parse#primitivet--what-comes-back) for the details.
+
+## What you've done
+
+- Saved typed data to disk with `assertStringify`
+- Loaded it back with `assertParse` and watched it refuse corrupt input
+- Picked the right variant for each situation
+
+Next we'll do something more ambitious: hand the bookmark service to an LLM and let it create bookmarks from natural language.
+
+→ [Step 5: LLM function calling](/docs/tutorial/llm)

--- a/website/src/content/docs/tutorial/llm.mdx
+++ b/website/src/content/docs/tutorial/llm.mdx
@@ -1,0 +1,196 @@
+---
+title: Tutorial > 5. LLM function calling
+---
+
+# Step 5 — LLM function calling
+
+So far, only humans have called our bookmark service. Now we'll let an LLM call it. The user types something like *"Save https://typia.io for me, tag it as docs"* — the LLM picks the right method on a `BookmarkService` class, fills the arguments from the conversation, and we execute the call.
+
+The whole "describe the service to the LLM" step is **one line**.
+
+## The service
+
+A small class with two methods. Notice it's just TypeScript — no decorators, no schemas. JSDoc comments will become the LLM-facing descriptions.
+
+```typescript copy filename="src/BookmarkService.ts"
+import { randomUUID } from "node:crypto";
+import typia from "typia";
+
+import { Bookmark } from "./bookmark";
+import { loadAll, saveAll } from "./store";
+
+export class BookmarkService {
+  /**
+   * Add a new bookmark.
+   *
+   * The id and createdAt are generated server-side — don't ask the user for them.
+   * Use the URL the user gave you verbatim, and pick a short title from the user's
+   * description (or from the URL host if they didn't say).
+   */
+  async add(props: {
+    /** The URL the user wants to save. Must be a valid URL. */
+    url: Bookmark["url"];
+    /** A short human-readable title. */
+    title: Bookmark["title"];
+    /** Optional one-paragraph description. */
+    description?: Bookmark["description"];
+    /** At least one tag, e.g. ["docs", "validation"]. */
+    tags: Bookmark["tags"];
+  }): Promise<{ id: Bookmark["id"] }> {
+    const all = await loadAll();
+    const bookmark: Bookmark = {
+      id: randomUUID(),
+      url: props.url,
+      title: props.title,
+      ...(props.description !== undefined && {
+        description: props.description,
+      }),
+      tags: props.tags,
+      createdAt: new Date().toISOString(),
+    };
+    await saveAll([...all, bookmark]);
+    return { id: bookmark.id };
+  }
+
+  /**
+   * List bookmarks tagged with a given keyword.
+   */
+  async list(props: { tag: string }): Promise<{ items: Bookmark[] }> {
+    const all = await loadAll();
+    return { items: all.filter((b) => b.tags.includes(props.tag)) };
+  }
+}
+```
+
+> The LLM-application schema has two rules: every method must take **one keyworded-object parameter**, and the return type must be an **object** (or `void`). If you ever try to write `add(url: string, tags: string[])` directly, the compiler will reject it — see [restrictions](/docs/llm/application#restrictions).
+
+## Turn the class into LLM tools
+
+```typescript copy filename="src/05-llm.ts"
+import typia from "typia";
+
+import { BookmarkService } from "./BookmarkService";
+
+const app = typia.llm.application<BookmarkService>();
+
+for (const fn of app.functions) {
+  console.log(fn.name);
+  console.log(fn.description);
+  console.log(JSON.stringify(fn.parameters, null, 2));
+  console.log("---");
+}
+```
+
+Run it. typia generated an `ILlmApplication` that holds two functions (`add` and `list`), each with the full JSON Schema for its parameters, the JSDoc as the description, and the validation/parse/coerce methods you'll see in a moment.
+
+## Hand it to an LLM
+
+Pick whichever SDK you already use — the same `typia.llm.controller<Class>(name, instance)` plugs into all three. We'll use the [Vercel AI SDK](https://github.com/vercel/ai) because it's the shortest.
+
+> [!TIP]
+>
+> Running this step calls the OpenAI API, which costs a few cents per invocation. If you don't have an OpenAI account, reading the code is enough to follow the rest of the tutorial — you can come back later. You'll need `OPENAI_API_KEY` in your environment:
+>
+> ```bash
+> # macOS / Linux
+> export OPENAI_API_KEY=sk-...
+>
+> # Windows PowerShell
+> $env:OPENAI_API_KEY = "sk-..."
+> ```
+>
+> Or use a `.env` file with `dotenv` if you prefer.
+
+```bash filename="Terminal"
+npm i @ai-sdk/openai @typia/vercel ai
+```
+
+Then:
+
+```typescript copy filename="src/05-vercel.ts"
+import { openai } from "@ai-sdk/openai";
+import { toVercelTools } from "@typia/vercel";
+import { generateText } from "ai";
+import type { Tool } from "ai";
+import typia from "typia";
+
+import { BookmarkService } from "./BookmarkService";
+
+const tools: Record<string, Tool> = toVercelTools({
+  controllers: [
+    typia.llm.controller<BookmarkService>(
+      "bookmarks",
+      new BookmarkService(),
+    ),
+  ],
+});
+
+const result = await generateText({
+  model: openai("gpt-4o"),
+  tools,
+  prompt: "Save https://typia.io for me — tag it as docs and typescript.",
+});
+
+console.log(result.text);
+```
+
+Run it (you need `OPENAI_API_KEY` in your environment). The model picks the `add` tool, fills `url`, `title`, and `tags` from the prompt, and the SDK actually invokes `BookmarkService.add(...)` against your local file. (If you'd rather have the tool names prefixed with the controller name, pass `toVercelTools({ controllers, prefix: true })` — then the tool is `bookmarks_add`.)
+
+> Same idea, different SDK:
+>
+> - LangChain → `toLangChainTools({ controllers })` from [`@typia/langchain`](/docs/utilization/langchain)
+> - MCP server → `registerMcpControllers({ server, controllers })` from [`@typia/mcp`](/docs/utilization/mcp)
+>
+> Same controller. Same harness. Pick whichever transport your project already has.
+
+## Why the LLM almost always gets it right
+
+LLMs are not deterministic. Even capable models routinely:
+
+- pass a single string where the schema wants an array
+- return `"42"` instead of `42`
+- forget to close a JSON bracket
+- wrap the answer in ` ```json ... ``` `
+
+typia wraps the tool in the **three-layer function calling harness** — same one [`llm.application`](/docs/llm/application#the-function-calling-harness) and the other LLM APIs use:
+
+| Layer | Method(s) | What it does |
+|-------|-----------|--------------|
+| 1. Lenient JSON parsing | `func.parse(text)` | Accept malformed JSON, strip markdown fences, recover unclosed brackets |
+| 2. Type coercion | `func.parse(text)` or `func.coerce(obj)` | `"42"` → `42`, `"true"` → `true`, recursively, based on the schema |
+| 3. Validation feedback | `func.validate(args)` + `LlmJson.stringify(failure)` | Check formats/ranges/lengths, then format the errors as annotated JSON the model can read |
+
+`parse` covers layers 1 and 2 in one call (use it when the LLM gave you a raw string). `coerce` is just layer 2 (use it when the SDK already JSON-parsed). `validate + stringify` form layer 3.
+
+Run the harness, send the annotated errors back as a system message, retry. In production at [AutoBe](https://github.com/wrtnlabs/autobe) this took a Qwen model from **6.75% raw success** to **100%** on compiler AST types — the hardest realistic test case there is.
+
+The framework adapters (`@typia/vercel`, `@typia/langchain`, `@typia/mcp`) already wire all three layers for you. When validation fails, the tool returns an error-annotated payload to the model and the model self-corrects on its own next turn. You usually don't write the feedback loop yourself — but if you want to, see [`LlmJson`](/docs/llm/json#putting-it-all-together--the-validation-feedback-loop) for the full pattern.
+
+## A peek at the feedback format
+
+When the LLM produces an invalid argument, the tool's failure response looks like this:
+
+```json
+{
+  "url": "lol",                   // ❌ [{"path":"$input.url","expected":"string & Format<\"url\">"}]
+  "title": "",                     // ❌ [{"path":"$input.title","expected":"string & MinLength<1>"}]
+  "tags": []                       // ❌ [{"path":"$input.tags","expected":"Array<…> & MinItems<1>"}]
+}
+```
+
+The model reads "expected `string & Format<\"url\">`" and tries again with a real URL. Without that information, it has to guess what went wrong from a generic 400 error and ends up retrying randomly.
+
+## Structured output (no function picking involved)
+
+If all you need is "ask the LLM for one specific JSON shape," skip the class — use [`typia.llm.structuredOutput<T>()`](/docs/llm/structuredOutput) or [`typia.llm.parameters<T>()`](/docs/llm/parameters). They give you the schema and the parse/coerce/validate trio without the function-calling layer on top.
+
+## What you've done
+
+- Wrote a normal TypeScript class
+- Turned its methods into LLM tools with one line
+- Plugged the result into the Vercel AI SDK (or any other supported framework)
+- Got automatic validation, coercion, and self-correction for free
+
+Next we'll plug the same `BookmarkService` into Hono so it's reachable from a normal HTTP client — and we'll share the same `Bookmark` type between validation, the HTTP handler, and the LLM tools.
+
+→ [Step 6: Plug into a framework](/docs/tutorial/integrations)

--- a/website/src/content/docs/tutorial/next-steps.mdx
+++ b/website/src/content/docs/tutorial/next-steps.mdx
@@ -1,0 +1,61 @@
+---
+title: Tutorial > 7. Next steps
+---
+
+# Step 7 — Next steps
+
+You've built something real. The same `Bookmark` interface drove validation, JSON serialization, HTTP request handling, and LLM tool descriptions — without writing any of them twice. That's the whole pitch.
+
+Here are good places to go from here.
+
+## Reference pages worth bookmarking
+
+| If you want to… | Read |
+|-----------------|------|
+| Decide between `is` / `assert` / `validate` for a specific call | [Runtime Validators](/docs/validators/is) |
+| Look up which tags exist (`Format`, `Minimum`, …) | [Special Tags](/docs/validators/tags) |
+| Generate an OpenAPI schema | [`json.schemas`](/docs/json/schema) |
+| Speed up JSON output | [`json.assertStringify`](/docs/json/stringify) |
+| Build LLM tools from a TypeScript class | [`llm.application`](/docs/llm/application) |
+| Build LLM tools from an OpenAPI document | [`HttpLlm`](/docs/llm/http) |
+| Understand the parse/coerce/validate harness | [`LlmJson`](/docs/llm/json) |
+| Build a chatbot on top of the tools | [Agentica](/docs/llm/chat) |
+| Stream binary data (Protocol Buffer) | [`protobuf.encode`](/docs/protobuf/encode) |
+| Generate test fixtures | [`random`](/docs/random) |
+
+## Playgrounds and demos
+
+- **[Playground](/playground)** — paste TypeScript in, see the compiled JavaScript come out. Great for quickly checking what typia emits for a type you're considering.
+- **[BBS chatbot](https://nestia.io/chat/bbs)** — full Agentica chatbot built around a CRUD-style class, same architecture as step 5.
+- **[Shopping chatbot](/chat/shopping)** — Agentica driving a real REST API through Swagger / OpenAPI — same idea as step 5, but starting from `HttpLlm.controller` instead of `typia.llm.controller`.
+
+## Performance facts to keep in mind
+
+- Runtime validation up to **20,000× faster** than `class-validator` ([benchmark](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics))
+- JSON serialization up to **200× faster** than `class-transformer` ([benchmark](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics#stringify))
+- LLM function calling: **6.75% → 100%** success rate on hard types when running the typia harness ([AutoBe story](https://github.com/wrtnlabs/autobe))
+
+The benchmarks are reproducible — run `pnpm benchmark` from the repo.
+
+## Common questions
+
+**My tests pass but my service throws "no transform has been configured" in production.**
+You built with stock `tsc` (or your bundler ran SWC/Babel) instead of `ttsc` / `ts-patch` / `@typia/unplugin`. Re-read the [verify-your-setup step in Install](/docs/tutorial/install#verify-your-setup) — the fix is always at the build-tool layer, not in your code.
+
+**The bundler I use isn't listed.**
+typia covers the common ones via `@ttsc/unplugin` (modern) and `@typia/unplugin` (legacy). If yours isn't there, the [generation mode](/docs/setup/legacy#generation) — `npx typia generate --input src --output dist-typia` — lets typia emit `.ts` files ahead of time, which any tool can then compile normally.
+
+**I want to validate against a runtime schema, not a TypeScript type.**
+That's [`LlmJson.validate(schema)`](/docs/llm/json#llmjsonvalidate--runtime-validator-from-a-schema). Slower than the AOT-compiled validator, but works when the schema comes from a database or a remote registry.
+
+**I'm building an MCP server / Vercel agent / LangChain agent and want to reuse one class for all three.**
+You can. `typia.llm.controller<Class>(name, instance)` produces a controller that all three adapters accept. See [`utilization/mcp`](/docs/utilization/mcp), [`utilization/vercel`](/docs/utilization/vercel), [`utilization/langchain`](/docs/utilization/langchain).
+
+## Get involved
+
+- **GitHub** — [github.com/samchon/typia](https://github.com/samchon/typia) (issues, PRs, discussions)
+- **Discord** — [discord.gg/E94XhzrUCZ](https://discord.gg/E94XhzrUCZ)
+- **Donate** — [opencollective.com/typia](https://opencollective.com/typia)
+- **Bug reports** — open an issue with a minimal reproduction (a single `.ts` file is plenty)
+
+Thanks for following along.

--- a/website/src/content/docs/tutorial/refining-types.mdx
+++ b/website/src/content/docs/tutorial/refining-types.mdx
@@ -1,0 +1,151 @@
+---
+title: Tutorial > 3. Refining types
+---
+
+# Step 3 — Refining types with tags
+
+The `Bookmark` interface from the last step accepts *any* string for `url` and *any* string array for `tags`. That's not realistic — we want `url` to actually be a URL, and we'd like `tags` to be a non-empty array of short strings.
+
+typia adds these constraints through **type tags** that you intersect into the base type. They are real TypeScript types, so the compiler enforces correctness (no typos in tag names), and the runtime validator picks them up automatically.
+
+## Tightening `Bookmark`
+
+Replace your `bookmark.ts` with this version:
+
+```typescript copy filename="src/bookmark.ts"
+import { tags } from "typia";
+
+export interface Bookmark {
+  /**
+   * Stable identifier. UUID v4.
+   */
+  id: string & tags.Format<"uuid">;
+
+  /**
+   * The URL we're saving.
+   */
+  url: string & tags.Format<"url"> & tags.MaxLength<2048>;
+
+  /**
+   * Human-readable title for the link.
+   */
+  title: string & tags.MinLength<1> & tags.MaxLength<200>;
+
+  /**
+   * Optional one-paragraph description.
+   */
+  description?: string & tags.MaxLength<5000>;
+
+  /**
+   * Tags for filtering / grouping.
+   * At least one tag, no more than 16, each ≤ 32 characters.
+   */
+  tags: Array<string & tags.MaxLength<32>>
+    & tags.MinItems<1>
+    & tags.MaxItems<16>;
+
+  /**
+   * When the bookmark was created.
+   */
+  createdAt: string & tags.Format<"date-time">;
+}
+```
+
+What changed:
+
+- `id` must be a UUID
+- `url` must be a URL of at most 2 048 characters
+- `title` must be between 1 and 200 characters
+- `description` is still optional but capped at 5 000 characters
+- `tags` is a 1–16 element array; each element is at most 32 characters
+- `createdAt` must be an ISO-8601 date-time
+
+Everything else stays the same. The validators we wrote in step 2 immediately pick up the new constraints — no changes to their call sites.
+
+## See the new errors
+
+```typescript copy filename="src/03-tags.ts"
+import typia from "typia";
+
+import { Bookmark } from "./bookmark";
+
+const candidate: unknown = {
+  id: "not-a-uuid",
+  url: "lol",
+  title: "",
+  tags: [],
+  createdAt: "yesterday",
+};
+
+const result = typia.validate<Bookmark>(candidate);
+if (!result.success) {
+  for (const err of result.errors) {
+    console.log(`${err.path}: expected ${err.expected}, got`, err.value);
+  }
+}
+```
+
+Run it:
+
+```bash filename="Terminal"
+npx ttsx src/03-tags.ts
+```
+
+```
+$input.id:        expected string & Format<"uuid">,       got 'not-a-uuid'
+$input.url:       expected string & Format<"url">,         got 'lol'
+$input.title:     expected string & MinLength<1>,          got ''
+$input.tags:      expected Array<…> & MinItems<1>,         got []
+$input.createdAt: expected string & Format<"date-time">,   got 'yesterday'
+```
+
+The `expected` strings echo back the same intersection syntax you wrote in `bookmark.ts`. If you ever wonder "what was supposed to be there?", the error literally tells you.
+
+## The tag catalogue (the parts we'll use)
+
+| Tag | Base type | What it does |
+|-----|-----------|--------------|
+| `tags.Format<"uuid" \| "email" \| "url" \| "date" \| "date-time" \| …>` | `string` | Built-in format check |
+| `tags.MinLength<N>` / `tags.MaxLength<N>` | `string` | Length bounds |
+| `tags.Pattern<"...">` | `string` | Regex |
+| `tags.Minimum<N>` / `tags.Maximum<N>` | `number`, `bigint` | Range |
+| `tags.Type<"int32" \| "uint32" \| "float" \| ...>` | `number`, `bigint` | Sub-type |
+| `tags.MinItems<N>` / `tags.MaxItems<N>` | `Array<T>` | Length bounds |
+| `tags.UniqueItems` | `Array<T>` | Pairwise distinct |
+
+The full list is on the [Special Tags](/docs/validators/tags) page. Tags compose with `&` and `|` like any other TypeScript type — you can build expressions like `(number & tags.Type<"int32">) | (bigint & tags.Type<"uint64">)`.
+
+## Bonus — making test data that satisfies the type
+
+Now that the type is precise, `typia.random` can produce realistic instances:
+
+```typescript copy filename="src/03-random.ts"
+import typia from "typia";
+
+import { Bookmark } from "./bookmark";
+
+const fake = typia.random<Bookmark>();
+console.log(fake);
+```
+
+```
+{
+  id: '8d62f9c0-...',
+  url: 'http://example.com/...',
+  title: 'p0WkQNbe...',
+  tags: [ 'L8b', 'kHrJ' ],
+  createdAt: '2049-...'
+}
+```
+
+You get a value that satisfies *every* constraint on the type. Useful for test fixtures and for seeding development databases.
+
+## What you've done
+
+- Replaced loose primitive types with tagged variants that carry constraints
+- Watched the validator's error messages tighten automatically
+- Generated realistic fake bookmarks straight from the type
+
+Next we'll save and load these bookmarks to disk — and use typia to make sure the file we read back actually contains what we expect.
+
+→ [Step 4: JSON parse & stringify](/docs/tutorial/json)

--- a/website/src/content/docs/utilization/hono.mdx
+++ b/website/src/content/docs/utilization/hono.mdx
@@ -2,27 +2,28 @@
 title: Guide Documents > Utilization Cases > Hono
 ---
 
-[Hono](https://hono.dev) is a small, simple, and ultrafast web framework for the Edges.
+# Hono
 
-If you are using `Hono` with `typia`, you can use [ `@hono/typia-validator` ](https://github.com/honojs/middleware/tree/main/packages/typia-validator) to validate the request body.
+[Hono](https://hono.dev) is a small, fast web framework that runs everywhere — Node, Bun, Cloudflare Workers, Deno, edge runtimes. With typia you get one-line request validation that doesn't ship `class-validator` or a schema library to the edge.
 
+The integration is [`@hono/typia-validator`](https://github.com/honojs/middleware/tree/main/packages/typia-validator). You pass it a [`createValidate`](/docs/validators/validate#reusable-factories--and-standard-schema-support) factory result and Hono runs the validator before your handler:
 
-```typescript copy showLineNumbers {7, 8, 13}
+```typescript copy showLineNumbers {7-8, 13}
 import { Hono } from "hono";
-import { typiaValidator } from '@hono/typia-validator'
+import { typiaValidator } from "@hono/typia-validator";
 import typia, { type tags } from "typia";
 
 import { IBbsArticle } from "../structures/IBbsArticle";
 
-/** create a validate function */
+// build a reusable validator from the type
 const validate = typia.createValidate<IBbsArticle>();
 
 const app = new Hono();
 
 app.post("/",
-  typiaValidator('json', validate),
+  typiaValidator("json", validate),
   (c) => {
-    const data = c.req.valid("json");
+    const data = c.req.valid("json"); // typed as IBbsArticle
     return c.json({
       id: data.id,
       title: data.title,
@@ -33,3 +34,13 @@ app.post("/",
 
 export default app;
 ```
+
+That's it. Hono parses the request body, the validator checks it against `IBbsArticle` (including any `tags.Format`/`tags.MinLength`/etc. you attached to the type), and `c.req.valid("json")` returns the typed value on success.
+
+`@hono/typia-validator` works for `"json"`, `"form"`, `"query"`, `"param"`, and `"header"` targets — anywhere Hono accepts a validator.
+
+## Where to go next
+
+- The underlying validator → [`validate`](/docs/validators/validate)
+- Tags for constraints (lengths, formats, ranges) → [Special Tags](/docs/validators/tags)
+- Hono docs → [hono.dev](https://hono.dev)

--- a/website/src/content/docs/utilization/langchain.mdx
+++ b/website/src/content/docs/utilization/langchain.mdx
@@ -5,7 +5,18 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `toLangChainTools()` function
+# LangChain.js
+
+[`@typia/langchain`](https://github.com/samchon/typia/tree/master/packages/langchain) plugs typia controllers into [LangChain.js](https://github.com/langchain-ai/langchainjs). Every method on your TypeScript class — or every endpoint in an OpenAPI document — becomes a `DynamicStructuredTool` ready for `AgentExecutor` and friends, with the same parse/coerce/validate/feedback machinery as [`typia.llm.application`](/docs/llm/application#the-function-calling-harness) wired in automatically.
+
+```typescript copy filename="signature"
+import { toLangChainTools } from "@typia/langchain";
+
+export function toLangChainTools(props: {
+  controllers: Array<ILlmController | IHttpLlmController>;
+  prefix?: boolean;   // default false; if true, tool names are "{controller}_{method}"
+}): DynamicStructuredTool[];
+```
 
 <Tabs items={[
     <code>@typia/langchain</code>,
@@ -41,14 +52,6 @@ export function toLangChainTools(props: {
   </Tabs.Tab>
 </Tabs>
 
-[LangChain.js](https://github.com/langchain-ai/langchainjs) integration for [`typia`](https://github.com/samchon/typia).
-
-`toLangChainTools()` converts TypeScript classes or OpenAPI documents into LangChain `DynamicStructuredTool[]` at once.
-
-Every class method becomes a tool, JSDoc comments become tool descriptions, and TypeScript types become JSON schemas — all at compile time. For OpenAPI documents, every API endpoint is converted to a `DynamicStructuredTool` with schemas from the specification.
-
-Lenient JSON parsing, type coercion, and validation feedback are all embedded automatically — the complete **function calling harness** that turns unreliable LLM output into 100% correct structured data.
-
 ## Setup
 
 ```bash filename="Terminal"
@@ -57,15 +60,8 @@ npm install typia
 npx typia setup
 ```
 
-## From TypeScript Class
+## From a TypeScript class
 
-<Tabs items={[
-    "LangChain Agent",
-    <code>Calculator</code>,
-    <code>BbsArticleService</code>,
-    <code>IBbsArticle</code>,
-  ]}>
-  <Tabs.Tab>
 ```typescript filename="src/main.ts" showLineNumbers {1-6, 10-15, 17-27}
 import { ChainValues, Runnable } from "@langchain/core";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
@@ -97,7 +93,14 @@ const result: ChainValues = await executor.invoke({
   input: "What is 10 + 5?",
 });
 ```
-  </Tabs.Tab>
+
+Every method on `Calculator` is now a LangChain tool. JSDoc comments become tool descriptions, TypeScript types become JSON schemas. Tool names default to the bare method name; pass `prefix: true` to get `{controllerName}_{methodName}`.
+
+<Tabs items={[
+    <code>Calculator</code>,
+    <code>BbsArticleService</code>,
+    <code>IBbsArticle</code>,
+  ]}>
   <Tabs.Tab>
     <LocalSource
       path="tests/test-langchain/src/structures/Calculator.ts"
@@ -118,18 +121,13 @@ const result: ChainValues = await executor.invoke({
   </Tabs.Tab>
 </Tabs>
 
-Create controllers from TypeScript classes with `typia.llm.controller<Class>()`, and pass them to `toLangChainTools()`.
-
-  - `controllers`: Array of controllers created via `typia.llm.controller<Class>()` or `HttpLlm.controller()`
-  - `prefix`: When `true` (default), tool names are formatted as `{controllerName}_{methodName}`. Set to `false` to use bare method names
-
 <Callout type="warning">
-**Type Restrictions**
-
-Every method's parameter type must be a keyworded object type with static keys — not a primitive, array, or union. The return type must also be an object type or `void`. Primitive return types like `number` or `string` are not allowed; wrap them in an object (e.g., `{ value: number }`). See [`typia.llm.application()` Restrictions](../llm/application#restrictions) for details.
+**Method type rules.** Every method's parameter type must be a keyworded object with static keys (no primitives, arrays, or unions). The return type must be an object or `void`. See [`typia.llm.application` restrictions](/docs/llm/application#restrictions) for the full list.
 </Callout>
 
-## From OpenAPI Document
+## From an OpenAPI document
+
+For REST APIs documented with Swagger / OpenAPI, swap [`HttpLlm.controller`](/docs/llm/http) in:
 
 ```typescript filename="src/main.ts" showLineNumbers {1-3, 5-18}
 import { DynamicStructuredTool } from "@langchain/core/tools";
@@ -152,72 +150,32 @@ const tools: DynamicStructuredTool[] = toLangChainTools({
 });
 ```
 
-Create controllers from OpenAPI documents with `HttpLlm.controller()`, and pass them to `toLangChainTools()`.
+## The function calling harness
 
-  - `name`: Controller name used as prefix for tool names
-  - `document`: Swagger/OpenAPI document (v2.0, v3.0, or v3.1)
-  - `connection`: HTTP connection info including `host` and optional `headers`
-
-## The Function Calling Harness
-
-`toLangChainTools()` embeds lenient JSON parsing, type coercion, and validation feedback in every tool — all automatically. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
+Every tool carries the harness — lenient parsing, type coercion, validation feedback. When validation fails, the tool returns the original input annotated with `// ❌` markers:
 
 ```json
 {
   "name": "John",
-  "age": "twenty", // ❌ [{"path":"$input.age","expected":"number"}]
+  "age": "twenty",      // ❌ [{"path":"$input.age","expected":"number"}]
   "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
-  "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
+  "hobbies": "reading"  // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
 }
 ```
 
-The LLM reads this feedback and self-corrects on the next turn.
+For the mechanics see [`LlmJson`](/docs/llm/json).
 
-<Callout type="warning">
-**Bypassing LangChain's Built-in Validation**
+<Callout type="info">
+**Why typia replaces LangChain's built-in validator**
 
-LangChain internally uses `@cfworker/json-schema` to validate tool arguments, which throws `ToolInputParsingException` before custom validation can run. `@typia/langchain` solves this by using a passthrough Zod schema (`z.record(z.unknown())`), allowing `typia`'s much more detailed and accurate validator to handle all argument validation instead.
+LangChain validates tool arguments with `@cfworker/json-schema`, which throws `ToolInputParsingException` *before* anything else can run. `@typia/langchain` works around this by registering a permissive passthrough Zod schema (`z.record(z.unknown())`) — then runs typia's much more detailed validator inside the tool body. You get the harness output instead of a generic JSON-schema error.
 </Callout>
 
-In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator by [Wrtn Technologies](https://wrtn.io)), `qwen3-coder-next` showed only **6.75%** raw function calling success rate on compiler AST types. However, with the complete harness, it reached **100%** — across all four tested Qwen models.
+## Structured output
 
-Working on compiler AST means working on any type and any use case.
+For LangChain's `withStructuredOutput`, hand it the schema from [`typia.llm.parameters`](/docs/llm/parameters) and validate the result with [`typia.validate`](/docs/validators/validate):
 
-  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
-  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
-  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
-
-```typescript filename="AutoBeTest.IExpression" showLineNumbers
-// Compiler AST may be the hardest type structure possible
-//
-// Unlimited union types + unlimited depth + recursive references
-export type IExpression =
-  | IBooleanLiteral
-  | INumericLiteral
-  | IStringLiteral
-  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
-  | IObjectLiteralExpression  // <- recursive (contains IExpression)
-  | INullLiteral
-  | IUndefinedKeyword
-  | IIdentifier
-  | IPropertyAccessExpression // <- recursive
-  | IElementAccessExpression  // <- recursive
-  | ITypeOfExpression         // <- recursive
-  | IPrefixUnaryExpression    // <- recursive
-  | IPostfixUnaryExpression   // <- recursive
-  | IBinaryExpression         // <- recursive (left & right)
-  | IArrowFunction            // <- recursive (body is IExpression)
-  | ICallExpression           // <- recursive (args are IExpression[])
-  | INewExpression            // <- recursive
-  | IConditionalPredicate     // <- recursive (then & else branches)
-  | ... // 30+ expression types total
-```
-
-## Structured Output
-
-Use `typia.llm.parameters<T>()` with LangChain's `withStructuredOutput()`:
-
-```typescript filename="src/main.ts" copy showLineNumbers {1-3, 5-11, 13-14, 16-22, 25-28}
+```typescript filename="src/main.ts" copy showLineNumbers {1-3, 13-14, 25-28}
 import { ChatOpenAI } from "@langchain/openai";
 import { dedent, LlmJson } from "@typia/utils";
 import typia, { tags } from "typia";
@@ -241,10 +199,10 @@ const member: IMember = await model.invoke(dedent`
   and joined to this community at 2022-01-01.
 `);
 
-// Validate the result
 const result = typia.validate<IMember>(member);
 if (!result.success) {
   console.error(LlmJson.stringify(result));
+  // → send `LlmJson.stringify(result)` back to the model for correction
 }
 ```
 
@@ -258,6 +216,12 @@ if (!result.success) {
 > }
 > ```
 
-The `IMember` interface is the single source of truth. `typia.llm.parameters<IMember>()` generates the JSON schema, and `typia.validate<IMember>()` validates the output — all from the same type. If validation fails, feed the error back to the LLM for correction.
+The `IMember` interface is the single source of truth. The schema and the validator both come from it; the feedback loop closes the gap between what the model produced and what your code expected.
 
+## Where to go next
 
+- Source TypeScript class for the tools → [`typia.llm.application`](/docs/llm/application)
+- Source OpenAPI document for the tools → [`HttpLlm`](/docs/llm/http)
+- Harness internals → [`LlmJson`](/docs/llm/json)
+- Same idea, different framework → [Vercel AI SDK](/docs/utilization/vercel) · [MCP](/docs/utilization/mcp)
+- Full agent loop on top → [Agentica](/docs/llm/chat)

--- a/website/src/content/docs/utilization/mcp.mdx
+++ b/website/src/content/docs/utilization/mcp.mdx
@@ -5,7 +5,26 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `registerMcpControllers()` function
+# MCP (Model Context Protocol)
+
+[`@typia/mcp`](https://github.com/samchon/typia/tree/master/packages/mcp) registers typia controllers as [MCP](https://modelcontextprotocol.io) tools. Every method on your TypeScript class — or every endpoint in an OpenAPI document — becomes an MCP tool, with the same parse/coerce/validate/feedback machinery as [`typia.llm.application`](/docs/llm/application#the-function-calling-harness) wired in automatically.
+
+```typescript copy filename="signature"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerMcpControllers } from "@typia/mcp";
+
+export function registerMcpControllers(props: {
+  server: McpServer | Server;
+  controllers: Array<ILlmController | IHttpLlmController>;
+  preserve?: boolean;
+}): void;
+```
+
+| Argument | Meaning |
+|----------|---------|
+| `server` | An MCP server instance (`McpServer` or raw `Server` from the MCP SDK) |
+| `controllers` | An array of controllers — either [`typia.llm.controller<Class>()`](/docs/llm/application) or [`HttpLlm.controller()`](/docs/llm/http) |
+| `preserve` | `false` (default): typia owns the server's tool list. `true`: coexist with the MCP SDK's `McpServer.registerTool()` calls. |
 
 <Tabs items={[
     <code>@typia/mcp</code>,
@@ -42,14 +61,6 @@ export function registerMcpControllers(props: {
   </Tabs.Tab>
 </Tabs>
 
-[MCP (Model Context Protocol)](https://modelcontextprotocol.io) integration for [`typia`](https://github.com/samchon/typia).
-
-`registerMcpControllers()` converts TypeScript classes or OpenAPI documents into MCP tools at once.
-
-Every class method becomes a tool, JSDoc comments become tool descriptions, and TypeScript types become JSON schemas — all at compile time. For OpenAPI documents, every API endpoint is converted to an MCP tool with schemas from the specification.
-
-Lenient JSON parsing, type coercion, and validation feedback are all embedded automatically — the complete **function calling harness** that turns unreliable LLM output into 100% correct structured data.
-
 ## Setup
 
 ```bash filename="Terminal"
@@ -58,16 +69,9 @@ npm install typia
 npx typia setup
 ```
 
-## From TypeScript Class
+## From a TypeScript class
 
-<Tabs items={[
-    "MCP Server",
-    <code>Calculator</code>,
-    <code>BbsArticleService</code>,
-    <code>IBbsArticle</code>,
-  ]}>
-  <Tabs.Tab>
-```typescript filename="src/main.ts" showLineNumbers {1-2, 9-16}
+```typescript filename="src/main.ts" showLineNumbers {1-3, 12-19}
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerMcpControllers } from "@typia/mcp";
 import typia from "typia";
@@ -79,18 +83,23 @@ const server: McpServer = new McpServer({
   name: "my-server",
   version: "1.0.0",
 });
+
 registerMcpControllers({
   server,
   controllers: [
     typia.llm.controller<Calculator>("calculator", new Calculator()),
-    typia.llm.controller<BbsArticleService>(
-      "bbs",
-      new BbsArticleService(),
-    ),
+    typia.llm.controller<BbsArticleService>("bbs", new BbsArticleService()),
   ],
 });
 ```
-  </Tabs.Tab>
+
+Every method on `Calculator` and `BbsArticleService` becomes an MCP tool. JSDoc comments turn into tool descriptions, TypeScript types turn into JSON schemas. Tool names are `{controllerName}_{methodName}` (e.g. `calculator_add`, `bbs_create`).
+
+<Tabs items={[
+    <code>Calculator</code>,
+    <code>BbsArticleService</code>,
+    <code>IBbsArticle</code>,
+  ]}>
   <Tabs.Tab>
     <LocalSource
       path="tests/test-mcp/src/structures/Calculator.ts"
@@ -111,21 +120,15 @@ registerMcpControllers({
   </Tabs.Tab>
 </Tabs>
 
-Create controllers from TypeScript classes with `typia.llm.controller<Class>()`, and pass them to `registerMcpControllers()`.
-
-  - `server`: Target MCP server instance (`McpServer` or raw `Server` from `@modelcontextprotocol/sdk`)
-  - `controllers`: Array of controllers created via `typia.llm.controller<Class>()` or `HttpLlm.controller()`
-  - `preserve`: When `true`, typia tools coexist with existing `McpServer.registerTool()` tools. Default is `false`
-
 <Callout type="warning">
-**Type Restrictions**
-
-Every method's parameter type must be a keyworded object type with static keys — not a primitive, array, or union. The return type must also be an object type or `void`. Primitive return types like `number` or `string` are not allowed; wrap them in an object (e.g., `{ value: number }`). See [`typia.llm.application()` Restrictions](../llm/application#restrictions) for details.
+**Method type rules.** Every method's parameter type must be a keyworded object with static keys (no primitives, arrays, or unions). The return type must be an object or `void`. See [`typia.llm.application` restrictions](/docs/llm/application#restrictions) for the full list.
 </Callout>
 
-## From OpenAPI Document
+## From an OpenAPI document
 
-```typescript filename="src/main.ts" showLineNumbers {1-3, 5-18}
+When the API you want to expose is described by Swagger/OpenAPI, use [`HttpLlm.controller`](/docs/llm/http) — it produces controllers that `registerMcpControllers` accepts the same way:
+
+```typescript filename="src/main.ts" showLineNumbers {1-3, 9-21}
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerMcpControllers } from "@typia/mcp";
 import { HttpLlm } from "@typia/utils";
@@ -134,6 +137,7 @@ const server: McpServer = new McpServer({
   name: "my-server",
   version: "1.0.0",
 });
+
 registerMcpControllers({
   server,
   controllers: [
@@ -151,65 +155,29 @@ registerMcpControllers({
 });
 ```
 
-Create controllers from OpenAPI documents with `HttpLlm.controller()`, and pass them to `registerMcpControllers()`.
+Every operation in the Swagger document becomes an MCP tool, with the same harness wrapping each one.
 
-  - `name`: Controller name used as prefix for tool names
-  - `document`: Swagger/OpenAPI document (v2.0, v3.0, or v3.1)
-  - `connection`: HTTP connection info including `host` and optional `headers`
+## The function calling harness
 
-## The Function Calling Harness
-
-`registerMcpControllers()` embeds lenient JSON parsing, type coercion, and validation feedback in every tool — all automatically. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
+Every tool registered through `registerMcpControllers` carries built-in lenient JSON parsing, type coercion, and validation feedback — same as the underlying [`typia.llm.application`](/docs/llm/application). When validation fails, the tool returns the input annotated with `// ❌` markers, which the LLM reads and self-corrects from:
 
 ```json
 {
   "name": "John",
-  "age": "twenty", // ❌ [{"path":"$input.age","expected":"number"}]
+  "age": "twenty",      // ❌ [{"path":"$input.age","expected":"number"}]
   "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
-  "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
+  "hobbies": "reading"  // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
 }
 ```
 
-The LLM reads this feedback and self-corrects on the next turn.
+For the mechanics of `parse` / `coerce` / `validate` / `stringify`, see [`LlmJson`](/docs/llm/json). For the same harness pattern in `typia.llm.application`, see [Function calling harness](/docs/llm/application#the-function-calling-harness).
 
-In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator by [Wrtn Technologies](https://wrtn.io)), `qwen3-coder-next` showed only **6.75%** raw function calling success rate on compiler AST types. However, with the complete harness, it reached **100%** — across all four tested Qwen models.
+## Preserve mode — coexisting with `registerTool`
 
-Working on compiler AST means working on any type and any use case.
-
-  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
-  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
-  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
-
-```typescript filename="AutoBeTest.IExpression" showLineNumbers
-// Compiler AST may be the hardest type structure possible
-//
-// Unlimited union types + unlimited depth + recursive references
-export type IExpression =
-  | IBooleanLiteral
-  | INumericLiteral
-  | IStringLiteral
-  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
-  | IObjectLiteralExpression  // <- recursive (contains IExpression)
-  | INullLiteral
-  | IUndefinedKeyword
-  | IIdentifier
-  | IPropertyAccessExpression // <- recursive
-  | IElementAccessExpression  // <- recursive
-  | ITypeOfExpression         // <- recursive
-  | IPrefixUnaryExpression    // <- recursive
-  | IPostfixUnaryExpression   // <- recursive
-  | IBinaryExpression         // <- recursive (left & right)
-  | IArrowFunction            // <- recursive (body is IExpression)
-  | ICallExpression           // <- recursive (args are IExpression[])
-  | INewExpression            // <- recursive
-  | IConditionalPredicate     // <- recursive (then & else branches)
-  | ... // 30+ expression types total
-```
-
-## Preserve Mode
+By default `registerMcpControllers` owns the server's tool list. If you've already registered tools the standard way with `McpServer.registerTool(...)` and want typia's tools to coexist, pass `preserve: true`.
 
 <Tabs items={[
-    "Preserve Test",
+    "Preserve test",
     <code>Calculator</code>,
   ]}>
   <Tabs.Tab>
@@ -227,8 +195,11 @@ export type IExpression =
   </Tabs.Tab>
 </Tabs>
 
-By default, `registerMcpControllers()` replaces the MCP server's tool handlers (standalone mode). Set `preserve: true` to coexist with `McpServer.registerTool()`.
+In the test above, an `"echo"` tool registered through `McpServer.registerTool` lives alongside four calculator tools registered through `registerMcpControllers` — five tools total. If two registrations would produce the same tool name, registration fails at startup so you can fix it before clients ever see the conflict.
 
-In the above test, the `"echo"` tool registered via `McpServer.registerTool()` and the calculator tools registered via `registerMcpControllers()` work together — 5 tools total. If duplicate names are detected, it throws at registration time.
+## Where to go next
 
-
+- Same idea, different framework → [Vercel AI SDK](/docs/utilization/vercel) · [LangChain](/docs/utilization/langchain)
+- Source TypeScript class for the tools → [`typia.llm.application`](/docs/llm/application)
+- Source OpenAPI document for the tools → [`HttpLlm`](/docs/llm/http)
+- Building a full chatbot → [Agentica](/docs/llm/chat)

--- a/website/src/content/docs/utilization/nestjs.mdx
+++ b/website/src/content/docs/utilization/nestjs.mdx
@@ -2,12 +2,20 @@
 title: Guide Documents > Utilization Cases > NestJS
 ---
 
-[Nestia](https://nestia.io) is a set of helper libraries for `NestJS`, supporting below features:
+# NestJS
 
-  - `@nestia/core`: superfast decorators using `typia`
-  - `@nestia/sdk`: evolved **SDK** and **Swagger** generators
-  - `@nestia/migrate`: Swagger to NestJS
-  - `nestia`: just CLI (command line interface) tool
+[Nestia](https://nestia.io) is the NestJS integration layer built on top of typia. It replaces the usual `class-validator` + `@nestjs/swagger` setup with decorators that read your TypeScript interfaces directly — no DTO classes, no decorator soup.
+
+It ships four packages:
+
+| Package | What it does |
+|---------|-------------|
+| `@nestia/core` | Superfast NestJS decorators backed by typia (`@TypedBody`, `@TypedRoute`, `@TypedQuery`, …) |
+| `@nestia/sdk` | Evolved SDK and Swagger generators that read NestJS controllers and emit type-safe client code |
+| `@nestia/migrate` | Swagger → NestJS scaffolding |
+| `nestia` | CLI for the above |
+
+## Minimal controller
 
 ```typescript copy showLineNumbers {14, 16}
 import { Controller } from "@nestjs/common";
@@ -23,16 +31,28 @@ export class BbsArticlesController {
    * @param input Content to store
    * @returns Newly archived article
    */
-  @TypedRoute.Post() // 200x faster and safer JSON.stringify()
+  @TypedRoute.Post()                          // ~200x faster, type-safe JSON.stringify
   public async store(
-    @TypedBody() input: IBbsArticle.IStore, // 20,000x faster validator
-  ): Promise<IBbsArticle>;
-    // do not need DTO class definition,
-    // just fine with interface
+    @TypedBody() input: IBbsArticle.IStore,   // ~20,000x faster validator
+  ): Promise<IBbsArticle> {
+    /* … no DTO class. Plain interface works. */
+  }
 }
 ```
 
+The decorators are interchangeable with the standard NestJS ones — same shape, same testing approach, much less boilerplate. `@TypedBody` validates with [`typia.assert`](/docs/validators/assert) and `@TypedRoute` serializes with [`typia.json.assertStringify`](/docs/json/stringify).
+
+## SDK generation
+
+`@nestia/sdk` reads the same controller files and emits a typed client SDK plus a Swagger document. The TypeScript types you wrote on the server become the request/response types on the client, automatically.
+
 ![nestia-sdk-demo](https://user-images.githubusercontent.com/13158709/215004990-368c589d-7101-404e-b81b-fbc936382f05.gif)
 
-  - Left: `NestJS` server code
-  - Right: Client code using `SDK`
+- Left: NestJS server code
+- Right: Client code using the generated SDK
+
+## Where to go next
+
+- Full Nestia docs: [nestia.io](https://nestia.io)
+- The underlying validator/serializer pair: [`assert`](/docs/validators/assert) · [`json.assertStringify`](/docs/json/stringify)
+- LLM agents that drive a Nestia backend: [Agentica](/docs/llm/chat)

--- a/website/src/content/docs/utilization/trpc.mdx
+++ b/website/src/content/docs/utilization/trpc.mdx
@@ -2,6 +2,10 @@
 title: Guide Documents > Utilization Cases > tRPC
 ---
 
+# tRPC
+
+[tRPC](https://trpc.io) lets you call server procedures from the client with full type safety. By default, you wire up `input` and `output` validation with a schema library (`zod`, `valibot`, …). typia replaces that with [`createAssert`](/docs/validators/assert#reusable-factories) — same one-line validator, generated from the TypeScript type directly.
+
 ```typescript copy showLineNumbers {11-12}
 import { initTRPC } from "@trpc/server";
 import { v4 } from "uuid";
@@ -27,3 +31,14 @@ export const appRouter = server.router({
 });
 export type AppRouter = typeof appRouter;
 ```
+
+`typia.createAssert<T>()` returns `(input: unknown) => T` — exactly the shape tRPC's `.input()` and `.output()` expect for a validator. On a mismatch the procedure rejects the call with a `TypeGuardError` carrying the path of the bad field.
+
+If you want a Standard Schema-compliant validator (so the same definition also slots into other tools), use [`typia.createValidate`](/docs/validators/validate#reusable-factories--and-standard-schema-support) instead.
+
+## Where to go next
+
+- Validator that throws → [`assert`](/docs/validators/assert)
+- Validator that returns errors → [`validate`](/docs/validators/validate)
+- Constraint tags → [Special Tags](/docs/validators/tags)
+- tRPC docs → [trpc.io](https://trpc.io)

--- a/website/src/content/docs/utilization/vercel.mdx
+++ b/website/src/content/docs/utilization/vercel.mdx
@@ -5,7 +5,18 @@ import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `toVercelTools()` function
+# Vercel AI SDK
+
+[`@typia/vercel`](https://github.com/samchon/typia/tree/master/packages/vercel) plugs typia controllers into the [Vercel AI SDK](https://github.com/vercel/ai). Every method on your TypeScript class — or every endpoint in an OpenAPI document — becomes a `Tool` ready for `generateText`/`streamText`, with the same parse/coerce/validate/feedback machinery as [`typia.llm.application`](/docs/llm/application#the-function-calling-harness) wired in automatically.
+
+```typescript copy filename="signature"
+import { toVercelTools } from "@typia/vercel";
+
+export function toVercelTools(props: {
+  controllers: Array<ILlmController | IHttpLlmController>;
+  prefix?: boolean;   // default false; if true, tool names are "{controller}_{method}"
+}): Record<string, Tool>;
+```
 
 <Tabs items={[
     <code>@typia/vercel</code>,
@@ -41,14 +52,6 @@ export function toVercelTools(props: {
   </Tabs.Tab>
 </Tabs>
 
-[Vercel AI SDK](https://github.com/vercel/ai) integration for [`typia`](https://github.com/samchon/typia).
-
-`toVercelTools()` converts TypeScript classes or OpenAPI documents into Vercel AI SDK `Record<string, Tool>` at once.
-
-Every class method becomes a tool, JSDoc comments become tool descriptions, and TypeScript types become JSON schemas — all at compile time. For OpenAPI documents, every API endpoint is converted to a Vercel tool with schemas from the specification.
-
-Lenient JSON parsing, type coercion, and validation feedback are all embedded automatically — the complete **function calling harness** that turns unreliable LLM output into 100% correct structured data.
-
 ## Setup
 
 ```bash filename="Terminal"
@@ -57,16 +60,9 @@ npm install typia
 npx typia setup
 ```
 
-## From TypeScript Class
+## From a TypeScript class
 
-<Tabs items={[
-    "Vercel AI Tools",
-    <code>Calculator</code>,
-    <code>BbsArticleService</code>,
-    <code>IBbsArticle</code>,
-  ]}>
-  <Tabs.Tab>
-```typescript filename="src/main.ts" showLineNumbers {1-3, 7-14, 16-20}
+```typescript filename="src/main.ts" showLineNumbers {1-3, 7-11}
 import { openai } from "@ai-sdk/openai";
 import { toVercelTools } from "@typia/vercel";
 import { generateText, GenerateTextResult, Tool } from "ai";
@@ -86,7 +82,14 @@ const result: GenerateTextResult = await generateText({
   tools,
 });
 ```
-  </Tabs.Tab>
+
+Every method on `Calculator` is now a Vercel `Tool`. JSDoc comments become tool descriptions, TypeScript types become JSON schemas. Tool names default to the bare method name; pass `prefix: true` to `toVercelTools` to get `{controllerName}_{methodName}` instead.
+
+<Tabs items={[
+    <code>Calculator</code>,
+    <code>BbsArticleService</code>,
+    <code>IBbsArticle</code>,
+  ]}>
   <Tabs.Tab>
     <LocalSource
       path="tests/test-vercel/src/structures/Calculator.ts"
@@ -107,20 +110,15 @@ const result: GenerateTextResult = await generateText({
   </Tabs.Tab>
 </Tabs>
 
-Create controllers from TypeScript classes with `typia.llm.controller<Class>()`, and pass them to `toVercelTools()`.
-
-  - `controllers`: Array of controllers created via `typia.llm.controller<Class>()` or `HttpLlm.controller()`
-  - `prefix`: When `true` (default), tool names are formatted as `{controllerName}_{methodName}`. Set to `false` to use bare method names
-
 <Callout type="warning">
-**Type Restrictions**
-
-Every method's parameter type must be a keyworded object type with static keys — not a primitive, array, or union. The return type must also be an object type or `void`. Primitive return types like `number` or `string` are not allowed; wrap them in an object (e.g., `{ value: number }`). See [`typia.llm.application()` Restrictions](../llm/application#restrictions) for details.
+**Method type rules.** Every method's parameter type must be a keyworded object with static keys (no primitives, arrays, or unions). The return type must be an object or `void`. See [`typia.llm.application` restrictions](/docs/llm/application#restrictions) for the full list.
 </Callout>
 
-## From OpenAPI Document
+## From an OpenAPI document
 
-```typescript filename="src/main.ts" showLineNumbers {1-3, 5-18}
+For REST APIs documented with Swagger / OpenAPI, swap [`HttpLlm.controller`](/docs/llm/http) in:
+
+```typescript filename="src/main.ts" showLineNumbers {1-3, 5-16}
 import { toVercelTools } from "@typia/vercel";
 import { HttpLlm } from "@typia/utils";
 import { Tool } from "ai";
@@ -141,66 +139,28 @@ const tools: Record<string, Tool> = toVercelTools({
 });
 ```
 
-Create controllers from OpenAPI documents with `HttpLlm.controller()`, and pass them to `toVercelTools()`.
+Every API operation becomes a tool with parameters, descriptions, and the same harness wrapping each call.
 
-  - `name`: Controller name used as prefix for tool names
-  - `document`: Swagger/OpenAPI document (v2.0, v3.0, or v3.1)
-  - `connection`: HTTP connection info including `host` and optional `headers`
+## The function calling harness
 
-## The Function Calling Harness
-
-`toVercelTools()` embeds lenient JSON parsing, type coercion, and validation feedback in every tool — all automatically. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
+Every tool produced by `toVercelTools` carries lenient JSON parsing, type coercion, and validation feedback. When validation fails, the tool returns the original input annotated with inline `// ❌` markers — the LLM reads it and self-corrects on the next turn:
 
 ```json
 {
   "name": "John",
-  "age": "twenty", // ❌ [{"path":"$input.age","expected":"number"}]
+  "age": "twenty",      // ❌ [{"path":"$input.age","expected":"number"}]
   "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
-  "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
+  "hobbies": "reading"  // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
 }
 ```
 
-The LLM reads this feedback and self-corrects on the next turn.
+For the mechanics of `parse` / `coerce` / `validate` / `stringify`, see [`LlmJson`](/docs/llm/json).
 
-In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator by [Wrtn Technologies](https://wrtn.io)), `qwen3-coder-next` showed only **6.75%** raw function calling success rate on compiler AST types. However, with the complete harness, it reached **100%** — across all four tested Qwen models.
+## Structured output
 
-Working on compiler AST means working on any type and any use case.
+For Vercel's `generateObject` (i.e. structured output, no function-picking involved), use [`typia.llm.parameters<T>()`](/docs/llm/parameters) plus a `validate` callback that runs [`typia.validate`](/docs/validators/validate):
 
-  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
-  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
-  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
-
-```typescript filename="AutoBeTest.IExpression" showLineNumbers
-// Compiler AST may be the hardest type structure possible
-//
-// Unlimited union types + unlimited depth + recursive references
-export type IExpression =
-  | IBooleanLiteral
-  | INumericLiteral
-  | IStringLiteral
-  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
-  | IObjectLiteralExpression  // <- recursive (contains IExpression)
-  | INullLiteral
-  | IUndefinedKeyword
-  | IIdentifier
-  | IPropertyAccessExpression // <- recursive
-  | IElementAccessExpression  // <- recursive
-  | ITypeOfExpression         // <- recursive
-  | IPrefixUnaryExpression    // <- recursive
-  | IPostfixUnaryExpression   // <- recursive
-  | IBinaryExpression         // <- recursive (left & right)
-  | IArrowFunction            // <- recursive (body is IExpression)
-  | ICallExpression           // <- recursive (args are IExpression[])
-  | INewExpression            // <- recursive
-  | IConditionalPredicate     // <- recursive (then & else branches)
-  | ... // 30+ expression types total
-```
-
-## Structured Output
-
-Use `typia.llm.parameters<T>()` with Vercel's `jsonSchema()` to generate structured output with validation:
-
-```typescript filename="src/main.ts" copy showLineNumbers {1, 3-4, 6-12, 14-30}
+```typescript filename="src/main.ts" copy showLineNumbers {1, 3-4, 14-30}
 import { openai } from "@ai-sdk/openai";
 import { dedent, LlmJson } from "@typia/utils";
 import { generateObject, jsonSchema } from "ai";
@@ -246,12 +206,19 @@ const { object } = await generateObject({
 > }
 > ```
 
-The `IMember` interface is the single source of truth. `typia.llm.parameters<IMember>()` generates the JSON schema, and `typia.validate<IMember>()` validates the output — all from the same type.
+The `IMember` interface is the single source of truth. `typia.llm.parameters<IMember>()` produces the schema, `typia.validate<IMember>()` checks the result, and `LlmJson.stringify` formats any validation failure for the LLM to self-correct on retry.
 
-## Error Handling
+## Runtime errors vs. validation errors
+
+There are two distinct failure modes:
+
+- **Validation error** — the LLM passed arguments that don't match the schema. Tool returns the annotated input so the model can fix it.
+- **Runtime error** — the tool itself threw (e.g. divide-by-zero, network error, business-rule violation).
+
+`@typia/vercel` catches the runtime error and surfaces it as `{ error: true, message: "..." }`. That keeps the conversation alive — the model can see the failure and either retry with different inputs or apologize to the user.
 
 <Tabs items={[
-    "Error Handling Test",
+    "Error handling test",
     <code>Calculator</code>,
   ]}>
   <Tabs.Tab>
@@ -269,6 +236,10 @@ The `IMember` interface is the single source of truth. `typia.llm.parameters<IMe
   </Tabs.Tab>
 </Tabs>
 
-When a tool execution throws a runtime error (e.g., division by zero), `@typia/vercel` catches the exception and returns `{ error: true, message: "Error: Division by zero is not allowed" }`. This is different from validation errors — validation errors indicate wrong argument types, while runtime errors indicate the function itself failed.
+## Where to go next
 
-
+- Source TypeScript class for the tools → [`typia.llm.application`](/docs/llm/application)
+- Source OpenAPI document for the tools → [`HttpLlm`](/docs/llm/http)
+- Harness internals (`parse`, `coerce`, `validate`, `stringify`) → [`LlmJson`](/docs/llm/json)
+- Same idea, different framework → [LangChain](/docs/utilization/langchain) · [MCP](/docs/utilization/mcp)
+- Full agent loop on top → [Agentica](/docs/llm/chat)

--- a/website/src/content/docs/validators/assert.mdx
+++ b/website/src/content/docs/validators/assert.mdx
@@ -1,323 +1,262 @@
 ---
-title: Guide Documents > Runtime Validators > assert() functions
+title: Guide Documents > Runtime Validators > assert() function
 ---
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
 import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
-import RemoteSource from "../../../components/RemoteSource";
 
-## `assert()` function
+# `typia.assert()` — throw on the first invalid field
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>,
-]}>
-  <Tabs.Tab>
-```typescript
-export function assert<T>(input: T): T;
-export function assert<T>(input: unknown): T;
+```typescript copy filename="signature"
+function assert<T>(input: T): T;
+function assert<T>(input: unknown): T;
+function assert<T>(input: unknown,
+                   errorFactory?: (props: TypeGuardError.IProps) => Error): T;
 ```
+
+`typia.assert<T>` is the throwing variant of [`is`](/docs/validators/is). If `input` matches `T`, it returns `input` unchanged. If it doesn't, it throws a `TypeGuardError` that points at exactly **one** failing property — the first one it encounters.
+
+Use it when you want an exception to propagate up the stack (HTTP request handlers, message queue consumers, boot-time config loading).
+
+## First example
+
+```typescript copy filename="hello-assert.ts"
+import typia, { tags } from "typia";
+
+interface User {
+  id: string & tags.Format<"uuid">;
+  age: number & tags.Type<"uint32"> & tags.Minimum<19>;
+}
+
+const user = typia.assert<User>(await loadUserFromRequest());
+// → returns the same value, typed as User
+// → throws TypeGuardError if any field is wrong
+```
+
+If `age` is `18`, you get a `TypeGuardError` carrying:
+
+| Field | Value |
+|-------|-------|
+| `method` | `"typia.assert"` |
+| `path` | `"$input.age"` |
+| `expected` | `"number & Minimum<19>"` |
+| `value` | `18` |
+
+The error includes a default `message` ready for logging, but the structured fields above are usually what you want to surface to clients.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/validators/assert.ts"
+      filename="examples/src/validators/assert.ts"
+      showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
+    <LocalSource
+      path="examples/bin/validators/assert.js"
+      filename="examples/bin/validators/assert.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## `TypeGuardError` reference
+
+```typescript copy
+class TypeGuardError<T = any> extends Error {
+  readonly method: string;       // "typia.assert", "typia.assertEquals", …
+  readonly path: string | undefined;  // e.g. "$input.user.age"
+  readonly expected: string;     // e.g. "string & Format<\"uuid\">"
+  readonly value: unknown;       // the offending value
+  readonly description?: string; // hint when the value is `undefined`
+}
+```
+
+<Tabs items={[<code>TypeGuardError.ts</code>]}>
+  <Tabs.Tab>
+    <LocalSource
       path="packages/typia/src/TypeGuardError.ts"
       filename="@samchon/typia"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Asserts a value type.
+The `path` uses `$input.x.y` notation so you can copy it into a UI error message without further processing.
 
-`typia.assert<T>()` function throws a `TypeGuardError` when wrong type comes. 
+### Customizing the thrown error
 
-The `TypeGuardError` instance has only the first type error info, with access path and expected type. In the below example case, as the `age` property is wrong with its definition (`@exclusiveMinimum`), such `TypeGuardError` would be thrown:
+Pass an `errorFactory` second argument to throw whatever your framework expects instead of `TypeGuardError`:
 
-  - `method`: `typia.assert()`
-  - `path`: `input.age`
-  - `value`: `18`,
-  - `expected`: `number & ExclusiveMinimum<19>`
+```typescript copy
+import typia from "typia";
 
-<br/>
-<Alert severity="success">
-  <AlertTitle> 
-    **AOT compilation** 
-  </AlertTitle>
-
-If you'd used other competitive validator libraries like `ajv` or `class-validator`, you may found that `typia` does not require any extra schema definition. If you have not experienced them, I can sure that you may get shocked after reading below extra schema definition files.
-
- - `ajv` requires [JSON schema definition](https://github.com/samchon/typia/blob/master/test/schemas/json/swagger/ObjectHierarchical.json).
- - `class-validator` requires [DTO class with decorator function calls](https://github.com/samchon/typia/blob/master/benchmark/structures/class-validator/ClassValidatorObjectHierarchical.ts).
-
-Yeah, `typia` needs only pure TypeScript type. As `typia` is a compiler library, it can analyze TypeScript type by itself, and possible to write the optimal validation code like below. This is the key principle of `typia`, which needs only one line with pure TypeScript type.
-
-</Alert>
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/assert.ts" 
-      filename="examples/src/validators/assert.ts" 
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/assert.js" 
-      filename="examples/bin/validators/assert.js" 
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## `assertEquals()` function
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>,
-]}>
-  <Tabs.Tab>
-```typescript
-export function assertEquals<T>(input: T): T;
-export function assertEquals<T>(input: unknown): T;
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-More strict assert function prohibiting superfluous properties.
-
-`typia.assert<T>()` function inspects `input` value type and throws `TypeGuardError` when mismatched, however, it can't detect superfluous properties. If you want to prohibit those superfluous properties, therefore throws an `TypeGuardError` when superfluous property exists, use `typia.assertEquals<T()>` function instead.
-
-In the below example case, as `sex` property is not defined in the `IMember` type, such `TypeGuardError` would be thrown:
-
-  - `method`: `typia.assertEquals()`
-  - `path`: `input.sex`
-  - `value`: `1`,
-  - `expected`: `undefined`
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/assertEquals.ts" 
-      filename="examples/src/validators/assertEquals.ts" 
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/assertEquals.js" 
-      filename="examples/bin/validators/assertEquals.js" 
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## `assertGuard()` functions
-
-<Tabs items={[
-    <code>typia</code>, 
-    <code>TypeGuardError.ts</code>,
-]}>
-  <Tabs.Tab>
-```typescript
-export function assertGuard<T>(input: T): asserts input is T;
-export function assertGuard<T>(input: unknown): asserts input is T;
-
-export function assertGuardEquals<T>(input: T): asserts input is T;
-export function assertGuardEquals<T>(input: unknown): asserts input is T;
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-Assertion guard of a value type.
-
-`typia.assertGuard<T>()` is similar with [`typia.assert<T>()`](#assert-function) throwing a `TypeGuardError` when wrong type. 
-
-However, [`typia.assert<T>()`](#assert-function) returns the parametric input value itself when there's no type problem on the parametric input value, whereas the `typia.assertGuard<T>()` function returns nothing. Instead, the parametric input value would be automatically cased to the type `T`. This is the concept of "Assertion Guard" of a value type.
-
-Such similarities and differences of `typia.assertGuard<T>()` and [`typia.assert<T>()`](#assert-function) functions are the same in the case of `typia.assertGuardEquals<T>()` and [`typia.assertEquals<T>()`](#assertequals-function) functions. If there's no type problem on the `typia.assertGuardEquals<T>()` function, it also performs the "Assertion Guard".
-
-Look at the below code, then you may understand what the "Assertion Guard" means.
-
-<LocalSource 
-  path="examples/src/validators/assertGuard.ts" 
-  filename="examples/src/validators/validatorassertGuard.ts" 
-  showLineNumbers />
-
-## Reusable functions
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>TypeGuardError.ts</code>,
-  <code>AssertionGuard.ts</code>,
-]}>
-  <Tabs.Tab>
-```typescript
-export function createAssert<T>(): (input: unknown) => T;
-export function createAssertEquals<T>(): (input: unknown) => T;
-
-export function createAssertGuard<T>(): AssertionGuard<T>;
-export function createAssertGuardEquals<T>(): AssertionGuard<T>;
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts"
-      filename="typia/TypeGuardError.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-```typescript
-export type AssertionGuard<T> = (input: unknown) => asserts input is T;
-```
-  </Tabs.Tab>
-</Tabs>
-
-Reusable `typia.assert<T>()` function generators.
-
-If you repeat to call `typia.assert<T>()` function on the same type, size of JavaScript files would be larger because of duplicated AOT compilation. To prevent it, you can generate reusable function through `typia.createAssert<T>()` function.
-
-Just look at the code below, then you may understand how to use it.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/createAssert.ts" 
-      filename="examples/src/validators/createAssert.ts" 
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/createAssert.js" 
-      filename="examples/bin/validators/createAssert.js" 
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-<Alert severity="warning">
-  <AlertTitle>
-    **Explicitly of Assertion Guard** 
-  </AlertTitle>
-
-Be careful when using `typia.createAssertGuard<T>()` or `typia.createAssertGuardEquals<T>()` functions. 
-
-When calling those functions, you've to declare the variable type explicit on the caller variable. If you don't do it, so that the caller variables come the implicit function type, TypeScript compiler throws an error like below. This is a special limitation of TypeScript compiler about the "Assertion Guard".
-
-<LocalSource 
-  path="examples/src/validators/createAssertGuard.ts" 
-  filename="examples/src/validators/createAssertGuard.ts" 
-  showLineNumbers />
-
-</Alert>
-
-## Restrictions
-
-`typia.assert<T>()` function does not check `function` and user-defined `class` types. 
-
-It validates only the primitive properties. Therefore, `typia.assert<T>()` function does not perform the `instanceof ClassName` for user-defined classes. If you want to validate the user-defined class type in addition to the property types, do it by yourself. Also, `typia.assert<T>()` function does not validate the function type either, unless configuring `functional` property of `plugin` option in the `tsconfig.json` file.
-
-```json filename="tsconfig.json"
-{
-  "compilerOptions": {
-    "plugins": [
-      {
-        "transform": "typia/lib/transform",
-        "functional": true
-      }
-    ]
+class HttpException extends Error {
+  constructor(message: string, public readonly status: number) {
+    super(message);
   }
 }
+
+typia.assert<User>(input, (info) =>
+  new HttpException(`Invalid ${info.path}: expected ${info.expected}`, 400),
+);
 ```
 
-By the way, there're some exception cases. 
+The factory receives the same `TypeGuardError.IProps` and its return value is thrown directly.
 
-If JS native class type like `Date`, `Uint8Array`, or `Map<Key, T>` being utilized, `typia.assert<T>()` function validates them. Especially about the `Set<T>`, and `Map<Key, T>` class cases, `typia.assert<T>()` function validates all of their contained element types, too.
+## Rejecting extra properties — `assertEquals`
 
-Therefore, the `instanceof` statement does not be used only for the user-defined classes.
+`assert` allows properties not declared on `T`. `assertEquals` rejects them — the first extra key becomes the thrown error:
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+```typescript copy
+typia.assert<User>({ id: "...", age: 25, sex: 1 });       // ok (sex ignored)
+typia.assertEquals<User>({ id: "...", age: 25, sex: 1 }); // throws on `sex`
+```
+
+The thrown `TypeGuardError` for the extra property has `expected: "undefined"` and `path` pointing at the extra key:
+
+| Field | Value |
+|-------|-------|
+| `method` | `"typia.assertEquals"` |
+| `path` | `"$input.sex"` |
+| `expected` | `"undefined"` |
+| `value` | `1` |
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/is-map.ts" 
-      filename="examples/src/validators/is-map.ts" 
+    <LocalSource
+      path="examples/src/validators/assertEquals.ts"
+      filename="examples/src/validators/assertEquals.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/is-map.js" 
-      filename="examples/bin/validators/is-map.js" 
+    <LocalSource
+      path="examples/bin/validators/assertEquals.js"
+      filename="examples/bin/validators/assertEquals.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Customization
+## Assertion guards — `assertGuard`
 
-You can enhance validation logic by special tags.
+`typia.assert<T>` returns the validated value:
 
-Also, with those tags, you can add your custom validation logic, too.
+```typescript
+const user: User = typia.assert<User>(input);
+```
 
-If you want to know about such special tags detaily, read below article:
+That's convenient but it makes you assign to a new variable. If you'd rather **narrow the original variable in place**, use `typia.assertGuard<T>`. It returns nothing — but its return type is `asserts input is T`, so TypeScript narrows the argument after the call:
 
-  - [Special Tags](../tags/)
-    - [Outline](../tags/#outline)
-    - [Type Tags](../tags/#type-tags)
-    - [Comment Tags](../tags/#comment-tags)
-    - [Customization](../tags/#customization)
+```typescript copy
+import typia from "typia";
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+const input: unknown = await fetchSomething();
+
+typia.assertGuard<User>(input);
+// from this line on, `input` is typed as User
+console.log(input.age);
+```
+
+`typia.assertGuardEquals<T>` is the strict-keys variant. Both throw `TypeGuardError` on mismatch.
+
+<LocalSource
+  path="examples/src/validators/assertGuard.ts"
+  filename="examples/src/validators/assertGuard.ts"
+  showLineNumbers />
+
+## Reusable factories
+
+Same idea as [`createIs`](/docs/validators/is#3-call-it-many-times-for-the-same-type--build-a-reusable-checker-once) — when you call `assert<T>` from many places, hoist the checker once:
+
+```typescript copy
+import typia, { AssertionGuard } from "typia";
+
+export const assertUser = typia.createAssert<User>();
+export const assertUserEquals = typia.createAssertEquals<User>();
+
+export const guardUser: AssertionGuard<User> = typia.createAssertGuard<User>();
+export const guardUserEquals: AssertionGuard<User> = typia.createAssertGuardEquals<User>();
+```
+
+> [!IMPORTANT]
+>
+> **Annotate the variable type for `createAssertGuard`.**
+>
+> TypeScript cannot infer an `asserts ... is T` signature without an explicit annotation. If you write `const guard = typia.createAssertGuard<User>()`, the compiler will refuse to narrow `input` after `guard(input)`. Always declare the variable as `AssertionGuard<T>`.
+
+<LocalSource
+  path="examples/src/validators/createAssertGuard.ts"
+  filename="examples/src/validators/createAssertGuard.ts"
+  showLineNumbers />
+
+`createAssert*` factories accept an optional `errorFactory` that applies to every call.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/assert-custom-tags.ts" 
-      filename="examples/src/validators/assert-custom-tags.ts" 
+    <LocalSource
+      path="examples/src/validators/createAssert.ts"
+      filename="examples/src/validators/createAssert.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/assert-custom-tags.js" 
-      filename="examples/bin/validators/assert-custom-tags.js" 
+    <LocalSource
+      path="examples/bin/validators/createAssert.js"
+      filename="examples/bin/validators/createAssert.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## What `assert` does not check
+
+Same rules as [`is`](/docs/validators/is#what-is-does-not-check): user-defined classes are walked by property (no `instanceof`), and function types are skipped unless you enable the `functional` transformer flag.
+
+Built-in classes (`Date`, `Set<T>`, `Map<K, V>`, `Uint8Array`) are checked end-to-end, including their elements:
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/validators/is-map.ts"
+      filename="examples/src/validators/is-map.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/validators/is-map.js"
+      filename="examples/bin/validators/is-map.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## Adding constraints — type tags
+
+Intersect [type tags](/docs/validators/tags) into the type to express formats, ranges, and length limits:
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/validators/assert-custom-tags.ts"
+      filename="examples/src/validators/assert-custom-tags.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/validators/assert-custom-tags.js"
+      filename="examples/bin/validators/assert-custom-tags.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
 ## Performance
 
-Super-fast and super-safe.
-
-Comparing `typia.assert<T>()` function with other competitive libraries, maximum 20,000x faster. 
-
-Furthermore, only `typia` can validate complicate union types.
+Same emission strategy as [`is`](/docs/validators/is#performance), plus the per-field error-throwing branches. Still up to 20,000× faster than `class-validator` on hard-to-validate union structures, and still the only listed library that handles arbitrary unions:
 
 ![Assert Function Benchmark](https://github.com/samchon/typia/raw/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics/images/assert.svg)
 
 > Measured on [AMD Ryzen 9 7940HS, Rog Flow x13](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics#assert)
 
-Components               | `typia` | `TypeBox` | `ajv` | `io-ts` | `zod` | `C.V.`
--------------------------|--------|-----------|-------|---------|-------|------------------
-**Easy to use**          | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ 
-[Object (simple)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectSimple.ts)          | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectHierarchical.ts)    | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectRecursive.ts)       | ✔ | ❌ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (union, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionImplicit.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Object (union, explicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionExplicit.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-[Object (additional tags)](https://github.com/samchon/typia/#comment-tags)        | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (template literal types)](https://github.com/samchon/typia/blob/master/test/src/structures/TemplateUnion.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-[Object (dynamic properties)](https://github.com/samchon/typia/blob/master/test/src/structures/DynamicTemplate.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-[Array (rest tuple)](https://github.com/samchon/typia/blob/master/test/src/structures/TupleRestAtomic.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayHierarchical.ts)     | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Array (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursive.ts)        | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-[Array (recursive, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionExplicit.ts) | ✔ | ✔ | ❌ | ✔ | ✔ | ❌
-[Array (R+U, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionImplicit.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedNullable.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/src/schemas/IJsonSchema.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+## Where to go next
 
-> `C.V.` means `class-validator`
+- Just want a boolean → [`is`](/docs/validators/is)
+- Want every error at once → [`validate`](/docs/validators/validate)
+- Constraints (formats, ranges, lengths) → [Special Tags](/docs/validators/tags)
+- Validating function calls → [Functional Module](/docs/validators/functional)

--- a/website/src/content/docs/validators/functional.mdx
+++ b/website/src/content/docs/validators/functional.mdx
@@ -7,136 +7,169 @@ import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `assertFunction()`
+# `typia.functional` — wrap a function so its inputs and outputs are checked
 
-<Tabs items={[
-  <code>typia</code>,
-  <code>TypeGuardError.ts</code>
-]}>
-  <Tabs.Tab>
-```typescript showLineNumbers
-export namespace functional {
-  export function assertFunction<T extends Function>(func: T): T;
-  export function assertParameters<T extends Function>(func: T): T;
-  export function assertReturn<T extends Function>(func: T): T;
+Sometimes the value you want to validate isn't a single object — it's *what flows through a function*. `typia.functional` wraps a function so every call validates its arguments against the declared parameter types and its return value against the declared return type. The wrapping is transparent: the wrapped function has the same signature as the original.
 
-  export function assertEqualsFunction<T extends Function>(func: T): T;
-  export function assertEqualsParameters<T extends Function>(func: T): T;
-  export function assertEqualsReturn<T extends Function>(func: T): T;
-}
+```typescript copy filename="hello-functional.ts"
+import typia from "typia";
+
+const add = typia.functional.assertFunction(
+  (x: number, y: number): number => x + y,
+);
+
+add(1, 2);        // → 3
+add(1, "wrong");  // → throws TypeGuardError on $input.parameters[1]
 ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/typia/src/TypeGuardError.ts" 
-      filename="typia/TypeGuardError.ts" 
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
 
-Asserts a function.
+> [!IMPORTANT]
+>
+> **You must enable the `functional` transformer flag** to use this module — without it, typia skips function types and the wrappers won't be emitted. Add `compilerOptions.plugins` to your `tsconfig.json` (this is one of the few cases where the modern `ttsc` setup also needs the explicit plugin entry; with `ts-patch` the setup wizard already added the entry — you only need to add the flag):
+>
+> ```json filename="tsconfig.json"
+> {
+>   "compilerOptions": {
+>     "plugins": [
+>       { "transform": "typia/lib/transform", "functional": true }
+>     ]
+>   }
+> }
+> ```
 
-`typia.functional.assertFunction<T>()` asserts a function, by wrapping the parameter function and checking its parameters and return value through [`typia.assert<T>()`](../assert) function. If some parameter or return value does not match the expected type, it throws a `TypeGuardError` error.
+## The three families
 
-For reference, `TypeGuardError.path` would be a little bit different with individual [`typia.assert<T>()`](../assert) function. If `TypeGuardError` occurs from some parameter, the path would start from `$input.parameters[<index>]`. Otherwise the path would start from `$input.return`.
+For each underlying validator there is a matching `functional.*` wrapper:
 
-  - `$input.parameters[0].~`
-  - `$input.return.~`
+| Underlying | Wrapper | On failure |
+|------------|---------|------------|
+| [`assert`](/docs/validators/assert) | `functional.assertFunction` | throws `TypeGuardError` |
+| [`is`](/docs/validators/is) | `functional.isFunction` | returns `null` (or `Promise<null>` for async) |
+| [`validate`](/docs/validators/validate) | `functional.validateFunction` | returns `IValidation<Output>` |
 
-By the way, if you don't want to assert both parameters and return value, but one of them, you can use `typia.functional.assertParameters<T>()` or `typia.functional.assertReturn<T>()` instead. Otherwise, if you want to prohibit superfluous properties, `typia.functional.assertEqualsFunction<T>()` would be helpful.
+Each family also gives you scoped variants — check only the parameters, only the return value, or both:
 
-Also, if what you want is not just finding the first type error through assertion, but also finding every type errors, utilize [`typia.functional.validateFunction<T>()`](#validatefunction) function instead. Otherwise, you don't need the reason why, but just want to know whether the function is valid or not, use [`typia.functional.isFunction<T>()`](#isfunction) function.
+| Function | What it checks |
+|----------|----------------|
+| `functional.assertFunction(fn)` | parameters **and** return |
+| `functional.assertParameters(fn)` | parameters only |
+| `functional.assertReturn(fn)` | return only |
+| `functional.isFunction(fn)` | params + return, returns `Output \| null` |
+| `functional.isParameters(fn)` | params only |
+| `functional.isReturn(fn)` | return only |
+| `functional.validateFunction(fn)` | params + return, returns `IValidation<Output>` |
+| `functional.validateParameters(fn)` | params only |
+| `functional.validateReturn(fn)` | return only |
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/functional/assertFunction.ts" 
-      filename="examples/src/functional/assertFunction.ts" 
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/functional/assertFunction.js" 
-      filename="examples/bin/functional/assertFunction.js" 
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
+Each function also has an `…Equals…` variant (e.g. `assertEqualsFunction`) that additionally rejects extra object properties.
 
-## `isFunction()`
+## `assertFunction` — throw the first parameter/return mismatch
 
-```typescript filename="typia" showLineNumbers
+```typescript copy
 export namespace functional {
-  export function isFunction<T extends (...args: any[]) => any>(
-    func: T,
-  ): T extends (...args: infer Arguments) => infer Output
-    ? Output extends Promise<infer R>
-      ? (...args: Arguments) => Promise<R | null>
-      : (...args: Arguments) => Output | null
-    : never;
-  export function isParameters<T extends (...args: any[]) => any>(
-    func: T,
-  ): T extends (...args: infer Arguments) => infer Output
-    ? (...args: Arguments) => Output | null
-    : never;
-  export function isReturn<T extends (...args: any[]) => any>(
-    func: T,
-  ): T extends (...args: infer Arguments) => infer Output
-    ? (...args: Arguments) => Output | null
-    : never;
+  function assertFunction<T extends Function>(func: T): T;
+  function assertParameters<T extends Function>(func: T): T;
+  function assertReturn<T extends Function>(func: T): T;
 
-  export function isEqualsFunction;
-  export function isEqualsParameters;
-  export function isEqualsReturn;
+  function assertEqualsFunction<T extends Function>(func: T): T;
+  function assertEqualsParameters<T extends Function>(func: T): T;
+  function assertEqualsReturn<T extends Function>(func: T): T;
 }
 ```
 
-Tests a function.
+When a parameter is wrong, the `TypeGuardError.path` starts with `$input.parameters[<i>]`:
 
-`typia.functional.isFunction<T>()` tests a function, by wrapping the parameter function and checking its parameters and return value through [`typia.is<T>()`](../is) function. If some parameter or return value does not match the expected type, it returns `null`. Otherwise, it returns the return value of the parameter function.
+```
+TypeGuardError: invalid type on $input.parameters[1], expect to be number
+```
 
-By the way, if you don't want to test both parameters and return value, but one of them, you can use `typia.functional.isParameters<T>()` or `typia.functional.isReturn<T>()` instead. Otherwise, if you want to prohibit superfluous properties, `typia.functional.equalsFunction<T>()` would be helpful.
+When the return value is wrong, the path starts with `$input.return`:
 
-Also, if what you want is not just type checking, but want to know the detailed reason(s) why, utilize [`typia.functional.assertFunction<T>`()](#assertfunction) or [`typia.functional.validateFunction<T>()`](#validatefunction) instead.
+```
+TypeGuardError: invalid type on $input.return.id, expect to be string & Format<"uuid">
+```
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+Promise returns are handled — the wrapped function still returns a `Promise`, the validation just happens after `await`.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/functional/isFunction.ts" 
-      filename="examples/src/functional/isFunction.ts" 
+    <LocalSource
+      path="examples/src/functional/assertFunction.ts"
+      filename="examples/src/functional/assertFunction.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/functional/isFunction.js" 
-      filename="examples/bin/functional/isFunction.js" 
+    <LocalSource
+      path="examples/bin/functional/assertFunction.js"
+      filename="examples/bin/functional/assertFunction.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## `isFunction` — return `null` on mismatch
+
+```typescript copy
+namespace functional {
+  function isFunction<T>(func: T): /* same signature, output ⇒ Output|null */;
+  function isParameters<T>(func: T): /* same signature, output ⇒ Output|null */;
+  function isReturn<T>(func: T): /* same signature, output ⇒ Output|null */;
+
+  function equalsFunction;
+  function equalsParameters;
+  function equalsReturn;
+}
+```
+
+Drop-in for cases where you'd rather check the return for `null` than catch an exception. Async-aware: `(x: number) => Promise<R>` becomes `(x: number) => Promise<R | null>`.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/functional/isFunction.ts"
+      filename="examples/src/functional/isFunction.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/functional/isFunction.js"
+      filename="examples/bin/functional/isFunction.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Validates a function.
+## `validateFunction` — full error list
 
-`typia.functional.validateFunction<T>()` validates a function, by wrapping the parameter function and checking its parameters and return value through [`typia.validate<T>()`](../validate) function. If some parameter or return value does not match the expected type, it returns a `IValidation.IFailure` typed object. Otherwise, it returns a `IValidation.ISuccess` typed object instead.
+`validateFunction` returns an `IValidation<Output>` instead of throwing or null-ing out. Same `path` notation (`$input.parameters[i]`, `$input.return`) as `assertFunction`.
 
-For reference, `IValidation.IError.path` would be a little bit different with individual [`typia.validate<T>()`](../validate) function. If `IValidation.IError` occurs from some parameter, the path would start from `$input.parameters[<index>]`. Otherwise the path would start from `$input.return`.
+Use this when you want to surface every type error at once — for example, when an LLM is calling your function and you need to send all the mistakes back in one round-trip:
 
-  - `$input.parameters[0].~`
-  - `$input.return.~`
-
-By the way, if you don't want to validate both parameters and return value, but one of them, you can use `typia.functional.validateParameters<T>()` or `typia.functional.validateReturn<T>()` instead. Otherwise, if you want to prohibit superfluous properties, `typia.functional.validateEqualsFunction<T>()` would be helpful.
-
-Also, if what you want is not retrieving every type errors, but just finding the first type error, utilize [`typia.functional.assertFunction<T>()`](#assertfunction) function instead. Otherwise, you don't need the reason why, but just want to know whether the function is valid or not, use [`typia.functional.isFunction<T>()`](#isfunction) function.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/functional/validateFunction.ts" 
-      filename="examples/src/functional/validateFunction.ts" 
+    <LocalSource
+      path="examples/src/functional/validateFunction.ts"
+      filename="examples/src/functional/validateFunction.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/functional/validateFunction.js" 
-      filename="examples/bin/functional/validateFunction.js" 
+    <LocalSource
+      path="examples/bin/functional/validateFunction.js"
+      filename="examples/bin/functional/validateFunction.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
+
+## Picking the right wrapper
+
+| You want… | Use |
+|-----------|-----|
+| Throw on the first bad parameter or return | `assertFunction` |
+| Return `null` when something is wrong | `isFunction` |
+| Get every error back in one shot | `validateFunction` |
+| Only check the parameters (return is trusted) | `…Parameters` variant |
+| Only check the return (parameters are trusted) | `…Return` variant |
+| Reject extra object properties as well | `…Equals…` variant |
+
+## Where to go next
+
+- The underlying single-value validators — [`is`](/docs/validators/is), [`assert`](/docs/validators/assert), [`validate`](/docs/validators/validate)
+- Constraints on parameter/return types — [Special Tags](/docs/validators/tags)
+- Using this for LLM tool argument validation — [`typia.llm.application`](/docs/llm/application)

--- a/website/src/content/docs/validators/is.mdx
+++ b/website/src/content/docs/validators/is.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guide Documents > Runtime Validators > is() functions
+title: Guide Documents > Runtime Validators > is() function
 ---
 import { Tabs } from 'nextra/components'
 import Alert from '@mui/material/Alert';
@@ -7,222 +7,225 @@ import AlertTitle from '@mui/material/AlertTitle';
 
 import LocalSource from '../../../components/LocalSource';
 
-## `is()` function
+# `typia.is()` — quick yes / no type check
 
-```typescript copy filename="typia"
-export function is<T>(input: T): input is T;
-export function is<T>(input: unknown): input is T;
+```typescript copy filename="signature"
+function is<T>(input: T): input is T;
+function is<T>(input: unknown): input is T;
 ```
 
-Tests a value type.
+`typia.is<T>` is the simplest validator: it returns `true` if `input` matches type `T`, and `false` otherwise.
 
-When you need to test an instance type, just call `typia.is<T>()` function.
+It is also a [type guard](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates), so on the `true` branch TypeScript narrows the variable to `T` automatically — you don't have to cast.
 
-If the `input` value is following type `T`, `true` value would be returned. Otherwise, `false` would be returned.
+## First example
 
-<br/>
-<Alert severity="success">
-  <AlertTitle> 
-    **AOT compilation** 
-  </AlertTitle>
+```typescript copy filename="hello-is.ts"
+import typia from "typia";
 
-If you'd used other competitive validator libraries like `ajv` or `class-validator`, you may found that `typia` does not require any extra schema definition. If you have not experienced them, I can sure that you may get shocked after reading below extra schema definition files.
+interface User {
+  id: string;
+  age: number;
+}
 
- - `ajv` requires [JSON schema definition](https://github.com/samchon/typia/blob/master/test/schemas/json/swagger/ObjectHierarchical.json).
- - `class-validator` requires [DTO class with decorator function calls](https://github.com/samchon/typia/blob/master/benchmark/structures/class-validator/ClassValidatorObjectHierarchical.ts).
+const input: unknown = await fetchSomething();
 
-Yeah, `typia` needs only pure TypeScript type. As `typia` is a compiler library, it can analyze TypeScript type by itself, and possible to write the optimal validation code like below. This is the key principle of `typia`, which needs only one line with pure TypeScript type.
+if (typia.is<User>(input)) {
+  // input is now `User` inside this block
+  console.log(input.age);
+}
+```
 
-</Alert>
+That's the whole API. Behind the scenes, typia rewrites `typia.is<User>` at compile time into a hand-written checker specialized to `User` — no schema lookup, no reflection. The result is the fastest validator in the JavaScript ecosystem; see [pure TypeScript](/docs/pure) for the long explanation.
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+The tabs below show the same example as a full source file (left) and the JavaScript typia actually emits (right). The "Compiled JavaScript" side is what your bundler ships — there's no schema interpreter at runtime, just the inline checks. (You'll see this same source/compiled-output tab pattern on every validator page.)
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/is.ts" 
+    <LocalSource
+      path="examples/src/validators/is.ts"
       filename="examples/src/validators/is.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/is.js" 
+    <LocalSource
+      path="examples/bin/validators/is.js"
       filename="examples/bin/validators/is.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## `equals()` function
+## Three things to know
 
-```typescript copy filename="typia"
-export function equals<T>(input: T): input is T;
-export function equals<T>(input: unknown): input is T;
+### 1. It is the cheapest check — and it returns the *least* information
+
+You get a boolean. No path, no expected type, no list of errors. If you need any of that, jump to:
+
+- [`assert`](/docs/validators/assert) — throw a `TypeGuardError` carrying the first failing path
+- [`validate`](/docs/validators/validate) — return an `IValidation` with **every** failing path
+
+If a yes/no answer is all you need, `is` is the right pick because the emitted code is the shortest.
+
+### 2. Extra properties are allowed by default — use `equals` to reject them
+
+```typescript
+interface Point { x: number; y: number; }
+
+typia.is<Point>({ x: 1, y: 2, z: 3 });      // → true  (z is ignored)
+typia.equals<Point>({ x: 1, y: 2, z: 3 });  // → false (z is rejected)
 ```
 
-More strict checker prohibiting superfluous properties.
+`typia.equals<T>` has exactly the same signature as `typia.is<T>` but also rejects any property that isn't declared on `T`. Use it when extra fields should be a hard error — for example, when validating data that someone else might have over-populated.
 
-`typia.is<T>()` can test instance type, but it allows superfluous properties. 
-
-If you want to prohibit those superfluous properties, you can use `typia.equals<T>()` function instead.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/equals.ts" 
+    <LocalSource
+      path="examples/src/validators/equals.ts"
       filename="examples/src/validators/equals.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/equals.js" 
+    <LocalSource
+      path="examples/bin/validators/equals.js"
       filename="examples/bin/validators/equals.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Reusable functions
+### 3. Call it many times for the same type → build a reusable checker once
 
-```typescript copy filename="typia"
-export function createIs<T>(): (input: unknown) => input is T;
-export function createEquals<T>(): (input: unknown) => input is T;
+Every `typia.is<T>` call expands into the type-specific checker at that call site. If you call it from 20 places with the same `T`, you get 20 copies in the compiled JavaScript. To avoid that, hoist the checker with `typia.createIs<T>()`:
+
+```typescript copy filename="reusable.ts"
+import typia from "typia";
+
+const isUser = typia.createIs<User>();
+
+// ...elsewhere
+if (isUser(input)) { /* ... */ }
 ```
 
-Reusable `typia.is<T>()` function generators.
+`typia.createEquals<T>()` is the strict counterpart. Both factories take no arguments and return a plain `(input: unknown) => input is T` function.
 
-If you repeat to call `typia.is<T>()` function on the same type, size of JavaScript files would be larger because of duplicated AOT compilation. To prevent it, you can generate reusable function through `typia.createIs<T>()` function.
-
-Just look at the code below, then you may understand how to use it.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/createIs.ts" 
+    <LocalSource
+      path="examples/src/validators/createIs.ts"
       filename="examples/src/validators/createIs.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/createIs.js" 
+    <LocalSource
+      path="examples/bin/validators/createIs.js"
       filename="examples/bin/validators/createIs.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Auto Type Casting
+## Type narrowing in practice
 
-```typescript copy filename="typia"
-export function is<T>(input: unknown): input is T;
-export function equals<T>(input: unknown): input is T;
-export function createIs<T>(): (input: unknown) => input is T;
-export function createEquals<T>(): (input: unknown) => input is T;
-```
+Because `typia.is<T>` is declared as a TypeScript type predicate (`input is T`), the compiler narrows the variable for you:
 
-`typia.is<T>()` function can be used for type casting.
-
-When target `input` value is following the type `T`, therefore `true` value be returned, `typia.is<T>()` function automatically casts the `input` value to the type `T`. Therefore, you can utilize the `typia.is<T>()` function for safe type casting tool like below:
-
-<LocalSource 
-  path="examples/src/validators/is-cast.ts" 
+<LocalSource
+  path="examples/src/validators/is-cast.ts"
   filename="examples/src/validators/is-cast.ts"
   showLineNumbers />
 
-## Restrictions
+You will see this pattern a lot in HTTP handlers, message bus consumers, and anywhere a value enters the program with type `unknown`.
 
-`typia.is<T>()` function does not check `function` and user-defined `class` types. 
+## What `is` does not check
 
-It validates only the primitive properties. Therefore, `typia.is<T>()` function does not perform the `instanceof ClassName` for user-defined classes. If you want to validate the user-defined class type in addition to the property types, do it by yourself. Also, `typia.is<T>()` function does not validate the function type either, unless configuring `functional` property of `plugin` option in the `tsconfig.json` file.
+`typia.is<T>` walks structural properties; it does **not** call `instanceof` for user-defined classes, and it does **not** dive into function types.
 
-```json filename="tsconfig.json"
-{
-  "compilerOptions": {
-    "plugins": [
-      {
-        "transform": "typia/lib/transform",
-        "functional": true
-      }
-    ]
+- **User-defined classes** — `typia.is<MyClass>(input)` only checks `input`'s properties against `MyClass`. If you also need `input instanceof MyClass`, write that check yourself.
+- **Function types** — function types are skipped by default. To validate function signatures (and use [`typia.functional.*`](/docs/validators/functional)), enable `functional` in your tsconfig:
+
+  ```json filename="tsconfig.json"
+  {
+    "compilerOptions": {
+      "plugins": [
+        {
+          "transform": "typia/lib/transform",
+          "functional": true
+        }
+      ]
+    }
   }
-}
-```
+  ```
 
-By the way, there're some exception cases. 
+Built-in classes — `Date`, `Uint8Array`, `Set<T>`, `Map<K, V>` — are checked properly, including their elements:
 
-If JS native class type like `Date`, `Uint8Array`, or `Map<Key, T>` being utilized, `typia.is<T>()` function validates them. Especially about the `Set<T>`, and `Map<Key, T>` class cases, `typia.is<T>()` function validates all of their contained element types, too.
-
-Therefore, the `instanceof` statement does not be used only for the user-defined classes.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/is-map.ts" 
+    <LocalSource
+      path="examples/src/validators/is-map.ts"
       filename="examples/src/validators/is-map.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/is-map.js" 
+    <LocalSource
+      path="examples/bin/validators/is-map.js"
       filename="examples/bin/validators/is-map.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Customization
+So the rule is "skip user-defined classes and functions; check everything else", and the only thing you commonly need to add yourself is `instanceof MyClass` on top.
 
-You can enhance validation logic by special tags.
+## Adding constraints — type tags
 
-Also, with those tags, you can add your custom validation logic, too.
+`number` is a useful type. `number & tags.Type<"uint32"> & tags.Minimum<1>` is much more useful. typia lets you intersect [type tags](/docs/validators/tags) into a base type to express constraints like "non-negative integer", "valid email", "1-100 string". They participate in `is`, `assert`, `validate`, `random` — every validator-shaped function.
 
-If you want to know about such special tags detaily, read below article:
-
-  - [Special Tags](../tags/)
-    - [Outline](../tags/#outline)
-    - [Type Tags](../tags/#type-tags)
-    - [Comment Tags](../tags/#comment-tags)
-    - [Customization](../tags/#customization)
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/is-custom-tags.ts" 
+    <LocalSource
+      path="examples/src/validators/is-custom-tags.ts"
       filename="examples/src/validators/is-custom-tags.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/is-custom-tags.js" 
+    <LocalSource
+      path="examples/bin/validators/is-custom-tags.js"
       filename="examples/bin/validators/is-custom-tags.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
+See [Special Tags](/docs/validators/tags) for the full catalogue.
+
 ## Performance
 
-Super-fast and super-safe.
-
-Comparing `typia.is<T>()` function with other competitive libraries, maximum 20,000x faster. 
-
-Furthermore, only `typia` can validate complicate union types.
+`typia.is<T>` is the fastest of the validators — it ships only the comparison logic, no error-collection, no path tracking. It is also the fastest validator across the JavaScript ecosystem on this kind of work: up to **20,000× faster than `class-validator`** on union-heavy structures, and notably the only one of the popular libraries that correctly handles arbitrary unions.
 
 ![Is Function Benchmark](https://github.com/samchon/typia/raw/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics/images/is.svg)
 
 > Measured on [AMD Ryzen 9 7940HS, Rog Flow x13](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics#is)
 
-Components               | `typia` | `TypeBox` | `ajv` | `io-ts` | `zod` | `C.V.`
--------------------------|--------|-----------|-------|---------|-------|------------------
-**Easy to use**          | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ 
-[Object (simple)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectSimple.ts)          | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectHierarchical.ts)    | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectRecursive.ts)       | ✔ | ❌ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (union, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionImplicit.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Object (union, explicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionExplicit.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-[Object (additional tags)](https://github.com/samchon/typia/#comment-tags)        | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (template literal types)](https://github.com/samchon/typia/blob/master/test/src/structures/TemplateUnion.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-[Object (dynamic properties)](https://github.com/samchon/typia/blob/master/test/src/structures/DynamicTemplate.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-[Array (rest tuple)](https://github.com/samchon/typia/blob/master/test/src/structures/TupleRestAtomic.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayHierarchical.ts)     | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Array (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursive.ts)        | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-[Array (recursive, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionExplicit.ts) | ✔ | ✔ | ❌ | ✔ | ✔ | ❌
-[Array (R+U, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionImplicit.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedNullable.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/src/schemas/IJsonSchema.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+| Components | `typia` | `TypeBox` | `ajv` | `io-ts` | `zod` | `C.V.` |
+|------------|---------|-----------|-------|---------|-------|--------|
+| **Easy to use** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [Object (simple)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectSimple.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| [Object (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectHierarchical.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| [Object (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectRecursive.ts) | ✔ | ❌ | ✔ | ✔ | ✔ | ✔ |
+| [Object (union, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionImplicit.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [Object (union, explicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionExplicit.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ❌ |
+| [Object (additional tags)](https://github.com/samchon/typia/#comment-tags) | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| [Object (template literal types)](https://github.com/samchon/typia/blob/master/test/src/structures/TemplateUnion.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌ |
+| [Object (dynamic properties)](https://github.com/samchon/typia/blob/master/test/src/structures/DynamicTemplate.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌ |
+| [Array (rest tuple)](https://github.com/samchon/typia/blob/master/test/src/structures/TupleRestAtomic.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [Array (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayHierarchical.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| [Array (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursive.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ❌ |
+| [Array (recursive, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionExplicit.ts) | ✔ | ✔ | ❌ | ✔ | ✔ | ❌ |
+| [Array (R+U, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionImplicit.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [Array (repeated)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedNullable.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedUnionWithTuple.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/test/src/structures/UltimateUnion.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
-> `C.V.` means `class-validator`
+> `C.V.` means `class-validator`.
+
+## Where to go next
+
+- Need an error path or to throw instead of returning a boolean → [`assert`](/docs/validators/assert)
+- Need every error at once for a form, not just the first → [`validate`](/docs/validators/validate)
+- Want to constrain values (formats, ranges, lengths) → [Special Tags](/docs/validators/tags)
+- Validating function calls → [Functional Module](/docs/validators/functional)

--- a/website/src/content/docs/validators/tags.mdx
+++ b/website/src/content/docs/validators/tags.mdx
@@ -7,217 +7,200 @@ import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## Outline
+# Special Tags — adding constraints to a type
 
-`typia` can perform additional validation through [type tags](#type-tags) and [comment tags](#comment-tags).
+TypeScript can say "this is a `number`". It cannot say "this is a non-negative 32-bit integer". typia closes that gap with two parallel mechanisms:
 
-When you need additional validation logic that is not supported in pure TypeScript type spec, you can use [type tags](#type-tags) and [comment tags](#comment-tags) for it. For example, if you define a type with intersection symbol like `number & typia.tags.Type<"uint32">` and validates it, `typia` will check the target numeric value is unsigned integer or not.
+- **Type tags** — branded types you intersect into the base, like `number & tags.Type<"uint32"> & tags.Minimum<0>`. Recommended.
+- **Comment tags** — `@`-prefixed JSDoc tags like `@type uint32`. Provided for compatibility with older codebases.
 
-Also, in TypeScript (and JavaScript), writing `@` character in comment is called [Comment Tag](#comment-tags) and `typia` utilizes such comment tags for enhancing type validation logic. As you can see from below example code, `typia` analyzes `@tagName value` patterned comment tags, and generates optimal validation logic in the compilation level.
+Whichever you use, every validator and `random` will respect the constraint and the emitted JavaScript will include the corresponding check.
 
-Therefore, don't be afraid `typia` uses only pure TypeScript types for type validation schema. Don't be afraid about TypeScript does not support `integer` type. With those [type tags](#type-tags) and [comment tags](#comment-tags), you can express every types in the world.
+## A first taste
 
-  - Q: How to validate integer type? TypeScript does not support it
-    - A1: Use type tag `number & typia.tags.Type<"int32">`
-    - A2: Write a comment tag `@type int32` on the target property
-  - Q: Type Tag vs Comment Tags, which one is better
-    - A1: Type Tag is recommended because it is much safer and generous
-    - A2: Comment Tag is designed for legacy JSDoc styled projects
+```typescript copy filename="constrained-user.ts"
+import typia, { tags } from "typia";
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+interface User {
+  id: string & tags.Format<"uuid">;
+  age: number & tags.Type<"uint32"> & tags.Minimum<19>;
+  email: string & tags.Format<"email">;
+}
+
+typia.assert<User>(input);
+//  - id must be a UUID string
+//  - age must be an unsigned 32-bit integer ≥ 19
+//  - email must look like an email address
+```
+
+Compiled output — note that each constraint becomes inline code:
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/is-type-tag.ts" 
-      filename="examples/src/validators/is-type-tag.ts" 
+    <LocalSource
+      path="examples/src/validators/is-type-tag.ts"
+      filename="examples/src/validators/is-type-tag.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/is-type-tag.js" 
-      filename="examples/bin/validators/is-type-tag.js" 
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## Type Tags
-
-By using type tags, you can utilize additional validation logics.
-
-Just import one of type tags from `typia`, and combine it with target through intersection symbol like `number & typia.tags.Type<"uint32">` case. If you want to declare an union validation logic, combine `|` and bracket (`()`) symbols properly like below:
-
-  - `number & (Type<"uint32"> | Type<"double">)`
-    - `number` type can be both `uint32` and `double`
-  - `(number & Type<"int32">) | (bigint & Type<"uint64">)`
-    - `number` is `int32`
-    - `bigint` is `uint64`
-  - `(number & (Type<"int32">)| Type<"float">) | (bigint & Type<"uint64">)`
-    - `number` can be both `int32` and `float`
-    - `bigint` is `uint64`
-
-Here is the entire list of type tags that `typia` basically supports. 
-
-For reference, when you take a mistake that choosing different target type, TypeScript compiler would block it with compilation error message. Also, if you take a mistake that placing invalid argument on the type, it would also be blocked IDE and compiler. Therefore, have a confidence when using them. 
-
-  - number
-    - `number & Type<{keyword}>`
-      - `int32`
-      - `uint32`
-      - `uint64`
-      - `int64`
-      - `float`
-      - `double`
-    - `number & Minimum<{number}>`
-    - `number & Maximum<{number}>`
-    - `number & ExclusiveMaximum<{number}>`
-    - `number & ExclusiveMinimum<{number}>`
-    - `number & MultipleOf<{number}>`
-  - bigint
-    - `bigint & Type<{keyword}>`
-      - `int64`
-      - `uint64`
-    - `bigint & Minimum<{bigint}>`
-    - `bigint & Maximum<{bigint}>`
-    - `bigint & ExclusiveMaximum<{bigint}>`
-    - `bigint & ExclusiveMinimum<{bigint}>`
-    - `bigint & MultipleOf<{bigint}>`
-  - string
-    - `string & MinLength<{number}>`
-    - `string & MaxLength<{number}>`
-    - `string & Pattern<{regex}>`
-    - `string & Format<{keyword}>`
-      - `byte`
-      - `password`
-      - `regex`
-      - `uuid`
-      - `email`
-      - `hostname`
-      - `idn-email`
-      - `idn-hostname`
-      - `iri`
-      - `iri-reference`
-      - `ipv4`
-      - `ipv6`
-      - `uri`
-      - `uri-reference`
-      - `uri-template`
-      - `url`
-      - `date-time`
-      - `date`
-      - `time`
-      - `duration`
-      - `json-pointer`
-      - `relative-json-pointer`
-  - array
-    - `Array<T> & MinItems<{number}>`
-    - `Array<T> & MaxItems<{number}>`
-    - `Array<T> & UniqueItems`
-
-Also, if you need custom validation logic, just make it by yourself referencing [Customization](#customization) section. It is easy to define. For such type safety and generous use case reasons even customization supporting, I recommend you to use type tags instead of [comment tags](#comment-tags), unless you are maintaining a legacy JSDoc styled project.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/is-type-tag.ts" 
-      filename="examples/src/validators/is-type-tag.ts" 
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/is-type-tag.js" 
-      filename="examples/bin/validators/is-type-tag.js" 
+    <LocalSource
+      path="examples/bin/validators/is-type-tag.js"
+      filename="examples/bin/validators/is-type-tag.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Comment Tags
+## Type tags — the recommended way
 
-`typia` supports those comment tags, too.
+You import `tags` from `typia` and intersect them into the base type:
 
-Here is the entire list of comment tags that `typia` supports.
+```typescript copy
+import typia, { tags } from "typia";
 
-  - number
-    - `@type {string}`
-      - `int` / `int32`
-      - `uint` / `uint32`
-      - `int64`
-      - `uint64`
-      - `float`
-    - `@minimum {number}`
-    - `@maximum {number}`
-    - `@exclusiveMinimum {number}`
-    - `@exclusiveMaximum {number}`
-    - `@multipleOf {number}`
-  - bigint
-    - `@type uint64`
-    - `@minimum {bigint}`
-    - `@maximum {bigint}`
-    - `@exclusiveMinimum {bigint}`
-    - `@exclusiveMaximum {bigint}`
-    - `@multipleOf {bigint}`
-  - string
-    - `@minLength {number}`
-    - `@maxLength {number}`
-    - `@pattern {regex}`
-    - `@format {keyword}`
-      - `byte`
-      - `password`
-      - `regex`
-      - `uuid`
-      - `email`
-      - `hostname`
-      - `idn-email`
-      - `idn-hostname`
-      - `iri`
-      - `iri-reference`
-      - `ipv4`
-      - `ipv6`
-      - `uri`
-      - `uri-reference`
-      - `uri-template`
-      - `url`
-      - `date-time`
-      - `date`
-      - `time`
-      - `duration`
-      - `json-pointer`
-      - `relative-json-pointer`
-  - array
-    - `@minItems {number}`
-    - `@maxItems {number}`
-    - `@uniqueItems`
+type Price = number & tags.Type<"double"> & tags.Minimum<0>;
+```
 
-By the way, I do not recommend this way, because it can't perform union numeric types, and can be used for only object property type. It can't be used standalone, and cannot be used for element type of `Array` and `Map` even when they're declared on object property. Also, When you declare `@type int32` statement, target `number` type be fixed as `int32` type, and never can have another numeric type by declaring union statements.
+Type tags compose with `|` and `&` exactly like regular TypeScript types:
 
-Also, those comment tags are not type safe. If you take a mistake when writing a comment tag, it will not be detected by the compiler, and will cause an error at runtime. For example, if you write a miss-spelled keyword like `@type unit32`, the target `number` type would be `double` type, and you can identify it just by running the program (or visiting playground website).
+```typescript copy
+// number can be either a uint32 or a double
+type N = number & (tags.Type<"uint32"> | tags.Type<"double">);
 
-<br/>
-<Alert severity="warning">
-  <AlertTitle>
-    **Why supports comment tags?**
-  </AlertTitle>
+// number-or-bigint, with different constraints per branch
+type ID =
+  | (number & tags.Type<"int32">)
+  | (bigint  & tags.Type<"uint64">);
 
-Despite these disadvantages, comment tags are still maintained for compatibility with legacy JSDoc-style projects.
+// number that can be either int32 or float, OR bigint that is uint64
+type Mixed =
+  | (number & (tags.Type<"int32"> | tags.Type<"float">))
+  | (bigint  & tags.Type<"uint64">);
+```
 
-If your codebase already describes validation rules in comments, you can keep that style and migrate incrementally instead of rewriting everything to type tags at once.
+If you intersect a tag with the wrong base type (e.g. `tags.MaxLength<100>` on a `number`), the TypeScript compiler will reject it.
 
-</Alert>
+### Full catalogue
 
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+#### `number` and `bigint`
+
+| Tag | Notes |
+|-----|-------|
+| `tags.Type<"int32" \| "uint32" \| "int64" \| "uint64" \| "float" \| "double">` | Sub-type of `number` (or, for `int64`/`uint64`, of `bigint`) |
+| `tags.Minimum<N>` | `value >= N` |
+| `tags.Maximum<N>` | `value <= N` |
+| `tags.ExclusiveMinimum<N>` | `value > N` |
+| `tags.ExclusiveMaximum<N>` | `value < N` |
+| `tags.MultipleOf<N>` | `value % N === 0` |
+
+For `bigint`, `tags.Type<...>` accepts `"int64"` or `"uint64"`; range tags accept `bigint` literals.
+
+#### `string`
+
+| Tag | Notes |
+|-----|-------|
+| `tags.MinLength<N>` | `value.length >= N` |
+| `tags.MaxLength<N>` | `value.length <= N` |
+| `tags.Pattern<R>` | regex (passed as a string literal) |
+| `tags.Format<F>` | one of the formats below |
+| `tags.ContentMediaType<MT>` | OpenAPI `contentMediaType` (e.g. `"image/png"`) |
+
+`Format` accepts: `byte`, `password`, `regex`, `uuid`, `email`, `hostname`, `idn-email`, `idn-hostname`, `iri`, `iri-reference`, `ipv4`, `ipv6`, `uri`, `uri-reference`, `uri-template`, `url`, `date-time`, `date`, `time`, `duration`, `json-pointer`, `relative-json-pointer`.
+
+> `Format` and `Pattern` are mutually exclusive on the same string — pick one.
+
+#### `Array<T>`
+
+| Tag | Notes |
+|-----|-------|
+| `tags.MinItems<N>` | `arr.length >= N` |
+| `tags.MaxItems<N>` | `arr.length <= N` |
+| `tags.UniqueItems` | All elements pairwise distinct |
+
+#### Other useful tags
+
+| Tag | What it does |
+|-----|--------------|
+| `tags.Default<V>` | Records a default value in JSON Schema output |
+| `tags.Example<V>` / `tags.Examples<Record>` | Records example(s) in JSON Schema output |
+| `tags.Constant<V, {title, description}>` | Single-value literal with metadata |
+| `tags.JsonSchemaPlugin<{...}>` | Inject arbitrary `x-…` JSON Schema fields |
+| `tags.Sequence<N>` | Protobuf field number ([protobuf docs](/docs/protobuf/message)) |
+
+## Comment tags — for older codebases
+
+If you'd rather write JSDoc, the same constraints exist as `@`-prefixed tags:
+
+| Comment tag | Equivalent type tag |
+|-------------|---------------------|
+| `@type int32` | `tags.Type<"int32">` |
+| `@minimum 0` | `tags.Minimum<0>` |
+| `@maximum 100` | `tags.Maximum<100>` |
+| `@exclusiveMinimum 0` | `tags.ExclusiveMinimum<0>` |
+| `@exclusiveMaximum 100` | `tags.ExclusiveMaximum<100>` |
+| `@multipleOf 0.5` | `tags.MultipleOf<0.5>` |
+| `@minLength 3` | `tags.MinLength<3>` |
+| `@maxLength 100` | `tags.MaxLength<100>` |
+| `@pattern ^[a-z]+$` | `tags.Pattern<"^[a-z]+$">` |
+| `@format uuid` | `tags.Format<"uuid">` |
+| `@minItems 1` | `tags.MinItems<1>` |
+| `@maxItems 10` | `tags.MaxItems<10>` |
+| `@uniqueItems` | `tags.UniqueItems` |
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/is-comment-tag.ts" 
-      filename="examples/src/validators/is-comment-tag.ts" 
+    <LocalSource
+      path="examples/src/validators/is-comment-tag.ts"
+      filename="examples/src/validators/is-comment-tag.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/is-comment-tag.js" 
-      filename="examples/bin/validators/is-comment-tag.js" 
+    <LocalSource
+      path="examples/bin/validators/is-comment-tag.js"
+      filename="examples/bin/validators/is-comment-tag.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
+
+> [!CAUTION]
+>
+> **Type tags > comment tags. Always, unless you can't.**
+>
+> - Comment tags are **not type-checked**. `@type unit32` (typo of `uint32`) silently falls back to `double`, and you only notice at runtime.
+> - Comment tags only work on **object properties**. They don't apply to element types of `Array` or `Map`, and they can't be combined with union types.
+> - Comment tags can't express union constraints. `@type int32` locks the property to `int32`; you can't follow it with `@type float`.
+>
+> Comment tags exist for JSDoc-style codebases that want to migrate incrementally without rewriting every property at once.
 
 ## Customization
+
+```typescript copy
+type Postfix<P extends string> = tags.TagBase<{
+  kind: "postfix";
+  target: "string";
+  value: P;
+  validate: `$input.endsWith("${P}")`;
+}>;
+
+type IsEven = tags.TagBase<{
+  kind: "isEven";
+  target: "number";
+  value: undefined;
+  validate: `$input % 2 === 0`;
+  // or:
+  // validate: (value: number) => value % 2 === 0;
+}>;
+```
+
+`tags.TagBase<Props>` builds a new tag. The minimum properties are:
+
+- `kind` — the tag's name (must be unique among intersected tags)
+- `target` — `"number" | "bigint" | "string" | "array"` (or a `Record<Target, string>` map if the tag spans multiple bases)
+- `value` — the constant captured by the tag (useful when the tag has a parameter, e.g. `Postfix<".com">`)
+- `validate` — either an inline expression string referencing `$input`, or a regular function
+
+You can also set `exclusive: true | string[]` to mark a tag as mutually exclusive with itself or with named other tags.
+
+Example tag definitions from the standard library — refer to these as templates:
 
 <Tabs items={[
     <code>TagBase.ts</code>,
@@ -226,52 +209,51 @@ If your codebase already describes validation rules in comments, you can keep th
     <code>Pattern.ts</code>,
 ]}>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/tags/TagBase.ts" 
+    <LocalSource
+      path="packages/interface/src/tags/TagBase.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/tags/Minimum.ts" 
+    <LocalSource
+      path="packages/interface/src/tags/Minimum.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/tags/Type.ts" 
+    <LocalSource
+      path="packages/interface/src/tags/Type.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/tags/Pattern.ts" 
+    <LocalSource
+      path="packages/interface/src/tags/Pattern.ts"
       filename="@typia/interface"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Above types are supported by `typia` basically. 
+End-to-end example with three custom tags (`Postfix`, `Dollar`, `IsEven`):
 
-If you make a custom type tag extending `typia.tags.TagBase<Props>` type, and utilize it on your type with intersection symbol like `number & Minimum<3>`, its validation logic `3 <= $input` would be inserted into the compiled JavaScript file.
-
-Also, as you can see from the `typia.tags.TagBase<Props>` type, you have to specify which `target` type is the tag for, and need to define the tag can be compatible with others or not through `exclusive` options. If your custom tag has multiple `target` types, you can support all of those `target` types by defining `validate` property as `Record<Target, string>` type like `Type` tag case.
-
-In the Korean proverb, there's a word that, "it is much better to do it once than to hear it a hundred times". Let's see how custom type tag of `typia` can be defined and utilized through an example code. I'll define three custom tag types, `Postfix`, `Dollar` and `IsEven`.
-
-Here is the example code, and I think that it may easy to understand.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/is-custom-tags.ts" 
-      filename="examples/src/validators/is-custom-tags.ts" 
+    <LocalSource
+      path="examples/src/validators/is-custom-tags.ts"
+      filename="examples/src/validators/is-custom-tags.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/is-custom-tags.js" 
-      filename="examples/bin/validators/is-custom-tags.js" 
+    <LocalSource
+      path="examples/bin/validators/is-custom-tags.js"
+      filename="examples/bin/validators/is-custom-tags.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
+
+## Where tags are used
+
+- [`is`](/docs/validators/is), [`assert`](/docs/validators/assert), [`validate`](/docs/validators/validate) — runtime checking
+- [`random`](/docs/random) — generated values respect the constraint
+- [`json.schemas`](/docs/json/schema), [`llm.parameters`](/docs/llm/parameters) — exported as JSON Schema fields (`format`, `minimum`, …)
+- [`protobuf.message`](/docs/protobuf/message) — `tags.Type<"uint32">` selects the wire type; `tags.Sequence<N>` picks the field number

--- a/website/src/content/docs/validators/validate.mdx
+++ b/website/src/content/docs/validators/validate.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guide Documents > Runtime Validators > validate() functions
+title: Guide Documents > Runtime Validators > validate() function
 ---
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
@@ -7,14 +7,91 @@ import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
 
-## `validate()` function
+# `typia.validate()` — collect every error at once
 
-<Tabs items={[
-  <code>typia</code>, 
-  <code>IValidation.ts</code>,
-]}>
+```typescript copy filename="signature"
+function validate<T>(input: T): IValidation<T>;
+function validate<T>(input: unknown): IValidation<T>;
+```
+
+`typia.validate<T>` walks the entire structure and reports **every** field that doesn't match `T`, instead of stopping at the first one like [`assert`](/docs/validators/assert).
+
+Use it when you need a list of errors to render — form validation, request body checks, LLM function-calling feedback loops.
+
+## First example
+
+```typescript copy filename="hello-validate.ts"
+import typia, { tags } from "typia";
+
+interface User {
+  id: string & tags.Format<"uuid">;
+  age: number & tags.Type<"uint32">;
+}
+
+const result = typia.validate<User>(input);
+
+if (result.success) {
+  // result.data is User
+  console.log(result.data.id);
+} else {
+  // result.errors is IValidation.IError[]
+  for (const e of result.errors) {
+    console.log(`${e.path}: expected ${e.expected}, got`, e.value);
+  }
+}
+```
+
+If `id` is the literal `5` and `age` is `20.75`, you get:
+
+```
+$input.id : expected "string & Format<\"uuid\">", got 5
+$input.age: expected "number & Type<\"uint32\">", got 20.75
+```
+
+Both errors arrive in a single pass. `assert` would have thrown on `id` and stopped.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
+    <LocalSource
+      path="examples/src/validators/validate.ts"
+      filename="examples/src/validators/validate.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/validators/validate.js"
+      filename="examples/bin/validators/validate.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## The `IValidation<T>` shape
+
 ```typescript copy
+type IValidation<T> = IValidation.ISuccess<T> | IValidation.IFailure;
+
+namespace IValidation {
+  interface ISuccess<T> {
+    success: true;
+    data: T;
+  }
+  interface IFailure {
+    success: false;
+    data: unknown;
+    errors: IError[];
+  }
+  interface IError {
+    path: string;       // "$input.user.age"
+    expected: string;   // "number & Minimum<19>"
+    value: unknown;     // the bad value
+    description?: string;
+  }
+}
+```
+
+<Tabs items={[<code>typia</code>, <code>IValidation.ts</code>]}>
+  <Tabs.Tab>
+```typescript
 export function validate<T>(input: T): IValidation<T>;
 export function validate<T>(input: unknown): IValidation<T>;
 ```
@@ -27,160 +104,59 @@ export function validate<T>(input: unknown): IValidation<T>;
   </Tabs.Tab>
 </Tabs>
 
-Validates a value type.
+The two halves of the union share a `success` boolean — TypeScript narrows the rest accordingly when you check it:
 
-`typia.validate<T>()` function validates `input` value type, and archives every type errors detaily into `IValidation.IFailure.errors` array, when the `input` value is not following the promised type `T`. Of course, if the parametric `input` value is following the type `T`, `IValidation.ISuccess` instance would be returned.
-
-In the below example case, as `id` and `age` values are different with its definition of `IMember`, such errors would be archived into the `IValidation.IFailure.errors` array.
-
-  - `errors[0]`
-    - `path`: `input.id`
-    - `expected`: `string & Format<"uuid">`
-    - `value`: 5
-  - `errors[1]`
-    - `path`: `input.age`
-    - `expected`: `number & Format<"uint32">`
-    - `value`: 20.75
-
-<br/>
-<Alert severity="success">
-  <AlertTitle> 
-    **AOT compilation** 
-  </AlertTitle>
-
-If you'd used other competitive validator libraries like `ajv` or `class-validator`, you may found that `typia` does not require any extra schema definition. If you have not experienced them, I can sure that you may get shocked after reading below extra schema definition files.
-
- - `ajv` requires [JSON schema definition](https://github.com/samchon/typia/blob/master/test/schemas/json/swagger/ObjectHierarchical.json).
- - `class-validator` requires [DTO class with decorator function calls](https://github.com/samchon/typia/blob/master/benchmark/structures/class-validator/ClassValidatorObjectHierarchical.ts).
-
-Yeah, `typia` needs only pure TypeScript type. As `typia` is a compiler library, it can analyze TypeScript type by itself, and possible to write the optimal validation code like below. This is the key principle of `typia`, which needs only one line with pure TypeScript type.
-
-</Alert>
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/validate.ts" 
-      filename="examples/src/validators/validate.ts" 
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/validate.js" 
-      filename="examples/bin/validators/validate.js" 
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## `validateEquals()` function
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>IValidation.ts</code>,
-]}>
-  <Tabs.Tab>
 ```typescript copy
-export function validateEquals<T>(input: T): IValidation<T>;
-export function validateEquals<T>(input: unknown): IValidation<T>;
+const result: IValidation<string> = typia.validate<string>(something);
+
+if (result.success) {
+  result.data;   // string
+} else {
+  result.errors; // IValidation.IError[]
+}
 ```
+
+This pattern is called a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions), and it's the cleanest way to consume `validate`'s return value.
+
+## Rejecting extra properties — `validateEquals`
+
+`validate` allows extra properties on objects. `validateEquals` reports each one as its own error:
+
+```typescript copy
+const r = typia.validateEquals<User>({ id: "uuid…", age: 25, sex: 1 });
+// r.success === false
+// r.errors[0] = { path: "$input.sex", expected: "undefined", value: 1 }
+```
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/validators/validateEquals.ts"
+      filename="examples/src/validators/validateEquals.ts"
+      showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
     <LocalSource
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface"
+      path="examples/bin/validators/validateEquals.js"
+      filename="examples/bin/validators/validateEquals.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-More strict validate function prohibiting superfluous properties.
+## Reusable factories — and Standard Schema support
 
-`typia.validate<T>` function detects every type errors of `input` value, however, it can't detect superfluous properties. If you want to prohibit those superfluous properties, so that archive them into `IValidation.IFailure.errors` array, use `typia.validateEquals<T>()` function instead.
-
-In the below example case, as `id` property is different with its type definition and `sex` property is not defined in the `IMember` type, such errors would be archived into the `IValidation.IFailure.errors` array:
-
-  - `errors[0]`
-    - `path`: `input.id`
-    - `expected`: `string (@format uuid)`
-    - `value`: `something`
-  - `errors[1]`
-    - `path`: `input.sex`
-    - `expected`: `undefined`
-    - `value`: `1`
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/validateEquals.ts" 
-      filename="examples/src/validators/validateEquals.ts" 
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/validateEquals.js" 
-      filename="examples/bin/validators/validateEquals.js" 
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-## Reusable functions
-
-<Tabs items={[
-  <code>typia</code>, 
-  <code>IValidation.ts</code>,
-]}>
-  <Tabs.Tab>
 ```typescript copy
-export function createValidate<T> = (input: unknown) => IValidation<T> & StandardSchemaV1<T, T>;
-export function createValidateEquals<T> = (input: unknown) => IValidation<T> & StandardSchemaV1<T, T>;
+const validateUser = typia.createValidate<User>();
+const validateUserEquals = typia.createValidateEquals<User>();
 ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
 
-Reusable `typia.validate<T>()` function generators.
+Each factory returns a function `(input: unknown) => IValidation<T>` that you can call from anywhere — the per-type code is emitted once at the factory call site.
 
-If you repeat to call `typia.validate<T>()` function on the same type, size of JavaScript files would be larger because of duplicated AOT compilation. To prevent it, you can generate reusable function through `typia.createValidate<T>()` function.
-
-Just look at the code below, then you may understand how to use it.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/createValidate.ts" 
-      filename="examples/src/validators/createValidate.ts" 
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/createValidate.js" 
-      filename="examples/bin/validators/createValidate.js" 
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-This reusable function implements [Standard Schema](https://standardschema.dev/) interface. Therefore, you can use this function with [a library which accepts Standard Schema interface](https://standardschema.dev/#:~:text=what%20tools%20%2F%20frameworks%20accept%20spec-compliant%20schemas%3F), such as [upfetch](https://github.com/L-Blondy/up-fetch):
+`createValidate` and `createValidateEquals` go a step further: the returned function also implements the [Standard Schema](https://standardschema.dev/) interface (`StandardSchemaV1<T, T>`). That makes the validator a drop-in for any library that accepts Standard Schema, like [up-fetch](https://github.com/L-Blondy/up-fetch):
 
 ```typescript copy
 import typia from "typia";
 import { up } from "up-fetch";
-
-const upfetch = up(fetch);
-const schema = typia.createValidate<ISmallTodo>();
-
-// passes
-await upfetch("https://jsonplaceholder.typicode.com/todos/1", {
-  schema,
-});
-
-// fails
-await upfetch("https://jsonplaceholder.typicode.com/todos/10", {
-  schema,
-})
 
 interface ISmallTodo {
   userId: number;
@@ -189,151 +165,90 @@ interface ISmallTodo {
   title: string;
   completed: boolean;
 }
+
+const upfetch = up(fetch);
+const schema = typia.createValidate<ISmallTodo>();
+
+// id ≤ 5 → success
+await upfetch("https://jsonplaceholder.typicode.com/todos/1", { schema });
+
+// id = 10 → validation failure surfaced by up-fetch
+await upfetch("https://jsonplaceholder.typicode.com/todos/10", { schema });
 ```
 
-## Restrictions
-
-`typia.validate<T>()` function does not check `function` and user-defined `class` types. 
-
-It validates only the primitive properties. Therefore, `typia.validate<T>()` function does not perform the `instanceof ClassName` for user-defined classes. If you want to validate the user-defined class type in addition to the property types, do it by yourself. Also, `typia.validate<T>()` function does not validate the function type either, unless configuring `functional` property of `plugin` option in the `tsconfig.json` file.
-
-```json filename="tsconfig.json"
-{
-  "compilerOptions": {
-    "plugins": [
-      {
-        "transform": "typia/lib/transform",
-        "functional": true
-      }
-    ]
-  }
-}
-```
-
-By the way, there're some exception cases. 
-
-If JS native class type like `Date`, `Uint8Array`, or `Map<Key, T>` being utilized, `typia.validate<T>()` function validates them. Especially about the `Set<T>`, and `Map<Key, T>` class cases, `typia.validate<T>()` function validates all of their contained element types, too.
-
-Therefore, the `instanceof` statement does not be used only for the user-defined classes.
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/validate-map.ts" 
-      filename="examples/src/validators/validate-map.ts" 
+    <LocalSource
+      path="examples/src/validators/createValidate.ts"
+      filename="examples/src/validators/createValidate.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/validate-map.js" 
-      filename="examples/bin/validators/validate-map.js" 
+    <LocalSource
+      path="examples/bin/validators/createValidate.js"
+      filename="examples/bin/validators/createValidate.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-## Discriminated Union
+## What `validate` does not check
 
-<Tabs items={[
-    <code>typia</code>, 
-    <code>IValidation.ts</code>,
-  ]}
-  defaultIndex={1}
->
+Same rules as the rest of the validator family — see [`is` § What is does not check](/docs/validators/is#what-is-does-not-check). User-defined classes are walked by property, function types are skipped unless `functional` is on, native classes (`Date`, `Set`, `Map`, `Uint8Array`) are inspected end-to-end.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-```typescript copy
-export function validate<T>(input: T): IValidation<T>;
-export function validate<T>(input: unknown): IValidation<T>;
-export function createValidate<T>(): (input: unknown) => IValidation<T>;
-```
+    <LocalSource
+      path="examples/src/validators/validate-map.ts"
+      filename="examples/src/validators/validate-map.ts"
+      showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="packages/interface/src/schema/IValidation.ts"
-      filename="@typia/interface"
+    <LocalSource
+      path="examples/bin/validators/validate-map.js"
+      filename="examples/bin/validators/validate-map.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
 
-Specify type through if condition.
+## Adding constraints — type tags
 
-`typia.IValidation<T>` is an union type of `typia.IValidation.ISuccess<T>` and `typia.IValidation.IFailure`. Also, they have a common property `success` of boolean type, but different literal values. In that case, if you write a `if condition` about the `success` property, you can specify the union type like below.
+Intersect [type tags](/docs/validators/tags) (formats, ranges, lengths) into the type. The error `expected` field repeats the same intersection syntax, so users see exactly what was required:
 
-In TypeScript, such union type specification through common property (of different literal value() is called "Discriminated Union". Therefore, when using `typia.validate<T>()` function, let's utilize such discriminated union specification for convenience.
-
-```typescript copy
-import typia from "typia";
-
-const something: unknown = ...;
-const result: typia.IValidation<string> = typia.validate<string>(something);
-
-if (results.success) {
-  // become typia.IValidation.Success<string> type
-  result.data; // accessible
-} else {
-  // become typia.IValidation.Failure type
-  result.errors; //accessible
-}
-```
-
-## Customization
-
-You can enhance validation logic by special tags.
-
-Also, with those tags, you can add your custom validation logic, too.
-
-If you want to know about such special tags detaily, read below article:
-
-  - [Special Tags](../tags/)
-    - [Outline](../tags/#outline)
-    - [Type Tags](../tags/#type-tags)
-    - [Comment Tags](../tags/#comment-tags)
-    - [Customization](../tags/#customization)
-
-<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/validators/validate-custom-tags.ts" 
-      filename="examples/src/validators/validate-custom-tags.ts" 
+    <LocalSource
+      path="examples/src/validators/validate-custom-tags.ts"
+      filename="examples/src/validators/validate-custom-tags.ts"
       showLineNumbers />
   </Tabs.Tab>
   <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/validators/validate-custom-tags.js" 
-      filename="examples/bin/validators/validate-custom-tags.js" 
+    <LocalSource
+      path="examples/bin/validators/validate-custom-tags.js"
+      filename="examples/bin/validators/validate-custom-tags.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
+
+## When to choose `validate` over `assert`
+
+| Scenario | Use |
+|----------|-----|
+| One field is wrong → throw an exception | [`assert`](/docs/validators/assert) |
+| Need to render every field error to the user (form, request body) | `validate` |
+| LLM function-calling feedback loop ("tell the model all its mistakes") | `validate` + [`LlmJson.stringify`](/docs/llm/json) |
+| Just a yes/no answer | [`is`](/docs/validators/is) |
 
 ## Performance
 
-Super-fast and super-safe.
-
-Comparing `typia.validate<T>()` function with other competitive libraries, maximum 20,000x faster. 
-
-Furthermore, only `typia` can validate complicate union types.
+`validate` does the most work — it walks the entire structure even after finding errors, and collects each one with path and expected-type strings. It's still up to 20,000× faster than the JS-ecosystem alternatives on union-heavy types, and still the only one that handles arbitrary unions:
 
 ![validate Function Benchmark](https://github.com/samchon/typia/raw/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics/images/validate.svg)
 
 > Measured on [AMD Ryzen 9 7940HS, Rog Flow x13](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics#validate)
 
-Components               | `typia` | `TypeBox` | `ajv` | `io-ts` | `zod` | `C.V.`
--------------------------|--------|-----------|-------|---------|-------|------------------
-**Easy to use**          | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ 
-[Object (simple)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectSimple.ts)          | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectHierarchical.ts)    | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectRecursive.ts)       | ✔ | ❌ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (union, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionImplicit.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Object (union, explicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionExplicit.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-[Object (additional tags)](https://github.com/samchon/typia/#comment-tags)        | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (template literal types)](https://github.com/samchon/typia/blob/master/test/src/structures/TemplateUnion.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-[Object (dynamic properties)](https://github.com/samchon/typia/blob/master/test/src/structures/DynamicTemplate.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-[Array (rest tuple)](https://github.com/samchon/typia/blob/master/test/src/structures/TupleRestAtomic.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayHierarchical.ts)     | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Array (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursive.ts)        | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-[Array (recursive, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionExplicit.ts) | ✔ | ✔ | ❌ | ✔ | ✔ | ❌
-[Array (R+U, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionImplicit.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedNullable.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/src/schemas/IJsonSchema.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+## Where to go next
 
-> `C.V.` means `class-validator`
+- Throw on first failure → [`assert`](/docs/validators/assert)
+- Yes/no check → [`is`](/docs/validators/is)
+- Constraints (formats, ranges, lengths) → [Special Tags](/docs/validators/tags)
+- LLM auto-correction loop → [LlmJson.stringify](/docs/llm/json)

--- a/website/src/movies/HomeHeroMovie.tsx
+++ b/website/src/movies/HomeHeroMovie.tsx
@@ -3,6 +3,7 @@
 import ComputerIcon from "@mui/icons-material/Computer";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import MenuBookIcon from "@mui/icons-material/MenuBook";
+import RocketLaunchIcon from "@mui/icons-material/RocketLaunch";
 import { Box, Button, Container, Grid, Typography } from "@mui/material";
 import { ReactNode } from "react";
 
@@ -107,10 +108,16 @@ const HomeHeroMovie = () => {
           }}
         >
           <HeroButton
+            title="Start Tutorial"
+            icon={<RocketLaunchIcon />}
+            href="/docs/tutorial"
+            variant="contained"
+          />
+          <HeroButton
             title="Guide Documents"
             icon={<MenuBookIcon />}
             href="/docs"
-            variant="contained"
+            variant="outlined"
           />
           <HeroButton
             title="Playground"


### PR DESCRIPTION
## Summary

- Rewrite every reference page under `website/src/content/docs/**` for clarity. Concrete first example, clear mental model, restrictions stated up front, cross-links instead of duplicated paragraphs. Translated-style prose ("Yeah,", "You may understand", "I can sure") removed.
- Add a 7-step **Tutorial track** at `/docs/tutorial` that walks a beginner from `npm install` to a working LLM-driven Bookmark service. Same `Bookmark` type drives validation, JSON, HTTP, and LLM tools across the seven steps.
- Surface the Tutorial from the landing page hero and the docs sidebar.

## What changed

| Area | Before | After |
|------|--------|-------|
| Reference docs (35 pages) | Originally translated prose, repeating intro alerts, page-end benchmark tables on every validator page, occasional API drift from source | Each page opens with one-sentence what+why → smallest example → variants → restrictions → "where to go next". Cross-linked instead of repeated. |
| Tutorial | none | New 7-step track (`install` → `first-validator` → `refining-types` → `json` → `llm` → `integrations` → `next-steps`) |
| Landing page | "Guide Documents / Playground / GitHub" CTAs | Added "Start Tutorial" as the primary CTA |
| Sidebar `_meta.ts` | no Tutorial entry | Tutorial slot added between Setup and Pure TypeScript |

## How it was reviewed

Three rounds of the AGENTS.md §4.3 *Research Review Rounds* workflow, with the discussion records (knowledge bases, proposals, lead-validation) kept locally in `.discussions/website-rewrite/` for future reference. Across the three rounds the lead applied **34 verified fixes**: 8 broken anchor links, 11 beginner-experience improvements, 6 tutorial-flow corrections, 4 harness-consistency fixes, 2 API-completeness gap fills, and 3 source-accuracy corrections (`misc.clone` return type, `functional.equals*` naming, `Match` → `Matches` typo in the `class-validator` comparison).

`typos` reports clean across `website/src/content/`.

## Test plan

- [ ] `cd website && npm install && npm run build` to validate MDX, navigation, and rendering
- [ ] Visit the rendered site:
  - [ ] `/docs` — Introduction loads and lists "Start Tutorial" CTA
  - [ ] `/docs/tutorial` — Welcome page loads; each "→ next step" link resolves
  - [ ] `/docs/validators/is`, `assert`, `validate` — reference pages render with their LocalSource tabs and benchmark images
  - [ ] `/docs/llm/application` — strict-mode section renders and cross-link to `structuredOutput#strict-mode--reject-extra-properties` resolves
  - [ ] Anchor links — spot-check `validate#reusable-factories--and-standard-schema-support`, `tags#comment-tags--for-older-codebases`, `json#putting-it-all-together--the-validation-feedback-loop`
- [ ] `npx typos website/src/content` — clean
- [ ] Skim the new tutorial in order; verify each step's code copy-pastes and runs against the previous step's filesystem state

🤖 Generated with [Claude Code](https://claude.com/claude-code)