### PR TITLE
chore: drop dependabot groups for catalog dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,3 @@ updates:
     allow:
       - dependency-name: "@typescript/native-preview"
       - dependency-name: "ttsc"
-    groups:
-      typescript:
-        patterns:
-          - "@typescript/native-preview"
-          - "ttsc"


### PR DESCRIPTION
## Summary

- Drop the `groups: typescript` block from `.github/dependabot.yml` so `@typescript/native-preview` and `ttsc` arrive as separate dependabot PRs instead of a single grouped PR.
- Both packages live in `pnpm-workspace.yaml`'s `catalog:typescript`; the grouped update path trips two **currently-open** dependabot-core defects that desync the lockfile from `package.json`:
  - [dependabot/dependabot-core#12244](https://github.com/dependabot/dependabot-core/issues/12244) — "incorrectly updates pnpm lock `specifier` for versions specified in workspace catalog": dependabot rewrites the importer-level `specifier:` from `catalog:xxx` to a direct version constraint when bumping a cataloged package.
  - [dependabot/dependabot-core#14339](https://github.com/dependabot/dependabot-core/issues/14339) — "PNPM with catalog creates an incorrect pnpm-lock.yaml file": triggered specifically by `groups:` + multiple catalog dependencies.

## Concrete failure observed

PR #1855 (the grouped `@typescript/native-preview` + `ttsc` PR) failed CI with:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
because pnpm-lock.yaml is not up to date with <ROOT>/package.json
```

PR diff shows the exact #12244 symptom — only `ttsc`'s importer entry got rewritten, the other cataloged packages kept their catalog references:

```yaml
   ttsc:
-    specifier: catalog:typescript
-    version: 0.10.2
+    specifier: ^0.11.0
+    version: 0.11.0
```

`package.json` was unchanged (still `catalog:typescript`), so the frozen install bailed.

## Why this fix is the right scope

`groups:` removal is a direct mitigation for #14339 (the group-update lockfile-rewrite path is no longer entered). #12244 can still in principle fire for an individual catalog package, but single-package PRs reduce the trigger surface and let each bump be inspected on its own. If #12244 still fires on individual PRs, the next step is a post-PR fix-up workflow that re-runs `pnpm install --no-frozen-lockfile`, not adding `ignore:` (which would defeat the purpose of dependabot watching the catalog).

## Follow-up

PR #1855 is stale anyway (it tries to downgrade `ttsc` to `^0.11.0` while master is already on `^0.12.3`). After this lands, close #1855 and wait for the next dependabot cycle to open fresh per-package PRs.

## Test plan

- [ ] Wait for the next dependabot run after merge.
- [ ] Confirm two separate PRs appear (one for `@typescript/native-preview`, one for `ttsc`) instead of one grouped PR.
- [ ] Confirm each PR's `pnpm-lock.yaml` keeps `specifier: catalog:typescript` on its target package, and that CI's `pnpm install` no longer fails with `ERR_PNPM_OUTDATED_LOCKFILE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)