### PR TITLE
fix(typia): avoid panic on qualified JSDoc parameter names

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/benchmark",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Benchmark program of typia performance",
   "main": "bin/index.js",
   "scripts": {

--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/config",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Shared build configuration for typia packages",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/examples",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Example codes for typia website",
   "scripts": {
     "build": "rimraf bin && ttsc && prettier --write --ignore-path /dev/null \"bin/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm run build:packages",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -201,13 +201,38 @@ func metadata_js_doc_parameter_name(tag *nativeast.Node) string {
   if tag.Kind.String() != "KindJSDocParameterTag" && tag.Kind.String() != "KindJSDocPropertyTag" {
     return ""
   }
-  // `name` is a DeclarationName: typically an Identifier, but for nested
-  // JSDoc parameter names like `@param obj.field description` the parser
-  // produces a QualifiedName, and upstream's (*Node).Text() panics with
-  // `Unhandled case in Node.Text: *ast.QualifiedName` if we call .Text()
-  // directly. NodeText in the ttsc shim covers QualifiedName and any
-  // other DeclarationName Kind that upstream's switch doesn't.
-  return nativeast.NodeText(tag.AsJSDocParameterOrPropertyTag().Name())
+  return metadata_js_doc_parameter_name_text(tag.AsJSDocParameterOrPropertyTag().Name())
+}
+
+// `name` is a DeclarationName: typically an Identifier, but for nested
+// JSDoc parameter names like `@param obj.field description` the parser
+// produces a QualifiedName, and upstream's (*Node).Text() panics with
+// `Unhandled case in Node.Text: *ast.QualifiedName` if we call .Text()
+// directly. Walk the qualified chain manually and fall back to Text() for
+// the leaf Identifier.
+func metadata_js_doc_parameter_name_text(name *nativeast.Node) string {
+  if name == nil {
+    return ""
+  }
+  if name.Kind == nativeast.KindQualifiedName {
+    qn := name.AsQualifiedName()
+    if qn == nil {
+      return ""
+    }
+    left := metadata_js_doc_parameter_name_text(qn.Left)
+    right := ""
+    if qn.Right != nil {
+      right = qn.Right.Text()
+    }
+    if left == "" {
+      return right
+    }
+    if right == "" {
+      return left
+    }
+    return left + "." + right
+  }
+  return name.Text()
 }
 
 func metadata_js_doc_type_expression_text(tag *nativeast.Node) string {

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -201,11 +201,13 @@ func metadata_js_doc_parameter_name(tag *nativeast.Node) string {
   if tag.Kind.String() != "KindJSDocParameterTag" && tag.Kind.String() != "KindJSDocPropertyTag" {
     return ""
   }
-  name := tag.AsJSDocParameterOrPropertyTag().Name()
-  if name == nil {
-    return ""
-  }
-  return name.Text()
+  // `name` is a DeclarationName: typically an Identifier, but for nested
+  // JSDoc parameter names like `@param obj.field description` the parser
+  // produces a QualifiedName, and upstream's (*Node).Text() panics with
+  // `Unhandled case in Node.Text: *ast.QualifiedName` if we call .Text()
+  // directly. NodeText in the ttsc shim covers QualifiedName and any
+  // other DeclarationName Kind that upstream's switch doesn't.
+  return nativeast.NodeText(tag.AsJSDocParameterOrPropertyTag().Name())
 }
 
 func metadata_js_doc_type_expression_text(tag *nativeast.Node) string {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/debug",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Convenient debug program for typia",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/template/package.json
+++ b/tests/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/template",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Template structures for typia testing.",
   "main": "lib/index.js",
   "types": "src/index.ts",

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-error",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Test program of typia generated error",
   "main": "index.js",
   "scripts": {

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-langchain",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Test suite for @typia/langchain package",
   "scripts": {
     "start": "ttsx src/index.ts",

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-mcp",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Test suite for @typia/mcp package",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-automated",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Automated test features of typia.",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-generate",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Test typia generation command",
   "scripts": {
     "build": "ttsc",

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-schema",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Test features for JSON schema, LLM schema and protobuf message of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-openapiautomated",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Automated test features of openapi.",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-utils",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Automated test features of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-vercel",
-  "version": "13.0.0-dev.20260519",
+  "version": "13.0.0-dev.20260520",
   "description": "Test suite for @typia/vercel package",
   "scripts": {
     "start": "ttsx src/index.ts",


### PR DESCRIPTION
## Summary
- `metadata_js_doc_parameter_name` previously called `.Text()` directly on the JSDoc tag's `Name()`. For nested parameter names like `@param obj.field description`, the parser produces a `QualifiedName`, which upstream typescript-go's `(*Node).Text()` switch does not handle — it panics with `Unhandled case in Node.Text: *ast.QualifiedName`.
- Route the name through `nativeast.NodeText`, the ttsc shim that covers `QualifiedName` and other `DeclarationName` kinds the upstream switch misses. The shim is also nil-safe, so the explicit nil guard is no longer needed.

## Test plan
- [ ] `pnpm test:go`
- [ ] `go test -tags typia_native_internal ./...` from `packages/typia/test`
- [ ] `pnpm test` (full suite, since the transform path is touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)