### PR TITLE
fix(typia): preserve variadic primitive tuples

### DIFF
--- a/packages/interface/src/typings/Primitive.ts
+++ b/packages/interface/src/typings/Primitive.ts
@@ -1,6 +1,5 @@
 import { Format } from "../tags/Format";
 import { Equal } from "./internal/Equal";
-import { IsTuple } from "./internal/IsTuple";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
 
@@ -47,7 +46,7 @@ type PrimitiveMain<Instance> = Instance extends [never]
 
 type PrimitiveObject<Instance extends object> =
   Instance extends Array<infer T>
-    ? IsTuple<Instance> extends true
+    ? IsPrimitiveTuple<Instance> extends true
       ? PrimitiveTuple<Instance>
       : PrimitiveMain<T>[]
     : {
@@ -71,6 +70,14 @@ type PrimitiveTuple<T extends readonly any[]> = number extends T["length"]
 type PrimitiveVariadicTuple<T extends readonly any[]> = {
   [P in keyof T]: PrimitiveMain<T[P]>;
 };
+
+type IsPrimitiveTuple<T extends readonly any[]> = [T] extends [never]
+  ? false
+  : number extends T["length"]
+    ? T extends readonly [any, ...any[]]
+      ? true
+      : false
+    : true;
 
 interface IJsonable<T> {
   toJSON(): T;

--- a/packages/interface/src/typings/Primitive.ts
+++ b/packages/interface/src/typings/Primitive.ts
@@ -71,6 +71,9 @@ type PrimitiveVariadicTuple<T extends readonly any[]> = {
   [P in keyof T]: PrimitiveMain<T[P]>;
 };
 
+// Keep this broader tuple detection local to Primitive. Other helpers sharing
+// IsTuple still treat variadic tuples as arrays because their tuple recursions
+// do not preserve open-ended tuple shapes.
 type IsPrimitiveTuple<T extends readonly any[]> = [T] extends [never]
   ? false
   : number extends T["length"]

--- a/packages/interface/src/typings/Primitive.ts
+++ b/packages/interface/src/typings/Primitive.ts
@@ -54,17 +54,23 @@ type PrimitiveObject<Instance extends object> =
         [P in keyof Instance]: PrimitiveMain<Instance[P]>;
       };
 
-type PrimitiveTuple<T extends readonly any[]> = T extends []
-  ? []
-  : T extends [infer F]
-    ? [PrimitiveMain<F>]
-    : T extends [infer F, ...infer Rest extends readonly any[]]
-      ? [PrimitiveMain<F>, ...PrimitiveTuple<Rest>]
-      : T extends [(infer F)?]
-        ? [PrimitiveMain<F>?]
-        : T extends [(infer F)?, ...infer Rest extends readonly any[]]
-          ? [PrimitiveMain<F>?, ...PrimitiveTuple<Rest>]
-          : [];
+type PrimitiveTuple<T extends readonly any[]> = number extends T["length"]
+  ? PrimitiveVariadicTuple<T>
+  : T extends []
+    ? []
+    : T extends [infer F]
+      ? [PrimitiveMain<F>]
+      : T extends [infer F, ...infer Rest extends readonly any[]]
+        ? [PrimitiveMain<F>, ...PrimitiveTuple<Rest>]
+        : T extends [(infer F)?]
+          ? [PrimitiveMain<F>?]
+          : T extends [(infer F)?, ...infer Rest extends readonly any[]]
+            ? [PrimitiveMain<F>?, ...PrimitiveTuple<Rest>]
+            : [];
+
+type PrimitiveVariadicTuple<T extends readonly any[]> = {
+  [P in keyof T]: PrimitiveMain<T[P]>;
+};
 
 interface IJsonable<T> {
   toJSON(): T;

--- a/packages/interface/src/typings/internal/IsTuple.ts
+++ b/packages/interface/src/typings/internal/IsTuple.ts
@@ -1,9 +1,8 @@
 /**
- * Checks if an array type is a tuple or regular array.
+ * Checks if an array type is a tuple (fixed length) or regular array.
  *
- * Returns `true` for tuple types like `[string, number]` and variadic tuples
- * like `[string, ...number[], boolean]`, and `false` for array types like
- * `string[]`.
+ * Returns `true` for tuple types like `[string, number]` where length is fixed,
+ * and `false` for array types like `string[]` where length is variable.
  *
  * @template T Array or tuple type to check
  */
@@ -11,12 +10,8 @@ export type IsTuple<T extends readonly any[] | { length: number }> = [
   T,
 ] extends [never]
   ? false
-  : T extends any[]
-    ? any[] extends T
+  : T extends readonly any[]
+    ? number extends T["length"]
       ? false
       : true
-    : T extends readonly any[]
-      ? readonly any[] extends T
-        ? false
-        : true
-      : false;
+    : false;

--- a/packages/interface/src/typings/internal/IsTuple.ts
+++ b/packages/interface/src/typings/internal/IsTuple.ts
@@ -1,8 +1,9 @@
 /**
- * Checks if an array type is a tuple (fixed length) or regular array.
+ * Checks if an array type is a tuple or regular array.
  *
- * Returns `true` for tuple types like `[string, number]` where length is fixed,
- * and `false` for array types like `string[]` where length is variable.
+ * Returns `true` for tuple types like `[string, number]` and variadic tuples
+ * like `[string, ...number[], boolean]`, and `false` for array types like
+ * `string[]`.
  *
  * @template T Array or tuple type to check
  */
@@ -10,8 +11,12 @@ export type IsTuple<T extends readonly any[] | { length: number }> = [
   T,
 ] extends [never]
   ? false
-  : T extends readonly any[]
-    ? number extends T["length"]
+  : T extends any[]
+    ? any[] extends T
       ? false
       : true
-    : false;
+    : T extends readonly any[]
+      ? readonly any[] extends T
+        ? false
+        : true
+      : false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,19 @@ importers:
         specifier: catalog:utils
         version: 6.1.3
 
+  tests/test-interface:
+    dependencies:
+      '@typia/interface':
+        specifier: workspace:^
+        version: link:../../packages/interface
+    devDependencies:
+      '@typescript/native-preview':
+        specifier: catalog:typescript
+        version: 7.0.0-dev.20260527.2
+      ttsc:
+        specifier: catalog:typescript
+        version: 0.15.1
+
   tests/test-langchain:
     dependencies:
       '@langchain/core':

--- a/tests/test-interface/package.json
+++ b/tests/test-interface/package.json
@@ -1,0 +1,31 @@
+{
+  "private": true,
+  "name": "@typia/test-interface",
+  "version": "13.0.0-dev.20260605.1",
+  "description": "Type tests for @typia/interface.",
+  "scripts": {
+    "start": "ttsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/typia"
+  },
+  "keywords": [
+    "typia",
+    "interface",
+    "test"
+  ],
+  "author": "Jeongho Nam",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/samchon/typia/issues"
+  },
+  "homepage": "https://typia.io",
+  "devDependencies": {
+    "@typescript/native-preview": "catalog:typescript",
+    "ttsc": "catalog:typescript"
+  },
+  "dependencies": {
+    "@typia/interface": "workspace:^"
+  }
+}

--- a/tests/test-interface/src/typings/test_primitive_variadic_tuple.ts
+++ b/tests/test-interface/src/typings/test_primitive_variadic_tuple.ts
@@ -1,0 +1,74 @@
+import { Primitive, tags } from "@typia/interface";
+
+export type PrimitiveVariadicTupleCases = [
+  AssertAssignable<ExpectedLiteralVariadic, LiteralVariadic>,
+  AssertAssignable<LiteralVariadic, ExpectedLiteralVariadic>,
+  AssertAssignable<ExpectedDateRest, DateRest>,
+  AssertAssignable<DateRest, ExpectedDateRest>,
+  AssertAssignable<ExpectedObjectRest, ObjectRest>,
+  AssertAssignable<ObjectRest, ExpectedObjectRest>,
+  AssertAssignable<ExpectedOptionalTuple, OptionalTuple>,
+  AssertAssignable<OptionalTuple, ExpectedOptionalTuple>,
+  AssertAssignable<ExpectedStringArray, StringArray>,
+  AssertAssignable<StringArray, ExpectedStringArray>,
+  AssertAssignable<ExpectedDateArray, DateArray>,
+  AssertAssignable<DateArray, ExpectedDateArray>,
+  AssertAssignable<ExpectedObjectArray, ObjectArray>,
+  AssertAssignable<ObjectArray, ExpectedObjectArray>,
+  AssertAssignable<ExpectedUnionTuple, UnionTuple>,
+  AssertAssignable<UnionTuple, ExpectedUnionTuple>,
+];
+
+export const validLiteral: LiteralVariadic = ["asdf", "middle", "zxcv"];
+
+// @ts-expect-error literal head must not widen to string.
+export const invalidHead: LiteralVariadic = ["qwer", "middle", "zxcv"];
+
+// @ts-expect-error literal tail must not widen to string.
+export const invalidTail: LiteralVariadic = ["asdf", "middle", "qwer"];
+
+type AssertAssignable<Expected, Actual> = [Actual] extends [Expected]
+  ? true
+  : never;
+
+type DateTime = string & tags.Format<"date-time">;
+
+type LiteralVariadic = Primitive<["asdf", ...string[], "zxcv"]>;
+type ExpectedLiteralVariadic = ["asdf", ...string[], "zxcv"];
+
+type DateRest = Primitive<["head", ...Date[], "tail"]>;
+type ExpectedDateRest = ["head", ...DateTime[], "tail"];
+
+type ObjectRest = Primitive<[Date, ...IBoxedValue[], IBoxedDone]>;
+type ExpectedObjectRest = [DateTime, ...IPrimitiveValue[], IPrimitiveDone];
+
+type OptionalTuple = Primitive<[string, number?]>;
+type ExpectedOptionalTuple = [string, number?];
+
+type StringArray = Primitive<string[]>;
+type ExpectedStringArray = string[];
+
+type DateArray = Primitive<Date[]>;
+type ExpectedDateArray = DateTime[];
+
+type ObjectArray = Primitive<IBoxedValue[]>;
+type ExpectedObjectArray = IPrimitiveValue[];
+
+type UnionTuple = Primitive<["a", ...string[], "z"] | number[]>;
+type ExpectedUnionTuple = ["a", ...string[], "z"] | number[];
+
+interface IBoxedValue {
+  value: Number;
+}
+
+interface IPrimitiveValue {
+  value: number;
+}
+
+interface IBoxedDone {
+  done: Boolean;
+}
+
+interface IPrimitiveDone {
+  done: boolean;
+}

--- a/tests/test-interface/src/typings/test_primitive_variadic_tuple.ts
+++ b/tests/test-interface/src/typings/test_primitive_variadic_tuple.ts
@@ -1,25 +1,25 @@
 import { Primitive, tags } from "@typia/interface";
 
 export type PrimitiveVariadicTupleCases = [
-  AssertAssignable<ExpectedLiteralVariadic, LiteralVariadic>,
-  AssertAssignable<LiteralVariadic, ExpectedLiteralVariadic>,
-  AssertAssignable<ExpectedDateRest, DateRest>,
-  AssertAssignable<DateRest, ExpectedDateRest>,
-  AssertAssignable<ExpectedObjectRest, ObjectRest>,
-  AssertAssignable<ObjectRest, ExpectedObjectRest>,
-  AssertAssignable<ExpectedOptionalTuple, OptionalTuple>,
-  AssertAssignable<OptionalTuple, ExpectedOptionalTuple>,
-  AssertAssignable<ExpectedStringArray, StringArray>,
-  AssertAssignable<StringArray, ExpectedStringArray>,
-  AssertAssignable<ExpectedDateArray, DateArray>,
-  AssertAssignable<DateArray, ExpectedDateArray>,
-  AssertAssignable<ExpectedObjectArray, ObjectArray>,
-  AssertAssignable<ObjectArray, ExpectedObjectArray>,
-  AssertAssignable<ExpectedUnionTuple, UnionTuple>,
-  AssertAssignable<UnionTuple, ExpectedUnionTuple>,
+  Assert<IsEqual<LiteralVariadic, ExpectedLiteralVariadic>>,
+  Assert<IsEqual<DateRest, ExpectedDateRest>>,
+  Assert<IsEqual<ObjectRest, ExpectedObjectRest>>,
+  Assert<IsEqual<OptionalTuple, ExpectedOptionalTuple>>,
+  Assert<IsEqual<StringArray, ExpectedStringArray>>,
+  Assert<IsEqual<DateArray, ExpectedDateArray>>,
+  Assert<IsEqual<ObjectArray, ExpectedObjectArray>>,
+  Assert<IsEqual<UnionTuple, ExpectedUnionTuple>>,
 ];
 
+export const validLiteralWithoutMiddle: LiteralVariadic = ["asdf", "zxcv"];
 export const validLiteral: LiteralVariadic = ["asdf", "middle", "zxcv"];
+export const validLiteralWithLongMiddle: LiteralVariadic = [
+  "asdf",
+  "a",
+  "b",
+  "c",
+  "zxcv",
+];
 
 // @ts-expect-error literal head must not widen to string.
 export const invalidHead: LiteralVariadic = ["qwer", "middle", "zxcv"];
@@ -27,9 +27,43 @@ export const invalidHead: LiteralVariadic = ["qwer", "middle", "zxcv"];
 // @ts-expect-error literal tail must not widen to string.
 export const invalidTail: LiteralVariadic = ["asdf", "middle", "qwer"];
 
-type AssertAssignable<Expected, Actual> = [Actual] extends [Expected]
-  ? true
-  : never;
+export const validDateRest: DateRest = [
+  "head",
+  "2026-06-08T00:00:00.000Z" as DateTime,
+  "tail",
+];
+
+// @ts-expect-error Date rest elements must be converted to date-time strings.
+export const invalidDateRest: DateRest = ["head", new Date(), "tail"];
+
+export const validObjectRest: ObjectRest = [
+  "2026-06-08T00:00:00.000Z" as DateTime,
+  { value: 1 },
+  { done: true },
+];
+
+// @ts-expect-error boxed object rest property must be converted to number.
+export const invalidObjectRestValue: ObjectRest = [
+  "2026-06-08T00:00:00.000Z" as DateTime,
+  { value: new Number(1) },
+  { done: true },
+];
+
+// @ts-expect-error boxed tail property must be converted to boolean.
+export const invalidObjectRestTail: ObjectRest = [
+  "2026-06-08T00:00:00.000Z" as DateTime,
+  { value: 1 },
+  { done: new Boolean(true) },
+];
+
+type Assert<T extends true> = T;
+
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;
 
 type DateTime = string & tags.Format<"date-time">;
 

--- a/tests/test-interface/src/typings/test_primitive_variadic_tuple.ts
+++ b/tests/test-interface/src/typings/test_primitive_variadic_tuple.ts
@@ -4,12 +4,15 @@ export type PrimitiveVariadicTupleCases = [
   Assert<IsEqual<LiteralVariadic, ExpectedLiteralVariadic>>,
   Assert<IsEqual<DateRest, ExpectedDateRest>>,
   Assert<IsEqual<TrailingDateRest, ExpectedTrailingDateRest>>,
+  Assert<IsEqual<LeadingDateRest, ExpectedLeadingDateRest>>,
   Assert<IsEqual<ObjectRest, ExpectedObjectRest>>,
   Assert<IsEqual<BrandedDateArray, ExpectedBrandedDateArray>>,
   Assert<IsEqual<OptionalTuple, ExpectedOptionalTuple>>,
   Assert<IsEqual<OptionalRest, ExpectedOptionalRest>>,
   Assert<IsEqual<StringArray, ExpectedStringArray>>,
   Assert<IsEqual<DateArray, ExpectedDateArray>>,
+  Assert<IsEqual<ReadonlyDateArray, ExpectedReadonlyDateArray>>,
+  Assert<IsEqual<ReadonlyDateRest, ExpectedReadonlyDateRest>>,
   Assert<IsEqual<ObjectArray, ExpectedObjectArray>>,
   Assert<IsEqual<UnionTuple, ExpectedUnionTuple>>,
 ];
@@ -46,6 +49,15 @@ export const invalidDateRest: DateRest = ["head", new Date(), "tail"];
 
 // @ts-expect-error trailing rest elements must be converted to date-time strings.
 export const invalidTrailingDateRest: TrailingDateRest = ["head", new Date()];
+
+export const validLeadingDateRestWithoutPrefix: LeadingDateRest = ["tail"];
+export const validLeadingDateRest: LeadingDateRest = [
+  "2026-06-08T00:00:00.000Z" as DateTime,
+  "tail",
+];
+
+// @ts-expect-error leading rest elements must be converted to date-time strings.
+export const invalidLeadingDateRest: LeadingDateRest = [new Date(), "tail"];
 
 export const validObjectRest: ObjectRest = [
   "2026-06-08T00:00:00.000Z" as DateTime,
@@ -96,6 +108,9 @@ type ExpectedDateRest = ["head", ...DateTime[], "tail"];
 type TrailingDateRest = Primitive<["head", ...Date[]]>;
 type ExpectedTrailingDateRest = ["head", ...DateTime[]];
 
+type LeadingDateRest = Primitive<[...Date[], "tail"]>;
+type ExpectedLeadingDateRest = [...DateTime[], "tail"];
+
 type ObjectRest = Primitive<[Date, ...IBoxedValue[], IBoxedDone]>;
 type ExpectedObjectRest = [DateTime, ...IPrimitiveValue[], IPrimitiveDone];
 
@@ -113,6 +128,12 @@ type ExpectedStringArray = string[];
 
 type DateArray = Primitive<Date[]>;
 type ExpectedDateArray = DateTime[];
+
+type ReadonlyDateArray = Primitive<readonly Date[]>;
+type ExpectedReadonlyDateArray = readonly DateTime[];
+
+type ReadonlyDateRest = Primitive<readonly ["head", ...Date[]]>;
+type ExpectedReadonlyDateRest = readonly ["head", ...DateTime[]];
 
 type ObjectArray = Primitive<IBoxedValue[]>;
 type ExpectedObjectArray = IPrimitiveValue[];

--- a/tests/test-interface/src/typings/test_primitive_variadic_tuple.ts
+++ b/tests/test-interface/src/typings/test_primitive_variadic_tuple.ts
@@ -3,8 +3,11 @@ import { Primitive, tags } from "@typia/interface";
 export type PrimitiveVariadicTupleCases = [
   Assert<IsEqual<LiteralVariadic, ExpectedLiteralVariadic>>,
   Assert<IsEqual<DateRest, ExpectedDateRest>>,
+  Assert<IsEqual<TrailingDateRest, ExpectedTrailingDateRest>>,
   Assert<IsEqual<ObjectRest, ExpectedObjectRest>>,
+  Assert<IsEqual<BrandedDateArray, ExpectedBrandedDateArray>>,
   Assert<IsEqual<OptionalTuple, ExpectedOptionalTuple>>,
+  Assert<IsEqual<OptionalRest, ExpectedOptionalRest>>,
   Assert<IsEqual<StringArray, ExpectedStringArray>>,
   Assert<IsEqual<DateArray, ExpectedDateArray>>,
   Assert<IsEqual<ObjectArray, ExpectedObjectArray>>,
@@ -33,8 +36,16 @@ export const validDateRest: DateRest = [
   "tail",
 ];
 
+export const validTrailingDateRest: TrailingDateRest = [
+  "head",
+  "2026-06-08T00:00:00.000Z" as DateTime,
+];
+
 // @ts-expect-error Date rest elements must be converted to date-time strings.
 export const invalidDateRest: DateRest = ["head", new Date(), "tail"];
+
+// @ts-expect-error trailing rest elements must be converted to date-time strings.
+export const invalidTrailingDateRest: TrailingDateRest = ["head", new Date()];
 
 export const validObjectRest: ObjectRest = [
   "2026-06-08T00:00:00.000Z" as DateTime,
@@ -56,6 +67,15 @@ export const invalidObjectRestTail: ObjectRest = [
   { done: new Boolean(true) },
 ];
 
+export const validOptionalRest: OptionalRest = [
+  "2026-06-08T00:00:00.000Z" as DateTime,
+  1,
+  undefined,
+];
+
+// @ts-expect-error optional-head rest falls back to primitive array elements.
+export const invalidOptionalRest: OptionalRest = [new Date()];
+
 type Assert<T extends true> = T;
 
 type IsEqual<X, Y> =
@@ -73,11 +93,20 @@ type ExpectedLiteralVariadic = ["asdf", ...string[], "zxcv"];
 type DateRest = Primitive<["head", ...Date[], "tail"]>;
 type ExpectedDateRest = ["head", ...DateTime[], "tail"];
 
+type TrailingDateRest = Primitive<["head", ...Date[]]>;
+type ExpectedTrailingDateRest = ["head", ...DateTime[]];
+
 type ObjectRest = Primitive<[Date, ...IBoxedValue[], IBoxedDone]>;
 type ExpectedObjectRest = [DateTime, ...IPrimitiveValue[], IPrimitiveDone];
 
+type BrandedDateArray = Primitive<IBrandedDateArray>;
+type ExpectedBrandedDateArray = DateTime[];
+
 type OptionalTuple = Primitive<[string, number?]>;
 type ExpectedOptionalTuple = [string, number?];
+
+type OptionalRest = Primitive<[Date?, ...Number[]]>;
+type ExpectedOptionalRest = Array<DateTime | number | undefined>;
 
 type StringArray = Primitive<string[]>;
 type ExpectedStringArray = string[];
@@ -105,4 +134,8 @@ interface IBoxedDone {
 
 interface IPrimitiveDone {
   done: boolean;
+}
+
+interface IBrandedDateArray extends Array<Date> {
+  brand: string;
 }

--- a/tests/test-interface/src/typings/test_tuple_helper_variadic_boundaries.ts
+++ b/tests/test-interface/src/typings/test_tuple_helper_variadic_boundaries.ts
@@ -1,0 +1,37 @@
+import { CamelCase, PascalCase, Resolved } from "@typia/interface";
+
+export type TupleHelperVariadicBoundaryCases = [
+  Assert<IsEqual<ResolvedVariadic, ExpectedResolvedVariadic>>,
+  Assert<IsEqual<CamelCaseVariadic, ExpectedCamelCaseVariadic>>,
+  Assert<IsEqual<PascalCaseVariadic, ExpectedPascalCaseVariadic>>,
+];
+
+type Assert<T extends true> = T;
+
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;
+
+type ResolvedVariadic = Resolved<[Date, ...Number[], Boolean]>;
+type ExpectedResolvedVariadic = Array<Date | number | boolean>;
+
+type CamelCaseVariadic = CamelCase<
+  [{ first_value: String }, ...Array<{ middle_value: Number }>, IBooleanTail]
+>;
+type ExpectedCamelCaseVariadic = Array<
+  { firstValue: string } | { middleValue: number } | { finalValue: boolean }
+>;
+
+type PascalCaseVariadic = PascalCase<
+  [{ first_value: String }, ...Array<{ middle_value: Number }>, IBooleanTail]
+>;
+type ExpectedPascalCaseVariadic = Array<
+  { FirstValue: string } | { MiddleValue: number } | { FinalValue: boolean }
+>;
+
+interface IBooleanTail {
+  final_value: Boolean;
+}

--- a/tests/test-interface/tsconfig.json
+++ b/tests/test-interface/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
﻿## Summary

- Fix `Primitive<T>` so variadic tuples like `["asdf", ...string[], "zxcv"]` stay tuples instead of widening to arrays.
- Keep the existing recursive path for fixed and optional tuples, and use mapped tuple conversion only for variable-length tuple branches.
- Add `@typia/test-interface` type tests covering literal head/tail preservation, Date/object rest conversion, optional tuple preservation, arrays, and tuple/array unions.

## Validation

- `pnpm --filter @typia/test-interface start`
- `pnpm --filter @typia/interface build`
- `pnpm --filter typia build`
- `pnpm --filter @typia/test-typia-schema start -- --include json_schema_tuple` currently fails locally before executing the selected test with `Unexpected token '{'` from the transform runner path.

Fixes #1517
