### PR TITLE
feat(test): verify typia tarballs against nestia (next)

### DIFF
--- a/.github/workflows/nestia.yml
+++ b/.github/workflows/nestia.yml
@@ -1,0 +1,169 @@
+name: nestia
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/nestia.yml"
+      - "experiments/**"
+      - "scripts/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: nestia-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Pack the typia tarballs once and share them with every matrix job below,
+  # instead of rebuilding them six times.
+  tarballs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/typia/native/go.mod
+          cache-dependency-path: packages/typia/native/go.sum
+
+      - name: Install typia dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build typia tarballs
+        run: pnpm package:tgz
+
+      - name: Upload tarballs
+        uses: actions/upload-artifact@v4
+        with:
+          name: typia-tarballs
+          path: experiments/tarballs/*.tgz
+          if-no-files-found: error
+          retention-days: 1
+
+  # Mirror nestia (next)'s own test.yml matrix so each suite runs in parallel,
+  # but against the local typia tarballs instead of the published release.
+  nestia:
+    needs: tarballs
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: go, run: "pnpm test:go" }
+          - { name: sdk, run: "pnpm --filter ./tests/test-sdk start" }
+          - { name: migrate, run: "pnpm --filter ./tests/test-migrate start" }
+          - {
+              name: transform-options,
+              run: "pnpm --filter ./tests/test-transform-options start",
+            }
+          - { name: e2e, run: "pnpm --filter ./tests/test-e2e start" }
+          - { name: benchmark, run: "pnpm --filter ./tests/test-benchmark start" }
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/typia/native/go.mod
+          cache-dependency-path: packages/typia/native/go.sum
+
+      - name: Download typia tarballs
+        uses: actions/download-artifact@v4
+        with:
+          name: typia-tarballs
+          path: experiments/tarballs
+
+      - name: Resolve ttsc version from typia lockfile
+        id: ttsc
+        run: |
+          # Pin nestia's ttsc to the exact version typia is currently locked
+          # against, so both sides exercise the same compiler when we override
+          # typia with the local tarballs.
+          node -e '
+          const fs = require("fs");
+          const text = fs.readFileSync("pnpm-lock.yaml", "utf8");
+          const match = text.match(/^\s{2}ttsc@([^\s:(]+)/m);
+          if (!match) {
+            console.error("ttsc not found in typia pnpm-lock.yaml");
+            process.exit(1);
+          }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, "version=" + match[1] + "\n");
+          console.log("Resolved ttsc version:", match[1]);
+          '
+
+      - name: Clone nestia (next)
+        run: |
+          rm -rf experiments/nestia
+          git clone --depth=1 --branch next https://github.com/samchon/nestia experiments/nestia
+
+      - name: Use local typia tarballs and pin ttsc
+        working-directory: experiments/nestia
+        env:
+          TTSC_VERSION: ${{ steps.ttsc.outputs.version }}
+        run: |
+          # nestia (next) resolves typia + ttsc through a catalog and may grow
+          # its own top-level `overrides:` block, in which case appending a
+          # second one makes pnpm fail with a duplicated-mapping-key YAML
+          # error. Merge our entries into the existing block instead, creating
+          # it only when absent, and no-op on re-run.
+          node -e '
+          const fs = require("fs");
+          const file = "pnpm-workspace.yaml";
+          const text = fs.readFileSync(file, "utf8");
+          if (text.includes("file:../tarballs/typia.tgz")) process.exit(0);
+          const entries = [
+            "  typia: file:../tarballs/typia.tgz",
+            "  \"@typia/core\": file:../tarballs/core.tgz",
+            "  \"@typia/interface\": file:../tarballs/interface.tgz",
+            "  \"@typia/transform\": file:../tarballs/transform.tgz",
+            "  \"@typia/utils\": file:../tarballs/utils.tgz",
+            "  ttsc: " + process.env.TTSC_VERSION,
+          ].join("\n");
+          const merged = /^overrides:[ \t]*$/m.test(text)
+            ? text.replace(/^overrides:[ \t]*$/m, (line) => line + "\n" + entries)
+            : text.replace(/\s*$/, "") + "\n\noverrides:\n" + entries + "\n";
+          fs.writeFileSync(file, merged);
+          '
+
+      - name: Install nestia dependencies
+        working-directory: experiments/nestia
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Use System Go For Source Plugin Build
+        run: echo "TTSC_GO_BINARY=$(go env GOROOT)/bin/go" >> "$GITHUB_ENV"
+
+      - name: Build nestia
+        working-directory: experiments/nestia
+        env:
+          # Mirror nestia's own test.yml: keep Node's native TS strip / module
+          # detection off so the e2e run matches nestia's CI environment.
+          NODE_OPTIONS: --no-experimental-strip-types --no-experimental-detect-module
+        run: pnpm build
+
+      - name: Run ${{ matrix.name }}
+        working-directory: experiments/nestia
+        env:
+          NODE_OPTIONS: --no-experimental-strip-types --no-experimental-detect-module
+        run: ${{ matrix.run }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/nestia.yml` that mirrors `samchon/ttsc`s nestia workflow but for the typia side: build typia tarballs once via `pnpm package:tgz`, then run nestias `next` branch test matrix (go, sdk, migrate, transform-options, e2e, benchmark) against those local tgz files.
- Override `typia`, `@typia/core`, `@typia/interface`, `@typia/transform`, `@typia/utils` in nestias `pnpm-workspace.yaml` with the freshly packed tarballs.
- Resolve the exact `ttsc` version from typias own `pnpm-lock.yaml` and pin it as a nestia override so both sides exercise the same compiler.

## Test plan
- [ ] CI: `tarballs` job builds typia tgz files successfully.
- [ ] CI: each `nestia / *` matrix entry installs nestia (next) against the local tarballs, builds, and runs the suite green.
