### PR TITLE
fix(typia): preserve empty object schema keywords

### DIFF
--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: benchmark
+description: The @typia/benchmark runner, fixtures, and per-CPU result archive. Read before running, modifying, or publishing benchmark results.
+---
+
 # Benchmark
 
 Read before running, modifying, or publishing benchmark results. The benchmark is the private `@typia/benchmark` workspace under `benchmark/`.

--- a/.codex/skills/development/SKILL.md
+++ b/.codex/skills/development/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: development
+description: Work rules, testing, validation, and change integrity. Read before writing or modifying code.
+---
+
 # Development
 
 Read before writing or modifying code.

--- a/.codex/skills/documentation/SKILL.md
+++ b/.codex/skills/documentation/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: documentation
+description: READMEs and the website guides. Read before writing or modifying docs.
+---
+
 # Documentation
 
 Read before writing or modifying docs.

--- a/.codex/skills/issue-pr-workflow/SKILL.md
+++ b/.codex/skills/issue-pr-workflow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: issue-pr-workflow
+description: GitHub issue triage, .wiki handoff updates, branch-per-issue implementation, mandatory Research Review Round, CI gating, PR comments, and issue closure. Read before sweeping issues or running the issue-to-PR loop.
+---
+
 # Issue PR Workflow
 
 Read before triaging GitHub issues into `.wiki`, implementing issue fixes, or running the branch-per-issue PR loop.

--- a/.codex/skills/multi-agent/SKILL.md
+++ b/.codex/skills/multi-agent/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: multi-agent
+description: Multi-agent workflows — Review Cycle, Discussion, and Research Review Round. Read the Briefing subagents rule before delegating to any subagent; read a mode in full only when the user asks for it by name.
+---
+
 # Multi-Agent Workflows
 
 Use only when the user explicitly asks for one of the named modes — Review Cycle, Discussion, or Research Review Round. Each mode composes the shared building blocks below; do not invent unnamed combinations. Read the **Briefing subagents** rule before delegating to any subagent; read a mode in full only when the user asks for it by name.

--- a/.codex/skills/project/SKILL.md
+++ b/.codex/skills/project/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: project
+description: What typia is, the package family, the JS-descriptor / Go-plugin boundary, the workspace layout, and the canonical commands.
+---
+
 # Project Outline
 
 ## What Typia Is

--- a/.codex/skills/pull-request/SKILL.md
+++ b/.codex/skills/pull-request/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pull-request
+description: PR submission flow and the release reference. Read only when the user explicitly asks for a pull request; never open, push, or propose a PR on your own initiative.
+---
+
 # Pull Request Submission
 
 Only act on this skill when the user explicitly asks for a pull request. Never open, propose, or push a new PR on your own initiative — not as a "helpful" follow-up to a finished change, not because the work looks done. (This bounds PR creation only; it does not change how you commit to a branch.) When the user does ask, follow this flow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Update only for repository-contract changes: a new skill area, a renamed or merg
 
 ### Skills
 
-- **Location.** `.codex/skills/<kebab-name>/SKILL.md`. No numeric prefix, no frontmatter: Claude Code only auto-discovers `.claude/skills/`, and Codex has no native skills system, so each SKILL.md is plain markdown that AGENTS.md points to.
+- **Location.** `.codex/skills/<kebab-name>/SKILL.md`. No numeric prefix. Each file starts with YAML frontmatter holding `name` (the kebab folder name) and `description` (the one-line pointer Codex shows); Claude Code only auto-discovers `.claude/skills/`, so AGENTS.md still points to each SKILL.md for that side.
 - **AGENTS.md pointer.** Each skill gets a `### Title` entry under `## Skills` with a one-paragraph pointer to the SKILL.md path.
 - **Create or merge.** Add a new skill when a substantial repository concern would otherwise inflate AGENTS.md beyond an index. Merge sibling concerns into one multi-section skill when they share most of their structure (`multi-agent/` is the precedent).
 - **Headings are plain.** No chapter numbers in skill or AGENTS.md headings. Use descriptive titles.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "13.0.0-dev.20260605.4",
+  "version": "13.0.0-dev.20260605.5",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm run build:packages",

--- a/packages/typia/native/core/programmers/iterate/json_schema_native.go
+++ b/packages/typia/native/core/programmers/iterate/json_schema_native.go
@@ -81,6 +81,7 @@ func json_schema_native(props struct {
     props.components.Schemas[props.native.Name] = JsonSchema{
       "type":       "object",
       "properties": JsonSchema{},
+      "required":   []string{},
     }
   }
   return json_schema_plugin(struct {

--- a/packages/typia/native/core/programmers/iterate/json_schema_object.go
+++ b/packages/typia/native/core/programmers/iterate/json_schema_object.go
@@ -117,9 +117,7 @@ func json_schema_create_object_schema(props struct {
     "type":                 "object",
     "properties":           properties,
     "additionalProperties": false,
-  }
-  if len(required) != 0 {
-    schema["required"] = required
+    "required":             required,
   }
   if title := json_schema_title(struct {
     description *string
@@ -138,6 +136,10 @@ func json_schema_create_object_schema(props struct {
     extra      json_schema_superfluous
   }{components: props.components, extra: extraMeta}); additional != nil {
     schema["additionalProperties"] = additional
+  }
+  if len(properties) == 0 && len(required) == 0 && extraMeta.additionalProperties != nil && len(extraMeta.patternProperties) == 0 {
+    delete(schema, "properties")
+    delete(schema, "required")
   }
   return json_schema_jsDocTags(schema, props.object.Type.JsDocTags)
 }

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.4",
+  "version": "13.0.0-dev.20260605.5",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/test/contract/native/json_schema_native_export_keeps_empty_required_test.go
+++ b/packages/typia/test/contract/native/json_schema_native_export_keeps_empty_required_test.go
@@ -7,17 +7,17 @@ import (
   nativemetadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
 
-// TestJsonSchemaNativeExportOmitsEmptyRequired verifies custom native schema
-// components do not serialize an empty required array.
+// TestJsonSchemaNativeExportKeepsEmptyRequired verifies custom native schema
+// components serialize an explicit empty required array.
 //
 // Custom native components synthesize an object schema with no properties.
-// JSON Schema draft-04 rejects `required: []`, so the component must retain its
-// object shape while omitting `required` entirely.
+// They are named empty objects rather than records, so the component must
+// retain explicit `properties: {}` and `required: []` object keywords.
 //
 // 1. Export a non-built-in native metadata component.
 // 2. Read the generated component schema.
-// 3. Assert it is an empty object without an owned `required` key.
-func TestJsonSchemaNativeExportOmitsEmptyRequired(t *testing.T) {
+// 3. Assert it is an empty object with an empty `required` key.
+func TestJsonSchemaNativeExportKeepsEmptyRequired(t *testing.T) {
   components := &nativeiterate.OpenApi_IComponents{}
 
   schemas := nativeiterate.Json_schema_native_export(nativeiterate.Json_schema_native_export_props{
@@ -44,7 +44,11 @@ func TestJsonSchemaNativeExportOmitsEmptyRequired(t *testing.T) {
   if len(properties) != 0 {
     t.Fatalf("custom native component should have no properties: %#v", properties)
   }
-  if _, ok := component["required"]; ok {
-    t.Fatalf("custom native component must omit empty required: %#v", component)
+  required, ok := component["required"].([]string)
+  if !ok {
+    t.Fatalf("custom native component required mismatch: %#v", component["required"])
+  }
+  if len(required) != 0 {
+    t.Fatalf("custom native component should have no required properties: %#v", required)
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "13.0.0-dev.20260605.4",
+  "version": "13.0.0-dev.20260605.5",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -269,45 +269,29 @@ export namespace OpenApiV3Downgrader {
               additionalItems: undefined,
             },
           });
-        else if (OpenApiTypeChecker.isObject(schema)) {
-          const { additionalProperties, properties, required, ...rest } =
-            schema;
-          const dynamicRecord: boolean =
-            (properties === undefined ||
-              Object.values(properties).every(
-                (value) => value === undefined,
-              )) &&
-            (required === undefined || required.length === 0) &&
-            additionalProperties !== undefined &&
-            additionalProperties !== false;
+        else if (OpenApiTypeChecker.isObject(schema))
           union.push({
-            ...rest,
-            ...(dynamicRecord === false
-              ? {
-                  properties:
-                    properties !== undefined
-                      ? Object.fromEntries(
-                          Object.entries(properties)
-                            .filter(([_, v]) => v !== undefined)
-                            .map(([key, value]) => [
-                              key,
-                              downgradeSchema(collection)(value),
-                            ]),
-                        )
-                      : {},
-                }
-              : {}),
-            ...(additionalProperties !== undefined
-              ? {
-                  additionalProperties:
-                    typeof additionalProperties === "object"
-                      ? downgradeSchema(collection)(additionalProperties)
-                      : additionalProperties,
-                }
-              : {}),
-            ...(dynamicRecord === false ? { required: required ?? [] } : {}),
+            ...schema,
+            properties:
+              schema.properties === undefined
+                ? undefined
+                : Object.fromEntries(
+                    Object.entries(schema.properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        downgradeSchema(collection)(value),
+                      ]),
+                  ),
+            additionalProperties:
+              schema.additionalProperties === undefined
+                ? undefined
+                : typeof schema.additionalProperties === "object"
+                  ? downgradeSchema(collection)(schema.additionalProperties)
+                  : schema.additionalProperties,
+            required: schema.required,
           });
-        } else if (OpenApiTypeChecker.isOneOf(schema))
+        else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };
       const visitConstant = (schema: OpenApi.IJsonSchema): void => {

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -272,9 +272,17 @@ export namespace OpenApiV3Downgrader {
         else if (OpenApiTypeChecker.isObject(schema)) {
           const { additionalProperties, properties, required, ...rest } =
             schema;
+          const dynamicRecord: boolean =
+            (properties === undefined ||
+              Object.values(properties).every(
+                (value) => value === undefined,
+              )) &&
+            (required === undefined || required.length === 0) &&
+            additionalProperties !== undefined &&
+            additionalProperties !== false;
           union.push({
             ...rest,
-            ...(properties !== undefined
+            ...(properties !== undefined && dynamicRecord === false
               ? {
                   properties: Object.fromEntries(
                     Object.entries(properties)
@@ -294,7 +302,9 @@ export namespace OpenApiV3Downgrader {
                       : additionalProperties,
                 }
               : {}),
-            ...(required !== undefined ? { required } : {}),
+            ...(required !== undefined && dynamicRecord === false
+              ? { required }
+              : {}),
           });
         } else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -282,16 +282,19 @@ export namespace OpenApiV3Downgrader {
             additionalProperties !== false;
           union.push({
             ...rest,
-            ...(properties !== undefined && dynamicRecord === false
+            ...(dynamicRecord === false
               ? {
-                  properties: Object.fromEntries(
-                    Object.entries(properties)
-                      .filter(([_, v]) => v !== undefined)
-                      .map(([key, value]) => [
-                        key,
-                        downgradeSchema(collection)(value),
-                      ]),
-                  ),
+                  properties:
+                    properties !== undefined
+                      ? Object.fromEntries(
+                          Object.entries(properties)
+                            .filter(([_, v]) => v !== undefined)
+                            .map(([key, value]) => [
+                              key,
+                              downgradeSchema(collection)(value),
+                            ]),
+                        )
+                      : {},
                 }
               : {}),
             ...(additionalProperties !== undefined
@@ -302,9 +305,7 @@ export namespace OpenApiV3Downgrader {
                       : additionalProperties,
                 }
               : {}),
-            ...(required !== undefined && dynamicRecord === false
-              ? { required }
-              : {}),
+            ...(dynamicRecord === false ? { required: required ?? [] } : {}),
           });
         } else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -269,26 +269,34 @@ export namespace OpenApiV3Downgrader {
               additionalItems: undefined,
             },
           });
-        else if (OpenApiTypeChecker.isObject(schema))
+        else if (OpenApiTypeChecker.isObject(schema)) {
+          const { additionalProperties, properties, required, ...rest } =
+            schema;
           union.push({
-            ...schema,
-            properties: schema.properties
-              ? Object.fromEntries(
-                  Object.entries(schema.properties)
-                    .filter(([_, v]) => v !== undefined)
-                    .map(([key, value]) => [
-                      key,
-                      downgradeSchema(collection)(value),
-                    ]),
-                )
-              : undefined,
-            additionalProperties:
-              typeof schema.additionalProperties === "object"
-                ? downgradeSchema(collection)(schema.additionalProperties)
-                : schema.additionalProperties,
-            required: schema.required,
+            ...rest,
+            ...(properties !== undefined
+              ? {
+                  properties: Object.fromEntries(
+                    Object.entries(properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        downgradeSchema(collection)(value),
+                      ]),
+                  ),
+                }
+              : {}),
+            ...(additionalProperties !== undefined
+              ? {
+                  additionalProperties:
+                    typeof additionalProperties === "object"
+                      ? downgradeSchema(collection)(additionalProperties)
+                      : additionalProperties,
+                }
+              : {}),
+            ...(required !== undefined ? { required } : {}),
           });
-        else if (OpenApiTypeChecker.isOneOf(schema))
+        } else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };
       const visitConstant = (schema: OpenApi.IJsonSchema): void => {

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -1,6 +1,5 @@
 import { OpenApi, OpenApiV3 } from "@typia/interface";
 
-import { OpenApiSchemaSanitizer } from "../../utils/internal/OpenApiSchemaSanitizer";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 
 export namespace OpenApiV3Downgrader {
@@ -271,26 +270,24 @@ export namespace OpenApiV3Downgrader {
             },
           });
         else if (OpenApiTypeChecker.isObject(schema))
-          union.push(
-            OpenApiSchemaSanitizer.omitEmptyRequired({
-              ...schema,
-              properties: schema.properties
-                ? Object.fromEntries(
-                    Object.entries(schema.properties)
-                      .filter(([_, v]) => v !== undefined)
-                      .map(([key, value]) => [
-                        key,
-                        downgradeSchema(collection)(value),
-                      ]),
-                  )
-                : undefined,
-              additionalProperties:
-                typeof schema.additionalProperties === "object"
-                  ? downgradeSchema(collection)(schema.additionalProperties)
-                  : schema.additionalProperties,
-              required: schema.required,
-            }),
-          );
+          union.push({
+            ...schema,
+            properties: schema.properties
+              ? Object.fromEntries(
+                  Object.entries(schema.properties)
+                    .filter(([_, v]) => v !== undefined)
+                    .map(([key, value]) => [
+                      key,
+                      downgradeSchema(collection)(value),
+                    ]),
+                )
+              : undefined,
+            additionalProperties:
+              typeof schema.additionalProperties === "object"
+                ? downgradeSchema(collection)(schema.additionalProperties)
+                : schema.additionalProperties,
+            required: schema.required,
+          });
         else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -413,31 +413,46 @@ export namespace OpenApiV3Upgrader {
             ...schema,
             items: convertSchema(components)(schema.items),
           });
-        else if (OpenApiV3TypeChecker.isObject(schema))
+        else if (OpenApiV3TypeChecker.isObject(schema)) {
+          const { additionalProperties, properties, required, ...rest } =
+            schema;
+          const dynamicRecord: boolean =
+            properties === undefined &&
+            required === undefined &&
+            additionalProperties !== undefined &&
+            additionalProperties !== false;
           union.push({
-            ...schema,
-            ...{
-              properties: schema.properties
-                ? Object.fromEntries(
-                    Object.entries(schema.properties)
-                      .filter(([_, v]) => v !== undefined)
-                      .map(([key, value]) => [
-                        key,
-                        convertSchema(components)(value),
-                      ]),
-                  )
-                : {},
-              additionalProperties:
-                schema.additionalProperties !== undefined
-                  ? typeof schema.additionalProperties === "object" &&
-                    schema.additionalProperties !== null
-                    ? convertSchema(components)(schema.additionalProperties)
-                    : schema.additionalProperties
-                  : undefined,
-              required: schema.required ?? [],
-            },
+            ...rest,
+            ...(dynamicRecord === false
+              ? {
+                  properties: properties
+                    ? Object.fromEntries(
+                        Object.entries(properties)
+                          .filter(([_, v]) => v !== undefined)
+                          .map(([key, value]) => [
+                            key,
+                            convertSchema(components)(value),
+                          ]),
+                      )
+                    : {},
+                }
+              : {}),
+            ...(additionalProperties !== undefined
+              ? {
+                  additionalProperties:
+                    typeof additionalProperties === "object" &&
+                    additionalProperties !== null
+                      ? convertSchema(components)(additionalProperties)
+                      : additionalProperties,
+                }
+              : {}),
+            ...(dynamicRecord === false
+              ? {
+                  required: required ?? [],
+                }
+              : {}),
           });
-        else if (OpenApiV3TypeChecker.isReference(schema)) union.push(schema);
+        } else if (OpenApiV3TypeChecker.isReference(schema)) union.push(schema);
         else union.push(schema);
       };
 

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -1,6 +1,5 @@
 import { IJsonSchemaAttribute, OpenApi, OpenApiV3 } from "@typia/interface";
 
-import { OpenApiSchemaSanitizer } from "../../utils/internal/OpenApiSchemaSanitizer";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { OpenApiV3TypeChecker } from "../../validators/OpenApiV3TypeChecker";
 import { OpenApiExclusiveEmender } from "./OpenApiExclusiveEmender";
@@ -415,31 +414,29 @@ export namespace OpenApiV3Upgrader {
             items: convertSchema(components)(schema.items),
           });
         else if (OpenApiV3TypeChecker.isObject(schema))
-          union.push(
-            OpenApiSchemaSanitizer.omitEmptyRequired({
-              ...schema,
-              ...{
-                properties: schema.properties
-                  ? Object.fromEntries(
-                      Object.entries(schema.properties)
-                        .filter(([_, v]) => v !== undefined)
-                        .map(([key, value]) => [
-                          key,
-                          convertSchema(components)(value),
-                        ]),
-                    )
-                  : {},
-                additionalProperties:
-                  schema.additionalProperties !== undefined
-                    ? typeof schema.additionalProperties === "object" &&
-                      schema.additionalProperties !== null
-                      ? convertSchema(components)(schema.additionalProperties)
-                      : schema.additionalProperties
-                    : undefined,
-                required: schema.required ?? [],
-              },
-            }),
-          );
+          union.push({
+            ...schema,
+            ...{
+              properties: schema.properties
+                ? Object.fromEntries(
+                    Object.entries(schema.properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        convertSchema(components)(value),
+                      ]),
+                  )
+                : {},
+              additionalProperties:
+                schema.additionalProperties !== undefined
+                  ? typeof schema.additionalProperties === "object" &&
+                    schema.additionalProperties !== null
+                    ? convertSchema(components)(schema.additionalProperties)
+                    : schema.additionalProperties
+                  : undefined,
+              required: schema.required ?? [],
+            },
+          });
         else if (OpenApiV3TypeChecker.isReference(schema)) union.push(schema);
         else union.push(schema);
       };
@@ -494,7 +491,7 @@ export namespace OpenApiV3Upgrader {
             allOf: undefined,
           },
         };
-      return OpenApiSchemaSanitizer.omitEmptyRequired({
+      return {
         ...input,
         type: "object" as const,
         properties: Object.fromEntries(
@@ -515,7 +512,7 @@ export namespace OpenApiV3Upgrader {
           allOf: undefined,
           required: [...new Set(objects.map((o) => o?.required ?? []).flat())],
         },
-      });
+      };
     };
 
   const retrieveObject =

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -413,49 +413,30 @@ export namespace OpenApiV3Upgrader {
             ...schema,
             items: convertSchema(components)(schema.items),
           });
-        else if (OpenApiV3TypeChecker.isObject(schema)) {
-          const { additionalProperties, properties, required, ...rest } =
-            schema;
-          const dynamicRecord: boolean =
-            (properties === undefined ||
-              Object.values(properties).every(
-                (value) => value === undefined,
-              )) &&
-            (required === undefined || required.length === 0) &&
-            additionalProperties !== undefined &&
-            additionalProperties !== false;
+        else if (OpenApiV3TypeChecker.isObject(schema))
           union.push({
-            ...rest,
-            ...(dynamicRecord === false
-              ? {
-                  properties: properties
-                    ? Object.fromEntries(
-                        Object.entries(properties)
-                          .filter(([_, v]) => v !== undefined)
-                          .map(([key, value]) => [
-                            key,
-                            convertSchema(components)(value),
-                          ]),
-                      )
-                    : {},
-                }
-              : {}),
-            ...(additionalProperties !== undefined
-              ? {
-                  additionalProperties:
-                    typeof additionalProperties === "object" &&
-                    additionalProperties !== null
-                      ? convertSchema(components)(additionalProperties)
-                      : additionalProperties,
-                }
-              : {}),
-            ...(dynamicRecord === false
-              ? {
-                  required: required ?? [],
-                }
-              : {}),
+            ...schema,
+            properties:
+              schema.properties === undefined
+                ? undefined
+                : Object.fromEntries(
+                    Object.entries(schema.properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        convertSchema(components)(value),
+                      ]),
+                  ),
+            additionalProperties:
+              schema.additionalProperties === undefined
+                ? undefined
+                : typeof schema.additionalProperties === "object" &&
+                    schema.additionalProperties !== null
+                  ? convertSchema(components)(schema.additionalProperties)
+                  : schema.additionalProperties,
+            required: schema.required,
           });
-        } else if (OpenApiV3TypeChecker.isReference(schema)) union.push(schema);
+        else if (OpenApiV3TypeChecker.isReference(schema)) union.push(schema);
         else union.push(schema);
       };
 

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -417,8 +417,11 @@ export namespace OpenApiV3Upgrader {
           const { additionalProperties, properties, required, ...rest } =
             schema;
           const dynamicRecord: boolean =
-            properties === undefined &&
-            required === undefined &&
+            (properties === undefined ||
+              Object.values(properties).every(
+                (value) => value === undefined,
+              )) &&
+            (required === undefined || required.length === 0) &&
             additionalProperties !== undefined &&
             additionalProperties !== false;
           union.push({

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -268,45 +268,29 @@ export namespace OpenApiV3_1Downgrader {
                 ? downgradeSchema(collection)(schema.additionalItems)
                 : schema.additionalItems,
           });
-        else if (OpenApiTypeChecker.isObject(schema)) {
-          const { additionalProperties, properties, required, ...rest } =
-            schema;
-          const dynamicRecord: boolean =
-            (properties === undefined ||
-              Object.values(properties).every(
-                (value) => value === undefined,
-              )) &&
-            (required === undefined || required.length === 0) &&
-            additionalProperties !== undefined &&
-            additionalProperties !== false;
+        else if (OpenApiTypeChecker.isObject(schema))
           union.push({
-            ...rest,
-            ...(dynamicRecord === false
-              ? {
-                  properties:
-                    properties !== undefined
-                      ? Object.fromEntries(
-                          Object.entries(properties)
-                            .filter(([_, v]) => v !== undefined)
-                            .map(([key, value]) => [
-                              key,
-                              downgradeSchema(collection)(value),
-                            ]),
-                        )
-                      : {},
-                }
-              : {}),
-            ...(additionalProperties !== undefined
-              ? {
-                  additionalProperties:
-                    typeof additionalProperties === "object"
-                      ? downgradeSchema(collection)(additionalProperties)
-                      : additionalProperties,
-                }
-              : {}),
-            ...(dynamicRecord === false ? { required: required ?? [] } : {}),
+            ...schema,
+            properties:
+              schema.properties === undefined
+                ? undefined
+                : Object.fromEntries(
+                    Object.entries(schema.properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        downgradeSchema(collection)(value),
+                      ]),
+                  ),
+            additionalProperties:
+              schema.additionalProperties === undefined
+                ? undefined
+                : typeof schema.additionalProperties === "object"
+                  ? downgradeSchema(collection)(schema.additionalProperties)
+                  : schema.additionalProperties,
+            required: schema.required,
           });
-        } else if (OpenApiTypeChecker.isOneOf(schema))
+        else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };
       visit(input);

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -268,26 +268,34 @@ export namespace OpenApiV3_1Downgrader {
                 ? downgradeSchema(collection)(schema.additionalItems)
                 : schema.additionalItems,
           });
-        else if (OpenApiTypeChecker.isObject(schema))
+        else if (OpenApiTypeChecker.isObject(schema)) {
+          const { additionalProperties, properties, required, ...rest } =
+            schema;
           union.push({
-            ...schema,
-            properties: schema.properties
-              ? Object.fromEntries(
-                  Object.entries(schema.properties)
-                    .filter(([_, v]) => v !== undefined)
-                    .map(([key, value]) => [
-                      key,
-                      downgradeSchema(collection)(value),
-                    ]),
-                )
-              : undefined,
-            additionalProperties:
-              typeof schema.additionalProperties === "object"
-                ? downgradeSchema(collection)(schema.additionalProperties)
-                : schema.additionalProperties,
-            required: schema.required,
+            ...rest,
+            ...(properties !== undefined
+              ? {
+                  properties: Object.fromEntries(
+                    Object.entries(properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        downgradeSchema(collection)(value),
+                      ]),
+                  ),
+                }
+              : {}),
+            ...(additionalProperties !== undefined
+              ? {
+                  additionalProperties:
+                    typeof additionalProperties === "object"
+                      ? downgradeSchema(collection)(additionalProperties)
+                      : additionalProperties,
+                }
+              : {}),
+            ...(required !== undefined ? { required } : {}),
           });
-        else if (OpenApiTypeChecker.isOneOf(schema))
+        } else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };
       visit(input);

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -1,6 +1,5 @@
 import { OpenApi, OpenApiV3_1 } from "@typia/interface";
 
-import { OpenApiSchemaSanitizer } from "../../utils/internal/OpenApiSchemaSanitizer";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 
 export namespace OpenApiV3_1Downgrader {
@@ -270,26 +269,24 @@ export namespace OpenApiV3_1Downgrader {
                 : schema.additionalItems,
           });
         else if (OpenApiTypeChecker.isObject(schema))
-          union.push(
-            OpenApiSchemaSanitizer.omitEmptyRequired({
-              ...schema,
-              properties: schema.properties
-                ? Object.fromEntries(
-                    Object.entries(schema.properties)
-                      .filter(([_, v]) => v !== undefined)
-                      .map(([key, value]) => [
-                        key,
-                        downgradeSchema(collection)(value),
-                      ]),
-                  )
-                : undefined,
-              additionalProperties:
-                typeof schema.additionalProperties === "object"
-                  ? downgradeSchema(collection)(schema.additionalProperties)
-                  : schema.additionalProperties,
-              required: schema.required,
-            }),
-          );
+          union.push({
+            ...schema,
+            properties: schema.properties
+              ? Object.fromEntries(
+                  Object.entries(schema.properties)
+                    .filter(([_, v]) => v !== undefined)
+                    .map(([key, value]) => [
+                      key,
+                      downgradeSchema(collection)(value),
+                    ]),
+                )
+              : undefined,
+            additionalProperties:
+              typeof schema.additionalProperties === "object"
+                ? downgradeSchema(collection)(schema.additionalProperties)
+                : schema.additionalProperties,
+            required: schema.required,
+          });
         else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -281,16 +281,19 @@ export namespace OpenApiV3_1Downgrader {
             additionalProperties !== false;
           union.push({
             ...rest,
-            ...(properties !== undefined && dynamicRecord === false
+            ...(dynamicRecord === false
               ? {
-                  properties: Object.fromEntries(
-                    Object.entries(properties)
-                      .filter(([_, v]) => v !== undefined)
-                      .map(([key, value]) => [
-                        key,
-                        downgradeSchema(collection)(value),
-                      ]),
-                  ),
+                  properties:
+                    properties !== undefined
+                      ? Object.fromEntries(
+                          Object.entries(properties)
+                            .filter(([_, v]) => v !== undefined)
+                            .map(([key, value]) => [
+                              key,
+                              downgradeSchema(collection)(value),
+                            ]),
+                        )
+                      : {},
                 }
               : {}),
             ...(additionalProperties !== undefined
@@ -301,9 +304,7 @@ export namespace OpenApiV3_1Downgrader {
                       : additionalProperties,
                 }
               : {}),
-            ...(required !== undefined && dynamicRecord === false
-              ? { required }
-              : {}),
+            ...(dynamicRecord === false ? { required: required ?? [] } : {}),
           });
         } else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -271,9 +271,17 @@ export namespace OpenApiV3_1Downgrader {
         else if (OpenApiTypeChecker.isObject(schema)) {
           const { additionalProperties, properties, required, ...rest } =
             schema;
+          const dynamicRecord: boolean =
+            (properties === undefined ||
+              Object.values(properties).every(
+                (value) => value === undefined,
+              )) &&
+            (required === undefined || required.length === 0) &&
+            additionalProperties !== undefined &&
+            additionalProperties !== false;
           union.push({
             ...rest,
-            ...(properties !== undefined
+            ...(properties !== undefined && dynamicRecord === false
               ? {
                   properties: Object.fromEntries(
                     Object.entries(properties)
@@ -293,7 +301,9 @@ export namespace OpenApiV3_1Downgrader {
                       : additionalProperties,
                 }
               : {}),
-            ...(required !== undefined ? { required } : {}),
+            ...(required !== undefined && dynamicRecord === false
+              ? { required }
+              : {}),
           });
         } else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -599,46 +599,27 @@ export namespace OpenApiV3_1Upgrader {
         }
         // OBJECT TYPE CASE
         else if (OpenApiV3_1TypeChecker.isObject(schema)) {
-          const { additionalProperties, properties, required, ...rest } =
-            schema;
-          const dynamicRecord: boolean =
-            (properties === undefined ||
-              Object.values(properties).every(
-                (value) => value === undefined,
-              )) &&
-            (required === undefined || required.length === 0) &&
-            additionalProperties !== undefined &&
-            additionalProperties !== false;
           union.push({
-            ...rest,
-            ...(dynamicRecord === false
-              ? {
-                  properties: properties
-                    ? Object.fromEntries(
-                        Object.entries(properties)
-                          .filter(([_, v]) => v !== undefined)
-                          .map(
-                            ([key, value]) =>
-                              [key, convertSchema(components)(value)] as const,
-                          ),
-                      )
-                    : {},
-                }
-              : {}),
-            ...(additionalProperties !== undefined
-              ? {
-                  additionalProperties:
-                    typeof additionalProperties === "object" &&
-                    additionalProperties !== null
-                      ? convertSchema(components)(additionalProperties)
-                      : additionalProperties,
-                }
-              : {}),
-            ...(dynamicRecord === false
-              ? {
-                  required: required ?? [],
-                }
-              : {}),
+            ...schema,
+            properties:
+              schema.properties === undefined
+                ? undefined
+                : Object.fromEntries(
+                    Object.entries(schema.properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(
+                        ([key, value]) =>
+                          [key, convertSchema(components)(value)] as const,
+                      ),
+                  ),
+            additionalProperties:
+              schema.additionalProperties === undefined
+                ? undefined
+                : typeof schema.additionalProperties === "object" &&
+                    schema.additionalProperties !== null
+                  ? convertSchema(components)(schema.additionalProperties)
+                  : schema.additionalProperties,
+            required: schema.required,
           });
         } else if (OpenApiV3_1TypeChecker.isReference(schema))
           union.push({

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -1,6 +1,5 @@
 import { IJsonSchemaAttribute, OpenApi, OpenApiV3_1 } from "@typia/interface";
 
-import { OpenApiSchemaSanitizer } from "../../utils/internal/OpenApiSchemaSanitizer";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { OpenApiV3_1TypeChecker } from "../../validators/OpenApiV3_1TypeChecker";
 import { OpenApiExclusiveEmender } from "./OpenApiExclusiveEmender";
@@ -600,31 +599,29 @@ export namespace OpenApiV3_1Upgrader {
         }
         // OBJECT TYPE CASE
         else if (OpenApiV3_1TypeChecker.isObject(schema))
-          union.push(
-            OpenApiSchemaSanitizer.omitEmptyRequired({
-              ...schema,
-              ...{
-                properties: schema.properties
-                  ? Object.fromEntries(
-                      Object.entries(schema.properties)
-                        .filter(([_, v]) => v !== undefined)
-                        .map(
-                          ([key, value]) =>
-                            [key, convertSchema(components)(value)] as const,
-                        ),
-                    )
-                  : {},
-                additionalProperties:
-                  schema.additionalProperties !== undefined
-                    ? typeof schema.additionalProperties === "object" &&
-                      schema.additionalProperties !== null
-                      ? convertSchema(components)(schema.additionalProperties)
-                      : schema.additionalProperties
-                    : undefined,
-                required: schema.required ?? [],
-              },
-            }),
-          );
+          union.push({
+            ...schema,
+            ...{
+              properties: schema.properties
+                ? Object.fromEntries(
+                    Object.entries(schema.properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(
+                        ([key, value]) =>
+                          [key, convertSchema(components)(value)] as const,
+                      ),
+                  )
+                : {},
+              additionalProperties:
+                schema.additionalProperties !== undefined
+                  ? typeof schema.additionalProperties === "object" &&
+                    schema.additionalProperties !== null
+                    ? convertSchema(components)(schema.additionalProperties)
+                    : schema.additionalProperties
+                  : undefined,
+              required: schema.required ?? [],
+            },
+          });
         else if (OpenApiV3_1TypeChecker.isReference(schema))
           union.push({
             ...schema,
@@ -707,7 +704,7 @@ export namespace OpenApiV3_1Upgrader {
             allOf: undefined,
           },
         };
-      return OpenApiSchemaSanitizer.omitEmptyRequired({
+      return {
         ...input,
         type: "object" as const,
         properties: Object.fromEntries(
@@ -728,7 +725,7 @@ export namespace OpenApiV3_1Upgrader {
           allOf: undefined,
           required: [...new Set(objects.map((o) => o?.required ?? []).flat())],
         },
-      });
+      };
     };
 
   const retrieveObject =

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -598,31 +598,46 @@ export namespace OpenApiV3_1Upgrader {
             });
         }
         // OBJECT TYPE CASE
-        else if (OpenApiV3_1TypeChecker.isObject(schema))
+        else if (OpenApiV3_1TypeChecker.isObject(schema)) {
+          const { additionalProperties, properties, required, ...rest } =
+            schema;
+          const dynamicRecord: boolean =
+            properties === undefined &&
+            required === undefined &&
+            additionalProperties !== undefined &&
+            additionalProperties !== false;
           union.push({
-            ...schema,
-            ...{
-              properties: schema.properties
-                ? Object.fromEntries(
-                    Object.entries(schema.properties)
-                      .filter(([_, v]) => v !== undefined)
-                      .map(
-                        ([key, value]) =>
-                          [key, convertSchema(components)(value)] as const,
-                      ),
-                  )
-                : {},
-              additionalProperties:
-                schema.additionalProperties !== undefined
-                  ? typeof schema.additionalProperties === "object" &&
-                    schema.additionalProperties !== null
-                    ? convertSchema(components)(schema.additionalProperties)
-                    : schema.additionalProperties
-                  : undefined,
-              required: schema.required ?? [],
-            },
+            ...rest,
+            ...(dynamicRecord === false
+              ? {
+                  properties: properties
+                    ? Object.fromEntries(
+                        Object.entries(properties)
+                          .filter(([_, v]) => v !== undefined)
+                          .map(
+                            ([key, value]) =>
+                              [key, convertSchema(components)(value)] as const,
+                          ),
+                      )
+                    : {},
+                }
+              : {}),
+            ...(additionalProperties !== undefined
+              ? {
+                  additionalProperties:
+                    typeof additionalProperties === "object" &&
+                    additionalProperties !== null
+                      ? convertSchema(components)(additionalProperties)
+                      : additionalProperties,
+                }
+              : {}),
+            ...(dynamicRecord === false
+              ? {
+                  required: required ?? [],
+                }
+              : {}),
           });
-        else if (OpenApiV3_1TypeChecker.isReference(schema))
+        } else if (OpenApiV3_1TypeChecker.isReference(schema))
           union.push({
             ...schema,
             ...{

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -602,8 +602,11 @@ export namespace OpenApiV3_1Upgrader {
           const { additionalProperties, properties, required, ...rest } =
             schema;
           const dynamicRecord: boolean =
-            properties === undefined &&
-            required === undefined &&
+            (properties === undefined ||
+              Object.values(properties).every(
+                (value) => value === undefined,
+              )) &&
+            (required === undefined || required.length === 0) &&
             additionalProperties !== undefined &&
             additionalProperties !== false;
           union.push({

--- a/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
@@ -303,29 +303,37 @@ export namespace SwaggerV2Downgrader {
               ? Object.values(schema.examples)
               : undefined,
           });
-        else if (OpenApiTypeChecker.isObject(schema))
+        else if (OpenApiTypeChecker.isObject(schema)) {
+          const { additionalProperties, properties, required, ...rest } =
+            schema;
           union.push({
-            ...schema,
-            properties: schema.properties
-              ? Object.fromEntries(
-                  Object.entries(schema.properties)
-                    .filter(([_, v]) => v !== undefined)
-                    .map(([key, value]) => [
-                      key,
-                      downgradeSchema(collection)(value),
-                    ]),
-                )
-              : undefined,
-            additionalProperties:
-              typeof schema.additionalProperties === "object"
-                ? downgradeSchema(collection)(schema.additionalProperties)
-                : schema.additionalProperties,
-            required: schema.required,
+            ...rest,
+            ...(properties !== undefined
+              ? {
+                  properties: Object.fromEntries(
+                    Object.entries(properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        downgradeSchema(collection)(value),
+                      ]),
+                  ),
+                }
+              : {}),
+            ...(additionalProperties !== undefined
+              ? {
+                  additionalProperties:
+                    typeof additionalProperties === "object"
+                      ? downgradeSchema(collection)(additionalProperties)
+                      : additionalProperties,
+                }
+              : {}),
+            ...(required !== undefined ? { required } : {}),
             examples: schema.examples
               ? Object.values(schema.examples)
               : undefined,
           });
-        else if (OpenApiTypeChecker.isOneOf(schema))
+        } else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };
       const visitConstant = (schema: OpenApi.IJsonSchema): void => {

--- a/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
@@ -303,48 +303,33 @@ export namespace SwaggerV2Downgrader {
               ? Object.values(schema.examples)
               : undefined,
           });
-        else if (OpenApiTypeChecker.isObject(schema)) {
-          const { additionalProperties, properties, required, ...rest } =
-            schema;
-          const dynamicRecord: boolean =
-            (properties === undefined ||
-              Object.values(properties).every(
-                (value) => value === undefined,
-              )) &&
-            (required === undefined || required.length === 0) &&
-            additionalProperties !== undefined &&
-            additionalProperties !== false;
+        else if (OpenApiTypeChecker.isObject(schema))
           union.push({
-            ...rest,
-            ...(dynamicRecord === false
-              ? {
-                  properties:
-                    properties !== undefined
-                      ? Object.fromEntries(
-                          Object.entries(properties)
-                            .filter(([_, v]) => v !== undefined)
-                            .map(([key, value]) => [
-                              key,
-                              downgradeSchema(collection)(value),
-                            ]),
-                        )
-                      : {},
-                }
-              : {}),
-            ...(additionalProperties !== undefined
-              ? {
-                  additionalProperties:
-                    typeof additionalProperties === "object"
-                      ? downgradeSchema(collection)(additionalProperties)
-                      : additionalProperties,
-                }
-              : {}),
-            ...(dynamicRecord === false ? { required: required ?? [] } : {}),
-            examples: schema.examples
-              ? Object.values(schema.examples)
-              : undefined,
+            ...schema,
+            properties:
+              schema.properties === undefined
+                ? undefined
+                : Object.fromEntries(
+                    Object.entries(schema.properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        downgradeSchema(collection)(value),
+                      ]),
+                  ),
+            additionalProperties:
+              schema.additionalProperties === undefined
+                ? undefined
+                : typeof schema.additionalProperties === "object"
+                  ? downgradeSchema(collection)(schema.additionalProperties)
+                  : schema.additionalProperties,
+            required: schema.required,
+            examples:
+              schema.examples === undefined
+                ? undefined
+                : Object.values(schema.examples),
           });
-        } else if (OpenApiTypeChecker.isOneOf(schema))
+        else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };
       const visitConstant = (schema: OpenApi.IJsonSchema): void => {

--- a/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
@@ -316,16 +316,19 @@ export namespace SwaggerV2Downgrader {
             additionalProperties !== false;
           union.push({
             ...rest,
-            ...(properties !== undefined && dynamicRecord === false
+            ...(dynamicRecord === false
               ? {
-                  properties: Object.fromEntries(
-                    Object.entries(properties)
-                      .filter(([_, v]) => v !== undefined)
-                      .map(([key, value]) => [
-                        key,
-                        downgradeSchema(collection)(value),
-                      ]),
-                  ),
+                  properties:
+                    properties !== undefined
+                      ? Object.fromEntries(
+                          Object.entries(properties)
+                            .filter(([_, v]) => v !== undefined)
+                            .map(([key, value]) => [
+                              key,
+                              downgradeSchema(collection)(value),
+                            ]),
+                        )
+                      : {},
                 }
               : {}),
             ...(additionalProperties !== undefined
@@ -336,9 +339,7 @@ export namespace SwaggerV2Downgrader {
                       : additionalProperties,
                 }
               : {}),
-            ...(required !== undefined && dynamicRecord === false
-              ? { required }
-              : {}),
+            ...(dynamicRecord === false ? { required: required ?? [] } : {}),
             examples: schema.examples
               ? Object.values(schema.examples)
               : undefined,

--- a/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
@@ -1,6 +1,5 @@
 import { OpenApi, SwaggerV2 } from "@typia/interface";
 
-import { OpenApiSchemaSanitizer } from "../../utils/internal/OpenApiSchemaSanitizer";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 
 export namespace SwaggerV2Downgrader {
@@ -305,29 +304,27 @@ export namespace SwaggerV2Downgrader {
               : undefined,
           });
         else if (OpenApiTypeChecker.isObject(schema))
-          union.push(
-            OpenApiSchemaSanitizer.omitEmptyRequired({
-              ...schema,
-              properties: schema.properties
-                ? Object.fromEntries(
-                    Object.entries(schema.properties)
-                      .filter(([_, v]) => v !== undefined)
-                      .map(([key, value]) => [
-                        key,
-                        downgradeSchema(collection)(value),
-                      ]),
-                  )
-                : undefined,
-              additionalProperties:
-                typeof schema.additionalProperties === "object"
-                  ? downgradeSchema(collection)(schema.additionalProperties)
-                  : schema.additionalProperties,
-              required: schema.required,
-              examples: schema.examples
-                ? Object.values(schema.examples)
-                : undefined,
-            }),
-          );
+          union.push({
+            ...schema,
+            properties: schema.properties
+              ? Object.fromEntries(
+                  Object.entries(schema.properties)
+                    .filter(([_, v]) => v !== undefined)
+                    .map(([key, value]) => [
+                      key,
+                      downgradeSchema(collection)(value),
+                    ]),
+                )
+              : undefined,
+            additionalProperties:
+              typeof schema.additionalProperties === "object"
+                ? downgradeSchema(collection)(schema.additionalProperties)
+                : schema.additionalProperties,
+            required: schema.required,
+            examples: schema.examples
+              ? Object.values(schema.examples)
+              : undefined,
+          });
         else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };

--- a/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
@@ -306,9 +306,17 @@ export namespace SwaggerV2Downgrader {
         else if (OpenApiTypeChecker.isObject(schema)) {
           const { additionalProperties, properties, required, ...rest } =
             schema;
+          const dynamicRecord: boolean =
+            (properties === undefined ||
+              Object.values(properties).every(
+                (value) => value === undefined,
+              )) &&
+            (required === undefined || required.length === 0) &&
+            additionalProperties !== undefined &&
+            additionalProperties !== false;
           union.push({
             ...rest,
-            ...(properties !== undefined
+            ...(properties !== undefined && dynamicRecord === false
               ? {
                   properties: Object.fromEntries(
                     Object.entries(properties)
@@ -328,7 +336,9 @@ export namespace SwaggerV2Downgrader {
                       : additionalProperties,
                 }
               : {}),
-            ...(required !== undefined ? { required } : {}),
+            ...(required !== undefined && dynamicRecord === false
+              ? { required }
+              : {}),
             examples: schema.examples
               ? Object.values(schema.examples)
               : undefined,

--- a/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
@@ -475,58 +475,33 @@ export namespace SwaggerV2Upgrader {
               : undefined,
           });
         else if (SwaggerV2TypeChecker.isObject(schema)) {
-          const {
-            additionalProperties,
-            examples,
-            properties,
-            required,
-            ...rest
-          } = schema;
-          const dynamicRecord: boolean =
-            (properties === undefined ||
-              Object.values(properties).every(
-                (value) => value === undefined,
-              )) &&
-            (required === undefined || required.length === 0) &&
-            additionalProperties !== undefined &&
-            additionalProperties !== false;
           union.push({
-            ...rest,
-            ...(dynamicRecord === false
-              ? {
-                  properties: properties
-                    ? Object.fromEntries(
-                        Object.entries(properties)
-                          .filter(([_, v]) => v !== undefined)
-                          .map(([key, value]) => [
-                            key,
-                            convertSchema(definitions)(value),
-                          ]),
-                      )
-                    : {},
-                }
-              : {}),
-            ...(additionalProperties !== undefined
-              ? {
-                  additionalProperties:
-                    typeof additionalProperties === "object" &&
-                    additionalProperties !== null
-                      ? convertSchema(definitions)(additionalProperties)
-                      : additionalProperties,
-                }
-              : {}),
-            ...(examples
-              ? {
-                  examples: Object.fromEntries(
-                    examples.map((v, i) => [`v${i}`, v]),
+            ...schema,
+            properties:
+              schema.properties === undefined
+                ? undefined
+                : Object.fromEntries(
+                    Object.entries(schema.properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        convertSchema(definitions)(value),
+                      ]),
                   ),
-                }
-              : {}),
-            ...(dynamicRecord === false
-              ? {
-                  required: required ?? [],
-                }
-              : {}),
+            additionalProperties:
+              schema.additionalProperties === undefined
+                ? undefined
+                : typeof schema.additionalProperties === "object" &&
+                    schema.additionalProperties !== null
+                  ? convertSchema(definitions)(schema.additionalProperties)
+                  : schema.additionalProperties,
+            examples:
+              schema.examples === undefined
+                ? undefined
+                : Object.fromEntries(
+                    schema.examples.map((v, i) => [`v${i}`, v]),
+                  ),
+            required: schema.required,
           });
         } else if (SwaggerV2TypeChecker.isReference(schema))
           union.push({

--- a/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
@@ -483,8 +483,11 @@ export namespace SwaggerV2Upgrader {
             ...rest
           } = schema;
           const dynamicRecord: boolean =
-            properties === undefined &&
-            required === undefined &&
+            (properties === undefined ||
+              Object.values(properties).every(
+                (value) => value === undefined,
+              )) &&
+            (required === undefined || required.length === 0) &&
             additionalProperties !== undefined &&
             additionalProperties !== false;
           union.push({

--- a/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
@@ -474,34 +474,58 @@ export namespace SwaggerV2Upgrader {
               ? Object.fromEntries(schema.examples.map((v, i) => [`v${i}`, v]))
               : undefined,
           });
-        else if (SwaggerV2TypeChecker.isObject(schema))
+        else if (SwaggerV2TypeChecker.isObject(schema)) {
+          const {
+            additionalProperties,
+            examples,
+            properties,
+            required,
+            ...rest
+          } = schema;
+          const dynamicRecord: boolean =
+            properties === undefined &&
+            required === undefined &&
+            additionalProperties !== undefined &&
+            additionalProperties !== false;
           union.push({
-            ...schema,
-            ...{
-              properties: schema.properties
-                ? Object.fromEntries(
-                    Object.entries(schema.properties)
-                      .filter(([_, v]) => v !== undefined)
-                      .map(([key, value]) => [
-                        key,
-                        convertSchema(definitions)(value),
-                      ]),
-                  )
-                : {},
-              additionalProperties:
-                schema.additionalProperties !== undefined
-                  ? typeof schema.additionalProperties === "object" &&
-                    schema.additionalProperties !== null
-                    ? convertSchema(definitions)(schema.additionalProperties)
-                    : schema.additionalProperties
-                  : undefined,
-            },
-            examples: schema.examples
-              ? Object.fromEntries(schema.examples.map((v, i) => [`v${i}`, v]))
-              : undefined,
-            required: schema.required ?? [],
+            ...rest,
+            ...(dynamicRecord === false
+              ? {
+                  properties: properties
+                    ? Object.fromEntries(
+                        Object.entries(properties)
+                          .filter(([_, v]) => v !== undefined)
+                          .map(([key, value]) => [
+                            key,
+                            convertSchema(definitions)(value),
+                          ]),
+                      )
+                    : {},
+                }
+              : {}),
+            ...(additionalProperties !== undefined
+              ? {
+                  additionalProperties:
+                    typeof additionalProperties === "object" &&
+                    additionalProperties !== null
+                      ? convertSchema(definitions)(additionalProperties)
+                      : additionalProperties,
+                }
+              : {}),
+            ...(examples
+              ? {
+                  examples: Object.fromEntries(
+                    examples.map((v, i) => [`v${i}`, v]),
+                  ),
+                }
+              : {}),
+            ...(dynamicRecord === false
+              ? {
+                  required: required ?? [],
+                }
+              : {}),
           });
-        else if (SwaggerV2TypeChecker.isReference(schema))
+        } else if (SwaggerV2TypeChecker.isReference(schema))
           union.push({
             ...schema,
             $ref: schema.$ref.replace(

--- a/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
@@ -1,6 +1,5 @@
 import { IJsonSchemaAttribute, OpenApi, SwaggerV2 } from "@typia/interface";
 
-import { OpenApiSchemaSanitizer } from "../../utils/internal/OpenApiSchemaSanitizer";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { SwaggerV2TypeChecker } from "../../validators/SwaggerV2TypeChecker";
 import { OpenApiExclusiveEmender } from "./OpenApiExclusiveEmender";
@@ -476,36 +475,32 @@ export namespace SwaggerV2Upgrader {
               : undefined,
           });
         else if (SwaggerV2TypeChecker.isObject(schema))
-          union.push(
-            OpenApiSchemaSanitizer.omitEmptyRequired({
-              ...schema,
-              ...{
-                properties: schema.properties
-                  ? Object.fromEntries(
-                      Object.entries(schema.properties)
-                        .filter(([_, v]) => v !== undefined)
-                        .map(([key, value]) => [
-                          key,
-                          convertSchema(definitions)(value),
-                        ]),
-                    )
-                  : {},
-                additionalProperties:
-                  schema.additionalProperties !== undefined
-                    ? typeof schema.additionalProperties === "object" &&
-                      schema.additionalProperties !== null
-                      ? convertSchema(definitions)(schema.additionalProperties)
-                      : schema.additionalProperties
-                    : undefined,
-              },
-              examples: schema.examples
+          union.push({
+            ...schema,
+            ...{
+              properties: schema.properties
                 ? Object.fromEntries(
-                    schema.examples.map((v, i) => [`v${i}`, v]),
+                    Object.entries(schema.properties)
+                      .filter(([_, v]) => v !== undefined)
+                      .map(([key, value]) => [
+                        key,
+                        convertSchema(definitions)(value),
+                      ]),
                   )
-                : undefined,
-              required: schema.required ?? [],
-            }),
-          );
+                : {},
+              additionalProperties:
+                schema.additionalProperties !== undefined
+                  ? typeof schema.additionalProperties === "object" &&
+                    schema.additionalProperties !== null
+                    ? convertSchema(definitions)(schema.additionalProperties)
+                    : schema.additionalProperties
+                  : undefined,
+            },
+            examples: schema.examples
+              ? Object.fromEntries(schema.examples.map((v, i) => [`v${i}`, v]))
+              : undefined,
+            required: schema.required ?? [],
+          });
         else if (SwaggerV2TypeChecker.isReference(schema))
           union.push({
             ...schema,
@@ -574,7 +569,7 @@ export namespace SwaggerV2Upgrader {
             allOf: undefined,
           },
         };
-      return OpenApiSchemaSanitizer.omitEmptyRequired({
+      return {
         ...input,
         type: "object" as const,
         properties: Object.fromEntries(
@@ -595,7 +590,7 @@ export namespace SwaggerV2Upgrader {
           allOf: undefined,
           required: [...new Set(objects.map((o) => o?.required ?? []).flat())],
         },
-      });
+      };
     };
 
   const retrieveObject =

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_empty_required.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_empty_required.ts
@@ -4,15 +4,15 @@ import { OpenApiValidator } from "@typia/utils";
 import typia, { tags } from "typia";
 
 /**
- * Verifies JSON schema omits empty `required` arrays.
+ * Verifies JSON schema keeps empty object keywords on named objects.
  *
- * Locks the OpenAPI/JSON Schema boundary for objects without required named
- * properties. Draft-04 and OpenAPI 3.0 reject `required: []`, while objects
- * with at least one required property must still emit the keyword.
+ * Locks the JSON schema boundary for named objects without required properties.
+ * Empty objects still need explicit `properties: {}` and `required: []`; only
+ * pure record schemas omit both named-object keywords.
  *
  * 1. Generate schemas for optional-only, filtered, record, and required objects.
- * 2. Assert empty required lists are omitted and optional fields stay optional.
- * 3. Assert non-empty required properties are still listed.
+ * 2. Assert named objects keep empty required lists and validate optionality.
+ * 3. Assert pure record schemas omit named-object keywords.
  */
 export const test_json_schema_empty_required = (): void => {
   interface IOptionalOnly {
@@ -38,11 +38,7 @@ export const test_json_schema_empty_required = (): void => {
   }
 
   const optionalOnly = object(typia.json.schema<IOptionalOnly>());
-  TestValidator.equals(
-    "optional-only required omitted",
-    hasOwn(optionalOnly, "required"),
-    false,
-  );
+  TestValidator.equals("optional-only required", optionalOnly.required, []);
   TestValidator.equals("optional-only properties", sorted(optionalOnly), [
     "count",
     "title",
@@ -60,17 +56,18 @@ export const test_json_schema_empty_required = (): void => {
 
   const filteredOnly = object(typia.json.schema<IFilteredOnly>());
   TestValidator.equals("filtered-only properties", sorted(filteredOnly), []);
-  TestValidator.equals(
-    "filtered-only required omitted",
-    hasOwn(filteredOnly, "required"),
-    false,
-  );
+  TestValidator.equals("filtered-only required", filteredOnly.required, []);
 
   const record = typia.json.schema<Record<string, string & tags.MinLength<1>>>()
     .schema as OpenApi.IJsonSchema.IObject;
   TestValidator.equals(
     "record required omitted",
     hasOwn(record, "required"),
+    false,
+  );
+  TestValidator.equals(
+    "record properties omitted",
+    hasOwn(record, "properties"),
     false,
   );
 

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_empty_required.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_empty_required.ts
@@ -55,7 +55,7 @@ export const test_json_schema_empty_required = (): void => {
   );
 
   const filteredOnly = object(typia.json.schema<IFilteredOnly>());
-  TestValidator.equals("filtered-only properties", sorted(filteredOnly), []);
+  TestValidator.equals("filtered-only properties", filteredOnly.properties, {});
   TestValidator.equals("filtered-only required", filteredOnly.required, []);
 
   const record = typia.json.schema<Record<string, string & tags.MinLength<1>>>()

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_spec_object_record.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_spec_object_record.ts
@@ -5,12 +5,12 @@ import typia, { tags } from "typia";
  * Verifies object and record schemas follow OpenAPI required semantics.
  *
  * Locks the object/record fixture used by the JSON schema spec tests. Named
- * required object properties must still populate `required`, but record-only
- * objects have no named required properties and therefore must omit it.
+ * object properties must still populate `properties` and `required`, but
+ * record-only objects have no named keys and therefore omit both keywords.
  *
  * 1. Generate schema for an object with required, optional, and nullable fields.
  * 2. Assert its named required properties are retained.
- * 3. Generate a record schema and assert it has no empty `required` array.
+ * 3. Generate a record schema and assert it has no named-object keywords.
  */
 export const test_json_schema_spec_object_record = (): void => {
   interface IObjectSpec {
@@ -54,7 +54,6 @@ export const test_json_schema_spec_object_record = (): void => {
     ),
     {
       type: "object",
-      properties: {},
       additionalProperties: {
         type: "string",
         minLength: 1,

--- a/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
@@ -111,11 +111,10 @@ export const test_openapi_converter_empty_required = (): void => {
       schemas.NoisyEmptyOpen!,
     );
     assertRecordKeywordsOmitted(`${name} upgraded record`, schemas.Record!);
-    if (schemas.NoisyRecord !== undefined)
-      assertRecordKeywordsOmitted(
-        `${name} upgraded noisy record`,
-        schemas.NoisyRecord,
-      );
+    assertNoisyRecordKeywordsPreserved(
+      `${name} upgraded noisy record`,
+      schemas.NoisyRecord!,
+    );
     assertObjectEmptyRequired(
       `${name} upgraded optional allOf`,
       schemas.Merged!,
@@ -168,7 +167,7 @@ export const test_openapi_converter_empty_required = (): void => {
     "downgraded swagger record",
     downgradedSwagger.definitions!.Record!,
   );
-  assertRecordKeywordsOmitted(
+  assertNoisyRecordKeywordsPreserved(
     "downgraded swagger noisy record",
     downgradedSwagger.definitions!.NoisyRecord!,
   );
@@ -198,7 +197,7 @@ export const test_openapi_converter_empty_required = (): void => {
     "downgraded v3.0 record",
     downgradedV30.components!.schemas!.Record!,
   );
-  assertRecordKeywordsOmitted(
+  assertNoisyRecordKeywordsPreserved(
     "downgraded v3.0 noisy record",
     downgradedV30.components!.schemas!.NoisyRecord!,
   );
@@ -228,7 +227,7 @@ export const test_openapi_converter_empty_required = (): void => {
     "downgraded v3.1 record",
     downgradedV31.components!.schemas!.Record!,
   );
-  assertRecordKeywordsOmitted(
+  assertNoisyRecordKeywordsPreserved(
     "downgraded v3.1 noisy record",
     downgradedV31.components!.schemas!.NoisyRecord!,
   );
@@ -271,6 +270,8 @@ const recordOpenApi = (): OpenApi.IJsonSchema.IObject => ({
 
 const emptyOpenApi = (): OpenApi.IJsonSchema.IObject => ({
   type: "object",
+  properties: {},
+  required: [],
 });
 
 const noisyEmptyOpenApi = (): OpenApi.IJsonSchema.IObject => ({
@@ -666,16 +667,50 @@ const assertRecordKeywordsOmitted = (
     {
       type: object.type,
       additionalProperties: object.additionalProperties,
-      properties: hasOwn(object, "properties"),
-      required: hasOwn(object, "required"),
+      properties: object.properties,
+      required: object.required,
     },
     {
       type: "object",
       additionalProperties: {
         type: "string",
       },
-      properties: false,
-      required: false,
+      properties: undefined,
+      required: undefined,
+    },
+  );
+};
+
+const assertNoisyRecordKeywordsPreserved = (
+  name: string,
+  schema:
+    | OpenApi.IJsonSchema
+    | OpenApiV3.IJsonSchema
+    | OpenApiV3_1.IJsonSchema
+    | OpenApiV3_2.IJsonSchema
+    | SwaggerV2.IJsonSchema,
+): void => {
+  const object = schema as
+    | OpenApi.IJsonSchema.IObject
+    | OpenApiV3.IJsonSchema.IObject
+    | OpenApiV3_1.IJsonSchema.IObject
+    | OpenApiV3_2.IJsonSchema.IObject
+    | SwaggerV2.IJsonSchema.IObject;
+  TestValidator.equals(
+    `${name} record shape`,
+    {
+      type: object.type,
+      additionalProperties: object.additionalProperties,
+      properties: object.properties,
+      required: object.required,
+    },
+    {
+      type: "object",
+      additionalProperties: {
+        type: "string",
+      },
+      properties: {},
+      required: [],
     },
   );
 };
@@ -700,17 +735,14 @@ const assertEmptyOpenObjectKeywords = (
     {
       type: object.type,
       properties: object.properties,
-      ownsAdditionalProperties: hasOwn(object, "additionalProperties"),
+      additionalProperties: object.additionalProperties,
       required: object.required,
     },
     {
       type: "object",
       properties: {},
-      ownsAdditionalProperties: false,
+      additionalProperties: undefined,
       required: [],
     },
   );
 };
-
-const hasOwn = (obj: object, key: string): boolean =>
-  Object.prototype.hasOwnProperty.call(obj, key);

--- a/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
@@ -30,6 +30,7 @@ export const test_openapi_converter_empty_required = (): void => {
         definitions: {
           Target: optionalSwagger(),
           Record: recordSwagger(),
+          NoisyRecord: noisyRecordSwagger(),
           Merged: mergedSwagger(),
           MergedRequired: mergedRequiredSwagger(),
           MergedRequiredFirst: mergedRequiredFirstSwagger(),
@@ -46,6 +47,7 @@ export const test_openapi_converter_empty_required = (): void => {
           schemas: {
             Target: optionalV3(),
             Record: recordV3(),
+            NoisyRecord: noisyRecordV3(),
             Merged: mergedV3(),
             MergedRequired: mergedRequiredV3(),
             MergedRequiredFirst: mergedRequiredFirstV3(),
@@ -63,6 +65,7 @@ export const test_openapi_converter_empty_required = (): void => {
           schemas: {
             Target: optionalV31(),
             Record: recordV31(),
+            NoisyRecord: noisyRecordV31(),
             Merged: mergedV31(),
             MergedRequired: mergedRequiredV31(),
             MergedRequiredFirst: mergedRequiredFirstV31(),
@@ -80,6 +83,7 @@ export const test_openapi_converter_empty_required = (): void => {
           schemas: {
             Target: optionalV32(),
             Record: recordV32(),
+            NoisyRecord: noisyRecordV32(),
             Merged: mergedV32(),
             MergedRequired: mergedRequiredV32(),
             MergedRequiredFirst: mergedRequiredFirstV32(),
@@ -91,6 +95,11 @@ export const test_openapi_converter_empty_required = (): void => {
   for (const [name, schemas] of upgraded) {
     assertObjectEmptyRequired(`${name} upgraded object`, schemas.Target!);
     assertRecordKeywordsOmitted(`${name} upgraded record`, schemas.Record!);
+    if (schemas.NoisyRecord !== undefined)
+      assertRecordKeywordsOmitted(
+        `${name} upgraded noisy record`,
+        schemas.NoisyRecord,
+      );
     assertObjectEmptyRequired(
       `${name} upgraded optional allOf`,
       schemas.Merged!,
@@ -117,6 +126,7 @@ export const test_openapi_converter_empty_required = (): void => {
       schemas: {
         Target: optionalOpenApi(),
         Record: recordOpenApi(),
+        NoisyRecord: noisyRecordOpenApi(),
         Required: requiredOpenApi(),
       },
     },
@@ -131,6 +141,10 @@ export const test_openapi_converter_empty_required = (): void => {
   assertRecordKeywordsOmitted(
     "downgraded swagger record",
     downgradedSwagger.definitions!.Record!,
+  );
+  assertRecordKeywordsOmitted(
+    "downgraded swagger noisy record",
+    downgradedSwagger.definitions!.NoisyRecord!,
   );
   assertObjectRequired(
     "downgraded swagger required",
@@ -150,6 +164,10 @@ export const test_openapi_converter_empty_required = (): void => {
     "downgraded v3.0 record",
     downgradedV30.components!.schemas!.Record!,
   );
+  assertRecordKeywordsOmitted(
+    "downgraded v3.0 noisy record",
+    downgradedV30.components!.schemas!.NoisyRecord!,
+  );
   assertObjectRequired(
     "downgraded v3.0 required",
     downgradedV30.components!.schemas!.Required!,
@@ -167,6 +185,10 @@ export const test_openapi_converter_empty_required = (): void => {
   assertRecordKeywordsOmitted(
     "downgraded v3.1 record",
     downgradedV31.components!.schemas!.Record!,
+  );
+  assertRecordKeywordsOmitted(
+    "downgraded v3.1 noisy record",
+    downgradedV31.components!.schemas!.NoisyRecord!,
   );
   assertObjectRequired(
     "downgraded v3.1 required",
@@ -205,6 +227,17 @@ const recordOpenApi = (): OpenApi.IJsonSchema.IObject => ({
   },
 });
 
+const noisyRecordOpenApi = (): OpenApi.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as OpenApi.IJsonSchema,
+  },
+  additionalProperties: {
+    type: "string",
+  },
+  required: [],
+});
+
 const optionalV3 = (): OpenApiV3.IJsonSchema.IObject => ({
   type: "object",
   properties: {
@@ -219,6 +252,17 @@ const recordV3 = (): OpenApiV3.IJsonSchema.IObject => ({
   additionalProperties: {
     type: "string",
   },
+});
+
+const noisyRecordV3 = (): OpenApiV3.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as OpenApiV3.IJsonSchema,
+  },
+  additionalProperties: {
+    type: "string",
+  },
+  required: [],
 });
 
 const optionalV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
@@ -237,6 +281,17 @@ const recordV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
   },
 });
 
+const noisyRecordV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as OpenApiV3_1.IJsonSchema,
+  },
+  additionalProperties: {
+    type: "string",
+  },
+  required: [],
+});
+
 const optionalV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
   type: "object",
   properties: {
@@ -253,6 +308,17 @@ const recordV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
   },
 });
 
+const noisyRecordV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as OpenApiV3_2.IJsonSchema,
+  },
+  additionalProperties: {
+    type: "string",
+  },
+  required: [],
+});
+
 const optionalSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
   type: "object",
   properties: {
@@ -267,6 +333,17 @@ const recordSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
   additionalProperties: {
     type: "string",
   },
+});
+
+const noisyRecordSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as SwaggerV2.IJsonSchema,
+  },
+  additionalProperties: {
+    type: "string",
+  },
+  required: [],
 });
 
 const emptyV3 = (): OpenApiV3.IJsonSchema.IObject => ({

--- a/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
@@ -29,6 +29,7 @@ export const test_openapi_converter_empty_required = (): void => {
         paths: {},
         definitions: {
           Target: optionalSwagger(),
+          Record: recordSwagger(),
           Merged: mergedSwagger(),
           MergedRequired: mergedRequiredSwagger(),
           MergedRequiredFirst: mergedRequiredFirstSwagger(),
@@ -44,6 +45,7 @@ export const test_openapi_converter_empty_required = (): void => {
         components: {
           schemas: {
             Target: optionalV3(),
+            Record: recordV3(),
             Merged: mergedV3(),
             MergedRequired: mergedRequiredV3(),
             MergedRequiredFirst: mergedRequiredFirstV3(),
@@ -60,6 +62,7 @@ export const test_openapi_converter_empty_required = (): void => {
         components: {
           schemas: {
             Target: optionalV31(),
+            Record: recordV31(),
             Merged: mergedV31(),
             MergedRequired: mergedRequiredV31(),
             MergedRequiredFirst: mergedRequiredFirstV31(),
@@ -76,6 +79,7 @@ export const test_openapi_converter_empty_required = (): void => {
         components: {
           schemas: {
             Target: optionalV32(),
+            Record: recordV32(),
             Merged: mergedV32(),
             MergedRequired: mergedRequiredV32(),
             MergedRequiredFirst: mergedRequiredFirstV32(),
@@ -86,6 +90,7 @@ export const test_openapi_converter_empty_required = (): void => {
   ] as const;
   for (const [name, schemas] of upgraded) {
     assertObjectEmptyRequired(`${name} upgraded object`, schemas.Target!);
+    assertRecordKeywordsOmitted(`${name} upgraded record`, schemas.Record!);
     assertObjectEmptyRequired(
       `${name} upgraded optional allOf`,
       schemas.Merged!,
@@ -111,6 +116,7 @@ export const test_openapi_converter_empty_required = (): void => {
     components: {
       schemas: {
         Target: optionalOpenApi(),
+        Record: recordOpenApi(),
         Required: requiredOpenApi(),
       },
     },
@@ -121,6 +127,10 @@ export const test_openapi_converter_empty_required = (): void => {
   assertObjectEmptyRequired(
     "downgraded swagger",
     downgradedSwagger.definitions!.Target!,
+  );
+  assertRecordKeywordsOmitted(
+    "downgraded swagger record",
+    downgradedSwagger.definitions!.Record!,
   );
   assertObjectRequired(
     "downgraded swagger required",
@@ -136,6 +146,10 @@ export const test_openapi_converter_empty_required = (): void => {
     "downgraded v3.0",
     downgradedV30.components!.schemas!.Target!,
   );
+  assertRecordKeywordsOmitted(
+    "downgraded v3.0 record",
+    downgradedV30.components!.schemas!.Record!,
+  );
   assertObjectRequired(
     "downgraded v3.0 required",
     downgradedV30.components!.schemas!.Required!,
@@ -149,6 +163,10 @@ export const test_openapi_converter_empty_required = (): void => {
   assertObjectEmptyRequired(
     "downgraded v3.1",
     downgradedV31.components!.schemas!.Target!,
+  );
+  assertRecordKeywordsOmitted(
+    "downgraded v3.1 record",
+    downgradedV31.components!.schemas!.Record!,
   );
   assertObjectRequired(
     "downgraded v3.1 required",
@@ -180,6 +198,13 @@ const requiredOpenApi = (): OpenApi.IJsonSchema.IObject => ({
   required: ["id"],
 });
 
+const recordOpenApi = (): OpenApi.IJsonSchema.IObject => ({
+  type: "object",
+  additionalProperties: {
+    type: "string",
+  },
+});
+
 const optionalV3 = (): OpenApiV3.IJsonSchema.IObject => ({
   type: "object",
   properties: {
@@ -187,6 +212,13 @@ const optionalV3 = (): OpenApiV3.IJsonSchema.IObject => ({
   },
   additionalProperties: false,
   required: [],
+});
+
+const recordV3 = (): OpenApiV3.IJsonSchema.IObject => ({
+  type: "object",
+  additionalProperties: {
+    type: "string",
+  },
 });
 
 const optionalV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
@@ -198,6 +230,13 @@ const optionalV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
   required: [],
 });
 
+const recordV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
+  type: "object",
+  additionalProperties: {
+    type: "string",
+  },
+});
+
 const optionalV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
   type: "object",
   properties: {
@@ -207,6 +246,13 @@ const optionalV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
   required: [],
 });
 
+const recordV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
+  type: "object",
+  additionalProperties: {
+    type: "string",
+  },
+});
+
 const optionalSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
   type: "object",
   properties: {
@@ -214,6 +260,13 @@ const optionalSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
   },
   additionalProperties: false,
   required: [],
+});
+
+const recordSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
+  type: "object",
+  additionalProperties: {
+    type: "string",
+  },
 });
 
 const emptyV3 = (): OpenApiV3.IJsonSchema.IObject => ({
@@ -405,3 +458,40 @@ const assertObjectRequired = (
     },
   );
 };
+
+const assertRecordKeywordsOmitted = (
+  name: string,
+  schema:
+    | OpenApi.IJsonSchema
+    | OpenApiV3.IJsonSchema
+    | OpenApiV3_1.IJsonSchema
+    | OpenApiV3_2.IJsonSchema
+    | SwaggerV2.IJsonSchema,
+): void => {
+  const object = schema as
+    | OpenApi.IJsonSchema.IObject
+    | OpenApiV3.IJsonSchema.IObject
+    | OpenApiV3_1.IJsonSchema.IObject
+    | OpenApiV3_2.IJsonSchema.IObject
+    | SwaggerV2.IJsonSchema.IObject;
+  TestValidator.equals(
+    `${name} record shape`,
+    {
+      type: object.type,
+      additionalProperties: object.additionalProperties,
+      properties: hasOwn(object, "properties"),
+      required: hasOwn(object, "required"),
+    },
+    {
+      type: "object",
+      additionalProperties: {
+        type: "string",
+      },
+      properties: false,
+      required: false,
+    },
+  );
+};
+
+const hasOwn = (obj: object, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(obj, key);

--- a/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
@@ -29,6 +29,8 @@ export const test_openapi_converter_empty_required = (): void => {
         paths: {},
         definitions: {
           Target: optionalSwagger(),
+          EmptyOpen: emptyOpenSwagger(),
+          NoisyEmptyOpen: noisyEmptyOpenSwagger(),
           Record: recordSwagger(),
           NoisyRecord: noisyRecordSwagger(),
           Merged: mergedSwagger(),
@@ -46,6 +48,8 @@ export const test_openapi_converter_empty_required = (): void => {
         components: {
           schemas: {
             Target: optionalV3(),
+            EmptyOpen: emptyOpenV3(),
+            NoisyEmptyOpen: noisyEmptyOpenV3(),
             Record: recordV3(),
             NoisyRecord: noisyRecordV3(),
             Merged: mergedV3(),
@@ -64,6 +68,8 @@ export const test_openapi_converter_empty_required = (): void => {
         components: {
           schemas: {
             Target: optionalV31(),
+            EmptyOpen: emptyOpenV31(),
+            NoisyEmptyOpen: noisyEmptyOpenV31(),
             Record: recordV31(),
             NoisyRecord: noisyRecordV31(),
             Merged: mergedV31(),
@@ -82,6 +88,8 @@ export const test_openapi_converter_empty_required = (): void => {
         components: {
           schemas: {
             Target: optionalV32(),
+            EmptyOpen: emptyOpenV32(),
+            NoisyEmptyOpen: noisyEmptyOpenV32(),
             Record: recordV32(),
             NoisyRecord: noisyRecordV32(),
             Merged: mergedV32(),
@@ -94,6 +102,14 @@ export const test_openapi_converter_empty_required = (): void => {
   ] as const;
   for (const [name, schemas] of upgraded) {
     assertObjectEmptyRequired(`${name} upgraded object`, schemas.Target!);
+    assertEmptyOpenObjectKeywords(
+      `${name} upgraded open empty`,
+      schemas.EmptyOpen!,
+    );
+    assertEmptyOpenObjectKeywords(
+      `${name} upgraded noisy open empty`,
+      schemas.NoisyEmptyOpen!,
+    );
     assertRecordKeywordsOmitted(`${name} upgraded record`, schemas.Record!);
     if (schemas.NoisyRecord !== undefined)
       assertRecordKeywordsOmitted(
@@ -125,6 +141,8 @@ export const test_openapi_converter_empty_required = (): void => {
     components: {
       schemas: {
         Target: optionalOpenApi(),
+        EmptyOpen: emptyOpenApi(),
+        NoisyEmptyOpen: noisyEmptyOpenApi(),
         Record: recordOpenApi(),
         NoisyRecord: noisyRecordOpenApi(),
         Required: requiredOpenApi(),
@@ -137,6 +155,14 @@ export const test_openapi_converter_empty_required = (): void => {
   assertObjectEmptyRequired(
     "downgraded swagger",
     downgradedSwagger.definitions!.Target!,
+  );
+  assertEmptyOpenObjectKeywords(
+    "downgraded swagger open empty",
+    downgradedSwagger.definitions!.EmptyOpen!,
+  );
+  assertEmptyOpenObjectKeywords(
+    "downgraded swagger noisy open empty",
+    downgradedSwagger.definitions!.NoisyEmptyOpen!,
   );
   assertRecordKeywordsOmitted(
     "downgraded swagger record",
@@ -160,6 +186,14 @@ export const test_openapi_converter_empty_required = (): void => {
     "downgraded v3.0",
     downgradedV30.components!.schemas!.Target!,
   );
+  assertEmptyOpenObjectKeywords(
+    "downgraded v3.0 open empty",
+    downgradedV30.components!.schemas!.EmptyOpen!,
+  );
+  assertEmptyOpenObjectKeywords(
+    "downgraded v3.0 noisy open empty",
+    downgradedV30.components!.schemas!.NoisyEmptyOpen!,
+  );
   assertRecordKeywordsOmitted(
     "downgraded v3.0 record",
     downgradedV30.components!.schemas!.Record!,
@@ -181,6 +215,14 @@ export const test_openapi_converter_empty_required = (): void => {
   assertObjectEmptyRequired(
     "downgraded v3.1",
     downgradedV31.components!.schemas!.Target!,
+  );
+  assertEmptyOpenObjectKeywords(
+    "downgraded v3.1 open empty",
+    downgradedV31.components!.schemas!.EmptyOpen!,
+  );
+  assertEmptyOpenObjectKeywords(
+    "downgraded v3.1 noisy open empty",
+    downgradedV31.components!.schemas!.NoisyEmptyOpen!,
   );
   assertRecordKeywordsOmitted(
     "downgraded v3.1 record",
@@ -227,6 +269,18 @@ const recordOpenApi = (): OpenApi.IJsonSchema.IObject => ({
   },
 });
 
+const emptyOpenApi = (): OpenApi.IJsonSchema.IObject => ({
+  type: "object",
+});
+
+const noisyEmptyOpenApi = (): OpenApi.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as OpenApi.IJsonSchema,
+  },
+  required: [],
+});
+
 const noisyRecordOpenApi = (): OpenApi.IJsonSchema.IObject => ({
   type: "object",
   properties: {
@@ -252,6 +306,20 @@ const recordV3 = (): OpenApiV3.IJsonSchema.IObject => ({
   additionalProperties: {
     type: "string",
   },
+});
+
+const emptyOpenV3 = (): OpenApiV3.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {},
+  required: [],
+});
+
+const noisyEmptyOpenV3 = (): OpenApiV3.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as OpenApiV3.IJsonSchema,
+  },
+  required: [],
 });
 
 const noisyRecordV3 = (): OpenApiV3.IJsonSchema.IObject => ({
@@ -281,6 +349,20 @@ const recordV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
   },
 });
 
+const emptyOpenV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {},
+  required: [],
+});
+
+const noisyEmptyOpenV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as OpenApiV3_1.IJsonSchema,
+  },
+  required: [],
+});
+
 const noisyRecordV31 = (): OpenApiV3_1.IJsonSchema.IObject => ({
   type: "object",
   properties: {
@@ -308,6 +390,20 @@ const recordV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
   },
 });
 
+const emptyOpenV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {},
+  required: [],
+});
+
+const noisyEmptyOpenV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as OpenApiV3_2.IJsonSchema,
+  },
+  required: [],
+});
+
 const noisyRecordV32 = (): OpenApiV3_2.IJsonSchema.IObject => ({
   type: "object",
   properties: {
@@ -333,6 +429,20 @@ const recordSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
   additionalProperties: {
     type: "string",
   },
+});
+
+const emptyOpenSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {},
+  required: [],
+});
+
+const noisyEmptyOpenSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
+  type: "object",
+  properties: {
+    stale: undefined as unknown as SwaggerV2.IJsonSchema,
+  },
+  required: [],
 });
 
 const noisyRecordSwagger = (): SwaggerV2.IJsonSchema.IObject => ({
@@ -566,6 +676,38 @@ const assertRecordKeywordsOmitted = (
       },
       properties: false,
       required: false,
+    },
+  );
+};
+
+const assertEmptyOpenObjectKeywords = (
+  name: string,
+  schema:
+    | OpenApi.IJsonSchema
+    | OpenApiV3.IJsonSchema
+    | OpenApiV3_1.IJsonSchema
+    | OpenApiV3_2.IJsonSchema
+    | SwaggerV2.IJsonSchema,
+): void => {
+  const object = schema as
+    | OpenApi.IJsonSchema.IObject
+    | OpenApiV3.IJsonSchema.IObject
+    | OpenApiV3_1.IJsonSchema.IObject
+    | OpenApiV3_2.IJsonSchema.IObject
+    | SwaggerV2.IJsonSchema.IObject;
+  TestValidator.equals(
+    `${name} object shape`,
+    {
+      type: object.type,
+      properties: object.properties,
+      ownsAdditionalProperties: hasOwn(object, "additionalProperties"),
+      required: object.required,
+    },
+    {
+      type: "object",
+      properties: {},
+      ownsAdditionalProperties: false,
+      required: [],
     },
   );
 };

--- a/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_converter_empty_required.ts
@@ -9,15 +9,15 @@ import {
 import { OpenApiConverter } from "@typia/utils";
 
 /**
- * Verifies OpenAPI conversion omits empty `required` arrays.
+ * Verifies OpenAPI conversion preserves empty `required` arrays.
  *
  * The converter family can synthesize object schemas from version upgrades,
- * downgrades, and `allOf` merges. Those paths must not reintroduce `required:
- * []` after typia's schema generator omits it.
+ * downgrades, and `allOf` merges. Version conversion must preserve explicit
+ * empty object keywords instead of stripping them as a cleanup step.
  *
  * 1. Upgrade Swagger/OpenAPI documents containing optional-only objects.
  * 2. Downgrade an emended OpenAPI document containing `required: []`.
- * 3. Assert every converted object keeps its shape and omits empty `required`.
+ * 3. Assert every converted object keeps its shape and empty `required`.
  */
 export const test_openapi_converter_empty_required = (): void => {
   const upgraded = [
@@ -85,8 +85,8 @@ export const test_openapi_converter_empty_required = (): void => {
     ],
   ] as const;
   for (const [name, schemas] of upgraded) {
-    assertObjectNoRequired(`${name} upgraded object`, schemas.Target!);
-    assertObjectNoRequired(
+    assertObjectEmptyRequired(`${name} upgraded object`, schemas.Target!);
+    assertObjectEmptyRequired(
       `${name} upgraded optional allOf`,
       schemas.Merged!,
       false,
@@ -118,7 +118,7 @@ export const test_openapi_converter_empty_required = (): void => {
   const downgradedSwagger = OpenApiConverter.downgradeDocument(emended, "2.0");
   const downgradedV30 = OpenApiConverter.downgradeDocument(emended, "3.0");
   const downgradedV31 = OpenApiConverter.downgradeDocument(emended, "3.1");
-  assertObjectNoRequired(
+  assertObjectEmptyRequired(
     "downgraded swagger",
     downgradedSwagger.definitions!.Target!,
   );
@@ -132,7 +132,7 @@ export const test_openapi_converter_empty_required = (): void => {
       },
     },
   );
-  assertObjectNoRequired(
+  assertObjectEmptyRequired(
     "downgraded v3.0",
     downgradedV30.components!.schemas!.Target!,
   );
@@ -146,7 +146,7 @@ export const test_openapi_converter_empty_required = (): void => {
       },
     },
   );
-  assertObjectNoRequired(
+  assertObjectEmptyRequired(
     "downgraded v3.1",
     downgradedV31.components!.schemas!.Target!,
   );
@@ -328,7 +328,7 @@ const mergedRequiredFirstSwagger = (): SwaggerV2.IJsonSchema.IAllOf => ({
   allOf: [requiredSwagger(), optionalSwagger()],
 });
 
-const assertObjectNoRequired = (
+const assertObjectEmptyRequired = (
   name: string,
   schema:
     | OpenApi.IJsonSchema
@@ -350,6 +350,7 @@ const assertObjectNoRequired = (
       type: object.type,
       properties: object.properties,
       additionalProperties: object.additionalProperties,
+      required: object.required,
     },
     {
       type: "object",
@@ -359,12 +360,8 @@ const assertObjectNoRequired = (
         },
       },
       additionalProperties: expectedAdditionalProperties,
+      required: [],
     },
-  );
-  TestValidator.equals(
-    `${name} required omitted`,
-    Object.prototype.hasOwnProperty.call(schema, "required"),
-    false,
   );
 };
 

--- a/tests/test-utils/src/features/openapi/test_openapi_converter_parameter_required.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_converter_parameter_required.ts
@@ -705,12 +705,12 @@ export const test_openapi_converter_parameter_required = (): void => {
     "/openapi/ref/{id}",
   );
   assertOpenApiV3ObjectSchemaOverride(
-    "v3.0 operation object parameter override sanitizes empty required",
+    "v3.0 operation object parameter override preserves empty required",
     OpenApiConverter.upgradeDocument(openApiV3ParameterDocument()),
     "/openapi/object/direct",
   );
   assertOpenApiV3ObjectSchemaOverride(
-    "v3.0 operation object parameter ref override sanitizes empty required",
+    "v3.0 operation object parameter ref override preserves empty required",
     OpenApiConverter.upgradeDocument(openApiV3ParameterDocument()),
     "/openapi/object/ref",
   );
@@ -740,12 +740,12 @@ export const test_openapi_converter_parameter_required = (): void => {
     "/openapi/ref/{id}",
   );
   assertOpenApiV3ObjectSchemaOverride(
-    "v3.1 operation object parameter override sanitizes empty required",
+    "v3.1 operation object parameter override preserves empty required",
     OpenApiConverter.upgradeDocument(openApiV31ParameterDocument()),
     "/openapi/object/direct",
   );
   assertOpenApiV3ObjectSchemaOverride(
-    "v3.1 operation object parameter ref override sanitizes empty required",
+    "v3.1 operation object parameter ref override preserves empty required",
     OpenApiConverter.upgradeDocument(openApiV31ParameterDocument()),
     "/openapi/object/ref",
   );
@@ -775,12 +775,12 @@ export const test_openapi_converter_parameter_required = (): void => {
     "/openapi/ref/{id}",
   );
   assertOpenApiV3ObjectSchemaOverride(
-    "v3.2 operation object parameter override sanitizes empty required",
+    "v3.2 operation object parameter override preserves empty required",
     OpenApiConverter.upgradeDocument(openApiV32ParameterDocument()),
     "/openapi/object/direct",
   );
   assertOpenApiV3ObjectSchemaOverride(
-    "v3.2 operation object parameter ref override sanitizes empty required",
+    "v3.2 operation object parameter ref override preserves empty required",
     OpenApiConverter.upgradeDocument(openApiV32ParameterDocument()),
     "/openapi/object/ref",
   );
@@ -814,10 +814,13 @@ export const test_openapi_converter_parameter_required = (): void => {
         upgradedObjectEmpty.schema,
         "required",
       ),
+      required: (upgradedObjectEmpty.schema as OpenApi.IJsonSchema.IObject)
+        .required,
     },
     {
       parameter: false,
-      schema: false,
+      schema: true,
+      required: [],
     },
   );
   TestValidator.equals(
@@ -1015,7 +1018,10 @@ const assertOpenApiV3ObjectSchemaOverride = (
       schema: {
         type: schema.type,
         properties: schema.properties,
-        required: Object.prototype.hasOwnProperty.call(schema, "required"),
+        required: {
+          own: Object.prototype.hasOwnProperty.call(schema, "required"),
+          value: schema.required,
+        },
       },
     },
     {
@@ -1031,7 +1037,10 @@ const assertOpenApiV3ObjectSchemaOverride = (
             type: "string",
           },
         },
-        required: false,
+        required: {
+          own: true,
+          value: [],
+        },
       },
     },
   );


### PR DESCRIPTION
## Summary

- Preserve explicit empty object keywords during OpenAPI version conversion instead of stripping `required: []` as a cleanup step.
- Emit `properties: {}` and `required: []` for named empty object schemas from the typia native JSON schema transform.
- Keep pure `Record<string, T>` schemas as dynamic objects without named `properties` or `required`.

## Validation

- `pnpm format`
- `git diff --check`
- `go test ./contract/native -run TestJsonSchemaNativeExportKeepsEmptyRequired` from `packages/typia/test`
- `pnpm test:go`
- Native transform of the focused JSON schema test files with an isolated `bin/verify/tsconfig.json`
- `node --check` on the focused transformed JSON schema outputs
- `pnpm --dir tests/test-typia-schema exec ttsx --no-plugins --project bin/verify/tsconfig.run.json bin/verify/run_schema_verify.ts`
- `pnpm --dir tests/test-utils exec ttsx --no-plugins --project bin/verify/tsconfig.json bin/verify/run_openapi_converter_empty_required.ts`

## Local Limitations

- Full `ttsx` suite execution is currently blocked before these focused tests by existing TypeScript-Go runner issues: an unrelated LLM application transform temp-path panic in plugin mode and pre-existing unused type-parameter diagnostics in `--no-plugins` mode. The changed schema and converter paths were verified with isolated runners.