### PR TITLE
feat(typia): accept generate file arguments

### DIFF
--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -36,7 +36,8 @@
     "@typia/utils": "workspace:^",
     "commander": "^10.0.0",
     "inquirer": "^8.2.5",
-    "randexp": "^0.5.3"
+    "randexp": "^0.5.3",
+    "tinyglobby": "^0.2.12"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",
@@ -50,7 +51,6 @@
     "rollup-plugin-auto-external": "catalog:rollup",
     "rollup-plugin-node-externals": "catalog:rollup",
     "suppress-warnings": "^1.0.2",
-    "tinyglobby": "^0.2.12",
     "ttsc": "catalog:typescript"
   },
   "sideEffects": [

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -25,7 +25,10 @@ export namespace TypiaGenerateWizard {
     command.argument("[files...]", "input .ts files or globs");
     command.option("--input <path>", "input directory");
     command.option("--output <directory>", "output directory");
-    command.option("--project <project>", "tsconfig.json file location");
+    command.option(
+      "--project <project>",
+      "tsconfig.json/jsconfig.json file or directory",
+    );
 
     const questioned = { value: false };
     const prompt = inquirer.createPromptModule;
@@ -110,9 +113,11 @@ export namespace TypiaGenerateWizard {
     const outputByKey: Map<string, string> =
       indexTransformedOutputs(transformed);
     const outputs: IOutputFile[] = entries.map((entry) => {
-      const output = outputByKey.get(
-        projectFileKey(projectKey(cwd, entry.file)),
-      );
+      const output = getTransformedOutput({
+        cwd,
+        entry,
+        outputByKey,
+      });
       if (output === undefined) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): no transformed output for ${entry.file}. Check that --project includes the file.`,
@@ -361,6 +366,11 @@ export namespace TypiaGenerateWizard {
       if (inputs.has(fileIdentityKey(stat))) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): output file would overwrite input file through a physical file alias: ${entry.target}`,
+        );
+      }
+      if (stat.nlink > 1) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): output file has multiple hard links: ${entry.target}`,
         );
       }
     }
@@ -733,6 +743,28 @@ export namespace TypiaGenerateWizard {
       map.set(projectFileKey(file), output);
     }
     return map;
+  }
+
+  function getTransformedOutput(props: {
+    cwd: string;
+    entry: IInputFile;
+    outputByKey: Map<string, string>;
+  }): string | undefined {
+    const output = props.outputByKey.get(
+      projectFileKey(projectKey(props.cwd, props.entry.file)),
+    );
+    if (output !== undefined) {
+      return output;
+    }
+
+    const real: string = resolveRealPath(props.entry.file);
+    if (
+      isSamePath(real, props.entry.file) ||
+      isSameOrChildPath(real, props.cwd) === false
+    ) {
+      return undefined;
+    }
+    return props.outputByKey.get(projectFileKey(projectKey(props.cwd, real)));
   }
 
   function projectKey(root: string, file: string): string {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -119,13 +119,17 @@ export namespace TypiaGenerateWizard {
 
     const binary = resolveTsgoBinary();
     const cwd = path.dirname(location.project);
-    const transformed = await transformProject({
+    const transformed = transformProject({
       binary,
       cwd,
       tsconfig: location.project,
     });
+    const outputByKey: Map<string, string> =
+      indexTransformedOutputs(transformed);
     const outputs: IOutputFile[] = entries.map((entry) => {
-      const output = transformed[projectKey(cwd, entry.file)];
+      const output = outputByKey.get(
+        projectFileKey(projectKey(cwd, entry.file)),
+      );
       if (output === undefined) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): no transformed output for ${entry.file}. Check that --project includes the file.`,
@@ -136,6 +140,7 @@ export namespace TypiaGenerateWizard {
 
     await ensureOutputDirectory(location.output);
     await ensureTargetDirectories(outputs.map(({ entry }) => entry.target));
+    await ensureTargetFiles(outputs.map(({ entry }) => entry.target));
     for (const { entry, output } of outputs) {
       await fs.promises.writeFile(entry.target, formatOutput(output), "utf8");
     }
@@ -184,6 +189,32 @@ export namespace TypiaGenerateWizard {
       } catch (exp) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): unable to create output parent directory ${directory}: ${formatUnknownError(exp)}`,
+        );
+      }
+    }
+  }
+
+  async function ensureTargetFiles(targets: string[]): Promise<void> {
+    const files: Map<string, string> = new Map();
+    for (const target of targets) {
+      files.set(filesystemKey(target), target);
+    }
+
+    for (const file of files.values()) {
+      let stat: fs.Stats;
+      try {
+        stat = await fs.promises.lstat(file);
+      } catch (exp) {
+        if (isMissingFileError(exp)) {
+          continue;
+        }
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): unable to inspect output file ${file}: ${formatUnknownError(exp)}`,
+        );
+      }
+      if (stat.isFile() === false) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): output file path is not a regular file: ${file}`,
         );
       }
     }
@@ -284,7 +315,11 @@ export namespace TypiaGenerateWizard {
             `Error on TypiaGenerateWizard.generate(): input pattern does not match any files: ${input}`,
           );
         }
-        output.push(...excludeOutputFiles(matches, directory));
+        output.push(
+          ...excludeOutputFiles(matches, directory).filter(
+            isSupportedExtension,
+          ),
+        );
       } else {
         const file: string = path.resolve(input);
         if (isSameOrChildPath(file, directory) === false) {
@@ -303,12 +338,12 @@ export namespace TypiaGenerateWizard {
     return input.replace(/\\/g, "/");
   }
 
-  async function transformProject(props: {
+  function transformProject(props: {
     binary: string;
     cwd: string;
     tsconfig: string;
-  }): Promise<Record<string, string>> {
-    const { TtscCompiler } = await import("ttsc");
+  }): Record<string, string> {
+    const TtscCompiler = loadTtscCompiler();
     const result: ITtscCompilerTransformation = new TtscCompiler({
       binary: props.binary,
       cwd: props.cwd,
@@ -327,6 +362,21 @@ export namespace TypiaGenerateWizard {
     );
   }
 
+  function loadTtscCompiler(): typeof import("ttsc").TtscCompiler {
+    const packageRoot: string = resolveTypiaPackageRoot();
+    const resolved: string | null = resolveFromRoots(
+      "ttsc",
+      resolveRuntimeRoots(packageRoot),
+    );
+    if (resolved === null) {
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): unable to resolve ttsc from the current project, typia package, or workspace root. Run "npm i -D ttsc @typescript/native-preview" before.`,
+      );
+    }
+    const imported = createRequire(resolved)(resolved) as typeof import("ttsc");
+    return imported.TtscCompiler;
+  }
+
   function resolveTsgoBinary(): string {
     const explicit: string | undefined = process.env.TTSC_TSGO_BINARY;
     if (explicit !== undefined && explicit.length !== 0) {
@@ -341,11 +391,11 @@ export namespace TypiaGenerateWizard {
     const packageRoot: string = resolveTypiaPackageRoot();
     const manifest: string | null = resolveFromRoots(
       "@typescript/native-preview/package.json",
-      [packageRoot, path.resolve(packageRoot, "..", "..")],
+      resolveRuntimeRoots(packageRoot),
     );
     if (manifest === null) {
       throw new URIError(
-        "Error on TypiaGenerateWizard.generate(): unable to resolve @typescript/native-preview from the typia package or workspace root.",
+        "Error on TypiaGenerateWizard.generate(): unable to resolve @typescript/native-preview from the current project, typia package, or workspace root.",
       );
     }
 
@@ -398,6 +448,10 @@ export namespace TypiaGenerateWizard {
       );
     }
     return path.dirname(resolved);
+  }
+
+  function resolveRuntimeRoots(packageRoot: string): string[] {
+    return [process.cwd(), packageRoot, path.resolve(packageRoot, "..", "..")];
   }
 
   function resolveFromRoots(request: string, roots: string[]): string | null {
@@ -461,8 +515,22 @@ export namespace TypiaGenerateWizard {
       : `// @ts-nocheck\n${output}`;
   }
 
+  function indexTransformedOutputs(
+    outputs: Record<string, string>,
+  ): Map<string, string> {
+    const map: Map<string, string> = new Map();
+    for (const [file, output] of Object.entries(outputs)) {
+      map.set(projectFileKey(file), output);
+    }
+    return map;
+  }
+
   function projectKey(root: string, file: string): string {
     return path.relative(root, file).replace(/\\/g, "/");
+  }
+
+  function projectFileKey(file: string): string {
+    return isCaseSensitive() ? file : file.toLowerCase();
   }
 
   function isSamePath(x: string, y: string): boolean {
@@ -485,6 +553,15 @@ export namespace TypiaGenerateWizard {
 
   function isCaseSensitive(): boolean {
     return process.platform !== "win32" && process.platform !== "darwin";
+  }
+
+  function isMissingFileError(exp: unknown): boolean {
+    return (
+      typeof exp === "object" &&
+      exp !== null &&
+      "code" in exp &&
+      exp.code === "ENOENT"
+    );
   }
 
   function formatDiagnostics(diagnostics: ITtscCompilerDiagnostic[]): string {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -139,7 +139,10 @@ export namespace TypiaGenerateWizard {
     });
 
     await ensureOutputDirectory(location.output);
-    await ensureTargetDirectories(outputs.map(({ entry }) => entry.target));
+    await ensureTargetDirectories({
+      output: location.output,
+      targets: outputs.map(({ entry }) => entry.target),
+    });
     await ensurePhysicalTargets({
       output: location.output,
       entries: outputs.map(({ entry }) => entry),
@@ -162,6 +165,7 @@ export namespace TypiaGenerateWizard {
 
   async function ensureOutputDirectory(output: string): Promise<void> {
     if (fs.existsSync(output) === false) {
+      await ensureCreatableDirectory(output);
       await fs.promises.mkdir(output, { recursive: true });
     } else {
       await ensureExistingDirectory({
@@ -171,14 +175,21 @@ export namespace TypiaGenerateWizard {
     }
   }
 
-  async function ensureTargetDirectories(targets: string[]): Promise<void> {
+  async function ensureTargetDirectories(props: {
+    output: string;
+    targets: string[];
+  }): Promise<void> {
     const directories: Map<string, string> = new Map();
-    for (const target of targets) {
+    for (const target of props.targets) {
       const directory: string = path.dirname(target);
       directories.set(filesystemKey(directory), directory);
     }
 
     for (const directory of directories.values()) {
+      await ensureOutputAncestorDirectories({
+        output: props.output,
+        directory,
+      });
       if (fs.existsSync(directory)) {
         await ensureExistingDirectory({
           label: "output parent path",
@@ -198,6 +209,72 @@ export namespace TypiaGenerateWizard {
         label: "output parent path",
         directory,
       });
+    }
+  }
+
+  async function ensureCreatableDirectory(directory: string): Promise<void> {
+    const parent: string = await nearestExistingAncestor(directory);
+    await ensureExistingDirectory({
+      label: "output parent path",
+      directory: parent,
+    });
+  }
+
+  async function nearestExistingAncestor(directory: string): Promise<string> {
+    let current: string = path.resolve(directory);
+    while (fs.existsSync(current) === false) {
+      const parent: string = path.dirname(current);
+      if (parent === current) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): unable to find existing output parent path: ${directory}`,
+        );
+      }
+      current = parent;
+    }
+    return current;
+  }
+
+  async function ensureOutputAncestorDirectories(props: {
+    output: string;
+    directory: string;
+  }): Promise<void> {
+    const output: string = path.resolve(props.output);
+    const directory: string = path.resolve(props.directory);
+    if (isSameOrChildPath(directory, output) === false) {
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): output parent path escapes output directory: ${props.directory}`,
+      );
+    }
+
+    const relative: string = path.relative(output, directory);
+    if (relative === "") {
+      return;
+    }
+
+    let current: string = output;
+    for (const segment of relative.split(path.sep)) {
+      current = path.join(current, segment);
+      let stat: fs.Stats;
+      try {
+        stat = await fs.promises.lstat(current);
+      } catch (exp) {
+        if (isMissingFileError(exp)) {
+          return;
+        }
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): unable to inspect output parent path ${current}: ${formatUnknownError(exp)}`,
+        );
+      }
+      if (stat.isSymbolicLink()) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): output parent path contains a symbolic link: ${current}`,
+        );
+      }
+      if (stat.isDirectory() === false) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): output parent path is not a directory: ${current}`,
+        );
+      }
     }
   }
 

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -110,7 +110,7 @@ export namespace TypiaGenerateWizard {
 
   async function build(location: IArguments): Promise<void> {
     location.output = path.resolve(location.output);
-    location.project = path.resolve(location.project);
+    location.project = resolveProjectConfigFile(location.project);
 
     const entries: IInputFile[] =
       location.files.length === 0
@@ -214,7 +214,7 @@ export namespace TypiaGenerateWizard {
 
   async function ensureCreatableDirectory(directory: string): Promise<void> {
     const parent: string = await nearestExistingAncestor(directory);
-    await ensureExistingDirectory({
+    await ensureExistingDirectoryPath({
       label: "output parent path",
       directory: parent,
     });
@@ -279,6 +279,33 @@ export namespace TypiaGenerateWizard {
   }
 
   async function ensureExistingDirectory(props: {
+    label: string;
+    directory: string;
+  }): Promise<void> {
+    await ensureExistingDirectoryPath(props);
+  }
+
+  async function ensureExistingDirectoryPath(props: {
+    label: string;
+    directory: string;
+  }): Promise<void> {
+    const directory: string = path.resolve(props.directory);
+    const parsed: path.ParsedPath = path.parse(directory);
+    const relative: string = path.relative(parsed.root, directory);
+    let current: string = parsed.root;
+    for (const segment of relative === "" ? [] : relative.split(path.sep)) {
+      current = path.join(current, segment);
+      await ensureExistingDirectorySegment({
+        label:
+          filesystemKey(current) === filesystemKey(directory)
+            ? props.label
+            : `${props.label} ancestor`,
+        directory: current,
+      });
+    }
+  }
+
+  async function ensureExistingDirectorySegment(props: {
     label: string;
     directory: string;
   }): Promise<void> {
@@ -507,6 +534,34 @@ export namespace TypiaGenerateWizard {
     );
   }
 
+  function resolveProjectConfigFile(project: string): string {
+    const resolved: string = path.resolve(project);
+    if (fs.existsSync(resolved) === false) {
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): project path does not exist: ${resolved}`,
+      );
+    }
+
+    const stat: fs.Stats = fs.statSync(resolved);
+    if (stat.isDirectory()) {
+      for (const filename of ["tsconfig.json", "jsconfig.json"]) {
+        const candidate: string = path.join(resolved, filename);
+        if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+          return resolveRealPath(candidate);
+        }
+      }
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): project directory has no tsconfig.json or jsconfig.json: ${resolved}`,
+      );
+    }
+    if (stat.isFile() === false) {
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): project path is not a file: ${resolved}`,
+      );
+    }
+    return resolveRealPath(resolved);
+  }
+
   function loadTtscCompiler(): typeof import("ttsc").TtscCompiler {
     const packageRoot: string = resolveTypiaPackageRoot();
     const resolved: string | null = resolveFromRoots(
@@ -686,6 +741,14 @@ export namespace TypiaGenerateWizard {
 
   function projectFileKey(file: string): string {
     return isCaseSensitive() ? file : file.toLowerCase();
+  }
+
+  function resolveRealPath(file: string): string {
+    try {
+      return fs.realpathSync(file);
+    } catch {
+      return file;
+    }
   }
 
   function isSamePath(x: string, y: string): boolean {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -147,7 +147,7 @@ export namespace TypiaGenerateWizard {
       output: location.output,
       entries: outputs.map(({ entry }) => entry),
     });
-    await ensureTargetFiles(outputs.map(({ entry }) => entry.target));
+    await ensureTargetFiles(outputs.map(({ entry }) => entry));
     for (const { entry, output } of outputs) {
       await fs.promises.writeFile(entry.target, formatOutput(output), "utf8");
     }
@@ -323,27 +323,34 @@ export namespace TypiaGenerateWizard {
     }
   }
 
-  async function ensureTargetFiles(targets: string[]): Promise<void> {
-    const files: Map<string, string> = new Map();
-    for (const target of targets) {
-      files.set(filesystemKey(target), target);
+  async function ensureTargetFiles(entries: IInputFile[]): Promise<void> {
+    const inputs: Set<string> = new Set();
+    const files: Map<string, IInputFile> = new Map();
+    for (const entry of entries) {
+      inputs.add(fileIdentityKey(await fs.promises.stat(entry.file)));
+      files.set(filesystemKey(entry.target), entry);
     }
 
-    for (const file of files.values()) {
+    for (const entry of files.values()) {
       let stat: fs.Stats;
       try {
-        stat = await fs.promises.lstat(file);
+        stat = await fs.promises.lstat(entry.target);
       } catch (exp) {
         if (isMissingFileError(exp)) {
           continue;
         }
         throw new URIError(
-          `Error on TypiaGenerateWizard.generate(): unable to inspect output file ${file}: ${formatUnknownError(exp)}`,
+          `Error on TypiaGenerateWizard.generate(): unable to inspect output file ${entry.target}: ${formatUnknownError(exp)}`,
         );
       }
       if (stat.isFile() === false) {
         throw new URIError(
-          `Error on TypiaGenerateWizard.generate(): output file path is not a regular file: ${file}`,
+          `Error on TypiaGenerateWizard.generate(): output file path is not a regular file: ${entry.target}`,
+        );
+      }
+      if (inputs.has(fileIdentityKey(stat))) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): output file would overwrite input file through a physical file alias: ${entry.target}`,
         );
       }
     }
@@ -358,6 +365,11 @@ export namespace TypiaGenerateWizard {
       );
     }
     const input = path.resolve(location.input);
+    if (fs.existsSync(input) === false) {
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): input path does not exist: ${input}`,
+      );
+    }
     if ((await isDirectory(input)) === false) {
       throw new URIError(
         "Error on TypiaGenerateWizard.generate(): input path is not a directory.",
@@ -692,6 +704,10 @@ export namespace TypiaGenerateWizard {
       "code" in exp &&
       exp.code === "ENOENT"
     );
+  }
+
+  function fileIdentityKey(stat: fs.Stats): string {
+    return `${stat.dev}:${stat.ino}`;
   }
 
   function formatDiagnostics(diagnostics: ITtscCompilerDiagnostic[]): string {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -402,10 +402,16 @@ export namespace TypiaGenerateWizard {
       location.output,
     )) {
       const file: string = path.resolve(input);
-      if (fs.existsSync(file) === false || (await isFile(file)) === false) {
+      if (fs.existsSync(file) === false) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): input file does not exist: ${input}`,
         );
+      } else if ((await isFile(file)) === false) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): input path is not a file: ${input}`,
+        );
+      } else if (isDeclarationFile(file)) {
+        continue;
       } else if (isSupportedExtension(file) === false) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): input file is not a supported TypeScript source: ${input}`,
@@ -649,6 +655,13 @@ export namespace TypiaGenerateWizard {
       ? filename
       : filename.toLowerCase();
     return TS_PATTERN.test(normalized) && !DTS_PATTERN.test(normalized);
+  }
+
+  function isDeclarationFile(filename: string): boolean {
+    const normalized: string = isCaseSensitive()
+      ? filename
+      : filename.toLowerCase();
+    return DTS_PATTERN.test(normalized);
   }
 
   function formatOutput(output: string): string {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -1,4 +1,4 @@
-import commander from "commander";
+import { createCommand } from "commander";
 import fs from "fs";
 import inquirer from "inquirer";
 import { createRequire } from "module";
@@ -20,12 +20,11 @@ export namespace TypiaGenerateWizard {
   }
 
   async function parseArguments(): Promise<IArguments> {
-    commander.program.option("--input [path]", "input directory");
-    commander.program.option("--output [directory]", "output directory");
-    commander.program.option(
-      "--project [project]",
-      "tsconfig.json file location",
-    );
+    const command = createCommand();
+    command.argument("[files...]", "input .ts files");
+    command.option("--input [path]", "input directory");
+    command.option("--output [directory]", "output directory");
+    command.option("--project [project]", "tsconfig.json file location");
 
     const questioned = { value: false };
     const prompt = inquirer.createPromptModule;
@@ -68,55 +67,51 @@ export namespace TypiaGenerateWizard {
     };
 
     return new Promise<IArguments>((resolve, reject) => {
-      commander.program.action(async (options: Partial<IArguments>) => {
+      command.action(async (files: string[], options: Partial<IArguments>) => {
         try {
-          options.input ??= await input("input")("input directory");
-          options.output ??= await input("output")("output directory");
-          options.project ??= await configure();
+          if (files.length !== 0 && options.input !== undefined) {
+            throw new URIError(
+              "Error on TypiaGenerateWizard.generate(): file arguments cannot be combined with --input.",
+            );
+          }
+          if (files.length === 0) {
+            options.input ??= await input("input")("input directory");
+          }
+          const output: string =
+            options.output ?? (await input("output")("output directory"));
+          const project: string = options.project ?? (await configure());
           if (questioned.value) console.log("");
-          resolve(options as IArguments);
+          resolve({
+            input: options.input,
+            output,
+            project,
+            files,
+          });
         } catch (exp) {
           reject(exp);
         }
       });
-      commander.program.parseAsync().catch(reject);
+      command.parseAsync(process.argv.slice(3), { from: "user" }).catch(reject);
     });
   }
 
   export interface IArguments {
-    input: string;
+    input?: string;
     output: string;
     project: string;
+    files: string[];
   }
 
   async function build(location: IArguments): Promise<void> {
-    location.input = path.resolve(location.input);
     location.output = path.resolve(location.output);
     location.project = path.resolve(location.project);
 
-    if ((await isDirectory(location.input)) === false) {
-      throw new URIError(
-        "Error on TypiaGenerateWizard.generate(): input path is not a directory.",
-      );
-    } else if (fs.existsSync(location.output) === false) {
-      await fs.promises.mkdir(location.output, { recursive: true });
-    } else if ((await isDirectory(location.output)) === false) {
-      const parent: string = path.join(location.output, "..");
-      if ((await isDirectory(parent)) === false) {
-        throw new URIError(
-          "Error on TypiaGenerateWizard.generate(): output path is not a directory.",
-        );
-      }
-      await fs.promises.mkdir(location.output);
-    }
+    await ensureOutputDirectory(location.output);
 
-    const files: string[] = [];
-    await gather({
-      location,
-      container: files,
-      from: location.input,
-      to: location.output,
-    });
+    const entries: IInputFile[] =
+      location.files.length === 0
+        ? await prepareDirectoryInput(location)
+        : await prepareFileInputs(location);
 
     const binary = resolveTsgoBinary();
     const cwd = path.dirname(location.project);
@@ -125,18 +120,91 @@ export namespace TypiaGenerateWizard {
       cwd,
       tsconfig: location.project,
     });
-    for (const file of files) {
-      const relative = path.relative(location.input, file);
-      const target = path.join(location.output, relative);
-      const output = transformed[projectKey(cwd, file)];
+    for (const entry of entries) {
+      const output = transformed[projectKey(cwd, entry.file)];
       if (output === undefined) {
         throw new URIError(
-          `Error on TypiaGenerateWizard.generate(): no transformed output for ${file}`,
+          `Error on TypiaGenerateWizard.generate(): no transformed output for ${entry.file}`,
         );
       }
-      await fs.promises.mkdir(path.dirname(target), { recursive: true });
-      await fs.promises.writeFile(target, formatOutput(output), "utf8");
+      await fs.promises.mkdir(path.dirname(entry.target), { recursive: true });
+      await fs.promises.writeFile(entry.target, formatOutput(output), "utf8");
     }
+  }
+
+  interface IInputFile {
+    file: string;
+    target: string;
+  }
+
+  async function ensureOutputDirectory(output: string): Promise<void> {
+    if (fs.existsSync(output) === false) {
+      await fs.promises.mkdir(output, { recursive: true });
+    } else if ((await isDirectory(output)) === false) {
+      throw new URIError(
+        "Error on TypiaGenerateWizard.generate(): output path is not a directory.",
+      );
+    }
+  }
+
+  async function prepareDirectoryInput(
+    location: IArguments,
+  ): Promise<IInputFile[]> {
+    if (location.input === undefined) {
+      throw new URIError(
+        "Error on TypiaGenerateWizard.generate(): input path is required.",
+      );
+    }
+    const input = path.resolve(location.input);
+    if ((await isDirectory(input)) === false) {
+      throw new URIError(
+        "Error on TypiaGenerateWizard.generate(): input path is not a directory.",
+      );
+    }
+
+    const files: string[] = [];
+    await gather({
+      location: {
+        input,
+        output: location.output,
+      },
+      container: files,
+      from: input,
+      to: location.output,
+    });
+    return files.map((file) => ({
+      file,
+      target: path.join(location.output, path.relative(input, file)),
+    }));
+  }
+
+  async function prepareFileInputs(
+    location: IArguments,
+  ): Promise<IInputFile[]> {
+    const targets: Set<string> = new Set();
+    const output: IInputFile[] = [];
+    for (const input of location.files) {
+      const file: string = path.resolve(input);
+      if (fs.existsSync(file) === false || (await isFile(file)) === false) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): input file does not exist: ${input}`,
+        );
+      } else if (isSupportedExtension(file) === false) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): input file is not a supported TypeScript source: ${input}`,
+        );
+      }
+
+      const target: string = path.join(location.output, path.basename(file));
+      if (targets.has(target)) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): duplicate output filename for ${target}`,
+        );
+      }
+      targets.add(target);
+      output.push({ file, target });
+    }
+    return output;
   }
 
   function transformProject(props: {
@@ -251,8 +319,16 @@ export namespace TypiaGenerateWizard {
     return stat.isDirectory();
   }
 
+  async function isFile(current: string): Promise<boolean> {
+    const stat: fs.Stats = await fs.promises.stat(current);
+    return stat.isFile();
+  }
+
   async function gather(props: {
-    location: IArguments;
+    location: {
+      input: string;
+      output: string;
+    };
     container: string[];
     from: string;
     to: string;

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -4,10 +4,9 @@ import inquirer from "inquirer";
 import { createRequire } from "module";
 import path from "path";
 import { glob, isDynamicPattern } from "tinyglobby";
-import {
-  type ITtscCompilerDiagnostic,
-  type ITtscCompilerTransformation,
-  TtscCompiler,
+import type {
+  ITtscCompilerDiagnostic,
+  ITtscCompilerTransformation,
 } from "ttsc";
 
 export namespace TypiaGenerateWizard {
@@ -120,7 +119,7 @@ export namespace TypiaGenerateWizard {
 
     const binary = resolveTsgoBinary();
     const cwd = path.dirname(location.project);
-    const transformed = transformProject({
+    const transformed = await transformProject({
       binary,
       cwd,
       tsconfig: location.project,
@@ -136,8 +135,8 @@ export namespace TypiaGenerateWizard {
     });
 
     await ensureOutputDirectory(location.output);
+    await ensureTargetDirectories(outputs.map(({ entry }) => entry.target));
     for (const { entry, output } of outputs) {
-      await fs.promises.mkdir(path.dirname(entry.target), { recursive: true });
       await fs.promises.writeFile(entry.target, formatOutput(output), "utf8");
     }
   }
@@ -159,6 +158,34 @@ export namespace TypiaGenerateWizard {
       throw new URIError(
         "Error on TypiaGenerateWizard.generate(): output path is not a directory.",
       );
+    }
+  }
+
+  async function ensureTargetDirectories(targets: string[]): Promise<void> {
+    const directories: Map<string, string> = new Map();
+    for (const target of targets) {
+      const directory: string = path.dirname(target);
+      directories.set(filesystemKey(directory), directory);
+    }
+
+    for (const directory of directories.values()) {
+      if (
+        fs.existsSync(directory) &&
+        (await isDirectory(directory)) === false
+      ) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): output parent path is not a directory: ${directory}`,
+        );
+      }
+    }
+    for (const directory of directories.values()) {
+      try {
+        await fs.promises.mkdir(directory, { recursive: true });
+      } catch (exp) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): unable to create output parent directory ${directory}: ${formatUnknownError(exp)}`,
+        );
+      }
     }
   }
 
@@ -198,7 +225,10 @@ export namespace TypiaGenerateWizard {
   ): Promise<IInputFile[]> {
     const targets: Set<string> = new Set();
     const output: IInputFile[] = [];
-    for (const input of await expandFileInputs(location.files)) {
+    for (const input of await expandFileInputs(
+      location.files,
+      location.output,
+    )) {
       const file: string = path.resolve(input);
       if (fs.existsSync(file) === false || (await isFile(file)) === false) {
         throw new URIError(
@@ -225,10 +255,18 @@ export namespace TypiaGenerateWizard {
       targets.add(key);
       output.push({ file, target });
     }
+    if (output.length === 0) {
+      throw new URIError(
+        "Error on TypiaGenerateWizard.generate(): input files do not include any source files outside the output directory.",
+      );
+    }
     return output;
   }
 
-  async function expandFileInputs(inputs: string[]): Promise<string[]> {
+  async function expandFileInputs(
+    inputs: string[],
+    directory: string,
+  ): Promise<string[]> {
     const output: string[] = [];
     for (const input of inputs) {
       const pattern: string = toGlobPattern(input);
@@ -246,23 +284,31 @@ export namespace TypiaGenerateWizard {
             `Error on TypiaGenerateWizard.generate(): input pattern does not match any files: ${input}`,
           );
         }
-        output.push(...matches);
+        output.push(...excludeOutputFiles(matches, directory));
       } else {
-        output.push(path.resolve(input));
+        const file: string = path.resolve(input);
+        if (isSameOrChildPath(file, directory) === false) {
+          output.push(file);
+        }
       }
     }
     return output;
+  }
+
+  function excludeOutputFiles(files: string[], directory: string): string[] {
+    return files.filter((file) => isSameOrChildPath(file, directory) === false);
   }
 
   function toGlobPattern(input: string): string {
     return input.replace(/\\/g, "/");
   }
 
-  function transformProject(props: {
+  async function transformProject(props: {
     binary: string;
     cwd: string;
     tsconfig: string;
-  }): Record<string, string> {
+  }): Promise<Record<string, string>> {
+    const { TtscCompiler } = await import("ttsc");
     const result: ITtscCompilerTransformation = new TtscCompiler({
       binary: props.binary,
       cwd: props.cwd,
@@ -421,6 +467,15 @@ export namespace TypiaGenerateWizard {
 
   function isSamePath(x: string, y: string): boolean {
     return filesystemKey(x) === filesystemKey(y);
+  }
+
+  function isSameOrChildPath(file: string, directory: string): boolean {
+    const fileKey: string = filesystemKey(path.resolve(file));
+    const directoryKey: string = filesystemKey(path.resolve(directory));
+    const directoryPrefix: string = directoryKey.endsWith(path.sep)
+      ? directoryKey
+      : `${directoryKey}${path.sep}`;
+    return fileKey === directoryKey || fileKey.startsWith(directoryPrefix);
   }
 
   function filesystemKey(file: string): string {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -31,6 +31,7 @@ export namespace TypiaGenerateWizard {
     const prompt = inquirer.createPromptModule;
 
     const input = (name: string) => async (message: string) => {
+      questioned.value = true;
       const result = await prompt()({
         type: "input",
         name,
@@ -39,32 +40,14 @@ export namespace TypiaGenerateWizard {
       });
       return result[name] as string;
     };
-    const select =
-      (name: string) =>
-      (message: string) =>
-      async <Choice extends string>(choices: Choice[]): Promise<Choice> => {
-        questioned.value = true;
-        return (
-          await prompt()({
-            type: "list",
-            name: name,
-            message: message,
-            choices: choices,
-          })
-        )[name];
-      };
     const configure = async (): Promise<string> => {
-      const files: string[] = await (
-        await fs.promises.readdir(process.cwd())
-      ).filter(
-        (str) =>
-          str.substring(0, 8) === "tsconfig" &&
-          str.substring(str.length - 5) === ".json",
-      );
-      if (files.length === 0)
-        throw new URIError(`Unable to find "tsconfig.json" file.`);
-      else if (files.length === 1) return files[0]!;
-      return select("tsconfig")("TS Config File")(files);
+      const file: string | null = findProjectConfigFile(process.cwd());
+      if (file === null) {
+        throw new URIError(
+          `Unable to find "tsconfig.json" or "jsconfig.json" file.`,
+        );
+      }
+      return file;
     };
 
     return new Promise<IArguments>((resolve, reject) => {
@@ -560,6 +543,23 @@ export namespace TypiaGenerateWizard {
       );
     }
     return resolveRealPath(resolved);
+  }
+
+  function findProjectConfigFile(directory: string): string | null {
+    let current: string = path.resolve(directory);
+    while (true) {
+      for (const filename of ["tsconfig.json", "jsconfig.json"]) {
+        const candidate: string = path.join(current, filename);
+        if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+          return resolveRealPath(candidate);
+        }
+      }
+      const parent: string = path.dirname(current);
+      if (parent === current) {
+        return null;
+      }
+      current = parent;
+    }
   }
 
   function loadTtscCompiler(): typeof import("ttsc").TtscCompiler {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -22,7 +22,7 @@ export namespace TypiaGenerateWizard {
   async function parseArguments(): Promise<IArguments> {
     const command = createCommand("typia generate");
     command.usage("[options] [files...]");
-    command.argument("[files...]", "input .ts files or globs");
+    command.argument("[files...]", "input TypeScript source files or globs");
     command.option("--input <path>", "input directory");
     command.option("--output <directory>", "output directory");
     command.option(

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -140,6 +140,10 @@ export namespace TypiaGenerateWizard {
 
     await ensureOutputDirectory(location.output);
     await ensureTargetDirectories(outputs.map(({ entry }) => entry.target));
+    await ensurePhysicalTargets({
+      output: location.output,
+      entries: outputs.map(({ entry }) => entry),
+    });
     await ensureTargetFiles(outputs.map(({ entry }) => entry.target));
     for (const { entry, output } of outputs) {
       await fs.promises.writeFile(entry.target, formatOutput(output), "utf8");
@@ -159,10 +163,11 @@ export namespace TypiaGenerateWizard {
   async function ensureOutputDirectory(output: string): Promise<void> {
     if (fs.existsSync(output) === false) {
       await fs.promises.mkdir(output, { recursive: true });
-    } else if ((await isDirectory(output)) === false) {
-      throw new URIError(
-        "Error on TypiaGenerateWizard.generate(): output path is not a directory.",
-      );
+    } else {
+      await ensureExistingDirectory({
+        label: "output path",
+        directory: output,
+      });
     }
   }
 
@@ -174,13 +179,11 @@ export namespace TypiaGenerateWizard {
     }
 
     for (const directory of directories.values()) {
-      if (
-        fs.existsSync(directory) &&
-        (await isDirectory(directory)) === false
-      ) {
-        throw new URIError(
-          `Error on TypiaGenerateWizard.generate(): output parent path is not a directory: ${directory}`,
-        );
+      if (fs.existsSync(directory)) {
+        await ensureExistingDirectory({
+          label: "output parent path",
+          directory,
+        });
       }
     }
     for (const directory of directories.values()) {
@@ -189,6 +192,55 @@ export namespace TypiaGenerateWizard {
       } catch (exp) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): unable to create output parent directory ${directory}: ${formatUnknownError(exp)}`,
+        );
+      }
+      await ensureExistingDirectory({
+        label: "output parent path",
+        directory,
+      });
+    }
+  }
+
+  async function ensureExistingDirectory(props: {
+    label: string;
+    directory: string;
+  }): Promise<void> {
+    const stat: fs.Stats = await fs.promises.lstat(props.directory);
+    if (stat.isSymbolicLink()) {
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): ${props.label} is a symbolic link: ${props.directory}`,
+      );
+    }
+    if (stat.isDirectory() === false) {
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): ${props.label} is not a directory: ${props.directory}`,
+      );
+    }
+  }
+
+  async function ensurePhysicalTargets(props: {
+    output: string;
+    entries: IInputFile[];
+  }): Promise<void> {
+    const output: string = await fs.promises.realpath(props.output);
+    const inputs: Set<string> = new Set();
+    for (const entry of props.entries) {
+      inputs.add(filesystemKey(await fs.promises.realpath(entry.file)));
+    }
+
+    for (const entry of props.entries) {
+      const parent: string = path.dirname(entry.target);
+      const directory: string = await fs.promises.realpath(parent);
+      if (isSameOrChildPath(directory, output) === false) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): output parent path escapes output directory through a symbolic link: ${parent}`,
+        );
+      }
+
+      const target: string = path.join(directory, path.basename(entry.target));
+      if (inputs.has(filesystemKey(target))) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): output file would overwrite input file through a symbolic link: ${entry.target}`,
         );
       }
     }
@@ -288,7 +340,7 @@ export namespace TypiaGenerateWizard {
     }
     if (output.length === 0) {
       throw new URIError(
-        "Error on TypiaGenerateWizard.generate(): input files do not include any source files outside the output directory.",
+        "Error on TypiaGenerateWizard.generate(): input files do not include any supported TypeScript source files outside the output directory.",
       );
     }
     return output;
@@ -301,9 +353,7 @@ export namespace TypiaGenerateWizard {
     const output: string[] = [];
     for (const input of inputs) {
       const pattern: string = toGlobPattern(input);
-      if (
-        isDynamicPattern(pattern, { caseSensitiveMatch: isCaseSensitive() })
-      ) {
+      if (isDynamicPattern(pattern, { caseSensitiveMatch: true })) {
         const matches: string[] = await glob(pattern, {
           absolute: true,
           caseSensitiveMatch: isCaseSensitive(),
@@ -506,7 +556,10 @@ export namespace TypiaGenerateWizard {
   }
 
   function isSupportedExtension(filename: string): boolean {
-    return TS_PATTERN.test(filename) && !DTS_PATTERN.test(filename);
+    const normalized: string = isCaseSensitive()
+      ? filename
+      : filename.toLowerCase();
+    return TS_PATTERN.test(normalized) && !DTS_PATTERN.test(normalized);
   }
 
   function formatOutput(output: string): string {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -24,9 +24,9 @@ export namespace TypiaGenerateWizard {
     const command = createCommand("typia generate");
     command.usage("[options] [files...]");
     command.argument("[files...]", "input .ts files or globs");
-    command.option("--input [path]", "input directory");
-    command.option("--output [directory]", "output directory");
-    command.option("--project [project]", "tsconfig.json file location");
+    command.option("--input <path>", "input directory");
+    command.option("--output <directory>", "output directory");
+    command.option("--project <project>", "tsconfig.json file location");
 
     const questioned = { value: false };
     const prompt = inquirer.createPromptModule;
@@ -117,7 +117,6 @@ export namespace TypiaGenerateWizard {
       location.files.length === 0
         ? await prepareDirectoryInput(location)
         : await prepareFileInputs(location);
-    await ensureOutputDirectory(location.output);
 
     const binary = resolveTsgoBinary();
     const cwd = path.dirname(location.project);
@@ -126,13 +125,18 @@ export namespace TypiaGenerateWizard {
       cwd,
       tsconfig: location.project,
     });
-    for (const entry of entries) {
+    const outputs: IOutputFile[] = entries.map((entry) => {
       const output = transformed[projectKey(cwd, entry.file)];
       if (output === undefined) {
         throw new URIError(
-          `Error on TypiaGenerateWizard.generate(): no transformed output for ${entry.file}`,
+          `Error on TypiaGenerateWizard.generate(): no transformed output for ${entry.file}. Check that --project includes the file.`,
         );
       }
+      return { entry, output };
+    });
+
+    await ensureOutputDirectory(location.output);
+    for (const { entry, output } of outputs) {
       await fs.promises.mkdir(path.dirname(entry.target), { recursive: true });
       await fs.promises.writeFile(entry.target, formatOutput(output), "utf8");
     }
@@ -141,6 +145,11 @@ export namespace TypiaGenerateWizard {
   interface IInputFile {
     file: string;
     target: string;
+  }
+
+  interface IOutputFile {
+    entry: IInputFile;
+    output: string;
   }
 
   async function ensureOutputDirectory(output: string): Promise<void> {
@@ -202,6 +211,11 @@ export namespace TypiaGenerateWizard {
       }
 
       const target: string = path.join(location.output, path.basename(file));
+      if (isSamePath(file, target)) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): output file would overwrite input file: ${input}`,
+        );
+      }
       const key: string = filesystemKey(target);
       if (targets.has(key)) {
         throw new URIError(
@@ -217,8 +231,11 @@ export namespace TypiaGenerateWizard {
   async function expandFileInputs(inputs: string[]): Promise<string[]> {
     const output: string[] = [];
     for (const input of inputs) {
-      if (isDynamicPattern(input, { caseSensitiveMatch: isCaseSensitive() })) {
-        const matches: string[] = await glob(input, {
+      const pattern: string = toGlobPattern(input);
+      if (
+        isDynamicPattern(pattern, { caseSensitiveMatch: isCaseSensitive() })
+      ) {
+        const matches: string[] = await glob(pattern, {
           absolute: true,
           caseSensitiveMatch: isCaseSensitive(),
           cwd: process.cwd(),
@@ -235,6 +252,10 @@ export namespace TypiaGenerateWizard {
       }
     }
     return output;
+  }
+
+  function toGlobPattern(input: string): string {
+    return input.replace(/\\/g, "/");
   }
 
   function transformProject(props: {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import inquirer from "inquirer";
 import { createRequire } from "module";
 import path from "path";
+import { glob, isDynamicPattern } from "tinyglobby";
 import {
   type ITtscCompilerDiagnostic,
   type ITtscCompilerTransformation,
@@ -20,8 +21,9 @@ export namespace TypiaGenerateWizard {
   }
 
   async function parseArguments(): Promise<IArguments> {
-    const command = createCommand();
-    command.argument("[files...]", "input .ts files");
+    const command = createCommand("typia generate");
+    command.usage("[options] [files...]");
+    command.argument("[files...]", "input .ts files or globs");
     command.option("--input [path]", "input directory");
     command.option("--output [directory]", "output directory");
     command.option("--project [project]", "tsconfig.json file location");
@@ -77,6 +79,11 @@ export namespace TypiaGenerateWizard {
           if (files.length === 0) {
             options.input ??= await input("input")("input directory");
           }
+          if (files.length !== 0 && options.output === undefined) {
+            throw new URIError(
+              "Error on TypiaGenerateWizard.generate(): output directory is required when file arguments are used.",
+            );
+          }
           const output: string =
             options.output ?? (await input("output")("output directory"));
           const project: string = options.project ?? (await configure());
@@ -106,12 +113,11 @@ export namespace TypiaGenerateWizard {
     location.output = path.resolve(location.output);
     location.project = path.resolve(location.project);
 
-    await ensureOutputDirectory(location.output);
-
     const entries: IInputFile[] =
       location.files.length === 0
         ? await prepareDirectoryInput(location)
         : await prepareFileInputs(location);
+    await ensureOutputDirectory(location.output);
 
     const binary = resolveTsgoBinary();
     const cwd = path.dirname(location.project);
@@ -183,7 +189,7 @@ export namespace TypiaGenerateWizard {
   ): Promise<IInputFile[]> {
     const targets: Set<string> = new Set();
     const output: IInputFile[] = [];
-    for (const input of location.files) {
+    for (const input of await expandFileInputs(location.files)) {
       const file: string = path.resolve(input);
       if (fs.existsSync(file) === false || (await isFile(file)) === false) {
         throw new URIError(
@@ -196,13 +202,37 @@ export namespace TypiaGenerateWizard {
       }
 
       const target: string = path.join(location.output, path.basename(file));
-      if (targets.has(target)) {
+      const key: string = filesystemKey(target);
+      if (targets.has(key)) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): duplicate output filename for ${target}`,
         );
       }
-      targets.add(target);
+      targets.add(key);
       output.push({ file, target });
+    }
+    return output;
+  }
+
+  async function expandFileInputs(inputs: string[]): Promise<string[]> {
+    const output: string[] = [];
+    for (const input of inputs) {
+      if (isDynamicPattern(input, { caseSensitiveMatch: isCaseSensitive() })) {
+        const matches: string[] = await glob(input, {
+          absolute: true,
+          caseSensitiveMatch: isCaseSensitive(),
+          cwd: process.cwd(),
+          onlyFiles: true,
+        });
+        if (matches.length === 0) {
+          throw new URIError(
+            `Error on TypiaGenerateWizard.generate(): input pattern does not match any files: ${input}`,
+          );
+        }
+        output.push(...matches);
+      } else {
+        output.push(path.resolve(input));
+      }
     }
     return output;
   }
@@ -333,10 +363,7 @@ export namespace TypiaGenerateWizard {
     from: string;
     to: string;
   }): Promise<void> {
-    if (props.from === props.location.output) return;
-    if (fs.existsSync(props.to) === false) {
-      await fs.promises.mkdir(props.to);
-    }
+    if (isSamePath(props.from, props.location.output)) return;
 
     for (const file of await fs.promises.readdir(props.from)) {
       const next: string = path.join(props.from, file);
@@ -369,6 +396,19 @@ export namespace TypiaGenerateWizard {
 
   function projectKey(root: string, file: string): string {
     return path.relative(root, file).replace(/\\/g, "/");
+  }
+
+  function isSamePath(x: string, y: string): boolean {
+    return filesystemKey(x) === filesystemKey(y);
+  }
+
+  function filesystemKey(file: string): string {
+    const normalized: string = path.normalize(file);
+    return isCaseSensitive() ? normalized : normalized.toLowerCase();
+  }
+
+  function isCaseSensitive(): boolean {
+    return process.platform !== "win32" && process.platform !== "darwin";
   }
 
   function formatDiagnostics(diagnostics: ITtscCompilerDiagnostic[]): string {

--- a/packages/typia/src/executable/typia.ts
+++ b/packages/typia/src/executable/typia.ts
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 const USAGE = `Wrong command has been detected. Use like below:
 
-  npx typia generate 
+  npx typia generate
     --input {directory} \\
     --output {directory}
 
+  npx typia generate
+    --output {directory} \\
+    {file...}
+
     --npx typia generate --input src/templates --output src/functional
+    --npx typia generate --output src/functional src/**/*.typia.ts
 `;
 
 const halt = (desc: string): never => {

--- a/packages/typia/src/executable/typia.ts
+++ b/packages/typia/src/executable/typia.ts
@@ -1,16 +1,15 @@
 #!/usr/bin/env node
 const USAGE = `Wrong command has been detected. Use like below:
 
-  npx typia generate
-    --input {directory} \\
-    --output {directory}
+  npx typia generate [options] [files...]
 
   npx typia generate
-    --output {directory} \\
-    {file...}
+    --input src/templates \\
+    --output src/generated
 
-    --npx typia generate --input src/templates --output src/functional
-    --npx typia generate --output src/functional src/**/*.typia.ts
+  npx typia generate
+    --output src/generated \\
+    src/**/*.typia.ts
 `;
 
 const halt = (desc: string): never => {

--- a/packages/typia/src/executable/typia.ts
+++ b/packages/typia/src/executable/typia.ts
@@ -52,6 +52,6 @@ const main = async (): Promise<void> => {
   } else halt(USAGE);
 };
 main().catch((exp) => {
-  console.error(exp);
+  console.error(exp instanceof URIError ? exp.message : exp);
   process.exit(-1);
 });

--- a/packages/typia/src/executable/typia.ts
+++ b/packages/typia/src/executable/typia.ts
@@ -9,7 +9,7 @@ const USAGE = `Wrong command has been detected. Use like below:
 
   npx typia generate
     --output src/generated \\
-    src/**/*.typia.ts
+    "src/**/*.typia.ts"
 `;
 
 const halt = (desc: string): never => {
@@ -18,12 +18,26 @@ const halt = (desc: string): never => {
 };
 
 const loadNativePreview = (): void => {
+  loadPackage(
+    "@typescript/native-preview/package.json",
+    `@typescript/native-preview has not been installed. Run "npm i -D ttsc @typescript/native-preview" before.`,
+  );
+};
+
+const loadTtsc = (): void => {
+  loadPackage(
+    "ttsc/package.json",
+    `ttsc has not been installed. Run "npm i -D ttsc @typescript/native-preview" before.`,
+  );
+};
+
+const loadPackage = (request: string, desc: string): void => {
   const resolvers: Array<() => string> = [
     () =>
-      require.resolve("@typescript/native-preview/package.json", {
+      require.resolve(request, {
         paths: [process.cwd()],
       }),
-    () => require.resolve("@typescript/native-preview/package.json"),
+    () => require.resolve(request),
   ];
   for (const resolve of resolvers) {
     try {
@@ -31,9 +45,11 @@ const loadNativePreview = (): void => {
       return;
     } catch {}
   }
-  halt(
-    `@typescript/native-preview has not been installed. Run "npm i -D @typescript/native-preview" before.`,
-  );
+  halt(desc);
+};
+
+const isHelp = (args: string[]): boolean => {
+  return args.some((arg) => arg === "--help" || arg === "-h");
 };
 
 const main = async (): Promise<void> => {
@@ -46,7 +62,10 @@ const main = async (): Promise<void> => {
 
   const type: string | undefined = process.argv[2];
   if (type === "generate") {
-    loadNativePreview();
+    if (isHelp(process.argv.slice(3)) === false) {
+      loadTtsc();
+      loadNativePreview();
+    }
     const { TypiaGenerateWizard } = await import("./TypiaGenerateWizard.js");
     await TypiaGenerateWizard.generate();
   } else halt(USAGE);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,9 @@ importers:
       randexp:
         specifier: ^0.5.3
         version: 0.5.3
+      tinyglobby:
+        specifier: ^0.2.12
+        version: 0.2.16
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: catalog:rollup
@@ -408,9 +411,6 @@ importers:
       suppress-warnings:
         specifier: ^1.0.2
         version: 1.0.2
-      tinyglobby:
-        specifier: ^0.2.12
-        version: 0.2.16
       ttsc:
         specifier: catalog:typescript
         version: 0.15.1

--- a/tests/test-typia-generate/jsconfig-dir/jsconfig.json
+++ b/tests/test-typia-generate/jsconfig-dir/jsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "ESNext"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["*"],
+    "noEmit": true,
+    "newLine": "lf",
+    "esModuleInterop": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "plugins": [{ "transform": "typia/lib/transform" }]
+  },
+  "include": ["src/generate_jsconfig.ts"]
+}

--- a/tests/test-typia-generate/jsconfig-dir/src/generate_jsconfig.ts
+++ b/tests/test-typia-generate/jsconfig-dir/src/generate_jsconfig.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+interface IJsConfigTemplate {
+  id: string;
+  value: number;
+}
+
+export const isJsConfig = typia.createIs<IJsConfigTemplate>();

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -7,9 +7,10 @@
     "build": "ttsc",
     "clean": "node -e \"require('fs').rmSync('src/output', { recursive: true, force: true })\"",
     "generate": "pnpm run generate:directory",
-    "generate:directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --input src/input --output src/output",
-    "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output src/input/modules/*.ts",
-    "start": "pnpm run generate:directory && pnpm run build && pnpm run generate:files && pnpm run build"
+    "generate:directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --input src/input --output src/output --project tsconfig.json",
+    "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/input/modules/*.ts\"",
+    "check:files": "node -e \"require('fs').accessSync('src/output/generate_module.ts')\"",
+    "start": "pnpm run generate:directory && pnpm run build && pnpm run generate:files && pnpm run check:files && pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -10,10 +10,12 @@
     "generate:directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --input src/input --output src/output --project tsconfig.json",
     "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/input/modules/*\"",
     "generate:files:literals": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output src/input/modules/generate_module.ts src/input/modules/ignored.d.ts",
+    "generate:files:project-directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project project-dir --output src/output project-dir/src/generate_project.ts",
     "generate:files:rerun": "ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/**/generate_module.ts\"",
     "check:files:errors": "node scripts/check-file-errors.cjs",
     "check:files": "node -e \"require('fs').accessSync('src/output/generate_module.ts')\"",
-    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:literals && pnpm run check:files && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
+    "check:files:project-directory": "node -e \"require('fs').accessSync('src/output/generate_project.ts')\"",
+    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:literals && pnpm run check:files && pnpm run generate:files:project-directory && pnpm run check:files:project-directory && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -8,7 +8,7 @@
     "clean": "node -e \"require('fs').rmSync('src/output', { recursive: true, force: true })\"",
     "generate": "pnpm run generate:directory",
     "generate:directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --input src/input --output src/output",
-    "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output src/input/modules/generate_module.ts",
+    "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output src/input/modules/*.ts",
     "start": "pnpm run generate:directory && pnpm run build && pnpm run generate:files && pnpm run build"
   },
   "repository": {

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -9,10 +9,11 @@
     "generate": "pnpm run generate:directory",
     "generate:directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --input src/input --output src/output --project tsconfig.json",
     "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/input/modules/*\"",
+    "generate:files:literals": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output src/input/modules/generate_module.ts src/input/modules/ignored.d.ts",
     "generate:files:rerun": "ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/**/generate_module.ts\"",
     "check:files:errors": "node scripts/check-file-errors.cjs",
     "check:files": "node -e \"require('fs').accessSync('src/output/generate_module.ts')\"",
-    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
+    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:literals && pnpm run check:files && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -9,8 +9,9 @@
     "generate": "pnpm run generate:directory",
     "generate:directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --input src/input --output src/output --project tsconfig.json",
     "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/input/modules/*.ts\"",
+    "generate:files:rerun": "ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/**/generate_module.ts\"",
     "check:files": "node -e \"require('fs').accessSync('src/output/generate_module.ts')\"",
-    "start": "pnpm run generate:directory && pnpm run build && pnpm run generate:files && pnpm run check:files && pnpm run build"
+    "start": "pnpm run generate:directory && pnpm run build && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -8,10 +8,11 @@
     "clean": "node -e \"require('fs').rmSync('src/output', { recursive: true, force: true })\"",
     "generate": "pnpm run generate:directory",
     "generate:directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --input src/input --output src/output --project tsconfig.json",
-    "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/input/modules/*.ts\"",
+    "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/input/modules/*\"",
     "generate:files:rerun": "ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/**/generate_module.ts\"",
+    "check:files:errors": "node scripts/check-file-errors.cjs",
     "check:files": "node -e \"require('fs').accessSync('src/output/generate_module.ts')\"",
-    "start": "pnpm run generate:directory && pnpm run build && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
+    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -11,11 +11,14 @@
     "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/input/modules/*\"",
     "generate:files:literals": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output src/input/modules/generate_module.ts src/input/modules/ignored.d.ts",
     "generate:files:project-directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project project-dir --output src/output project-dir/src/generate_project.ts",
+    "generate:files:implicit-project": "pnpm run clean && ttsx --cwd project-dir/src ../../node_modules/typia/src/executable/typia.ts generate --output ../../src/output generate_project.ts",
+    "generate:files:implicit-jsconfig": "pnpm run clean && ttsx --cwd jsconfig-dir/src ../../node_modules/typia/src/executable/typia.ts generate --output ../../src/output generate_jsconfig.ts",
     "generate:files:rerun": "ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/**/generate_module.ts\"",
     "check:files:errors": "node scripts/check-file-errors.cjs",
     "check:files": "node -e \"require('fs').accessSync('src/output/generate_module.ts')\"",
     "check:files:project-directory": "node -e \"require('fs').accessSync('src/output/generate_project.ts')\"",
-    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:literals && pnpm run check:files && pnpm run generate:files:project-directory && pnpm run check:files:project-directory && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
+    "check:files:implicit-jsconfig": "node -e \"require('fs').accessSync('src/output/generate_jsconfig.ts')\"",
+    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:literals && pnpm run check:files && pnpm run generate:files:project-directory && pnpm run check:files:project-directory && pnpm run generate:files:implicit-project && pnpm run check:files:project-directory && pnpm run generate:files:implicit-jsconfig && pnpm run check:files:implicit-jsconfig && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -5,8 +5,11 @@
   "description": "Test typia generation command",
   "scripts": {
     "build": "ttsc",
-    "generate": "ttsx node_modules/typia/src/executable/typia.ts generate --input src/input --output src/output",
-    "start": "pnpm run generate && pnpm run build"
+    "clean": "node -e \"require('fs').rmSync('src/output', { recursive: true, force: true })\"",
+    "generate": "pnpm run generate:directory",
+    "generate:directory": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --input src/input --output src/output",
+    "generate:files": "pnpm run clean && ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output src/input/modules/generate_module.ts",
+    "start": "pnpm run generate:directory && pnpm run build && pnpm run generate:files && pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -18,7 +18,7 @@
     "check:files": "node -e \"require('fs').accessSync('src/output/generate_module.ts')\"",
     "check:files:project-directory": "node -e \"require('fs').accessSync('src/output/generate_project.ts')\"",
     "check:files:implicit-jsconfig": "node -e \"require('fs').accessSync('src/output/generate_jsconfig.ts')\"",
-    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:literals && pnpm run check:files && pnpm run generate:files:project-directory && pnpm run check:files:project-directory && pnpm run generate:files:implicit-project && pnpm run check:files:project-directory && pnpm run generate:files:implicit-jsconfig && pnpm run check:files:implicit-jsconfig && pnpm run generate:files:rerun && pnpm run check:files && pnpm run build"
+    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:rerun && pnpm run check:files && pnpm run generate:files:literals && pnpm run check:files && pnpm run generate:files:project-directory && pnpm run check:files:project-directory && pnpm run generate:files:implicit-project && pnpm run check:files:project-directory && pnpm run generate:files:implicit-jsconfig && pnpm run check:files:implicit-jsconfig && pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/tests/test-typia-generate/project-dir/src/generate_project.ts
+++ b/tests/test-typia-generate/project-dir/src/generate_project.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+interface IProjectDirectoryTemplate {
+  id: string;
+  tags: string[];
+}
+
+export const isProjectDirectory = typia.createIs<IProjectDirectoryTemplate>();

--- a/tests/test-typia-generate/project-dir/tsconfig.json
+++ b/tests/test-typia-generate/project-dir/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.json",
+  "include": ["src/generate_project.ts"],
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  }
+}

--- a/tests/test-typia-generate/scripts/check-file-errors.cjs
+++ b/tests/test-typia-generate/scripts/check-file-errors.cjs
@@ -64,9 +64,44 @@ try {
   );
   expectFailure(
     "symlinked output root",
-    generate("--output", "src/output-link", "src/input/modules/generate_module.ts"),
+    generate(
+      "--output",
+      "src/output-link",
+      "src/input/modules/generate_module.ts",
+    ),
     "symbolic link",
   );
 } finally {
   fs.rmSync(link, { recursive: true, force: true });
+}
+
+const output = path.join(root, "src", "output");
+const ancestor = path.join(output, "link");
+const external = path.join(root, "src", "external-output");
+fs.rmSync(output, { recursive: true, force: true });
+fs.rmSync(external, { recursive: true, force: true });
+try {
+  fs.mkdirSync(output, { recursive: true });
+  fs.mkdirSync(external, { recursive: true });
+  fs.symlinkSync(
+    external,
+    ancestor,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  expectFailure(
+    "symlinked output ancestor",
+    generate(
+      "--output",
+      "src/output/link/new",
+      "src/input/modules/generate_module.ts",
+    ),
+    "symbolic link",
+  );
+  if (fs.existsSync(path.join(external, "new"))) {
+    console.error("Symlinked output ancestor created an external directory.");
+    process.exit(1);
+  }
+} finally {
+  fs.rmSync(output, { recursive: true, force: true });
+  fs.rmSync(external, { recursive: true, force: true });
 }

--- a/tests/test-typia-generate/scripts/check-file-errors.cjs
+++ b/tests/test-typia-generate/scripts/check-file-errors.cjs
@@ -42,6 +42,14 @@ const generate = (...args) => [
   ...args,
 ];
 
+const generateWithProject = (project, ...args) => [
+  "node_modules/typia/src/executable/typia.ts",
+  "generate",
+  "--project",
+  project,
+  ...args,
+];
+
 expectFailure(
   "literal unsupported file",
   generate("--output", "src/output", "package.json"),
@@ -104,4 +112,59 @@ try {
 } finally {
   fs.rmSync(output, { recursive: true, force: true });
   fs.rmSync(external, { recursive: true, force: true });
+}
+
+const tempInput = path.join(root, "src", "input-symlink");
+const tempSource = path.join(tempInput, "link", "new", "generate_module.ts");
+const tempProject = path.join(root, "tsconfig.file-errors.json");
+fs.rmSync(output, { recursive: true, force: true });
+fs.rmSync(external, { recursive: true, force: true });
+fs.rmSync(tempInput, { recursive: true, force: true });
+fs.rmSync(tempProject, { force: true });
+try {
+  fs.mkdirSync(path.dirname(tempSource), { recursive: true });
+  fs.copyFileSync(
+    path.join(root, "src", "input", "modules", "generate_module.ts"),
+    tempSource,
+  );
+  fs.writeFileSync(
+    tempProject,
+    JSON.stringify(
+      {
+        extends: "./tsconfig.json",
+        include: ["src/input-symlink/link/new/generate_module.ts"],
+      },
+      null,
+      2,
+    ),
+  );
+  fs.mkdirSync(output, { recursive: true });
+  fs.mkdirSync(external, { recursive: true });
+  fs.symlinkSync(
+    external,
+    ancestor,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  expectFailure(
+    "directory-mode symlinked output ancestor",
+    generateWithProject(
+      "tsconfig.file-errors.json",
+      "--input",
+      "src/input-symlink",
+      "--output",
+      "src/output",
+    ),
+    "symbolic link",
+  );
+  if (fs.existsSync(path.join(external, "new"))) {
+    console.error(
+      "Directory-mode symlinked output ancestor created an external directory.",
+    );
+    process.exit(1);
+  }
+} finally {
+  fs.rmSync(output, { recursive: true, force: true });
+  fs.rmSync(external, { recursive: true, force: true });
+  fs.rmSync(tempInput, { recursive: true, force: true });
+  fs.rmSync(tempProject, { force: true });
 }

--- a/tests/test-typia-generate/scripts/check-file-errors.cjs
+++ b/tests/test-typia-generate/scripts/check-file-errors.cjs
@@ -21,25 +21,27 @@ process.on("exit", () => {
 });
 
 const run = (args) =>
-  cp.execSync([ttsx, ...args].map(quote).join(" "), {
-    cwd: root,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      TTSC_CACHE_DIR: cache,
+  cp.execSync(
+    [ttsx, "--no-plugins", "--cache-dir", cache, ...args]
+      .map(quote)
+      .join(" "),
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        TTSC_CACHE_DIR: cache,
+      },
+      stdio: "pipe",
     },
-    stdio: "pipe",
-  });
+  );
 
 const removePath = (file) => {
   if (fs.existsSync(file) === false) return;
   const stat = fs.lstatSync(file);
   if (stat.isSymbolicLink()) {
-    try {
-      fs.rmSync(file, { force: true });
-    } catch {
-      fs.rmdirSync(file);
-    }
+    if (process.platform === "win32") fs.rmdirSync(file);
+    else fs.unlinkSync(file);
     return;
   }
   fs.rmSync(file, { recursive: true, force: true });
@@ -51,11 +53,9 @@ const expectFailure = (name, args, expected) => {
   } catch (exp) {
     const output = `${exp.stdout ?? ""}${exp.stderr ?? ""}`;
     if (output.includes(expected)) return;
-    console.error(`Unexpected ${name} failure output:\n${output}`);
-    process.exit(1);
+    throw new Error(`Unexpected ${name} failure output:\n${output}`);
   }
-  console.error(`Expected ${name} to fail.`);
-  process.exit(1);
+  throw new Error(`Expected ${name} to fail.`);
 };
 
 const generate = (...args) => [
@@ -81,9 +81,33 @@ expectFailure(
 );
 
 expectFailure(
+  "directory passed as literal file",
+  generate("--output", "src/output", "src/input/modules"),
+  "input path is not a file",
+);
+
+expectFailure(
   "declaration-only glob",
   generate("--output", "src/output", "src/input/modules/*.d.ts"),
   "supported TypeScript source files outside the output directory",
+);
+
+expectFailure(
+  "declaration-only literal",
+  generate("--output", "src/output", "src/input/modules/ignored.d.ts"),
+  "supported TypeScript source files outside the output directory",
+);
+
+expectFailure(
+  "missing directory input",
+  generateWithProject(
+    "tsconfig.files.json",
+    "--input",
+    "src/does-not-exist",
+    "--output",
+    "src/output",
+  ),
+  "input path does not exist",
 );
 
 const inputModule = path.join(
@@ -138,8 +162,7 @@ try {
     "symbolic link",
   );
   if (fs.existsSync(path.join(external, "new"))) {
-    console.error("Symlinked output ancestor created an external directory.");
-    process.exit(1);
+    throw new Error("Symlinked output ancestor created an external directory.");
   }
 } finally {
   removePath(output);
@@ -189,10 +212,9 @@ try {
     "symbolic link",
   );
   if (fs.existsSync(path.join(external, "new"))) {
-    console.error(
+    throw new Error(
       "Directory-mode symlinked output ancestor created an external directory.",
     );
-    process.exit(1);
   }
 } finally {
   removePath(output);
@@ -211,8 +233,7 @@ try {
     "physical file alias",
   );
   if (fs.readFileSync(inputModule, "utf8").includes("// @ts-nocheck")) {
-    console.error("Hard-linked output leaf rewrote the input source.");
-    process.exit(1);
+    throw new Error("Hard-linked output leaf rewrote the input source.");
   }
 } finally {
   removePath(output);

--- a/tests/test-typia-generate/scripts/check-file-errors.cjs
+++ b/tests/test-typia-generate/scripts/check-file-errors.cjs
@@ -58,6 +58,15 @@ const expectFailure = (name, args, expected) => {
   throw new Error(`Expected ${name} to fail.`);
 };
 
+const expectSuccess = (name, args) => {
+  try {
+    run(args);
+  } catch (exp) {
+    const output = `${exp.stdout ?? ""}${exp.stderr ?? ""}`;
+    throw new Error(`Unexpected ${name} failure output:\n${output}`);
+  }
+};
+
 const generate = (...args) => [
   "node_modules/typia/src/executable/typia.ts",
   "generate",
@@ -71,6 +80,14 @@ const generateWithProject = (project, ...args) => [
   "generate",
   "--project",
   project,
+  ...args,
+];
+
+const generateFromCwd = (cwd, ...args) => [
+  "--cwd",
+  cwd,
+  path.join(root, "node_modules", "typia", "src", "executable", "typia.ts"),
+  "generate",
   ...args,
 ];
 
@@ -298,4 +315,53 @@ try {
   }
 } finally {
   removePath(output);
+}
+
+const externalHardlink = path.join(root, "src", "external-hardlink.ts");
+removePath(output);
+removePath(externalHardlink);
+try {
+  fs.mkdirSync(output, { recursive: true });
+  fs.writeFileSync(externalHardlink, "external hardlink sentinel\n");
+  fs.linkSync(externalHardlink, path.join(output, "generate_module.ts"));
+  expectFailure(
+    "external hard-linked output leaf",
+    generate("--output", "src/output", "src/input/modules/generate_module.ts"),
+    "multiple hard links",
+  );
+  if (
+    fs.readFileSync(externalHardlink, "utf8") !==
+    "external hardlink sentinel\n"
+  ) {
+    throw new Error("External hard-linked output leaf was rewritten.");
+  }
+} finally {
+  removePath(output);
+  removePath(externalHardlink);
+}
+
+const projectAlias = path.join(root, "project-link");
+removePath(output);
+removePath(projectAlias);
+try {
+  fs.symlinkSync(
+    path.join(root, "project-dir"),
+    projectAlias,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  expectSuccess(
+    "implicit project through aliased cwd",
+    generateFromCwd(
+      path.join(projectAlias, "src"),
+      "--output",
+      path.join(root, "src", "output"),
+      "generate_project.ts",
+    ),
+  );
+  if (fs.existsSync(path.join(output, "generate_project.ts")) === false) {
+    throw new Error("Implicit project through aliased cwd wrote no output.");
+  }
+} finally {
+  removePath(output);
+  removePath(projectAlias);
 }

--- a/tests/test-typia-generate/scripts/check-file-errors.cjs
+++ b/tests/test-typia-generate/scripts/check-file-errors.cjs
@@ -75,6 +75,35 @@ const generateWithProject = (project, ...args) => [
 ];
 
 expectFailure(
+  "file arguments with input directory",
+  generate(
+    "--input",
+    "src/input",
+    "--output",
+    "src/output",
+    "src/input/modules/generate_module.ts",
+  ),
+  "file arguments cannot be combined with --input",
+);
+
+expectFailure(
+  "file arguments without output directory",
+  generate("src/input/modules/generate_module.ts"),
+  "output directory is required when file arguments are used",
+);
+
+expectFailure(
+  "duplicate file basename",
+  generate(
+    "--output",
+    "src/output",
+    "src/input/modules/generate_module.ts",
+    "src/input/modules/generate_module.ts",
+  ),
+  "duplicate output filename",
+);
+
+expectFailure(
   "literal unsupported file",
   generate("--output", "src/output", "package.json"),
   "input file is not a supported TypeScript source",
@@ -137,6 +166,38 @@ try {
   );
 } finally {
   removePath(link);
+}
+
+const existingLink = path.join(root, "src", "output-link-existing");
+const existingExternal = path.join(root, "src", "external-output-existing");
+removePath(existingLink);
+removePath(existingExternal);
+try {
+  fs.mkdirSync(path.join(existingExternal, "existing"), { recursive: true });
+  fs.symlinkSync(
+    existingExternal,
+    existingLink,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  expectFailure(
+    "symlinked output ancestor with existing root",
+    generate(
+      "--output",
+      "src/output-link-existing/existing",
+      "src/input/modules/generate_module.ts",
+    ),
+    "symbolic link",
+  );
+  if (
+    fs.existsSync(path.join(existingExternal, "existing", "generate_module.ts"))
+  ) {
+    throw new Error(
+      "Symlinked output ancestor with existing root wrote an external file.",
+    );
+  }
+} finally {
+  removePath(existingLink);
+  removePath(existingExternal);
 }
 
 const output = path.join(root, "src", "output");

--- a/tests/test-typia-generate/scripts/check-file-errors.cjs
+++ b/tests/test-typia-generate/scripts/check-file-errors.cjs
@@ -1,8 +1,10 @@
 const cp = require("child_process");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 
 const root = path.resolve(__dirname, "..");
+const cache = fs.mkdtempSync(path.join(os.tmpdir(), "typia-generate-errors-"));
 const ttsx = path.resolve(
   root,
   "..",
@@ -14,12 +16,34 @@ const ttsx = path.resolve(
 
 const quote = (str) => JSON.stringify(str);
 
+process.on("exit", () => {
+  fs.rmSync(cache, { recursive: true, force: true });
+});
+
 const run = (args) =>
   cp.execSync([ttsx, ...args].map(quote).join(" "), {
     cwd: root,
     encoding: "utf8",
+    env: {
+      ...process.env,
+      TTSC_CACHE_DIR: cache,
+    },
     stdio: "pipe",
   });
+
+const removePath = (file) => {
+  if (fs.existsSync(file) === false) return;
+  const stat = fs.lstatSync(file);
+  if (stat.isSymbolicLink()) {
+    try {
+      fs.rmSync(file, { force: true });
+    } catch {
+      fs.rmdirSync(file);
+    }
+    return;
+  }
+  fs.rmSync(file, { recursive: true, force: true });
+};
 
 const expectFailure = (name, args, expected) => {
   try {
@@ -62,11 +86,19 @@ expectFailure(
   "supported TypeScript source files outside the output directory",
 );
 
+const inputModule = path.join(
+  root,
+  "src",
+  "input",
+  "modules",
+  "generate_module.ts",
+);
+
 const link = path.join(root, "src", "output-link");
-fs.rmSync(link, { recursive: true, force: true });
+removePath(link);
 try {
   fs.symlinkSync(
-    path.join(root, "src", "input", "modules"),
+    path.dirname(inputModule),
     link,
     process.platform === "win32" ? "junction" : "dir",
   );
@@ -80,14 +112,14 @@ try {
     "symbolic link",
   );
 } finally {
-  fs.rmSync(link, { recursive: true, force: true });
+  removePath(link);
 }
 
 const output = path.join(root, "src", "output");
 const ancestor = path.join(output, "link");
 const external = path.join(root, "src", "external-output");
-fs.rmSync(output, { recursive: true, force: true });
-fs.rmSync(external, { recursive: true, force: true });
+removePath(output);
+removePath(external);
 try {
   fs.mkdirSync(output, { recursive: true });
   fs.mkdirSync(external, { recursive: true });
@@ -110,21 +142,21 @@ try {
     process.exit(1);
   }
 } finally {
-  fs.rmSync(output, { recursive: true, force: true });
-  fs.rmSync(external, { recursive: true, force: true });
+  removePath(output);
+  removePath(external);
 }
 
 const tempInput = path.join(root, "src", "input-symlink");
 const tempSource = path.join(tempInput, "link", "new", "generate_module.ts");
 const tempProject = path.join(root, "tsconfig.file-errors.json");
-fs.rmSync(output, { recursive: true, force: true });
-fs.rmSync(external, { recursive: true, force: true });
-fs.rmSync(tempInput, { recursive: true, force: true });
-fs.rmSync(tempProject, { force: true });
+removePath(output);
+removePath(external);
+removePath(tempInput);
+removePath(tempProject);
 try {
   fs.mkdirSync(path.dirname(tempSource), { recursive: true });
   fs.copyFileSync(
-    path.join(root, "src", "input", "modules", "generate_module.ts"),
+    inputModule,
     tempSource,
   );
   fs.writeFileSync(
@@ -163,8 +195,25 @@ try {
     process.exit(1);
   }
 } finally {
-  fs.rmSync(output, { recursive: true, force: true });
-  fs.rmSync(external, { recursive: true, force: true });
-  fs.rmSync(tempInput, { recursive: true, force: true });
-  fs.rmSync(tempProject, { force: true });
+  removePath(output);
+  removePath(external);
+  removePath(tempInput);
+  removePath(tempProject);
+}
+
+removePath(output);
+try {
+  fs.mkdirSync(output, { recursive: true });
+  fs.linkSync(inputModule, path.join(output, "generate_module.ts"));
+  expectFailure(
+    "hard-linked output leaf",
+    generate("--output", "src/output", "src/input/modules/generate_module.ts"),
+    "physical file alias",
+  );
+  if (fs.readFileSync(inputModule, "utf8").includes("// @ts-nocheck")) {
+    console.error("Hard-linked output leaf rewrote the input source.");
+    process.exit(1);
+  }
+} finally {
+  removePath(output);
 }

--- a/tests/test-typia-generate/scripts/check-file-errors.cjs
+++ b/tests/test-typia-generate/scripts/check-file-errors.cjs
@@ -1,0 +1,72 @@
+const cp = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const ttsx = path.resolve(
+  root,
+  "..",
+  "..",
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "ttsx.CMD" : "ttsx",
+);
+
+const quote = (str) => JSON.stringify(str);
+
+const run = (args) =>
+  cp.execSync([ttsx, ...args].map(quote).join(" "), {
+    cwd: root,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+const expectFailure = (name, args, expected) => {
+  try {
+    run(args);
+  } catch (exp) {
+    const output = `${exp.stdout ?? ""}${exp.stderr ?? ""}`;
+    if (output.includes(expected)) return;
+    console.error(`Unexpected ${name} failure output:\n${output}`);
+    process.exit(1);
+  }
+  console.error(`Expected ${name} to fail.`);
+  process.exit(1);
+};
+
+const generate = (...args) => [
+  "node_modules/typia/src/executable/typia.ts",
+  "generate",
+  "--project",
+  "tsconfig.files.json",
+  ...args,
+];
+
+expectFailure(
+  "literal unsupported file",
+  generate("--output", "src/output", "package.json"),
+  "input file is not a supported TypeScript source",
+);
+
+expectFailure(
+  "declaration-only glob",
+  generate("--output", "src/output", "src/input/modules/*.d.ts"),
+  "supported TypeScript source files outside the output directory",
+);
+
+const link = path.join(root, "src", "output-link");
+fs.rmSync(link, { recursive: true, force: true });
+try {
+  fs.symlinkSync(
+    path.join(root, "src", "input", "modules"),
+    link,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  expectFailure(
+    "symlinked output root",
+    generate("--output", "src/output-link", "src/input/modules/generate_module.ts"),
+    "symbolic link",
+  );
+} finally {
+  fs.rmSync(link, { recursive: true, force: true });
+}

--- a/tests/test-typia-generate/src/input/modules/generate_module.ts
+++ b/tests/test-typia-generate/src/input/modules/generate_module.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+interface IModuleTemplate {
+  id: string;
+  count: number;
+  active: boolean;
+}
+
+export const is = typia.createIs<IModuleTemplate>();
+export const assert = typia.createAssert<IModuleTemplate>();

--- a/tests/test-typia-generate/src/input/modules/ignored.d.ts
+++ b/tests/test-typia-generate/src/input/modules/ignored.d.ts
@@ -1,0 +1,3 @@
+export interface IgnoredDeclaration {
+  value: string;
+}

--- a/tests/test-typia-generate/tsconfig.files.json
+++ b/tests/test-typia-generate/tsconfig.files.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/input/modules/generate_module.ts"],
+}

--- a/website/src/content/docs/setup/legacy.mdx
+++ b/website/src/content/docs/setup/legacy.mdx
@@ -527,7 +527,7 @@ After installation, make sure the `prepare` script runs `ts-patch install`, then
 
 ## Generation
 
-`npx typia generate` is the fallback for build pipelines where a TypeScript transformer can't run — Babel in Create-React-App, raw SWC, and so on. typia reads the input directory or the positional `.ts` files you pass, expands every `typia.*<T>()` call site, and writes the transformed `.ts` files to the output directory. Your bundler then compiles those transformed files normally.
+`npx typia generate` is the fallback for build pipelines where a TypeScript transformer can't run — Babel in Create-React-App, raw SWC, and so on. typia reads the input directory or the positional TypeScript source files you pass, expands every `typia.*<T>()` call site, and writes the transformed source files to the output directory. Your bundler then compiles those transformed files normally.
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
@@ -599,7 +599,7 @@ File/glob mode writes each selected file as `--output/<basename>`. Duplicate bas
 `--project` accepts a `tsconfig.json` or `jsconfig.json` file, or a directory containing either file.
 When you omit `--project`, typia searches from the current working directory upward for the nearest `tsconfig.json` or `jsconfig.json`.
 
-The input directory or file list contains `.ts` files that import typia and re-export validators. typia reads each file, applies the transform, and writes the result to `--output`:
+The input directory or file list contains TypeScript source files that import typia and re-export validators. typia reads each file, applies the transform, and writes the result to `--output`:
 
 <Tabs items={['TypeScript Input', 'Generated TypeScript']}>
   <Tabs.Tab>

--- a/website/src/content/docs/setup/legacy.mdx
+++ b/website/src/content/docs/setup/legacy.mdx
@@ -591,7 +591,7 @@ Use `--input` when all templates live under one directory. When templates live b
 npx typia generate \
   --output src/generated \
   --project tsconfig.json \
-  src/**/*.typia.ts
+  "src/**/*.typia.ts"
 ```
 
 File/glob mode writes each selected file as `--output/<basename>`. Duplicate basenames are rejected instead of overwritten.
@@ -609,7 +609,8 @@ export const check = typia.createIs<IMember>();
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript copy filename="examples/src/generated/check.ts" showLineNumbers {3-13}
+```typescript copy filename="examples/src/generated/check.ts" showLineNumbers {4-14}
+// @ts-nocheck
 import typia from "typia";
 import { IMember } from "../structures/IMember";
 export const check = (input: any): input is IMember => {

--- a/website/src/content/docs/setup/legacy.mdx
+++ b/website/src/content/docs/setup/legacy.mdx
@@ -527,7 +527,7 @@ After installation, make sure the `prepare` script runs `ts-patch install`, then
 
 ## Generation
 
-`npx typia generate` is the fallback for build pipelines where a TypeScript transformer can't run — Babel in Create-React-App, raw SWC, and so on. typia reads the input directory, expands every `typia.*<T>()` call site, and writes the transformed `.ts` files to the output directory. Your bundler then compiles those transformed files normally.
+`npx typia generate` is the fallback for build pipelines where a TypeScript transformer can't run — Babel in Create-React-App, raw SWC, and so on. typia reads the input directory or the positional `.ts` files you pass, expands every `typia.*<T>()` call site, and writes the transformed `.ts` files to the output directory. Your bundler then compiles those transformed files normally.
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tabs.Tab>
@@ -585,7 +585,16 @@ When to use it:
 | SWC alone | `typia generate` |
 | Bundlers with SWC inside (Next.js, Vite, …) | [`@typia/unplugin`](#typiaunplugin) |
 
-The `--input` directory contains `.ts` files that import typia and re-export validators. typia reads each file, applies the transform, and writes the result to `--output`:
+Use `--input` when all templates live under one directory. When templates live beside feature modules, pass file paths or globs instead:
+
+```bash filename="Terminal" copy showLineNumbers
+npx typia generate \
+  --output src/generated \
+  --project tsconfig.json \
+  src/**/*.typia.ts
+```
+
+The input directory or file list contains `.ts` files that import typia and re-export validators. typia reads each file, applies the transform, and writes the result to `--output`:
 
 <Tabs items={['TypeScript Input', 'Generated TypeScript']}>
   <Tabs.Tab>

--- a/website/src/content/docs/setup/legacy.mdx
+++ b/website/src/content/docs/setup/legacy.mdx
@@ -596,6 +596,9 @@ npx typia generate \
 
 File/glob mode writes each selected file as `--output/<basename>`. Duplicate basenames are rejected instead of overwritten.
 
+`--project` accepts a `tsconfig.json` or `jsconfig.json` file, or a directory containing either file.
+When you omit `--project`, typia searches from the current working directory upward for the nearest `tsconfig.json` or `jsconfig.json`.
+
 The input directory or file list contains `.ts` files that import typia and re-export validators. typia reads each file, applies the transform, and writes the result to `--output`:
 
 <Tabs items={['TypeScript Input', 'Generated TypeScript']}>

--- a/website/src/content/docs/setup/legacy.mdx
+++ b/website/src/content/docs/setup/legacy.mdx
@@ -533,7 +533,7 @@ After installation, make sure the `prepare` script runs `ts-patch install`, then
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
 npm install typia
-npm install -D typescript
+npm install -D typescript ttsc @typescript/native-preview
 
 npx typia generate \
   --input src/templates \
@@ -544,7 +544,7 @@ npx typia generate \
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
 pnpm install typia
-pnpm install -D typescript
+pnpm install -D typescript ttsc @typescript/native-preview
 
 pnpm typia generate \
   --input src/templates \
@@ -555,7 +555,7 @@ pnpm typia generate \
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
 yarn add typia
-yarn add -D typescript
+yarn add -D typescript ttsc @typescript/native-preview
 
 yarn typia generate \
   --input src/templates \
@@ -566,7 +566,7 @@ yarn typia generate \
   <Tabs.Tab>
 ```bash filename="Terminal" copy showLineNumbers
 bun add typia
-bun add -d typescript
+bun add -d typescript ttsc @typescript/native-preview
 
 bun typia generate \
   --input src/templates \
@@ -593,6 +593,8 @@ npx typia generate \
   --project tsconfig.json \
   src/**/*.typia.ts
 ```
+
+File/glob mode writes each selected file as `--output/<basename>`. Duplicate basenames are rejected instead of overwritten.
 
 The input directory or file list contains `.ts` files that import typia and re-export validators. typia reads each file, applies the transform, and writes the result to `--output`:
 


### PR DESCRIPTION
## Summary

Adds positional file arguments to `typia generate` as an alternative to `--input` directory mode.

## Changes

- Parses `typia generate [files...]` after the top-level `generate` command has been consumed.
- Keeps existing `--input` directory mode and rejects mixing `--input` with positional files.
- Writes file-argument outputs directly into `--output` by basename, matching the requested `src/**/*.typia.ts --output src/generated` flow.
- Filters declaration files consistently for quoted globs and shell-expanded literal argv.
- Normalizes directory-valued `--project` paths to `tsconfig.json` / `jsconfig.json` before deriving transform keys.
- Hardens output path validation against symlink/junction ancestors, symlink target parents, and hard-link aliases.
- Adds focused `test-typia-generate` coverage for file-mode positives, CLI errors, path escape checks, and project-directory config resolution.

## Validation

- `pnpm --filter @typia/test-typia-generate check:files:errors`
- `pnpm --filter @typia/test-typia-generate generate:files`
- `pnpm --filter @typia/test-typia-generate check:files`
- `pnpm --filter @typia/test-typia-generate generate:files:literals`
- `pnpm --filter @typia/test-typia-generate generate:files:project-directory`
- `pnpm --filter @typia/test-typia-generate check:files:project-directory`
- `pnpm --filter @typia/test-typia-generate generate:files:rerun`
- `pnpm --filter typia build`
- `pnpm format`
- `git diff --check`

## Local Limitation

`pnpm --filter @typia/test-typia-generate build` currently fails on this Windows checkout even after `pnpm --dir tests/test-typia-generate run clean`, with the existing local `ttsc` error: `Unexpected token '{'`. The file-argument mode and focused error harness were validated separately, and GitHub CI should exercise the full suite on Ubuntu.

Fixes #1700