### PR TITLE
test(mcp): add error handling and unknown tool tests, document runtim…

### DIFF
--- a/tests/test-mcp/src/features/test_mcp_class_controller_error_handling.ts
+++ b/tests/test-mcp/src/features/test_mcp_class_controller_error_handling.ts
@@ -1,0 +1,90 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { registerMcpControllers } from "@typia/mcp";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+/**
+ * Verifies MCP tool handler catches runtime errors and returns `isError: true`.
+ *
+ * Locks the error-catching branch of `McpControllerRegistrar.handleToolCall`.
+ * When a tool's `execute` function throws (e.g. division by zero), the handler
+ * must catch the error and return a well-formed `CallToolResult` with
+ * `isError: true` and the error message as text content, rather than letting
+ * the exception propagate and crash the MCP server.
+ *
+ * 1. Register a `Calculator` controller with the MCP server.
+ * 2. Invoke the `divide` tool with `y: 0` to trigger a division-by-zero error.
+ * 3. Assert the result has `isError: true`.
+ * 4. Assert the text content contains the "Division by zero" error message.
+ */
+export const test_mcp_class_controller_error_handling =
+  async (): Promise<void> => {
+    // 1. Create class-based controller using typia.llm.controller
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+
+    // 2. Create McpServer with tools capability
+    const mcpServer: McpServer = new McpServer(
+      {
+        name: "test-server",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      },
+    );
+
+    // 3. Register controller
+    registerMcpControllers({
+      server: mcpServer,
+      controllers: [controller],
+      preserve: false,
+    });
+
+    // 4. Get tools/call handler
+    const rawServer: Server = mcpServer.server;
+    const requestHandlers: Map<string, Function> = (rawServer as any)
+      ._requestHandlers;
+    const callHandler: Function = requestHandlers.get("tools/call")!;
+
+    // 5. Test divide by zero (throws an error)
+    const result: CallToolResult = await callHandler(
+      {
+        method: "tools/call",
+        params: {
+          name: "divide",
+          arguments: {
+            x: 10,
+            y: 0,
+          },
+        },
+      },
+      { signal: new AbortController().signal },
+    );
+
+    // 6. Verify the result is an error
+    TestValidator.predicate(
+      "result should have isError: true",
+      () => result.isError === true,
+    );
+
+    // 7. Verify the error message contains the expected text
+    TestValidator.predicate(
+      "error should contain division by zero message",
+      () =>
+        result.content.some(
+          (c) =>
+            c.type === "text" &&
+            (c as { type: "text"; text: string }).text.includes(
+              "Division by zero",
+            ),
+        ),
+    );
+  };

--- a/tests/test-mcp/src/features/test_mcp_class_controller_unknown_tool.ts
+++ b/tests/test-mcp/src/features/test_mcp_class_controller_unknown_tool.ts
@@ -1,0 +1,86 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { registerMcpControllers } from "@typia/mcp";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+/**
+ * Verifies MCP tool handler returns `isError: true` for unknown tool names.
+ *
+ * Locks the unknown-tool fallback branch of `McpControllerRegistrar`'s
+ * `tools/call` handler. When an LLM calls a tool name that doesn't exist in
+ * the registry, the handler must return a well-formed `CallToolResult` with
+ * `isError: true` and a descriptive message, rather than throwing or
+ * returning undefined.
+ *
+ * 1. Register a `Calculator` controller with the MCP server.
+ * 2. Invoke a non-existent tool name `"nonExistentTool"`.
+ * 3. Assert the result has `isError: true`.
+ * 4. Assert the text content contains `"Unknown tool: nonExistentTool"`.
+ */
+export const test_mcp_class_controller_unknown_tool =
+  async (): Promise<void> => {
+    // 1. Create class-based controller using typia.llm.controller
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+
+    // 2. Create McpServer with tools capability
+    const mcpServer: McpServer = new McpServer(
+      {
+        name: "test-server",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      },
+    );
+
+    // 3. Register controller
+    registerMcpControllers({
+      server: mcpServer,
+      controllers: [controller],
+      preserve: false,
+    });
+
+    // 4. Get tools/call handler
+    const rawServer: Server = mcpServer.server;
+    const requestHandlers: Map<string, Function> = (rawServer as any)
+      ._requestHandlers;
+    const callHandler: Function = requestHandlers.get("tools/call")!;
+
+    // 5. Call a non-existent tool
+    const result: CallToolResult = await callHandler(
+      {
+        method: "tools/call",
+        params: {
+          name: "nonExistentTool",
+          arguments: {},
+        },
+      },
+      { signal: new AbortController().signal },
+    );
+
+    // 6. Verify the result is an error
+    TestValidator.predicate(
+      "result should have isError: true",
+      () => result.isError === true,
+    );
+
+    // 7. Verify the error message references the unknown tool name
+    TestValidator.predicate(
+      "error should contain unknown tool name",
+      () =>
+        result.content.some(
+          (c) =>
+            c.type === "text" &&
+            (c as { type: "text"; text: string }).text ===
+              "Unknown tool: nonExistentTool",
+        ),
+    );
+  };

--- a/website/src/content/docs/utilization/mcp.mdx
+++ b/website/src/content/docs/utilization/mcp.mdx
@@ -197,9 +197,38 @@ By default `registerMcpControllers` owns the server's tool list. If you've alrea
 
 In the test above, an `"echo"` tool registered through `McpServer.registerTool` lives alongside four calculator tools registered through `registerMcpControllers` — five tools total. If two registrations would produce the same tool name, registration fails at startup so you can fix it before clients ever see the conflict.
 
+## Runtime errors
+
+There are two distinct failure modes when a tool is called:
+
+- **Validation error** — the LLM passed arguments that don't match the schema. The tool returns `isError: true` with the annotated input (same `// ❌` markers as above) so the model can fix it.
+- **Runtime error** — the tool itself threw (e.g. divide-by-zero, network error, business-rule violation). The tool returns `isError: true` with the error name and message.
+
+In both cases the MCP conversation stays alive — the model sees the failure and can either retry with different inputs or inform the user.
+
+<Tabs items={[
+    "Error handling test",
+    <code>Calculator</code>,
+  ]}>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-mcp/src/features/test_mcp_class_controller_error_handling.ts"
+      filename="test_mcp_class_controller_error_handling.ts"
+      showLineNumbers
+      highlight="61-75, 77-91" />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-mcp/src/structures/Calculator.ts"
+      filename="Calculator.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
 ## Where to go next
 
 - Same idea, different framework → [Vercel AI SDK](/docs/utilization/vercel) · [LangChain](/docs/utilization/langchain)
 - Source TypeScript class for the tools → [`typia.llm.application`](/docs/llm/application)
 - Source OpenAPI document for the tools → [`HttpLlm`](/docs/llm/http)
+- Harness internals (`parse`, `coerce`, `validate`, `stringify`) → [`LlmJson`](/docs/llm/json)
 - Building a full chatbot → [Agentica](/docs/llm/chat)


### PR DESCRIPTION
## Summary

Adds two missing test cases to `@typia/mcp` and improves the MCP documentation.

### Tests
- **`test_mcp_class_controller_error_handling`**: Verifies that runtime errors (e.g. divide-by-zero) are caught and returned as `isError: true` with the error message — exercises the catch branch of `McpControllerRegistrar.handleToolCall`.
- **`test_mcp_class_controller_unknown_tool`**: Verifies that calling a non-existent tool returns `isError: true` with `"Unknown tool: ..."` — exercises the standalone handler fallback.

### Documentation
- Added "Runtime errors" section to `website/src/content/docs/utilization/mcp.mdx`, documenting the two failure modes (validation error vs runtime error) with a tabbed code example. This matches the pattern already established in the Vercel AI SDK docs.
- Added "Harness internals" link to the "Where to go next" section for parity with the Vercel docs page.

### Context
Comparing test coverage across the three adapter packages revealed that `@typia/mcp` (9 tests) was missing the error handling test that `@typia/vercel` had. The MCP documentation was also missing the "Runtime errors" section that the Vercel docs covered.
