### PR TITLE
fix(typia): export module subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "13.0.0-dev.20260605.2",
+  "version": "13.0.0-dev.20260605.3",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm run build:packages",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "13.0.0-dev.20260605.2",
+  "version": "13.0.0-dev.20260605.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "13.0.0-dev.20260605.2",
+  "version": "13.0.0-dev.20260605.3",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "13.0.0-dev.20260605.2",
+  "version": "13.0.0-dev.20260605.3",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./lib/module": "./src/module.ts",
+    "./lib/module": "./src/index.ts",
     "./lib/transform": "./src/transform.ts",
     "./lib/internal/*": "./src/internal/*.ts",
     "./package.json": "./package.json"
@@ -116,9 +116,9 @@
         "default": "./lib/index.js"
       },
       "./lib/module": {
-        "types": "./lib/module.d.ts",
-        "import": "./lib/module.mjs",
-        "default": "./lib/module.js"
+        "types": "./lib/index.d.ts",
+        "import": "./lib/index.mjs",
+        "default": "./lib/index.js"
       },
       "./lib/transform": {
         "types": "./lib/transform.d.ts",

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,10 +1,11 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.2",
+  "version": "13.0.0-dev.20260605.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./lib/module": "./src/module.ts",
     "./lib/transform": "./src/transform.ts",
     "./lib/internal/*": "./src/internal/*.ts",
     "./package.json": "./package.json"
@@ -113,6 +114,11 @@
         "types": "./lib/index.d.ts",
         "import": "./lib/index.mjs",
         "default": "./lib/index.js"
+      },
+      "./lib/module": {
+        "types": "./lib/module.d.ts",
+        "import": "./lib/module.mjs",
+        "default": "./lib/module.js"
       },
       "./lib/transform": {
         "types": "./lib/transform.d.ts",

--- a/packages/typia/test/contract/package/package_module_export_contract_test.go
+++ b/packages/typia/test/contract/package/package_module_export_contract_test.go
@@ -12,11 +12,12 @@ import (
 //
 // Vite 8 resolves bare package subpaths through package.json exports and fails
 // before reading the generated files. This pins both source-workspace and
-// published-package mappings to the actual module entrypoint files.
+// published-package mappings to the root entrypoint files that provide both
+// default and named TypeScript declarations for this compatibility subpath.
 //
 // 1. Read the typia package manifest.
-// 2. Assert source exports expose typia/lib/module through src/module.ts.
-// 3. Assert publish exports expose typia/lib/module through lib/module.* in
+// 2. Assert source exports expose typia/lib/module through src/index.ts.
+// 3. Assert publish exports expose typia/lib/module through lib/index.* in
 // the exact resolver-condition order.
 func TestPackageModuleExportContract(t *testing.T) {
 	root := testutil.RepoRoot(t)
@@ -35,7 +36,7 @@ func TestPackageModuleExportContract(t *testing.T) {
 	assertCompactJSON(
 		t,
 		source,
-		`"./src/module.ts"`,
+		`"./src/index.ts"`,
 		"typia source export for ./lib/module",
 	)
 
@@ -46,7 +47,7 @@ func TestPackageModuleExportContract(t *testing.T) {
 	assertCompactJSON(
 		t,
 		published,
-		`{"types":"./lib/module.d.ts","import":"./lib/module.mjs","default":"./lib/module.js"}`,
+		`{"types":"./lib/index.d.ts","import":"./lib/index.mjs","default":"./lib/index.js"}`,
 		"typia publish export for ./lib/module",
 	)
 }

--- a/packages/typia/test/contract/package/package_module_export_contract_test.go
+++ b/packages/typia/test/contract/package/package_module_export_contract_test.go
@@ -1,0 +1,54 @@
+package typia_test
+
+import (
+	"encoding/json"
+	testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+	"path/filepath"
+	"testing"
+)
+
+// TestPackageModuleExportContract verifies typia/lib/module stays exported.
+//
+// Vite 8 resolves bare package subpaths through package.json exports and fails
+// before reading the generated files. This pins both source-workspace and
+// published-package mappings to the actual module entrypoint files.
+//
+// 1. Read the typia package manifest.
+// 2. Assert source exports expose typia/lib/module through src/module.ts.
+// 3. Assert publish exports expose typia/lib/module through lib/module.*.
+func TestPackageModuleExportContract(t *testing.T) {
+	root := testutil.RepoRoot(t)
+
+	typiaPackage := testutil.ReadJSON[struct {
+		Exports       map[string]json.RawMessage `json:"exports"`
+		PublishConfig struct {
+			Exports map[string]json.RawMessage `json:"exports"`
+		} `json:"publishConfig"`
+	}](t, filepath.Join(root, "packages", "typia", "package.json"))
+
+	var source string
+	if err := json.Unmarshal(typiaPackage.Exports["./lib/module"], &source); err != nil {
+		t.Fatalf("typia source export for ./lib/module must be a string: %v", err)
+	}
+	if source != "./src/module.ts" {
+		t.Fatalf("typia source export for ./lib/module must point to src/module.ts: %q", source)
+	}
+
+	var published struct {
+		Types   string `json:"types"`
+		Import  string `json:"import"`
+		Default string `json:"default"`
+	}
+	if err := json.Unmarshal(typiaPackage.PublishConfig.Exports["./lib/module"], &published); err != nil {
+		t.Fatalf("typia publish export for ./lib/module must be an object: %v", err)
+	}
+	if published.Types != "./lib/module.d.ts" {
+		t.Fatalf("typia publish export for ./lib/module must expose module.d.ts: %q", published.Types)
+	}
+	if published.Import != "./lib/module.mjs" {
+		t.Fatalf("typia publish export for ./lib/module must expose module.mjs: %q", published.Import)
+	}
+	if published.Default != "./lib/module.js" {
+		t.Fatalf("typia publish export for ./lib/module must expose module.js: %q", published.Default)
+	}
+}

--- a/packages/typia/test/contract/package/package_module_export_contract_test.go
+++ b/packages/typia/test/contract/package/package_module_export_contract_test.go
@@ -1,11 +1,11 @@
 package typia_test
 
 import (
-  "bytes"
-  "encoding/json"
-  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
-  "path/filepath"
-  "testing"
+	"bytes"
+	"encoding/json"
+	testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+	"path/filepath"
+	"testing"
 )
 
 // TestPackageModuleExportContract verifies typia/lib/module stays exported.
@@ -19,46 +19,46 @@ import (
 // 3. Assert publish exports expose typia/lib/module through lib/module.* in
 // the exact resolver-condition order.
 func TestPackageModuleExportContract(t *testing.T) {
-  root := testutil.RepoRoot(t)
+	root := testutil.RepoRoot(t)
 
-  typiaPackage := testutil.ReadJSON[struct {
-    Exports       map[string]json.RawMessage `json:"exports"`
-    PublishConfig struct {
-      Exports map[string]json.RawMessage `json:"exports"`
-    } `json:"publishConfig"`
-  }](t, filepath.Join(root, "packages", "typia", "package.json"))
+	typiaPackage := testutil.ReadJSON[struct {
+		Exports       map[string]json.RawMessage `json:"exports"`
+		PublishConfig struct {
+			Exports map[string]json.RawMessage `json:"exports"`
+		} `json:"publishConfig"`
+	}](t, filepath.Join(root, "packages", "typia", "package.json"))
 
-  source, ok := typiaPackage.Exports["./lib/module"]
-  if !ok {
-    t.Fatal("typia source exports must expose ./lib/module")
-  }
-  assertCompactJSON(
-    t,
-    source,
-    `"./src/module.ts"`,
-    "typia source export for ./lib/module",
-  )
+	source, ok := typiaPackage.Exports["./lib/module"]
+	if !ok {
+		t.Fatal("typia source exports must expose ./lib/module")
+	}
+	assertCompactJSON(
+		t,
+		source,
+		`"./src/module.ts"`,
+		"typia source export for ./lib/module",
+	)
 
-  published, ok := typiaPackage.PublishConfig.Exports["./lib/module"]
-  if !ok {
-    t.Fatal("typia publish exports must expose ./lib/module")
-  }
-  assertCompactJSON(
-    t,
-    published,
-    `{"types":"./lib/module.d.ts","import":"./lib/module.mjs","default":"./lib/module.js"}`,
-    "typia publish export for ./lib/module",
-  )
+	published, ok := typiaPackage.PublishConfig.Exports["./lib/module"]
+	if !ok {
+		t.Fatal("typia publish exports must expose ./lib/module")
+	}
+	assertCompactJSON(
+		t,
+		published,
+		`{"types":"./lib/module.d.ts","import":"./lib/module.mjs","default":"./lib/module.js"}`,
+		"typia publish export for ./lib/module",
+	)
 }
 
 func assertCompactJSON(t *testing.T, input json.RawMessage, expected string, label string) {
-  t.Helper()
+	t.Helper()
 
-  buffer := bytes.NewBuffer(nil)
-  if err := json.Compact(buffer, input); err != nil {
-    t.Fatalf("%s must be valid JSON: %v", label, err)
-  }
-  if actual := buffer.String(); actual != expected {
-    t.Fatalf("%s mismatch:\nexpected: %s\nactual:   %s", label, expected, actual)
-  }
+	buffer := bytes.NewBuffer(nil)
+	if err := json.Compact(buffer, input); err != nil {
+		t.Fatalf("%s must be valid JSON: %v", label, err)
+	}
+	if actual := buffer.String(); actual != expected {
+		t.Fatalf("%s mismatch:\nexpected: %s\nactual:   %s", label, expected, actual)
+	}
 }

--- a/packages/typia/test/contract/package/package_module_export_contract_test.go
+++ b/packages/typia/test/contract/package/package_module_export_contract_test.go
@@ -1,10 +1,11 @@
 package typia_test
 
 import (
-	"encoding/json"
-	testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
-	"path/filepath"
-	"testing"
+  "bytes"
+  "encoding/json"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+  "path/filepath"
+  "testing"
 )
 
 // TestPackageModuleExportContract verifies typia/lib/module stays exported.
@@ -15,40 +16,49 @@ import (
 //
 // 1. Read the typia package manifest.
 // 2. Assert source exports expose typia/lib/module through src/module.ts.
-// 3. Assert publish exports expose typia/lib/module through lib/module.*.
+// 3. Assert publish exports expose typia/lib/module through lib/module.* in
+// the exact resolver-condition order.
 func TestPackageModuleExportContract(t *testing.T) {
-	root := testutil.RepoRoot(t)
+  root := testutil.RepoRoot(t)
 
-	typiaPackage := testutil.ReadJSON[struct {
-		Exports       map[string]json.RawMessage `json:"exports"`
-		PublishConfig struct {
-			Exports map[string]json.RawMessage `json:"exports"`
-		} `json:"publishConfig"`
-	}](t, filepath.Join(root, "packages", "typia", "package.json"))
+  typiaPackage := testutil.ReadJSON[struct {
+    Exports       map[string]json.RawMessage `json:"exports"`
+    PublishConfig struct {
+      Exports map[string]json.RawMessage `json:"exports"`
+    } `json:"publishConfig"`
+  }](t, filepath.Join(root, "packages", "typia", "package.json"))
 
-	var source string
-	if err := json.Unmarshal(typiaPackage.Exports["./lib/module"], &source); err != nil {
-		t.Fatalf("typia source export for ./lib/module must be a string: %v", err)
-	}
-	if source != "./src/module.ts" {
-		t.Fatalf("typia source export for ./lib/module must point to src/module.ts: %q", source)
-	}
+  source, ok := typiaPackage.Exports["./lib/module"]
+  if !ok {
+    t.Fatal("typia source exports must expose ./lib/module")
+  }
+  assertCompactJSON(
+    t,
+    source,
+    `"./src/module.ts"`,
+    "typia source export for ./lib/module",
+  )
 
-	var published struct {
-		Types   string `json:"types"`
-		Import  string `json:"import"`
-		Default string `json:"default"`
-	}
-	if err := json.Unmarshal(typiaPackage.PublishConfig.Exports["./lib/module"], &published); err != nil {
-		t.Fatalf("typia publish export for ./lib/module must be an object: %v", err)
-	}
-	if published.Types != "./lib/module.d.ts" {
-		t.Fatalf("typia publish export for ./lib/module must expose module.d.ts: %q", published.Types)
-	}
-	if published.Import != "./lib/module.mjs" {
-		t.Fatalf("typia publish export for ./lib/module must expose module.mjs: %q", published.Import)
-	}
-	if published.Default != "./lib/module.js" {
-		t.Fatalf("typia publish export for ./lib/module must expose module.js: %q", published.Default)
-	}
+  published, ok := typiaPackage.PublishConfig.Exports["./lib/module"]
+  if !ok {
+    t.Fatal("typia publish exports must expose ./lib/module")
+  }
+  assertCompactJSON(
+    t,
+    published,
+    `{"types":"./lib/module.d.ts","import":"./lib/module.mjs","default":"./lib/module.js"}`,
+    "typia publish export for ./lib/module",
+  )
+}
+
+func assertCompactJSON(t *testing.T, input json.RawMessage, expected string, label string) {
+  t.Helper()
+
+  buffer := bytes.NewBuffer(nil)
+  if err := json.Compact(buffer, input); err != nil {
+    t.Fatalf("%s must be valid JSON: %v", label, err)
+  }
+  if actual := buffer.String(); actual != expected {
+    t.Fatalf("%s mismatch:\nexpected: %s\nactual:   %s", label, expected, actual)
+  }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "13.0.0-dev.20260605.2",
+  "version": "13.0.0-dev.20260605.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "13.0.0-dev.20260605.2",
+  "version": "13.0.0-dev.20260605.3",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- export `typia/lib/module` from the source-workspace and published package manifests
- map the compatibility subpath to the root entrypoint files (`src/index.ts`, `lib/index.d.ts`, `lib/index.mjs`, and `lib/index.js`) so default-import declarations and runtime resolution stay aligned
- add a Go package contract test so the Vite-facing export and resolver-condition order cannot regress
- bump the published typia package-family dev versions to `13.0.0-dev.20260605.3` for the next package release flow

## Root Cause
`typia@12.0.1` introduced a package `exports` map without a `./lib/module` subpath. Vite 8 resolves package subpaths through that map and fails before it can read any generated files.

## Validation
- Reproduced the current failure with a packed typia package and `vite@8.0.1`: `./lib/module is not exported`.
- `go -C packages/typia/test test ./contract/package`
- `pnpm --filter typia build`
- Packed local `@typia/interface`, `@typia/utils`, and `typia`, installed them into a clean npm project with `vite@8.0.1` and `typescript@~6.0.3`, then verified:
  - packed `exports["./lib/module"]` resolves to `lib/index.d.ts`, `lib/index.mjs`, and `lib/index.js`
  - `import typia from "typia/lib/module"`
  - `require("typia/lib/module")`
  - `npx tsc --noEmit` with `allowSyntheticDefaultImports: false`
  - `npm exec -- vite build`
- `pnpm test:go`
- `pnpm package:tgz`
- `git diff --check`
- GitHub Actions are green for build, experiments, test, website, nestia tarballs/go/sdk/migrate/transform-options/e2e/benchmark, and spell-check. Socket PR Alerts is neutral/skipped.

## Local Limitations
No local limitation is known for the #1805 resolver path. This PR validates default ESM import, CommonJS require, TypeScript resolution without synthetic default imports, and Vite 8 build for the exported subpath. Broader named-ESM packaging behavior is unchanged from the existing root package surface.

Supersedes #1826.

Fixes #1805