### PR TITLE
fix(typia): jsdoc qualified parameter names

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/benchmark",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Benchmark program of typia performance",
   "main": "bin/index.js",
   "scripts": {

--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/config",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Shared build configuration for typia packages",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/examples",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Example codes for typia website",
   "scripts": {
     "build": "rimraf bin && ttsc && prettier --write --ignore-path /dev/null \"bin/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm run build:packages",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -205,7 +205,48 @@ func metadata_js_doc_parameter_name(tag *nativeast.Node) string {
   if name == nil {
     return ""
   }
-  return name.Text()
+  return metadata_js_doc_name_text(name)
+}
+
+func metadata_js_doc_name_text(node *nativeast.Node) string {
+  if text := metadata_node_source_text(node); text != "" {
+    return text
+  }
+  if node == nil {
+    return ""
+  }
+  if node.Kind == nativeast.KindQualifiedName {
+    name := node.AsQualifiedName()
+    if name == nil {
+      return ""
+    }
+    left := metadata_js_doc_name_text(name.Left)
+    right := metadata_js_doc_name_text(name.Right)
+    if left == "" {
+      return right
+    }
+    if right == "" {
+      return left
+    }
+    return left + "." + right
+  }
+  return node.Text()
+}
+
+func metadata_node_source_text(node *nativeast.Node) string {
+  if node == nil {
+    return ""
+  }
+  file := nativeast.GetSourceFileOfNode(node)
+  if file == nil {
+    return ""
+  }
+  source := file.Text()
+  start, end := node.Pos(), node.End()
+  if start < 0 || end > len(source) || start >= end {
+    return ""
+  }
+  return strings.TrimSpace(source[start:end])
 }
 
 func metadata_js_doc_type_expression_text(tag *nativeast.Node) string {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260520.3",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260520.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/test/go.work.sum
+++ b/packages/typia/test/go.work.sum
@@ -1,6 +1,5 @@
-github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/mackerelio/go-osstat v0.2.7/go.mod h1:dwpYh5pIPmvk+IEwBKNIWRFMB92mrC08CmXOhDC7nQk=
 github.com/matryer/moq v0.7.1/go.mod h1:IabIiFkaKCyHxej25INgFR+fnOxSZFMv2LYrU+ioyDs=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=

--- a/packages/typia/test/native/core/factories/internal/metadata/js_doc_parameter_name_reads_qualified_name_test.go
+++ b/packages/typia/test/native/core/factories/internal/metadata/js_doc_parameter_name_reads_qualified_name_test.go
@@ -1,0 +1,55 @@
+//go:build typia_native_internal
+// +build typia_native_internal
+
+package metadata
+
+import (
+	"path/filepath"
+	"testing"
+
+	nativeast "github.com/microsoft/typescript-go/shim/ast"
+	nativecore "github.com/microsoft/typescript-go/shim/core"
+	nativeparser "github.com/microsoft/typescript-go/shim/parser"
+)
+
+// TestJSDocParameterNameReadsQualifiedName verifies dotted JSDoc parameter names.
+//
+// TypeScript-Go represents `@param input.value` names as QualifiedName nodes,
+// and upstream Node.Text panics for that kind. Metadata extraction must read
+// the source span instead so generated Nestia/typia metadata can include nested
+// JSDoc parameter comments without aborting the native transform.
+//
+// 1. Parse an interface member with `@param input.value`.
+// 2. Walk the parsed JSDoc tags.
+// 3. Read each parameter name through the metadata helper.
+// 4. Assert the dotted name is returned without a panic.
+func TestJSDocParameterNameReadsQualifiedName(t *testing.T) {
+	file := nativeparser.ParseSourceFile(
+		nativeast.SourceFileParseOptions{FileName: filepath.Join(t.TempDir(), "qualified.ts")},
+		`interface Box {
+  /**
+   * @param input.value nested value
+   */
+  field: string;
+}
+`,
+		nativecore.ScriptKindTS,
+	)
+	member := file.Statements.Nodes[0].AsInterfaceDeclaration().Members.Nodes[0]
+
+	found := false
+	for _, jsdoc := range member.JSDoc(nil) {
+		doc := jsdoc.AsJSDoc()
+		if doc == nil || doc.Tags == nil {
+			continue
+		}
+		for _, tag := range doc.Tags.Nodes {
+			if metadata_js_doc_parameter_name(tag) == "input.value" {
+				found = true
+			}
+		}
+	}
+	if found == false {
+		t.Fatal("qualified JSDoc parameter name was not discovered")
+	}
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/debug",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Convenient debug program for typia",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/template/package.json
+++ b/tests/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/template",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Template structures for typia testing.",
   "main": "lib/index.js",
   "types": "src/index.ts",

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-error",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Test program of typia generated error",
   "main": "index.js",
   "scripts": {

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-langchain",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Test suite for @typia/langchain package",
   "scripts": {
     "start": "ttsx src/index.ts",

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-mcp",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Test suite for @typia/mcp package",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-automated",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Automated test features of typia.",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-generate",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Test typia generation command",
   "scripts": {
     "build": "ttsc",

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-schema",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Test features for JSON schema, LLM schema and protobuf message of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_application_qualified_param.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_application_qualified_param.ts
@@ -1,0 +1,38 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmApplication } from "@typia/interface";
+import typia from "typia";
+
+/**
+ * Verifies typia.llm.application accepts dotted JSDoc parameter names.
+ *
+ * TypeScript-Go parses `@param input.value` as a qualified name. The native
+ * metadata reader must preserve that text without calling `Node.Text()` on the
+ * qualified-name node, otherwise controller documentation from Nestia-style
+ * inputs can abort the transform before an application schema is emitted.
+ *
+ * 1. Declare a controller method with `@param input.value` documentation.
+ * 2. Generate the LLM application schema for that controller.
+ * 3. Assert the function and its parameter schema are present.
+ */
+export const test_llm_application_qualified_param = (): void => {
+  interface IRequest {
+    value: string;
+  }
+  interface IController {
+    /**
+     * Accept a nested request value.
+     *
+     * @param input.value Nested value documentation
+     */
+    accept(input: IRequest): void;
+  }
+
+  const app: ILlmApplication = typia.llm.application<IController>();
+  const func = app.functions.find((f) => f.name === "accept");
+
+  TestValidator.predicate("function exists", () => func !== undefined);
+  TestValidator.predicate(
+    "parameter schema exists",
+    () => func?.parameters.properties.input !== undefined,
+  );
+};

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-openapiautomated",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Automated test features of openapi.",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-utils",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Automated test features of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-vercel",
-  "version": "13.0.0-dev.20260520.2",
+  "version": "13.0.0-dev.20260521.1",
   "description": "Test suite for @typia/vercel package",
   "scripts": {
     "start": "ttsx src/index.ts",


### PR DESCRIPTION
## Summary
- Avoid `Node.Text()` for JSDoc parameter/property names when TypeScript-Go parses them as qualified names such as `input.value`.
- Add Go and TypeScript regression coverage for dotted `@param` names from Nestia-style controller docs.
- Bump the `typia` package dev version and keep `packages/typia/test/go.work.sum` in sync with the current Go workspace checksum set.

## Validation
- `pnpm test:go`
- `go test ./...` from `packages/typia/native`
- `pnpm --filter ./tests/test-typia-schema start`

## Note
- `go test -tags typia_native_internal ./...` from `packages/typia/test` still fails in the existing internal-test packages because their mirrored test packages cannot see native implementation symbols / internal imports. This failure is not specific to the new qualified-name test.
