### PR TITLE
docs(agents): split AGENTS.md into .codex/skills/* skill files

### DIFF
--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -1,0 +1,36 @@
+# Benchmark
+
+Read before running, modifying, or publishing benchmark results. The benchmark is the private `@typia/benchmark` workspace under `benchmark/`.
+
+## What it measures
+
+Throughput (MB/sec) of typia against competing libraries, across the canonical structure fixtures (`ObjectSimple`, `ObjectHierarchical`, `ObjectRecursive`, the union and array variants, `UltimateUnion`). `src/index.ts` drives ten categories:
+
+| Category | Operation | Compared against |
+| --- | --- | --- |
+| `is` | `typia.is` type guard (truthy path) | typebox, ajv, io-ts, zod, class-validator |
+| `assert` | `typia.assert` (throwing path) | same |
+| `validate` | `typia.validate` (error-collecting path) | same |
+| `assert-error` / `validate-error` | the same two on invalid input | same |
+| `optimizer` | optimized `is` codegen | typebox, class-validator |
+| `stringify` | `typia.json.*Stringify` | fast-json-stringify, `JSON.stringify`, class-transformer |
+| `server-assert` / `server-stringify` / `server-performance` | request/response cost in a real server | Express and Fastify, typia vs pure vs class-transformer |
+
+Each program wraps an operation in a `benchmark` Suite; `BenchmarkServer` runs programs in `tgrid` worker processes; `BenchmarkReporter` writes the markdown report and `HorizontalBarChart` renders the D3 SVGs.
+
+## Running
+
+```bash
+pnpm template   # regenerate src/programs/ from src/template/*.ts, then format + build
+pnpm build      # ttsc build → bin/   (tsconfig applies the typia transform plugin)
+pnpm start      # node bin/ → writes results for this machine
+pnpm start:bun  # bun bin/bun.js → Bun-runtime results
+```
+
+`pnpm start` keys the output directory off `os.cpus()[0].model`, so a run writes to `benchmark/results/<your CPU model>/` — `README.md` (the report: host metadata, one section per category with a table and an SVG) plus `images/*.svg`. A Bun run lands under `benchmark/results/<CPU>/bun/`.
+
+## Conventions
+
+- **`src/programs/` is generated.** It is produced by `pnpm template` from `src/template/*.ts` (one template module per category). Don't hand-edit `src/programs/`; to add a library or category, edit the matching template module, then regenerate. The benchmark carries its own fixtures under `src/structures/` (it does not import `@typia/template`), so add or change shapes there.
+- **Results are archived per CPU.** Each `results/<CPU model>/` directory is one machine's committed report. A new machine adds a new directory; don't overwrite another machine's results with yours. The markdown tables and SVGs are the published artifact (no JSON is kept in `results/`).
+- **Add a competitor by adding its programs and schemas.** Library-specific schemas live under `src/structures/<library>/`; the template that generates that category's programs must reference them. Keep the structure set identical across libraries so a row compares like for like.

--- a/.codex/skills/development/SKILL.md
+++ b/.codex/skills/development/SKILL.md
@@ -1,0 +1,76 @@
+# Development
+
+Read before writing or modifying code.
+
+## Work Rules
+
+- Match existing conventions. Before adding a file, function, or test, open a nearby peer in the same package and mirror its naming, location, and code style — don't create parallel structures.
+- Respect package boundaries. The Go source for the native transform lives in `packages/typia/native` and is shared across the typia plugin family. Don't fork a second native transform, and don't reintroduce a TypeScript-side transformer.
+- Preserve the contract. The public surface defined in `.codex/skills/project/SKILL.md` § What Typia Is changes only as a deliberate, separate change — don't rename or remove any of it incidentally.
+- Keep detection general. The native transform must locate target packages through their resolved package root (e.g. `require.resolve("typia/package.json")`), not through workspace-only path substrings — substring matching breaks the moment a consumer installs from npm, because the workspace path no longer exists and the transform can't locate the typia package. The same rule applies to generators: no hard-coded test, structure, or feature names.
+- Use the workspace catalogs. `pnpm-workspace.yaml` pins versions under `catalog:typescript`, `catalog:rollup`, and `catalog:utils`. New dependencies go through the matching catalog; internal references use `workspace:^`.
+- Don't commit `.env` files or the `.tgz` artifacts under `experiments/tarballs/`. Those are local build outputs; committing them corrupts the workflow.
+- Run `pnpm format` and stage the result before committing; never commit unformatted output. Note that `pnpm format` covers `**/*.ts` and Go only, not Markdown (see `.codex/skills/documentation/SKILL.md`).
+- When public behavior changes, update the matching guide page under `website/src/content/docs/**` in the same change.
+- When uncertain about scope, intent, or whether to invoke a multi-agent workflow, ask the user before automating.
+
+## Testing
+
+**One test case per file, named after what it asserts.** Applies to both layers.
+
+### Go unit tests
+
+Live under `packages/typia/test/` (mirroring the source layout — `native/cmd/`, `native/adapter/`, `native/transform/`, `metadata/`, …). One `Test*` per file, named after the assertion. Two layers coexist:
+
+- *Native-internal tests* under `packages/typia/test/native/` are gated by `//go:build typia_native_internal` and only run with `go test -tags typia_native_internal ./...`. They use `package main` and call the cmd entrypoints (e.g. `runBuild`) directly inside the test process; nothing spawns a `go run` subprocess.
+- *Public-API tests* under `adapter/`, `contract/`, `helpers/`, `internal/`, `metadata/`, `typings/`, `utils/` carry no build tag and run by default.
+
+### TypeScript suites
+
+The `tests/test-*` workspaces come in four shapes:
+
+- *Function-per-file* (`test-typia-schema`, `test-langchain`, `test-mcp`, `test-vercel`, `test-utils`): each file under `src/features/<group>/` exports exactly one `test_<snake_case>` function with a matching file name; `DynamicExecutor` (from `@nestia/e2e`) discovers them by prefix. Each adapter package (`@typia/langchain`, `@typia/mcp`, `@typia/vercel`) has a mirrored `tests/test-{name}` workspace under the same shape.
+- *Generator-driven matrix* (`test-typia-automated`, `test-utils-automated`): cross-product every typia operation with every `@typia/template` structure. `test-typia-automated` keeps the committed `src/composite/` files (ObjectSimple-only sanity layer) and additionally regenerates `src/features/<group>/` on every run via `TestAutomationController`; `test-utils-automated` regenerates `src/features/{validate,validateEquals}/` via `TestAutomation.generate()`. **Do not hand-edit anything under the regenerated `src/features/` trees — the next run discards it.** Add new operations or structures to the generator metadata and to `@typia/template`.
+- *CLI-driven generation* (`test-typia-generate`): hand-author `src/input/generate_*.ts`; `pnpm start` runs `typia generate` to write `src/output/` and then `ttsc`-compiles it. The suite passes if `ttsc` accepts the generated output.
+- *Stripping verification* (`test-error`): each `src/<group>/<name>.ts` is a typia call site that the transform must remove from emitted JS. The build succeeds with `ttsc --emit`; the harness compares `();` counts between source and bin and fails if the call survives.
+
+### Doc comments
+
+Open every case with a doc comment in the same three-part shape: a one-line `Verifies …` headline, a short paragraph stating the non-obvious *why* (which branch or regression is being pinned), and a 2–4-step numbered scenario.
+
+```ts
+/**
+ * Verifies typia.llm.schema emits `anyOf` for a discriminated union.
+ *
+ * Locks the union branch of the LLM schema converter. Object-shaped types
+ * route through `LlmTypeChecker.isObject`, but a named union has to be lifted
+ * into `$defs` and referenced via `$ref`, with `anyOf` describing the variants.
+ * A regression in branch selection would silently inline one variant and drop
+ * the other from the function-calling schema.
+ *
+ * 1. Declare two interfaces with a shared `type` discriminator and union them.
+ * 2. Call `typia.llm.schema<Animal>($defs)`.
+ * 3. Assert the call returns a `$ref`, and that `$defs["Animal"]` is `anyOf`.
+ */
+export const test_llm_schema_anyof = (): void => { /* ... */ };
+```
+
+Use `TestValidator` and `DynamicExecutor` from `@nestia/e2e` and each suite's local `internal/` helpers; don't reach into another suite's internals. Structure fixtures plus the `TestServant` runtime helper live in `@typia/template` — extend that package instead of duplicating shapes inside a test workspace.
+
+## Validation
+
+Match the scope of the command to the scope of the change. Report any command you couldn't run.
+
+- Touched the Go binary → `pnpm test:go` (runs `go test ./...` under `packages/typia/test` *without* the `typia_native_internal` build tag, so the public-API layer is exercised but the native-internal tests are skipped). For full coverage, also run `go test -tags typia_native_internal ./...` from the same directory; both require a prior `pnpm install`.
+- Touched one test workspace → `pnpm --filter ./tests/<name> start`.
+- Touched the transform, descriptors, or a shared package → `pnpm test`.
+- Touched packaging → `pnpm package:tgz` from `experiments/tarballs` (stages tarballs the website consumes) and try a clean install. Don't commit or hand-edit the staged tarballs.
+- Touched `website/src/content/docs/**` or anything else under `website/` → `cd website && npm install && npm run build` to validate MDX, nav, and tarball pickup.
+
+## Change Integrity
+
+Treat tests, fixtures, snapshots, CI workflows, package wiring, dependencies, core algorithms, and generated baselines as part of the specification. Changing them requires an explicit user request or a clear product reason, and the final report must call it out.
+
+When the Go source under `packages/typia/native` changes, the `typia` package version must bump in the same commit or PR — the native source ships in the npm package (declared in `packages/typia/package.json` `files`) and ttsc compiles it into a binary on first use, so a source change without a version bump leaves consumers' `npm install` returning a tree that compiles to the stale binary.
+
+For mechanical ports, migrations, or broad rewrites, preserve the existing algorithm and public behavior in reviewable slices. Prefer a concrete exemplar over abstract instructions, and inspect the diff before trusting a green test run.

--- a/.codex/skills/documentation/SKILL.md
+++ b/.codex/skills/documentation/SKILL.md
@@ -1,0 +1,31 @@
+# Documentation
+
+Read before writing or modifying docs.
+
+## READMEs
+
+README files are for the final reader of that package or directory. Start with what it is, when to use it, installation, the smallest working setup, and the common path. Keep the language direct and practical. Move compiler internals, protocol details, and edge cases into the website guides and link them as the next step.
+
+## Guide Documents
+
+User-facing guides live under `website/src/content/docs/**` as MDX and publish to https://typia.io/docs. The site is built with Next.js + Nextra (docs theme), exported as a static site, and deployed to GitHub Pages. One audience, one task per page.
+
+The tree is organized by feature area: top-level pages (`index.mdx`, `pure.mdx`, `random.mdx`, `misc.mdx`) for cross-cutting topics, `setup/` for installation and toolchain choices, and per-feature folders (`validators/`, `json/`, `protobuf/`, `llm/`) for the operation guides, plus `utilization/` for framework integrations (NestJS, tRPC, Hono, MCP, Vercel AI SDK, LangChain). Each folder owns a `_meta.ts` that sets sidebar order and labels (Nextra reads it as the source of truth; keys appear in declared order, and `{ display: "hidden" }` keeps a page reachable but off the nav). Update the matching `_meta.ts` when adding, renaming, or moving a guide. `llm/` runs deepest: beyond its operation guides it holds the adapter-architecture and integration patterns that `utilization/` only wires up.
+
+Pages pair a TypeScript source block with its compiled JavaScript in side-by-side tabs so the reader sees what the transform emits. Performance claims are backed by benchmark numbers, not adjectives.
+
+## Prose line breaks
+
+Write Markdown and MDX prose as one line per paragraph, matching the existing docs; never hard-wrap at a fixed column. Markdown soft-wraps on render, so a manual line break mid-paragraph changes nothing visible while making diffs noisy and edits awkward. Keep real line breaks only for paragraph boundaries, list items, headings, tables, and fenced code.
+
+This is a hand-maintained convention, not a format gate: `pnpm format` runs `prettier --write "**/*.ts"` plus the Go formatter and does **not** touch `*.md` / `*.mdx`, and the prettier config sets no `prose-wrap`. Keep the one-line-per-paragraph shape yourself.
+
+## Voice
+
+Write in the plain, direct, technical voice of the human-authored docs in this repo. Do not write like an AI assistant.
+
+- No AI-cliche phrasing: "not only X but also Y", "whether you're X or Y", "it's worth noting", "let's dive in", and reflexive hedging.
+- No marketing adjectives ("seamless", "powerful", "robust", "effortless"). State the behavior; where speed is the point, cite the benchmark instead of praising it.
+- No wrap-up sentence that just restates the paragraph. State the fact and stop.
+
+(Em-dashes and the emoji used in `_meta.ts` sidebar labels match the existing docs — keep them where they already fit. The point is plain, accurate prose, not a punctuation ban.)

--- a/.codex/skills/multi-agent/SKILL.md
+++ b/.codex/skills/multi-agent/SKILL.md
@@ -1,0 +1,59 @@
+# Multi-Agent Workflows
+
+Use only when the user explicitly asks for one of the named modes — Review Cycle, Discussion, or Research Review Round. Each mode composes the shared building blocks below; do not invent unnamed combinations. Read the **Briefing subagents** rule before delegating to any subagent; read a mode in full only when the user asks for it by name.
+
+## Building Blocks
+
+### Six-agent team
+
+Form a team of six agents. For looped modes, replace the team with six different agents at the start of each round or cycle.
+
+### Lead role
+
+The lead agent coordinates the team. In modes that produce proposals, the lead rechecks every proposal against the codebase and applies only changes that are technically sound and relevant. In modes that produce transcripts, the lead moderates and scribes, writing each statement in speaking order, recording the live discussion (not a retrospective summary), and not narrowing the topic unless the user did.
+
+### Briefing subagents
+
+Subagents start blind: they carry no conversation history and do not auto-load `AGENTS.md` or the skills. Give each a self-contained brief with the objective, the constraints, the context it needs, the output format, and which `AGENTS.md` sections (at least `## Attitude`) and `.codex/skills/*/SKILL.md` files to read. State the evidence and the constraints, not a pre-chosen answer; a leading hypothesis steers the agent to a shallow fix. A subagent runs its brief directly and does not re-delegate.
+
+### Topic directory
+
+Create `.discussions/<topic>/` with a short filesystem-safe topic name. Do not delete or overwrite existing discussion directories unless the user explicitly requests it.
+
+### Per-agent knowledge base
+
+Each agent creates a personal subdirectory under the topic directory and continuously maintains its own wiki-style knowledge base there. Between turns, agents read the updated transcript and each other's statements, keep researching, revise their knowledge bases, and prepare notes.
+
+### Three transcript rounds
+
+Run three unrestricted rounds recorded as `round1.md`, `round2.md`, and `round3.md`. Each round has a one-hour budget.
+
+### Stop condition for looped modes
+
+Continue while at least one verified proposal is accepted. Stop when no agent proposes an improvement, or when no proposal survives lead-agent validation.
+
+## Modes
+
+### Review Cycle
+
+Direct review of changed source, docs, and tests. No topic directory, no transcripts.
+
+1. Form the team. Each agent reads the changed source/docs/tests in full and proposes concrete improvements.
+2. Lead validates each proposal against the codebase and applies surviving ones.
+3. Start the next cycle with a fresh team. Apply the stop condition.
+
+### Discussion
+
+Open-ended topic exploration without changing code. No proposals, no validation.
+
+1. Create the topic directory. Form the team; each builds its knowledge base.
+2. Run the three transcript rounds directly under the topic directory.
+3. After `round3.md`, the lead writes agreed conclusions and major open points into `summary.md`, reports to the user, and waits.
+
+### Research Review Round
+
+Review that needs shared research before individual proposals — the discussion KB workflow plus the validation loop.
+
+1. Create the topic directory. Each round lives in its own `review-round-N/` subdirectory containing fresh agents' KB folders, `round1.md`, `round2.md`, `round3.md`, `proposals.md`, and `lead-validation.md`.
+2. In each round: agents build KBs from changed source/docs/tests plus relevant research → three transcript rounds → each agent submits its own concrete proposals (no consensus required; discussion is for shared understanding, not voting) → lead validates and applies surviving ones.
+3. Fresh team next round; apply the stop condition.

--- a/.codex/skills/project/SKILL.md
+++ b/.codex/skills/project/SKILL.md
@@ -1,0 +1,55 @@
+# Project Outline
+
+## What Typia Is
+
+Typia is a TypeScript transformer library built around one idea: a pure TypeScript type definition should replace the runtime helpers that other tools require schemas, decorators, or hand-written guards for. The compile-time transform reads those types and emits the runtime validator, serializer, schema, or decoder inline.
+
+The packages:
+
+- **`typia`** — the user-facing library and `typia` CLI. Exposes the runtime validators (`is`, `assert`, `assertGuard`, `validate`), enhanced JSON serde (`json.assertParse`, `json.assertStringify`, `json.schema`), LLM function-calling harness (`llm.application`, `llm.schema`, `llm.parse`, `llm.structuredOutput`), Protocol Buffer encoder/decoder (`protobuf.message`, `protobuf.assertEncode`, `protobuf.assertDecode`), and the random data generator (`random`).
+- **`@typia/interface`** — shared public typings (e.g. `IJsonSchema`, `ILlmSchema`, `IValidation`) consumed by every other package and by user code.
+- **`@typia/utils`** — runtime, OpenAPI, and LLM utility helpers (e.g. `LlmTypeChecker`) that live next to but outside the transform.
+- **`@typia/langchain`** — LangChain.js integration that adapts typia's LLM harness to LangChain tools.
+- **`@typia/mcp`** — Model Context Protocol integration.
+- **`@typia/vercel`** — Vercel AI SDK integration.
+
+Downstream projects (`@nestia/core`, `@agentica`, `@autobe`) build on top of typia but are not part of this repository's contract. The exported `typia.*` surface, the `@typia/interface` typings, the `typia` CLI flags, and the `ttsc.plugin` descriptor shape are public; renaming or removing any of them is a deliberate, separate change.
+
+## Architecture
+
+A single Go program under `packages/typia/native` performs the compile-time transform that emits validators, stringifiers, schemas, and decoders in place of `typia.*<T>()` call sites. `packages/typia` registers a Go command package that `ttsc` (the TypeScript-Go compiler with native plugin support) compiles into a binary on first use through its plugin manifest:
+
+```json
+"ttsc": { "plugin": { "transform": "typia/lib/transform" } }
+```
+
+The `transform.ts` files inside the typia packages are plugin descriptors, not transformers — there is no TypeScript-side transform anymore. The descriptor resolves to the Go entrypoint under `native/cmd/`; other packages compose on it. Consumers reach the binary through `ttsc` / `ttsx` and the published descriptors. Inside the repo, `scripts/with-ttsc-cache.cjs` wires the `TTSC_CACHE_DIR` (and, for runtime suites, the ts-node transpile-only loader) into every workspace command.
+
+## Layout
+
+- `packages/*` — the published packages, including the shared Go plugin under `packages/typia/native` and its Go unit tests under `packages/typia/test` (`go.work` resolves `ttsc` and its shims through `../node_modules/`).
+- `tests/template` — `@typia/template`, a workspace package that ships the structure fixtures (`ObjectSimple`, `ArrayHierarchical`, …) and the `TestServant` runtime helper consumed by the automated suites.
+- `tests/test-*` — feature-test workspaces:
+  - `test-typia-schema`, `test-langchain`, `test-mcp`, `test-vercel`, `test-utils` — function-per-file suites under `src/features/<group>/<name>.ts`, each file exporting one `test_<snake_case>` function discovered by `DynamicExecutor` (from `@nestia/e2e`).
+  - `test-typia-automated`, `test-utils-automated` — generator-driven matrix suites that cross every typia operation with every `@typia/template` structure.
+  - `test-typia-generate` — CLI-integration suite for the `typia generate` command.
+  - `test-error` — call-stripping verification: each call site must be removed from the emitted JS.
+- `tests/debug` — `@typia/debug`, a one-off `ttsx` runner for ad-hoc local repros.
+- `benchmark/` — `@typia/benchmark`, performance generators with archived results under `benchmark/results/**`. See `.codex/skills/benchmark/SKILL.md`.
+- `website/src/content/docs/**` — user-facing MDX guides published at https://typia.io/docs. See `.codex/skills/documentation/SKILL.md`.
+- `examples/`, `experiments/`, `scripts/`, `config/` — example sources, tarball staging, repo utilities, and shared build configuration.
+
+## Commands
+
+This project requires Node 24.x, pnpm 10.6.4, and Go 1.26+; exact versions are pinned in `.github/workflows/` and enforced by CI.
+
+```bash
+pnpm install
+pnpm format
+pnpm build
+pnpm test
+```
+
+`pnpm test` runs `pnpm test:packages` (builds `@typia/template`, then runs every `tests/test-*` workspace through `scripts/with-ttsc-cache.cjs`) followed by `pnpm test:toolchain` (`go test ./...` under `packages/typia/test`). It needs `go` on `PATH`. Run `pnpm install` before `go test`, or the Go workspace cannot resolve the `ttsc` shims through `../node_modules/`. Test workspaces execute TypeScript sources directly via the `ts-node` transpile-only loader; the wrapper script wires that loader and the shared `TTSC_CACHE_DIR` into every workspace command.
+
+Release-time commands (most contributors skip these): `pnpm package:next`, `pnpm package:latest`, `pnpm release`. `pnpm package:tgz` stages local tarballs in `experiments/tarballs/` for offline testing. See `.codex/skills/pull-request/SKILL.md` for the release flow.

--- a/.codex/skills/pull-request/SKILL.md
+++ b/.codex/skills/pull-request/SKILL.md
@@ -1,0 +1,29 @@
+# Pull Request Submission
+
+Only act on this skill when the user explicitly asks for a pull request. Never open, propose, or push a new PR on your own initiative — not as a "helpful" follow-up to a finished change, not because the work looks done. (This bounds PR creation only; it does not change how you commit to a branch.) When the user does ask, follow this flow.
+
+## Branch from the target
+
+Branch from the PR target (`master` unless stated otherwise); never commit to the target directly. Name the branch to reflect the change: `feat/<scope>`, `fix/<scope>`, `chore/<scope>`, `ci/<scope>`, `docs/<scope>`.
+
+## Group changes into logical commits
+
+Group changes into logical commits — one per coherent unit, not a single mega-commit when the diff is large. Use the repository's `type(scope): subject` Conventional Commits style; observed types are `feat`, `fix`, `perf`, `chore`, `test`, `docs`, and observed scopes include `native`, `typia`, `website`, `interface`, `mcp`, `deps`. Run `pnpm format` before each commit (see `.codex/skills/development/SKILL.md` § Work Rules). Merged PR commits carry the `(#<number>)` suffix; GitHub's squash-merge appends that number, so you don't write it yourself.
+
+If the change touches `packages/typia/native`, the same PR must bump the `typia` package version (see `.codex/skills/development/SKILL.md` § Change Integrity).
+
+## Write the PR body at open
+
+Write the PR body at open: intent, scope, deferred items, test plan. The repo's `PULL_REQUEST_TEMPLATE.md` asks you to test the change with `pnpm build` and `pnpm test` and to add a unit test for any new feature. Treat the body as the PR's historical intent statement. Don't rewrite it on every follow-up push — subsequent CI fixes, newly-found design issues, and deferred-item promotions go in `gh pr comment`. The comment thread is the PR's chronology.
+
+## Watch checks after every push
+
+CI runs as path-filtered GitHub Actions workflows: `build` (`pnpm build`), `test` (`pnpm test`), `spell-check` (typos), `experiments` (tarball smoke test), and `website` (Next.js build, and on a `master` push, deploy). After every push, watch `gh pr checks <PR>` with the Monitor tool until each check settles. Don't poll manually; the notification arrives when transitions complete. On failure, fetch the job log via `gh api repos/<owner>/<repo>/actions/jobs/<job-id>/logs` (returns the full log when `gh run view --log-failed` is empty), diagnose, fix in place, push as a new commit, and let the monitor resume.
+
+## Hand back without merging
+
+The agent does not merge, squash-merge, or rebase the target branch. Hand back to the user when all checks pass, or when the user has acknowledged a known-failing check.
+
+## Release flow (reference)
+
+Publishing is automated and not part of opening a PR. Pushing a git tag triggers `release.yml`: `publish` runs `pnpm package:latest` to npm with provenance, `release` generates GitHub release notes via `changelogithub`, and `website` rebuilds and redeploys the docs. `pnpm package:next` (via `next.bash`) publishes a `next`-tagged prerelease without committing or tagging. Don't run these unless the user explicitly asks for a release.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/
-.codex/
+.codex/*
+!.codex/skills/
 .discussions/
 .wiki/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,161 +1,60 @@
-## 1. Project
+## Attitude
 
-### 1.1. What Typia Is
+Follow the literal request; it is the contract, not a hint at what the user "really" wants.
 
-Typia is a TypeScript transformer library built around one idea: a pure TypeScript type definition should replace the runtime helpers that other tools require schemas, decorators, or hand-written guards for. The compile-time transform reads those types and emits the runtime validator, serializer, schema, or decoder inline.
+- **Scope is the user's to widen.** Reinterpret the goal, weigh alternatives, or expand the task only on an explicit hand-off ("figure it out", "you decide"). Take a confident, specific ask as given.
+- **Fidelity binds the goal, not the effort.** Within that goal, act with full initiative: do the substeps it needs, verify your work, surface what you notice. Literal scope is no excuse for passive execution.
+- **Default over ask.** On an ambiguous detail, pick the sensible default and say what you chose; reserve questions for forks only the user can settle.
 
-The packages:
+## Skills
 
-- **`typia`** — the user-facing library and `typia` CLI. Exposes the runtime validators (`is`, `assert`, `assertGuard`, `validate`), enhanced JSON serde (`json.assertParse`, `json.assertStringify`, `json.schema`), LLM function-calling harness (`llm.application`, `llm.schema`, `llm.parse`, `llm.structuredOutput`), Protocol Buffer encoder/decoder (`protobuf.message`, `protobuf.assertEncode`, `protobuf.assertDecode`), and the random data generator (`random`).
-- **`@typia/interface`** — shared public typings (e.g. `IJsonSchema`, `ILlmSchema`, `IValidation`) consumed by every other package and by user code.
-- **`@typia/utils`** — runtime, OpenAPI, and LLM utility helpers (e.g. `LlmTypeChecker`) that live next to but outside the transform.
-- **`@typia/langchain`** — LangChain.js integration that adapts typia's LLM harness to LangChain tools.
-- **`@typia/mcp`** — Model Context Protocol integration.
-- **`@typia/vercel`** — Vercel AI SDK integration.
+All conventions and workflows live as skills under `.codex/skills/`. Read the linked file when its topic applies.
 
-Downstream projects (`@nestia/core`, `@agentica`, `@autobe`) build on top of typia but are not part of this repository's contract.
+### Project Outline
 
-### 1.2. Architecture
+What typia is, the package family, the JS-descriptor / Go-plugin boundary, the workspace layout, and the canonical commands, `.codex/skills/project/SKILL.md`.
 
-A single Go program under `packages/typia/native` performs the compile-time transform that emits validators, stringifiers, schemas, and decoders in place of `typia.*<T>()` call sites. `packages/typia` registers a Go command package that `ttsc` (the TypeScript-Go compiler with native plugin support) compiles into a binary on first use through its plugin manifest (`"ttsc": { "plugin": { "transform": "typia/lib/transform" } }`); other packages compose on it.
+### Development
 
-The `transform.ts` files inside the typia packages are plugin descriptors, not transformers — there is no TypeScript-side transform anymore. Consumers reach the binary through `ttsc` / `ttsx` and the published descriptors. Inside the repo, `scripts/with-ttsc-cache.cjs` wires the `TTSC_CACHE_DIR` (and, for runtime suites, the ts-node loader) into every workspace command.
+Work rules, testing, validation, change integrity, `.codex/skills/development/SKILL.md`. Read before writing or modifying code.
 
-### 1.3. Layout
+### Documentation
 
-- `packages/*` — the published packages, including the shared Go plugin under `packages/typia/native` and its Go unit tests under `packages/typia/test`.
-- `tests/template` — `@typia/template`, a workspace package that ships the structure fixtures (`ObjectSimple`, `ArrayHierarchical`, …) consumed by the automated suites.
-- `tests/test-*` — feature-test workspaces:
-  - `test-typia-schema`, `test-langchain`, `test-mcp`, `test-vercel`, `test-utils` — function-per-file suites under `src/features/<group>/<name>.ts`, each file exporting one `test_<snake_case>` function discovered by `DynamicExecutor` (from `@nestia/e2e`).
-  - `test-typia-automated`, `test-utils-automated` — generator-driven matrix suites that cross every typia operation with every `@typia/template` structure. `test-typia-automated` keeps committed `src/composite/` files (ObjectSimple-only sanity layer) AND regenerates `src/features/<group>/` on every run via `TestAutomationController`; `test-utils-automated` regenerates `src/features/{validate,validateEquals}/` via `TestAutomation.generate()`. **Don't hand-edit those `src/features/` trees — they are discarded on the next run.**
-  - `test-typia-generate` — CLI-integration suite for the `typia generate` command. Hand-author `src/input/generate_*.ts`; `pnpm start` runs the CLI, writes `src/output/`, and `ttsc`-compiles it. The suite passes if `ttsc` accepts the generated output.
-  - `test-error` — call-stripping verification: each `src/<group>/<name>.ts` is a typia call site that the transform must remove from the emitted JS. The build succeeds with `ttsc --emit`; `index.js` then compares `();` counts in source vs. bin to confirm the call was stripped.
-- `tests/debug` — `@typia/debug`, a one-off `ttsx` runner for ad-hoc local repros.
-- `benchmark/` — benchmark generators with archived results under `benchmark/results/**`.
-- `website/src/content/docs/**` — user-facing MDX guides published at `typia.io/docs`.
-- `examples/`, `experiments/`, `scripts/`, `config/` — example sources, tarball staging, repo utilities, and shared build configuration.
+READMEs and the website guides, `.codex/skills/documentation/SKILL.md`. Read before writing or modifying docs.
 
-### 1.4. Commands
+### Multi-Agent Workflows
 
-This project requires Node 24.x, pnpm 10.6.4, and Go 1.26+; exact versions are pinned in `.github/workflows/` and enforced by CI.
+Review Cycle, Discussion, Research Review Round, `.codex/skills/multi-agent/SKILL.md`. Read the Briefing subagents rule before delegating to any subagent; read a mode in full only when the user asks for it by name.
 
-```bash
-pnpm install
-pnpm format
-pnpm build
-pnpm test
-```
+### Pull Request Submission
 
-`pnpm test` runs `pnpm test:packages` (which builds `@typia/template`, then runs every `tests/test-*` workspace through `scripts/with-ttsc-cache.cjs`) followed by `pnpm test:toolchain` (`go test ./...` under `packages/typia/test`). It needs `go` on `PATH`. Test workspaces execute TypeScript sources directly via the `ts-node` transpile-only loader; the wrapper script wires that loader and the shared `TTSC_CACHE_DIR` into every workspace command.
+PR submission flow and the release reference, `.codex/skills/pull-request/SKILL.md`. Read only when the user explicitly asks for a pull request; never open, push, or propose a PR on your own initiative.
 
-Release-time commands (most contributors skip these): `pnpm package:next`, `pnpm package:latest`, `pnpm release` handle version bumps and npm publishing; `pnpm package:tgz` stages local tarballs in `experiments/tarballs/` for offline testing.
+### Benchmark
 
-## 2. Development
+The `@typia/benchmark` runner, fixtures, and per-CPU result archive, `.codex/skills/benchmark/SKILL.md`. Read before running, modifying, or publishing benchmark results.
 
-### 2.1. Work Rules
+## Maintenance
 
-- Match existing conventions. Before adding a file, function, or test, open a nearby peer in the same package and mirror its naming, location, and code style — don't create parallel structures.
-- Respect package boundaries. The Go source for the native transform lives in `packages/typia/native` and is shared across the typia plugin family. Don't fork a second native transform, and don't reintroduce a TypeScript-side transformer.
-- Preserve the contract. The exported `typia.*` surface, the `@typia/interface` typings, the `typia` CLI flags, and the `ttsc.plugin` descriptor shape are public. Renaming or removing any of them is a deliberate, separate change.
-- Keep detection general. The native transform must locate target packages through their resolved package root (e.g. `require.resolve("typia/package.json")`), not through workspace-only path substrings — substring matching breaks the moment a consumer installs from npm, because the workspace path no longer exists and the transform can't locate the typia package. The same rule applies to generators: no hard-coded test, structure, or feature names.
-- Use the workspace catalogs. `pnpm-workspace.yaml` pins versions under `catalog:typescript`, `catalog:rollup`, and `catalog:utils`. New dependencies go through the matching catalog; internal references use `workspace:^`.
-- Don't commit `.env` files or the `.tgz` artifacts under `experiments/tarballs/`. Those are local build outputs; committing them corrupts the workflow.
-- When uncertain about scope, intent, or whether to invoke a §4 workflow, ask the user before automating.
-- Run `pnpm install` before `go test`. The Go test workspace at `packages/typia/test/go.work` resolves `ttsc` and its shims through `../node_modules/`, so the npm install must populate the tree first; otherwise `go test` fails to resolve the module replacements.
-- When public behavior changes, update the matching guide page under `website/src/content/docs/**` in the same change.
+### Writing style
 
-### 2.2. Testing
+AGENTS.md and SKILL.md files are read by humans as well as agents.
 
-**One test case per file, named after what it asserts.** Applies to both layers.
+- **Concise means no redundancy, no padding**: not the same as cramming long sentences into one dense paragraph.
+- **Concise does not mean gutted.** Drop repetition; keep the rule and the rationale that makes it usable.
+- **Match structure to content.** Bullets for parallel items, a short paragraph for a single idea, a code block for a command.
+- **State the rule first, then the reason.** Use negative phrasing only for named failure modes the affirmative does not already cover.
+- **Skills point, not paraphrase.** Don't restate what the website, READMEs, or source comments already say — link to them. Skills are for cross-cutting rules and conventions, not a second copy of project docs.
 
-- **Go unit tests** live under `packages/typia/test/` (mirroring the source layout — `native/cmd/`, `native/adapter/`, `native/transform/`, `metadata/`, …). One `Test*` per file, named after the assertion. Two layers coexist:
-  - *Native-internal tests* under `packages/typia/test/native/` are gated by `//go:build typia_native_internal` and only run with `go test -tags typia_native_internal ./...`. They use `package main` and call the cmd entrypoints (e.g. `runBuild`) directly inside the test process; nothing spawns a `go run` subprocess.
-  - *Public-API tests* under `adapter/`, `contract/`, `helpers/`, `internal/`, `metadata/`, `typings/`, `utils/` carry no build tag and run by default.
-- **TypeScript suites** under `tests/test-*` come in four shapes:
-  - *Function-per-file* (`test-typia-schema`, `test-langchain`, `test-mcp`, `test-vercel`, `test-utils`): each file under `src/features/<group>/` exports exactly one `test_<snake_case>` function with a matching file name; `DynamicExecutor` (from `@nestia/e2e`) discovers them by prefix. Each adapter package (`@typia/langchain`, `@typia/mcp`, `@typia/vercel`) has a mirrored `tests/test-{name}` workspace under the same shape.
-  - *Generator-driven matrix* (`test-typia-automated`, `test-utils-automated`): cross-product every typia operation with every `@typia/template` structure. `test-typia-automated` keeps the committed `src/composite/` files (ObjectSimple-only sanity layer) and additionally regenerates `src/features/<group>/` on every run via `TestAutomationController`; `test-utils-automated` regenerates `src/features/{validate,validateEquals}/` via `TestAutomation.generate()`. **Do not hand-edit anything under the regenerated `src/features/` trees — the next run discards it.** Add new operations or structures to the generator metadata and to `@typia/template`.
-  - *CLI-driven generation* (`test-typia-generate`): hand-author `src/input/generate_*.ts`; `pnpm start` runs `typia generate` to write `src/output/` and then `ttsc`-compiles it. The suite passes if `ttsc` accepts the generated output.
-  - *Stripping verification* (`test-error`): each `src/<group>/<name>.ts` is a typia call site that the transform must remove from emitted JS. The build succeeds with `ttsc --emit`; the harness compares `();` counts between source and bin and fails if the call survives.
+### AGENTS.md
 
-Open every case with a doc comment in the same three-part shape: a one-line `Verifies …` headline, a short paragraph stating the non-obvious *why* (which branch or regression is being pinned), and a 2–4-step numbered scenario.
+The single shared entry point for both Claude Code (via `CLAUDE.md → @AGENTS.md`) and Codex CLI; a table of contents, not content. The H2s are `## Attitude`, `## Skills`, and `## Maintenance`. `## Attitude` is the one place global agent-behavior rules live; everything else points to a skill.
 
-```ts
-/**
- * Verifies typia.llm.schema emits `anyOf` for a discriminated union.
- *
- * Locks the union branch of the LLM schema converter. Object-shaped types
- * route through `LlmTypeChecker.isObject`, but a named union has to be lifted
- * into `$defs` and referenced via `$ref`, with `anyOf` describing the variants.
- * A regression in branch selection would silently inline one variant and drop
- * the other from the function-calling schema.
- *
- * 1. Declare two interfaces with a shared `type` discriminator and union them.
- * 2. Call `typia.llm.schema<Animal>($defs)`.
- * 3. Assert the call returns a `$ref`, and that `$defs["Animal"]` is `anyOf`.
- */
-export const test_llm_schema_anyof = (): void => { /* ... */ };
-```
+Update only for repository-contract changes: a new skill area, a renamed or merged skill, a workflow that no longer fits an existing skill, a release-process change, or a coding-agent rule that applies globally before any skill loads.
 
-Use `TestValidator` and `DynamicExecutor` from `@nestia/e2e` and each suite's local `internal/` helpers; don't reach into another suite's internals. Structure fixtures plus the `TestServant` runtime helper live in `@typia/template` — extend that package instead of duplicating shapes inside a test workspace.
+### Skills
 
-### 2.3. Validation
-
-Match the scope of the command to the scope of the change. Report any command you couldn't run.
-
-- Touched the Go binary → `pnpm test:go` (which runs `go test ./...` under `packages/typia/test` *without* the `typia_native_internal` build tag, so the public-API layer is exercised but the ~57 native-internal tests are skipped). For full coverage, also run `go test -tags typia_native_internal ./...` from the same directory.
-- Touched one test workspace → `pnpm --filter ./tests/<name> start`.
-- Touched the transform, descriptors, or a shared package → `pnpm test`.
-- Touched packaging → `pnpm package:tgz` from `experiments/tarballs` (stages tarballs that the website consumes) and try a clean install. Tarballs staged under `experiments/tarballs/` are build outputs, not sources — `website/` consumes them at build time. Don't commit or hand-edit them.
-- Touched `website/src/content/docs/**` or anything else under `website/` → `cd website && npm install && npm run build` to validate MDX, nav, and tarball pickup.
-
-### 2.4. Change Integrity
-
-Treat tests, fixtures, snapshots, CI workflows, package wiring, dependencies, core algorithms, and generated baselines as part of the specification. Changing them requires an explicit user request or a clear product reason, and the final report must call it out. When the Go source under `packages/typia/native` changes, the `typia` package version must bump in the same commit or PR — the native source ships in the npm package (declared in `packages/typia/package.json` `files`) and ttsc compiles it into a binary on first use, so a source change without a version bump leaves consumers' `npm install` returning a tree that compiles to the stale binary.
-
-For mechanical ports, migrations, or broad rewrites, preserve the existing algorithm and public behavior in reviewable slices. Prefer a concrete exemplar over abstract instructions, and inspect the diff before trusting a green test run.
-
-## 3. Documentation
-
-User-facing guides live under `website/src/content/docs/**` and publish to `typia.io/docs`. One audience, one task per page. Update the page's `_meta.ts` when adding or moving it.
-
-Update `AGENTS.md` when the facts the rest of the doc depends on shift — the package family, the JS-descriptor / Go-plugin boundary, the test layering, the release flow. Treat it as a map, not a rulebook.
-
-When adding agent-facing rules, state the desired workflow first. Use negative constraints only for named failure modes, and include the reason so the rule points back to the intended behavior.
-
-Deeper guides for adapter architecture and integration patterns live under `website/src/content/docs/llm/`.
-
-## 4. Multi-Agent Workflows
-
-Use these workflows only when the user explicitly asks for the named workflow, a multi-agent review, or a multi-agent discussion. Use Review Cycles for direct review of changed source, docs, and tests; Discussions for open-ended topic exploration; and Research Review Rounds when review needs shared research before individual proposals.
-
-### 4.1. Review Cycles
-
-For an explicitly requested review cycle, form a team of six agents. Each agent must read the changed source, docs, and tests in full, then propose concrete improvements.
-
-The lead agent rechecks every proposal, verifies it against the codebase, and applies only changes that are technically sound and relevant.
-
-That is one cycle. For the next cycle, form a fresh team of six different agents and repeat. Continue while at least one verified proposal is accepted. Stop when no agent proposes an improvement, or when no proposal survives lead-agent validation.
-
-### 4.2. Discussions
-
-For a discussion task, create a new topic directory under `.discussions/<topic>/`. Use a short filesystem-safe topic name. Do not delete or overwrite existing discussion directories unless the user explicitly requests it.
-
-Form a team of six agents. Each agent researches the topic, creates a personal subdirectory under the topic directory, and continuously maintains its own wiki-style knowledge base there.
-
-When all agents are ready, run three unrestricted discussion rounds recorded as `round1.md`, `round2.md`, and `round3.md` in the topic directory. Each round has a one-hour budget. The lead agent moderates, acts as scribe, and does not narrow the topic unless the user did.
-
-The transcript files must record the live discussion, not a retrospective summary. The lead agent writes each statement in speaking order. Team agents read the updated transcript before speaking again and continue researching, revising their own knowledge bases, and preparing notes while waiting for their next turn.
-
-After `round3.md` is complete, the lead agent writes the agreed conclusions and major open points into `summary.md` in the topic directory, reports them to the user, and waits for the next instruction.
-
-### 4.3. Research Review Rounds
-
-For an explicitly requested research review, combine the `.discussions` knowledge-base workflow with the review validation loop.
-
-Create a new topic directory under `.discussions/<topic>/`. Each research review round gets its own `review-round-N/` subdirectory with six fresh agents, agent knowledge-base folders, `round1.md`, `round2.md`, `round3.md`, `proposals.md`, and `lead-validation.md`.
-
-In each round, agents build their own knowledge bases from the changed source, docs, tests, and any relevant research. Run the three live discussion transcripts as in Discussions: the lead agent records statements in speaking order while team agents read each other's statements, keep researching between turns, and refine their notes.
-
-At the end of a round, each agent submits its own concrete improvement proposals. Do not require consensus; discussion is for shared understanding, not voting. The lead agent verifies every proposal and applies only changes that are technically sound and relevant.
-
-For the next round, replace the team with six different agents and repeat. Continue while at least one verified proposal is accepted. Stop when no meaningful proposal remains, or when no proposal survives lead-agent validation.
+- **Location.** `.codex/skills/<kebab-name>/SKILL.md`. No numeric prefix, no frontmatter: Claude Code only auto-discovers `.claude/skills/`, and Codex has no native skills system, so each SKILL.md is plain markdown that AGENTS.md points to.
+- **AGENTS.md pointer.** Each skill gets a `### Title` entry under `## Skills` with a one-paragraph pointer to the SKILL.md path.
+- **Create or merge.** Add a new skill when a substantial repository concern would otherwise inflate AGENTS.md beyond an index. Merge sibling concerns into one multi-section skill when they share most of their structure (`multi-agent/` is the precedent).
+- **Headings are plain.** No chapter numbers in skill or AGENTS.md headings. Use descriptive titles.


### PR DESCRIPTION
## Intent

Restructure the monolithic `AGENTS.md` into a thin table of contents (`## Attitude`, `## Skills`, `## Maintenance`) that points to six skill files under `.codex/skills/`, mirroring the sibling `ttsc` repo's new skills layout — adapted to typia's reality, not copied.

## Scope

- **Ported & regrouped** from the old `AGENTS.md` sections: `project`, `development`, `documentation`, `multi-agent`.
- **New skills**, grounded in typia's actual code/CI (not ttsc's): `pull-request` (commit/PR/release flow, the six GitHub workflows) and `benchmark` (the `@typia/benchmark` workspace, per-CPU `results/` archive).
- **Deliberate divergences from ttsc** to match typia: kept em-dashes/emoji in the docs voice, and described prose-wrap as a hand-maintained convention (typia's `pnpm format` covers only `*.ts` + Go, with no `prose-wrap` set) rather than a format gate.
- **`.gitignore`**: un-ignore `.codex/skills/` (`.codex/*` + `!.codex/skills/`) so the skills are tracked, while Codex local session data stays ignored.

`CLAUDE.md` is unchanged (`@AGENTS.md`).

## Test plan

Documentation-only; no source, package, or workflow files touched, so the path-filtered `build`/`test`/`website`/`experiments` workflows do not run. `spell-check` runs on every PR.

- Every factual claim was verified against the repo by a six-agent review round (package family, native Go/JS-descriptor boundary, `ttsc` plugin manifest, the four test-workspace shapes, the Go build-tag scheme, the docs generator, the benchmark categories, the CI workflows).
- All cross-references (`.codex/skills/.../SKILL.md`, `§` sections) resolve; no stale `AGENTS.md` references remain in the repo.