### PR TITLE
fix(native): label TypeGuardError method as typia.<fn>, not the bare name

### DIFF
--- a/packages/typia/native/core/programmers/AssertProgrammer.go
+++ b/packages/typia/native/core/programmers/AssertProgrammer.go
@@ -182,10 +182,7 @@ func (assertProgrammerNamespace) Decompose(props AssertProgrammer_DecomposeProps
 }
 
 func (assertProgrammerNamespace) Write(props AssertProgrammer_IProps) *shimast.Node {
-  method := ""
-  if props.Modulo != nil {
-    method = props.Modulo.Text()
-  }
+  method := nativehelpers.ModuloMethodText(props.Modulo)
   functor := nativehelpers.NewFunctionProgrammer(method)
   result := AssertProgrammer.Decompose(AssertProgrammer_DecomposeProps{
     Config:  props.Config,

--- a/packages/typia/native/core/programmers/IsProgrammer.go
+++ b/packages/typia/native/core/programmers/IsProgrammer.go
@@ -212,10 +212,7 @@ func (isProgrammerNamespace) Decompose(props IsProgrammer_DecomposeProps) native
 }
 
 func (isProgrammerNamespace) Write(props IsProgrammer_IProps) *shimast.Node {
-  method := ""
-  if props.Modulo != nil {
-    method = props.Modulo.Text()
-  }
+  method := nativehelpers.ModuloMethodText(props.Modulo)
   functor := nativehelpers.NewFunctionProgrammer(method)
   result := IsProgrammer.Decompose(IsProgrammer_DecomposeProps{
     Config:  props.Config,

--- a/packages/typia/native/core/programmers/RandomProgrammer.go
+++ b/packages/typia/native/core/programmers/RandomProgrammer.go
@@ -1162,10 +1162,7 @@ func randomProgrammer_type_reference(context nativecontext.ITypiaContext, typ *s
 }
 
 func randomProgrammer_method_text(modulo *shimast.Node) string {
-  if modulo == nil {
-    return ""
-  }
-  return modulo.Text()
+  return nativehelpers.ModuloMethodText(modulo)
 }
 
 func randomProgrammer_errors(errors []nativefactories.MetadataFactory_IError) []nativecontext.TransformerError_MetadataFactory_IError {

--- a/packages/typia/native/core/programmers/ValidateProgrammer.go
+++ b/packages/typia/native/core/programmers/ValidateProgrammer.go
@@ -165,10 +165,7 @@ func (validateProgrammerNamespace) Decompose(props ValidateProgrammer_DecomposeP
 }
 
 func (validateProgrammerNamespace) Write(props ValidateProgrammer_IProps) *shimast.Node {
-  method := ""
-  if props.Modulo != nil {
-    method = props.Modulo.Text()
-  }
+  method := nativehelpers.ModuloMethodText(props.Modulo)
   functor := nativehelpers.NewFunctionProgrammer(method)
   result := ValidateProgrammer.Decompose(ValidateProgrammer_DecomposeProps{
     Config:  props.Config,

--- a/packages/typia/native/core/programmers/helpers/ModuloText.go
+++ b/packages/typia/native/core/programmers/helpers/ModuloText.go
@@ -1,0 +1,23 @@
+package helpers
+
+import (
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// ModuloMethodText renders a typia call accessor (e.g. `typia.assertEquals`,
+// `typia.createAssertEquals`) into the method label embedded in TypeGuardError.
+//
+// It mirrors the TypeScript transformer's `props.modulo.getText()`: the whole
+// callee expression text, so the `typia.` qualifier survives. The native
+// transform must hand this the full call expression — Node.Text() panics on a
+// PropertyAccessExpression, which is why GetTextOfNode (the source-span text)
+// is used instead.
+func ModuloMethodText(modulo *shimast.Node) string {
+  if modulo == nil {
+    return ""
+  }
+  return strings.TrimSpace(shimscanner.GetTextOfNode(modulo))
+}

--- a/packages/typia/native/core/programmers/http/HttpFormDataProgrammer.go
+++ b/packages/typia/native/core/programmers/http/HttpFormDataProgrammer.go
@@ -330,10 +330,7 @@ func httpFormDataProgrammer_decode_array(props struct {
 }
 
 func httpProgrammer_method_text(modulo *shimast.Node) string {
-  if modulo == nil {
-    return ""
-  }
-  return modulo.Text()
+  return nativehelpers.ModuloMethodText(modulo)
 }
 
 func httpProgrammer_import_type(context nativecontext.ITypiaContext, props nativeprogrammers.ImportProgrammer_TypeProps) *shimast.Node {

--- a/packages/typia/native/core/programmers/http/HttpParameterProgrammer.go
+++ b/packages/typia/native/core/programmers/http/HttpParameterProgrammer.go
@@ -34,10 +34,7 @@ func (httpParameterProgrammerNamespace) Write(props nativecontext.IProgrammerPro
     Type:       props.Type,
   })
   if result.Success == false {
-    code := ""
-    if props.Modulo != nil {
-      code = props.Modulo.Text()
-    }
+    code := nativehelpers.ModuloMethodText(props.Modulo)
     panic(nativecontext.TransformerError_from(struct {
       Code   string
       Errors []nativecontext.TransformerError_MetadataFactory_IError

--- a/packages/typia/native/core/programmers/json/JsonAssertParseProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonAssertParseProgrammer.go
@@ -98,10 +98,7 @@ func (jsonAssertParseProgrammerNamespace) Decompose(props JsonAssertParseProgram
 }
 
 func (jsonAssertParseProgrammerNamespace) Write(props nativecontext.IProgrammerProps) *shimast.Node {
-  method := ""
-  if props.Modulo != nil {
-    method = props.Modulo.Text()
-  }
+  method := nativehelpers.ModuloMethodText(props.Modulo)
   functor := nativehelpers.NewFunctionProgrammer(method)
   result := JsonAssertParseProgrammer.Decompose(JsonAssertParseProgrammer_DecomposeProps{
     Context: props.Context,

--- a/packages/typia/native/core/programmers/json/JsonIsParseProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonIsParseProgrammer.go
@@ -99,10 +99,7 @@ func (jsonIsParseProgrammerNamespace) Decompose(props JsonIsParseProgrammer_Deco
 }
 
 func (jsonIsParseProgrammerNamespace) Write(props nativecontext.IProgrammerProps) *shimast.Node {
-  method := ""
-  if props.Modulo != nil {
-    method = props.Modulo.Text()
-  }
+  method := nativehelpers.ModuloMethodText(props.Modulo)
   functor := nativehelpers.NewFunctionProgrammer(method)
   result := JsonIsParseProgrammer.Decompose(JsonIsParseProgrammer_DecomposeProps{
     Context: props.Context,

--- a/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
@@ -1327,10 +1327,7 @@ func jsonStringifyProgrammer_internal(context nativecontext.ITypiaContext, name 
 }
 
 func jsonStringifyProgrammer_method_text(modulo *shimast.Node) string {
-  if modulo == nil {
-    return ""
-  }
-  return modulo.Text()
+  return nativehelpers.ModuloMethodText(modulo)
 }
 
 func jsonStringifyProgrammer_feature_explore(input any) nativeinternal.FeatureProgrammer_IExplore {

--- a/packages/typia/native/core/programmers/json/JsonValidateParseProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonValidateParseProgrammer.go
@@ -87,10 +87,7 @@ func (jsonValidateParseProgrammerNamespace) Decompose(props JsonValidateParsePro
 }
 
 func (jsonValidateParseProgrammerNamespace) Write(props nativecontext.IProgrammerProps) *shimast.Node {
-  method := ""
-  if props.Modulo != nil {
-    method = props.Modulo.Text()
-  }
+  method := nativehelpers.ModuloMethodText(props.Modulo)
   functor := nativehelpers.NewFunctionProgrammer(method)
   result := JsonValidateParseProgrammer.Decompose(JsonValidateParseProgrammer_DecomposeProps{
     Context: props.Context,

--- a/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
+++ b/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
@@ -806,10 +806,7 @@ func llmProgrammer_type_reference(name string) *shimast.Node {
 }
 
 func llmProgrammer_method_text(modulo *shimast.Node) string {
-  if modulo == nil {
-    return ""
-  }
-  return modulo.Text()
+  return nativehelpers.ModuloMethodText(modulo)
 }
 
 func llmProgrammer_concat_description(summary *string, description *string) *string {

--- a/packages/typia/native/core/programmers/misc/MiscCloneProgrammer.go
+++ b/packages/typia/native/core/programmers/misc/MiscCloneProgrammer.go
@@ -1110,10 +1110,7 @@ func miscCloneProgrammer_type_name(context nativecontext.ITypiaContext, typ *shi
 }
 
 func miscCloneProgrammer_method_text(modulo *shimast.Node) string {
-  if modulo == nil {
-    return ""
-  }
-  return modulo.Text()
+  return nativehelpers.ModuloMethodText(modulo)
 }
 
 func miscCloneProgrammer_errors(errors []nativefactories.MetadataFactory_IError) []nativecontext.TransformerError_MetadataFactory_IError {

--- a/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
+++ b/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
@@ -1150,10 +1150,7 @@ func notationGeneralProgrammer_type_name(context nativecontext.ITypiaContext, ty
 }
 
 func notationGeneralProgrammer_method_text(modulo *shimast.Node) string {
-  if modulo == nil {
-    return ""
-  }
-  return modulo.Text()
+  return nativehelpers.ModuloMethodText(modulo)
 }
 
 func notationGeneralProgrammer_feature_explore(input any) nativeinternal.FeatureProgrammer_IExplore {

--- a/packages/typia/native/core/programmers/protobuf/ProtobufAssertEncodeProgrammer.go
+++ b/packages/typia/native/core/programmers/protobuf/ProtobufAssertEncodeProgrammer.go
@@ -138,8 +138,5 @@ func protobufAssertEncodeProgrammer_merge(groups ...map[string]*shimast.Node) ma
 }
 
 func protobufAssertEncodeProgrammer_method_text(modulo *shimast.Node) string {
-  if modulo == nil {
-    return ""
-  }
-  return modulo.Text()
+  return nativehelpers.ModuloMethodText(modulo)
 }

--- a/packages/typia/native/core/programmers/protobuf/ProtobufDecodeProgrammer.go
+++ b/packages/typia/native/core/programmers/protobuf/ProtobufDecodeProgrammer.go
@@ -838,8 +838,5 @@ func protobufDecodeProgrammer_internal(context nativecontext.ITypiaContext, name
 }
 
 func protobufDecodeProgrammer_method_text(modulo *shimast.Node) string {
-  if modulo == nil {
-    return ""
-  }
-  return modulo.Text()
+  return nativehelpers.ModuloMethodText(modulo)
 }

--- a/packages/typia/native/core/programmers/protobuf/ProtobufEncodeProgrammer.go
+++ b/packages/typia/native/core/programmers/protobuf/ProtobufEncodeProgrammer.go
@@ -1200,8 +1200,5 @@ func protobufEncodeProgrammer_internal(context nativecontext.ITypiaContext, name
 }
 
 func protobufEncodeProgrammer_method_text(modulo *shimast.Node) string {
-  if modulo == nil {
-    return ""
-  }
-  return modulo.Text()
+  return nativehelpers.ModuloMethodText(modulo)
 }

--- a/packages/typia/native/transform/CallExpressionTransformer.go
+++ b/packages/typia/native/transform/CallExpressionTransformer.go
@@ -85,12 +85,13 @@ func (callExpressionTransformerNamespace) TransformKnown(props CallExpressionTra
   if ok == false {
     return props.Expression.AsNode()
   }
+  // Keep the full callee expression (e.g. `typia.assertEquals`) as the modulo,
+  // mirroring the TypeScript transformer. Programmers render it into the
+  // TypeGuardError method label via nativehelpers.ModuloMethodText, which reads
+  // the source-span text so the `typia.` qualifier is preserved. (Reducing it
+  // to the bare name dropped the prefix, so errors reported `assertEquals`
+  // instead of `typia.assertEquals`.)
   modulo := props.Expression.Expression
-  if modulo != nil && modulo.Kind == shimast.KindPropertyAccessExpression {
-    if property := modulo.AsPropertyAccessExpression(); property != nil && property.Name() != nil {
-      modulo = property.Name()
-    }
-  }
   result := functor()(ITransformProps{
     Context:    props.Context,
     Modulo:     modulo,

--- a/packages/typia/native/transform/features/RandomTransformer.go
+++ b/packages/typia/native/transform/features/RandomTransformer.go
@@ -6,6 +6,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
   nativeprogrammers "github.com/samchon/typia/packages/typia/native/core/programmers"
+  nativehelpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
   nativetransform "github.com/samchon/typia/packages/typia/native/transform/internal"
 )
 
@@ -18,7 +19,7 @@ var randomTransformer_factory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{
 func (randomTransformerNamespace) Transform(props nativetransform.ITransformProps) *shimast.Node {
   if props.Expression == nil || props.Expression.TypeArguments == nil || len(props.Expression.TypeArguments.Nodes) == 0 {
     panic(nativetransform.NewTransformerError(nativetransform.TransformerError_IProps{
-      Code:    "typia." + props.Modulo.Text(),
+      Code:    nativehelpers.ModuloMethodText(props.Modulo),
       Message: "generic argument is not specified.",
     }))
   }
@@ -26,7 +27,7 @@ func (randomTransformerNamespace) Transform(props nativetransform.ITransformProp
   typ := props.Context.Checker.GetTypeFromTypeNode(node)
   if typ != nil && typ.IsTypeParameter() {
     panic(nativetransform.NewTransformerError(nativetransform.TransformerError_IProps{
-      Code:    "typia." + props.Modulo.Text(),
+      Code:    nativehelpers.ModuloMethodText(props.Modulo),
       Message: "non-specified generic argument.",
     }))
   }


### PR DESCRIPTION
## Problem

`typia.createAssertEquals<T>()` (and assert/assertGuardEquals) produced a `TypeGuardError` whose `method` was the **bare** `"createAssertEquals"` instead of `"typia.createAssertEquals"`. typia's own test harness asserts `exp.method === "typia.createAssertEquals"`, so every surplus-property case failed (204 cases in `test-typia-automated`).

## Root cause

`AssertProgrammer.Write` (and the Is/Validate/Json-parse programmers) derive the label from `props.Modulo.Text()`. But `CallExpressionTransformer.TransformKnown` reduced the callee `typia.assertEquals` (a `PropertyAccessExpression`) down to just its name identifier, dropping the `typia.` qualifier. The original TypeScript transformer uses `props.modulo.getText()` on the **full** callee expression.

## Fix

- Keep the full callee expression as the modulo (mirror the TS transformer).
- Render the label through one shared helper, `ModuloMethodText`, that reads the source-span text via `GetTextOfNode` — `Node.Text()` panics on a `PropertyAccessExpression`, which is why the reduction existed. All ~13 method-label sites across the programmers now go through this single helper instead of each calling `modulo.Text()`.

## Verification

`test-typia-automated`: **266 -> 52 errors** locally (the 204 surplus-property failures clear; no regressions). The remaining 52 are unrelated native-transform issues (`failed to understand the X type`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)