### PR TITLE
test(typia): cover boolean-literal discriminant in tagged unions

### DIFF
--- a/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_boolean_literal_union.ts
+++ b/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_boolean_literal_union.ts
@@ -1,0 +1,61 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+/**
+ * Verifies a boolean-literal discriminant survives in a tagged union's
+ * metadata.
+ *
+ * Pins the boolean-literal constant collection reported in #1841: a union keyed
+ * on `ok: false | true` must keep both literal values, one per branch. The
+ * collector reads each branch's `ok` constant independently, so a regression
+ * that defaulted the value (or compared the wrong literal) would collapse both
+ * branches onto `true` and silently break discriminated-union narrowing — while
+ * the existing `<true>`-only coverage in `test_reflect_schema_constant` stayed
+ * green.
+ *
+ * 1. Reflect a bare `false` literal and assert its boolean constant is `false`.
+ * 2. Reflect `{ ok: false; ... } | { ok: true; ... }`.
+ * 3. Collect every object's `ok` boolean constant and assert both `false` and
+ *    `true` are present (neither branch collapsed).
+ */
+export const test_reflect_schema_boolean_literal_union = (): void => {
+  // 1) a bare `false` literal must report `false`, not the `true`-only path
+  const literal = typia.reflect.schema<false>();
+  TestValidator.equals(
+    "false literal constant type",
+    literal.schema.constants[0]?.type,
+    "boolean",
+  );
+  TestValidator.equals(
+    "false literal constant value",
+    literal.schema.constants[0]?.values[0]?.value,
+    false,
+  );
+
+  // 2) the discriminated union from #1841
+  type U =
+    | { ok: false; error: { code: string } }
+    | { ok: true; code: string; data: { id: string } };
+  const union = typia.reflect.schema<U>();
+
+  // 3) gather the boolean constant of every `ok` property across branches
+  const okValues: boolean[] = [];
+  for (const object of union.components.objects)
+    for (const property of object.properties) {
+      const isOkKey =
+        property.key.constants[0]?.type === "string" &&
+        property.key.constants[0]?.values[0]?.value === "ok";
+      if (!isOkKey) continue;
+      const constant = property.value.constants[0];
+      if (constant?.type !== "boolean") continue;
+      for (const value of constant.values)
+        if (typeof value.value === "boolean") okValues.push(value.value);
+    }
+
+  TestValidator.predicate("false branch survives", () =>
+    okValues.includes(false),
+  );
+  TestValidator.predicate("true branch survives", () =>
+    okValues.includes(true),
+  );
+};


### PR DESCRIPTION
## Summary

While looking into #1841 (a boolean-literal discriminant reportedly collapsing to a single value), I checked the current `reflect.schema` output and the metadata is correct — but our test suite doesn't actually pin that behavior. `test_reflect_schema_constant` only exercises a bare `<true>` literal; there is no coverage for `<false>` nor for a boolean-keyed discriminated union.

This adds that missing regression coverage so a future change can't silently collapse a union's `false` branch onto `true` (which would break discriminated-union narrowing) without a test going red.

## What it checks

- a bare `false` literal reflects to a `boolean` constant with value `false`
- the discriminated union from #1841 keeps **both** `false` and `true` across its branch objects:

```ts
type U =
  | { ok: false; error: { code: string } }
  | { ok: true; code: string; data: { id: string } };
```

## Test

- New case `test_reflect_schema_boolean_literal_union` follows the existing `reflect.schema` suite shape (one case per file, `TestValidator`).
- `pnpm run build` passes locally; the reflected output for the new case was verified to contain both branch values (`[false, true]`).

Refs #1841