### PR TITLE
fix(native): alias CommonJS imports by per-file emit format

### DIFF
--- a/packages/typia/native/adapter/adapter.go
+++ b/packages/typia/native/adapter/adapter.go
@@ -110,15 +110,21 @@ func emitCallWithOptions(program *driver.Program, site CallSite, plugin PluginOp
 }
 
 func identifierSubstitutionsForEmit(program *driver.Program, file any) map[string]string {
-  if program == nil ||
-    program.ParsedConfig == nil ||
-    program.ParsedConfig.ParsedConfig == nil ||
-    program.ParsedConfig.ParsedConfig.CompilerOptions == nil ||
-    program.ParsedConfig.ParsedConfig.CompilerOptions.GetEmitModuleKind().String() != "CommonJS" {
+  if program == nil || program.TSProgram == nil {
     return nil
   }
   sourceFile, ok := file.(*shimast.SourceFile)
   if ok == false {
+    return nil
+  }
+  // Aliasing must follow each file's *emitted* module format, not the
+  // project-wide `module` option's name. Under `module: nodenext` a CommonJS
+  // package emits every `.ts` file as CommonJS, yet GetEmitModuleKind().String()
+  // reports "NodeNext"; keying off that name skips aliasing and leaves a bare
+  // identifier (e.g. `ArrayAny`) where the require() form (`template_1.ArrayAny`)
+  // is needed, throwing ReferenceError at runtime. GetEmitModuleFormatOfFile
+  // resolves the per-file format (extension + package.json type + module kind).
+  if program.TSProgram.GetEmitModuleFormatOfFile(sourceFile).String() != "CommonJS" {
     return nil
   }
   return commonJSImportIdentifierSubstitutions(sourceFile)

--- a/packages/typia/native/adapter/imports_test.go
+++ b/packages/typia/native/adapter/imports_test.go
@@ -1,0 +1,92 @@
+package adapter
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// writeAdapterProjectFile materializes one fixture file under root, creating
+// parent directories as needed. These tests build real tsconfig projects and
+// run the genuine program loader instead of mocking compiler internals, so the
+// per-file emit-format detection is exercised exactly as it is in production.
+func writeAdapterProjectFile(t *testing.T, root, name, contents string) {
+  t.Helper()
+  file := filepath.Join(root, filepath.FromSlash(name))
+  if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(file, []byte(contents), 0o644); err != nil {
+    t.Fatal(err)
+  }
+}
+
+func loadAdapterIndex(t *testing.T, packageJSON string) (*driver.Program, any) {
+  t.Helper()
+  root := t.TempDir()
+  writeAdapterProjectFile(t, root, "package.json", packageJSON)
+  writeAdapterProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true,
+    "allowImportingTsExtensions": true
+  },
+  "files": ["index.ts", "foo.ts"]
+}
+`)
+  writeAdapterProjectFile(t, root, "foo.ts", "export const Foo = 1;\n")
+  writeAdapterProjectFile(t, root, "index.ts", `import { Foo } from "./foo.ts";
+export const value = Foo;
+`)
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  source := prog.SourceFile(filepath.Join(root, "index.ts"))
+  if source == nil {
+    prog.Close()
+    t.Fatal("SourceFile did not find index.ts")
+  }
+  return prog, source
+}
+
+// TestIdentifierSubstitutionsForEmitAliasesPerFileCommonJS pins that import
+// aliasing follows each file's emitted module format, not the project-wide
+// `module` name. Under `module: nodenext` a package with no (or "commonjs")
+// type emits every `.ts` file as CommonJS, so an imported value referenced by a
+// generated transform node must be aliased to its require() form
+// (`foo_1.Foo`). The old check keyed off GetEmitModuleKind().String(), which is
+// "NodeNext" here, skipped aliasing, and left a bare `Foo`.
+func TestIdentifierSubstitutionsForEmitAliasesPerFileCommonJS(t *testing.T) {
+  prog, source := loadAdapterIndex(t, `{ "name": "fixture", "version": "1.0.0" }`+"\n")
+  defer prog.Close()
+
+  subs := identifierSubstitutionsForEmit(prog, source)
+  if subs == nil {
+    t.Fatalf("expected per-file CommonJS substitutions under module:nodenext, got nil")
+  }
+  if got := subs["Foo"]; got != "foo_1.Foo" {
+    t.Fatalf("expected Foo -> foo_1.Foo, got %q (full map %#v)", got, subs)
+  }
+}
+
+// TestIdentifierSubstitutionsForEmitSkipsPerFileESM is the other half: the same
+// nodenext project whose package declares `"type": "module"` emits every `.ts`
+// file as an ES module, where imported bindings keep their source names. No
+// require()-form aliasing must be applied.
+func TestIdentifierSubstitutionsForEmitSkipsPerFileESM(t *testing.T) {
+  prog, source := loadAdapterIndex(t, `{ "name": "fixture", "version": "1.0.0", "type": "module" }`+"\n")
+  defer prog.Close()
+
+  if subs := identifierSubstitutionsForEmit(prog, source); subs != nil {
+    t.Fatalf("expected no substitutions for an ESM-emitted file, got %#v", subs)
+  }
+}


### PR DESCRIPTION
## Problem

Under `module: nodenext` (the typia test/config default), `typia.createRandom<ArrayAny>()`, `typia.llm.controller<Calculator>()`, and any transform that references an imported value emitted a **bare identifier** (`ArrayAny`, `Calculator`) instead of the CommonJS require form (`template_1.ArrayAny`). At runtime this throws `ReferenceError: Calculator is not defined`.

This was the root cause of both the `test-langchain` `class_controller_validation` failure and the 256 `test-typia-automated` ArrayAny failures.

## Root cause

`identifierSubstitutionsForEmit` (native/adapter/adapter.go) gated import aliasing on the **project-wide** module option name:

```go
program.ParsedConfig...CompilerOptions.GetEmitModuleKind().String() != "CommonJS"
```

Under `module: nodenext` that string is `"NodeNext"`, so a CommonJS package (no `type`, or `"type": "commonjs"`) skipped aliasing entirely even though every `.ts` file emits as CommonJS per the implied node format.

## Fix

Drive aliasing off the **per-file** emit format via the tsgo API `Program.GetEmitModuleFormatOfFile`, which resolves each file's format from extension + `package.json` `type` + module kind. CommonJS-emitted files (including under `nodenext`) get aliased; ESM-emitted files (`.mts`, `"type": "module"`) do not.

## Tests

White-box test in `native/adapter/imports_test.go` building real `module: nodenext` projects, pinning both directions:
- commonjs package → `Foo` aliased to `foo_1.Foo`
- `"type": "module"` → no substitutions

Red-green verified (test fails against the old module-name check, passes with the per-file API).

End-to-end verified locally:
- `test-langchain --include class_controller_validation`: Success
- `test-typia-automated --include ArrayAny`: all 8 features Success

🤖 Generated with [Claude Code](https://claude.com/claude-code)