### PR TITLE
fix(native): native-transform type-analysis bugs (toward 0 errors)

### DIFF
--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -187,6 +187,11 @@ func metadata_node_description(symbol *nativeast.Symbol) *string {
 }
 
 func metadata_is_internal(symbol *nativeast.Symbol) bool {
+  for _, tag := range metadata_node_js_doc_tags(symbol) {
+    if tag.Name == "internal" {
+      return true
+    }
+  }
   return false
 }
 


### PR DESCRIPTION
Fixes wrong-logic / stub bugs in the Go-migrated metadata layer that the original TypeScript version did not have, diffed against legacy v12.1.1. Reduces test-typia-automated failures toward 0.

## metadata_is_internal honored

`metadata_is_internal` was a `return false` stub, so `@internal`-tagged properties were never filtered from object metadata. Legacy `emplace_metadata_object.ts` skips them via `symbol.getJsDocTags()`. Implemented by scanning the symbol's JSDoc tags for `"internal"` (reusing `metadata_node_js_doc_tags`). **ObjectInternal cases now pass.**

More metadata fixes (constant JSDoc tags, alias type arguments, recursive alias, nil guards) will be stacked here as each is verified against legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)