### PR TITLE
fix(typia): respect exact optional undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "13.0.0-dev.20260605.5",
+  "version": "13.0.0-dev.20260605.6",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm run build:packages",

--- a/packages/typia/native/adapter/adapter.go
+++ b/packages/typia/native/adapter/adapter.go
@@ -8,7 +8,7 @@ type PluginOptions struct {
   Functional bool
   Numeric    bool
   Finite     bool
-  Undefined  bool
+  Undefined  *bool
 }
 
 func (p PluginOptions) TransformOptions() nativecontext.ITransformOptions {
@@ -16,7 +16,7 @@ func (p PluginOptions) TransformOptions() nativecontext.ITransformOptions {
     Finite:     boolPointer(p.Finite),
     Numeric:    boolPointer(p.Numeric),
     Functional: boolPointer(p.Functional),
-    Undefined:  boolPointer(p.Undefined),
+    Undefined:  p.Undefined,
     Runtime:    "typia",
   }
 }

--- a/packages/typia/native/cmd/ttsc-typia/build.go
+++ b/packages/typia/native/cmd/ttsc-typia/build.go
@@ -185,6 +185,15 @@ func readTypiaPluginOptions(cwd, tsconfigPath string) typiaadapter.PluginOptions
     Functional: regexp.MustCompile(`(?s)"functional"\s*:\s*true`).MatchString(text),
     Numeric:    regexp.MustCompile(`(?s)"numeric"\s*:\s*true`).MatchString(text),
     Finite:     regexp.MustCompile(`(?s)"finite"\s*:\s*true`).MatchString(text),
-    Undefined:  regexp.MustCompile(`(?s)"undefined"\s*:\s*true`).MatchString(text),
+    Undefined:  readBooleanPluginOption(text, "undefined"),
   }
+}
+
+func readBooleanPluginOption(text string, name string) *bool {
+  matched := regexp.MustCompile(`(?s)"` + regexp.QuoteMeta(name) + `"\s*:\s*(true|false)`).FindStringSubmatch(text)
+  if matched == nil {
+    return nil
+  }
+  value := matched[1] == "true"
+  return &value
 }

--- a/packages/typia/native/cmd/ttsc-typia/plugin_options_undefined_false_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/plugin_options_undefined_false_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestPluginOptionsUndefinedFalsePreservesExplicitFalse verifies undefined option parsing.
+//
+// The exact optional-property workflow depends on distinguishing an omitted
+// plugin option from `"undefined": false`. The native command reads tsconfig
+// directly, so it must preserve explicit false instead of collapsing it into
+// the default nil option.
+//
+// 1. Write a tsconfig with the typia transformer and `"undefined": false`.
+// 2. Read plugin options through the native command helper.
+// 3. Assert the undefined option is a non-nil false pointer.
+func TestPluginOptionsUndefinedFalsePreservesExplicitFalse(t *testing.T) {
+  root := t.TempDir()
+  path := filepath.Join(root, "tsconfig.json")
+  if err := os.WriteFile(path, []byte(`{
+  "compilerOptions": {
+    "plugins": [
+      { "transform": "typia/lib/transform", "undefined": false }
+    ]
+  }
+}`), 0o644); err != nil {
+    t.Fatal(err)
+  }
+
+  options := readTypiaPluginOptions(root, path)
+  if options.Undefined == nil || *options.Undefined {
+    t.Fatalf("undefined=false should be preserved: %#v", options.Undefined)
+  }
+}

--- a/packages/typia/native/core/programmers/AssertProgrammer.go
+++ b/packages/typia/native/core/programmers/AssertProgrammer.go
@@ -303,7 +303,7 @@ func assertProgrammer_assert_object(props assertProgrammer_assertObjectProps) *s
     Config: nativeiterate.Check_object_IConfig{
       Equals:    props.Config.Equals,
       Assert:    true,
-      Undefined: true,
+      Undefined: nativehelpers.OptionPredicator.Undefined(props.Context.Options),
       Reduce: func(a *shimast.Expression, b *shimast.Expression) *shimast.Node {
         return assertProgrammer_binary(a, shimast.KindAmpersandAmpersandToken, b, props.Context.Emit)
       },

--- a/packages/typia/native/core/programmers/RandomProgrammer.go
+++ b/packages/typia/native/core/programmers/RandomProgrammer.go
@@ -260,6 +260,21 @@ func randomProgrammer_write_object_functions(props struct {
               Metadata: metadata,
             })
           },
+          StrictOptionalUndefined: func(metadata *schemametadata.MetadataSchema) bool {
+            return nativehelpers.OptionPredicator.StrictOptionalUndefined(props.Context, metadata)
+          },
+          OptionalProperty: func(metadata *schemametadata.MetadataSchema) bool {
+            return nativehelpers.OptionPredicator.ExactOptionalProperty(props.Context, metadata)
+          },
+          Optional: func() *shimast.Node {
+            return f.NewCallExpression(
+              randomProgrammer_coalesce(props.Context, "boolean", "randomBoolean"),
+              nil,
+              nil,
+              nil,
+              shimast.NodeFlagsNone,
+            )
+          },
           Object: object,
           Emit:   props.Context.Emit,
         }),

--- a/packages/typia/native/core/programmers/ValidateProgrammer.go
+++ b/packages/typia/native/core/programmers/ValidateProgrammer.go
@@ -290,7 +290,7 @@ func validateProgrammer_validate_object(props validateProgrammer_validateObjectP
   return nativeiterate.Check_object(nativeiterate.Check_objectProps{
     Config: nativeiterate.Check_object_IConfig{
       Equals:    props.Config.Equals,
-      Undefined: true,
+      Undefined: nativehelpers.OptionPredicator.Undefined(props.Context.Options),
       Assert:    false,
       Reduce: func(a *shimast.Expression, b *shimast.Expression) *shimast.Node {
         return validateProgrammer_binary(a, shimast.KindAmpersandAmpersandToken, b, props.Context.Emit)

--- a/packages/typia/native/core/programmers/helpers/CloneJoiner.go
+++ b/packages/typia/native/core/programmers/helpers/CloneJoiner.go
@@ -55,13 +55,25 @@ func (cloneJoinerNamespace) Object(props CloneJoiner_ObjectProps) *shimast.Node 
   properties := make([]*shimast.Node, 0, len(regular))
   for _, entry := range regular {
     str := entry.Key.GetSoleLiteral()
-    properties = append(properties, f.NewPropertyAssignment(
+    property := f.NewPropertyAssignment(
       nil,
       nativefactories.IdentifierFactory.Identifier(*str, props.Emit),
       nil,
       nil,
       entry.Expression,
-    ))
+    )
+    if entry.OptionalProperty {
+      properties = append(properties, f.NewSpreadAssignment(
+        f.NewParenthesizedExpression(nativefactories.ExpressionFactory.Conditional(
+          nativefactories.ExpressionFactory.IsRequired(entry.Input, props.Emit),
+          f.NewObjectLiteralExpression(f.NewNodeList([]*shimast.Node{property}), false),
+          f.NewObjectLiteralExpression(f.NewNodeList(nil), false),
+          props.Emit,
+        )),
+      ))
+    } else {
+      properties = append(properties, property)
+    }
   }
   literal := f.NewObjectLiteralExpression(
     f.NewNodeList(properties),

--- a/packages/typia/native/core/programmers/helpers/IExpressionEntry.go
+++ b/packages/typia/native/core/programmers/helpers/IExpressionEntry.go
@@ -6,8 +6,10 @@ import (
 )
 
 type IExpressionEntry struct {
-  Input      *shimast.Node
-  Key        *nativemetadata.MetadataSchema
-  Meta       *nativemetadata.MetadataSchema
-  Expression *shimast.Node
+  Input                   *shimast.Node
+  Key                     *nativemetadata.MetadataSchema
+  Meta                    *nativemetadata.MetadataSchema
+  Expression              *shimast.Node
+  OptionalProperty        bool
+  StrictOptionalUndefined bool
 }

--- a/packages/typia/native/core/programmers/helpers/OptionPredicator.go
+++ b/packages/typia/native/core/programmers/helpers/OptionPredicator.go
@@ -1,6 +1,9 @@
 package helpers
 
-import nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+import (
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
 
 type optionPredicatorNamespace struct{}
 
@@ -20,4 +23,17 @@ func (optionPredicatorNamespace) Finite(options nativecontext.ITransformOptions)
 
 func (optionPredicatorNamespace) Undefined(options nativecontext.ITransformOptions) bool {
   return options.Undefined == nil || *options.Undefined
+}
+
+func (optionPredicatorNamespace) StrictOptionalUndefined(context nativecontext.ITypiaContext, metadata *schemametadata.MetadataSchema) bool {
+  return OptionPredicator.ExactOptionalProperty(context, metadata) &&
+    metadata.Required
+}
+
+func (optionPredicatorNamespace) ExactOptionalProperty(context nativecontext.ITypiaContext, metadata *schemametadata.MetadataSchema) bool {
+  return context.CompilerOptions != nil &&
+    context.CompilerOptions.ExactOptionalPropertyTypes.IsTrue() &&
+    OptionPredicator.Undefined(context.Options) == false &&
+    metadata != nil &&
+    metadata.Optional
 }

--- a/packages/typia/native/core/programmers/helpers/RandomJoiner.go
+++ b/packages/typia/native/core/programmers/helpers/RandomJoiner.go
@@ -33,9 +33,12 @@ type RandomJoiner_TupleProps struct {
 }
 
 type RandomJoiner_ObjectProps struct {
-  Decode RandomJoiner_Decoder
-  Object *nativemetadata.MetadataObjectType
-  Emit   *shimprinter.EmitContext
+  Decode                  RandomJoiner_Decoder
+  Object                  *nativemetadata.MetadataObjectType
+  OptionalProperty        func(*nativemetadata.MetadataSchema) bool
+  StrictOptionalUndefined func(*nativemetadata.MetadataSchema) bool
+  Optional                func() *shimast.Node
+  Emit                    *shimprinter.EmitContext
 }
 
 type randomJoiner_DynamicPropertyProps struct {
@@ -141,13 +144,36 @@ func (randomJoinerNamespace) Object(props RandomJoiner_ObjectProps) *shimast.Nod
       continue
     }
     str := property.Key.GetSoleLiteral()
-    properties = append(properties, f.NewPropertyAssignment(
+    metadata := property.Value
+    optionalProperty := props.OptionalProperty != nil && props.OptionalProperty(property.Value)
+    strictOptionalUndefined := props.StrictOptionalUndefined != nil && props.StrictOptionalUndefined(property.Value)
+    if strictOptionalUndefined {
+      metadata = property.Value.ShallowClone()
+      metadata.Optional = false
+    }
+    propertyAssignment := f.NewPropertyAssignment(
       nil,
       nativefactories.IdentifierFactory.Identifier(*str, props.Emit),
       nil,
       nil,
-      props.Decode(property.Value),
-    ))
+      props.Decode(metadata),
+    )
+    if optionalProperty {
+      condition := f.NewKeywordExpression(shimast.KindTrueKeyword)
+      if props.Optional != nil {
+        condition = props.Optional()
+      }
+      properties = append(properties, f.NewSpreadAssignment(
+        f.NewParenthesizedExpression(nativefactories.ExpressionFactory.Conditional(
+          condition,
+          f.NewObjectLiteralExpression(f.NewNodeList([]*shimast.Node{propertyAssignment}), false),
+          f.NewObjectLiteralExpression(f.NewNodeList(nil), false),
+          props.Emit,
+        )),
+      ))
+    } else {
+      properties = append(properties, propertyAssignment)
+    }
   }
   for _, property := range props.Object.Properties {
     if property.Key.IsSoleLiteral() {

--- a/packages/typia/native/core/programmers/iterate/feature_object_entries.go
+++ b/packages/typia/native/core/programmers/iterate/feature_object_entries.go
@@ -45,6 +45,13 @@ func Feature_object_entries(props Feature_object_entriesProps) []nativehelpers.I
   for _, next := range props.Object.Properties {
     sole := next.Key.GetSoleLiteral()
     propInput := feature_object_entries_property_input(props.Input, sole, props.Context.Emit)
+    optionalProperty := sole != nil && nativehelpers.OptionPredicator.ExactOptionalProperty(props.Context, next.Value)
+    strictOptionalUndefined := sole != nil && nativehelpers.OptionPredicator.StrictOptionalUndefined(props.Context, next.Value)
+    metadata := next.Value
+    if strictOptionalUndefined {
+      metadata = next.Value.ShallowClone()
+      metadata.Optional = false
+    }
     postfix := ""
     if props.Config.Trace {
       if sole != nil {
@@ -55,12 +62,14 @@ func Feature_object_entries(props Feature_object_entriesProps) []nativehelpers.I
       }
     }
     output = append(output, nativehelpers.IExpressionEntry{
-      Input: propInput,
-      Key:   next.Key,
-      Meta:  next.Value,
+      Input:                   propInput,
+      Key:                     next.Key,
+      Meta:                    next.Value,
+      OptionalProperty:        optionalProperty,
+      StrictOptionalUndefined: strictOptionalUndefined,
       Expression: props.Config.Decoder(Feature_object_entriesDecoderProps{
         Input:    propInput,
-        Metadata: next.Value,
+        Metadata: metadata,
         Explore: Feature_object_entriesExplore{
           Tracable: props.Config.Path || props.Config.Trace,
           Source:   "function",

--- a/packages/typia/native/core/schemas/metadata/MetadataSchema.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataSchema.go
@@ -113,6 +113,14 @@ func MetadataSchema_initialize(parentResolved ...bool) *MetadataSchema {
   return meta
 }
 
+func (obj *MetadataSchema) ShallowClone() *MetadataSchema {
+  if obj == nil {
+    return nil
+  }
+  clone := *obj
+  return &clone
+}
+
 func (obj *MetadataSchema) ToJSON() *IMetadataSchema {
   output := &IMetadataSchema{
     Any:      obj.Any,

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.5",
+  "version": "13.0.0-dev.20260605.6",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/test/adapter/options/adapter_plugin_options_transform_options_test.go
+++ b/packages/typia/test/adapter/options/adapter_plugin_options_transform_options_test.go
@@ -1,43 +1,45 @@
 package typia_test
 
 import (
-	"testing"
+  "testing"
 
-	typiaadapter "github.com/samchon/typia/packages/typia/native/adapter"
+  typiaadapter "github.com/samchon/typia/packages/typia/native/adapter"
 )
 
 // TestAdapterPluginOptionsTransformOptions verifies plugin option projection.
 //
 // The ttsc plugin exposes a small Boolean option surface, while native typia
 // expects pointer-valued transform options. Enabled flags must become true
-// pointers, disabled flags must stay nil, and runtime must remain fixed to
-// `typia`.
+// pointers, disabled flags must stay nil, `undefined` must preserve explicit
+// false, and runtime must remain fixed to `typia`.
 //
 // 1. Project plugin options with two enabled flags and two disabled flags.
 // 2. Assert enabled flags become non-nil true pointers.
-// 3. Assert disabled flags remain nil.
-// 4. Assert runtime is pinned to the typia runtime package name.
+// 3. Assert disabled non-undefined flags remain nil.
+// 4. Assert explicit undefined=false remains a false pointer.
+// 5. Assert runtime is pinned to the typia runtime package name.
 func TestAdapterPluginOptionsTransformOptions(t *testing.T) {
-	options := typiaadapter.PluginOptions{
-		Functional: true,
-		Numeric:    false,
-		Finite:     true,
-		Undefined:  false,
-	}.TransformOptions()
+  disabled := false
+  options := typiaadapter.PluginOptions{
+    Functional: true,
+    Numeric:    false,
+    Finite:     true,
+    Undefined:  &disabled,
+  }.TransformOptions()
 
-	if options.Functional == nil || *options.Functional == false {
-		t.Fatalf("functional flag should be projected as true pointer: %#v", options.Functional)
-	}
-	if options.Finite == nil || *options.Finite == false {
-		t.Fatalf("finite flag should be projected as true pointer: %#v", options.Finite)
-	}
-	if options.Numeric != nil {
-		t.Fatalf("disabled numeric flag should stay nil: %#v", options.Numeric)
-	}
-	if options.Undefined != nil {
-		t.Fatalf("disabled undefined flag should stay nil: %#v", options.Undefined)
-	}
-	if options.Runtime != "typia" {
-		t.Fatalf("runtime should be typia: %q", options.Runtime)
-	}
+  if options.Functional == nil || *options.Functional == false {
+    t.Fatalf("functional flag should be projected as true pointer: %#v", options.Functional)
+  }
+  if options.Finite == nil || *options.Finite == false {
+    t.Fatalf("finite flag should be projected as true pointer: %#v", options.Finite)
+  }
+  if options.Numeric != nil {
+    t.Fatalf("disabled numeric flag should stay nil: %#v", options.Numeric)
+  }
+  if options.Undefined == nil || *options.Undefined {
+    t.Fatalf("explicit undefined=false should be preserved: %#v", options.Undefined)
+  }
+  if options.Runtime != "typia" {
+    t.Fatalf("runtime should be typia: %q", options.Runtime)
+  }
 }

--- a/packages/typia/test/native/cmd/ttsc-typia/plugin_options_missing_config_test.go
+++ b/packages/typia/test/native/cmd/ttsc-typia/plugin_options_missing_config_test.go
@@ -4,8 +4,8 @@
 package main
 
 import (
-	"path/filepath"
-	"testing"
+  "path/filepath"
+  "testing"
 )
 
 // TestPluginOptionsMissingConfigFallsBackToDefaults verifies unreadable config files are ignored.
@@ -17,10 +17,10 @@ import (
 // 1. Point option parsing at a nonexistent tsconfig file.
 // 2. Resolve the path through a temporary working directory.
 // 3. Read typia plugin options.
-// 4. Assert every option remains false.
+// 4. Assert every option remains unset.
 func TestPluginOptionsMissingConfigFallsBackToDefaults(t *testing.T) {
-	options := readTypiaPluginOptions(t.TempDir(), filepath.Join("missing", "tsconfig.json"))
-	if options.Functional || options.Numeric || options.Finite || options.Undefined {
-		t.Fatalf("missing config should return zero plugin options: %+v", options)
-	}
+  options := readTypiaPluginOptions(t.TempDir(), filepath.Join("missing", "tsconfig.json"))
+  if options.Functional || options.Numeric || options.Finite || options.Undefined != nil {
+    t.Fatalf("missing config should return zero plugin options: %+v", options)
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,6 +682,19 @@ importers:
         specifier: catalog:utils
         version: 11.0.0
 
+  tests/test-typia-exact-optional:
+    dependencies:
+      '@nestia/e2e':
+        specifier: catalog:utils
+        version: 10.0.2
+      typia:
+        specifier: workspace:^
+        version: link:../../packages/typia
+    devDependencies:
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.6.0
+
   tests/test-typia-generate:
     dependencies:
       typia:
@@ -13212,7 +13225,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.19.39
+      '@types/node': 18.19.130
       long: 5.3.2
 
   proxy-addr@2.0.7:

--- a/tests/test-mcp/src/features/test_mcp_class_controller_error_handling.ts
+++ b/tests/test-mcp/src/features/test_mcp_class_controller_error_handling.ts
@@ -13,9 +13,9 @@ import { Calculator } from "../structures/Calculator";
  *
  * Locks the error-catching branch of `McpControllerRegistrar.handleToolCall`.
  * When a tool's `execute` function throws (e.g. division by zero), the handler
- * must catch the error and return a well-formed `CallToolResult` with
- * `isError: true` and the error message as text content, rather than letting
- * the exception propagate and crash the MCP server.
+ * must catch the error and return a well-formed `CallToolResult` with `isError:
+ * true` and the error message as text content, rather than letting the
+ * exception propagate and crash the MCP server.
  *
  * 1. Register a `Calculator` controller with the MCP server.
  * 2. Invoke the `divide` tool with `y: 0` to trigger a division-by-zero error.

--- a/tests/test-mcp/src/features/test_mcp_class_controller_unknown_tool.ts
+++ b/tests/test-mcp/src/features/test_mcp_class_controller_unknown_tool.ts
@@ -12,10 +12,10 @@ import { Calculator } from "../structures/Calculator";
  * Verifies MCP tool handler returns `isError: true` for unknown tool names.
  *
  * Locks the unknown-tool fallback branch of `McpControllerRegistrar`'s
- * `tools/call` handler. When an LLM calls a tool name that doesn't exist in
- * the registry, the handler must return a well-formed `CallToolResult` with
- * `isError: true` and a descriptive message, rather than throwing or
- * returning undefined.
+ * `tools/call` handler. When an LLM calls a tool name that doesn't exist in the
+ * registry, the handler must return a well-formed `CallToolResult` with
+ * `isError: true` and a descriptive message, rather than throwing or returning
+ * undefined.
  *
  * 1. Register a `Calculator` controller with the MCP server.
  * 2. Invoke a non-existent tool name `"nonExistentTool"`.
@@ -73,14 +73,12 @@ export const test_mcp_class_controller_unknown_tool =
     );
 
     // 7. Verify the error message references the unknown tool name
-    TestValidator.predicate(
-      "error should contain unknown tool name",
-      () =>
-        result.content.some(
-          (c) =>
-            c.type === "text" &&
-            (c as { type: "text"; text: string }).text ===
-              "Unknown tool: nonExistentTool",
-        ),
+    TestValidator.predicate("error should contain unknown tool name", () =>
+      result.content.some(
+        (c) =>
+          c.type === "text" &&
+          (c as { type: "text"; text: string }).text ===
+            "Unknown tool: nonExistentTool",
+      ),
     );
   };

--- a/tests/test-typia-exact-optional/package.json
+++ b/tests/test-typia-exact-optional/package.json
@@ -1,0 +1,30 @@
+{
+  "private": true,
+  "name": "@typia/test-typia-exact-optional",
+  "version": "13.0.0-dev.20260605.5",
+  "description": "Test exact optional property behavior of typia.",
+  "scripts": {
+    "start": "ttsx src/index.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/typia"
+  },
+  "keywords": [
+    "typia",
+    "test"
+  ],
+  "author": "Jeongho Nam",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/samchon/typia/issues"
+  },
+  "homepage": "https://typia.io",
+  "dependencies": {
+    "@nestia/e2e": "catalog:utils",
+    "typia": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:utils"
+  }
+}

--- a/tests/test-typia-exact-optional/src/features/test_exact_optional_undefined_clone_random.ts
+++ b/tests/test-typia-exact-optional/src/features/test_exact_optional_undefined_clone_random.ts
@@ -1,0 +1,146 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+/**
+ * Verifies clone and random preserve exact optional omission.
+ *
+ * The `"undefined": false` option must not let clone synthesize missing
+ * optional keys as `undefined`, and random must generate either an omitted key
+ * or a valid value for optional-only properties.
+ *
+ * 1. Clone objects with missing optional keys and assert those keys stay absent.
+ * 2. Clone objects with explicit `| undefined` keys and assert those own keys are
+ *    preserved.
+ * 3. Generate random objects with optional inclusion forced off and on.
+ */
+export const test_exact_optional_undefined_clone_random = (): void => {
+  const missing: IExactOptionalClone = {
+    required: "value",
+    requiredUndefined: undefined,
+    nested: {},
+    array: [{}],
+  };
+  const cloned = typia.misc.clone<IExactOptionalClone>(missing);
+
+  assertOwn("clone root optional", cloned, "optional", false);
+  assertOwn("clone root optionalUndefined", cloned, "optionalUndefined", false);
+  assertOwn("clone nested optional", cloned.nested, "optional", false);
+  assertOwn(
+    "clone nested optionalUndefined",
+    cloned.nested,
+    "optionalUndefined",
+    false,
+  );
+  assertOwn("clone array optional", cloned.array[0]!, "optional", false);
+  assertOwn(
+    "clone array optionalUndefined",
+    cloned.array[0]!,
+    "optionalUndefined",
+    false,
+  );
+  assertOwn("clone requiredUndefined", cloned, "requiredUndefined", true);
+
+  const present: IExactOptionalClone = {
+    required: "value",
+    optional: "root",
+    optionalUndefined: undefined,
+    requiredUndefined: undefined,
+    nested: {
+      optional: 1,
+      optionalUndefined: undefined,
+    },
+    array: [
+      {
+        optional: 2,
+        optionalUndefined: undefined,
+      },
+    ],
+  };
+  const presentClone = typia.misc.clone<IExactOptionalClone>(present);
+
+  TestValidator.equals("clone present optional", presentClone.optional, "root");
+  assertOwn(
+    "clone present optionalUndefined",
+    presentClone,
+    "optionalUndefined",
+    true,
+  );
+  TestValidator.equals(
+    "clone present nested optional",
+    presentClone.nested.optional,
+    1,
+  );
+  assertOwn(
+    "clone present nested optionalUndefined",
+    presentClone.nested,
+    "optionalUndefined",
+    true,
+  );
+
+  const omitted = typia.random<IExactOptionalClone>({
+    boolean: () => false,
+    string: () => "value",
+    array: ({ element }) => [element(0, 1)],
+  });
+  assertOwn("random omitted root optional", omitted, "optional", false);
+  assertOwn(
+    "random omitted root optionalUndefined",
+    omitted,
+    "optionalUndefined",
+    false,
+  );
+  assertOwn(
+    "random omitted nested optional",
+    omitted.nested,
+    "optional",
+    false,
+  );
+  assertOwn(
+    "random omitted array optional",
+    omitted.array[0]!,
+    "optional",
+    false,
+  );
+
+  const included = typia.random<IExactOptionalClone>({
+    boolean: () => true,
+    string: () => "value",
+    array: ({ element }) => [element(0, 1)],
+  });
+  TestValidator.equals(
+    "random included root optional",
+    included.optional,
+    "value",
+  );
+  TestValidator.equals(
+    "random included nested optional",
+    typeof included.nested.optional,
+    "number",
+  );
+  TestValidator.equals(
+    "random included array optional",
+    typeof included.array[0]!.optional,
+    "number",
+  );
+};
+
+const assertOwn = (
+  name: string,
+  input: object,
+  key: string,
+  expected: boolean,
+): void => TestValidator.equals(name, key in input, expected);
+
+interface IExactOptionalClone {
+  required: string;
+  optional?: string;
+  optionalUndefined?: string | undefined;
+  requiredUndefined: string | undefined;
+  nested: IExactOptionalCloneNested;
+  array: IExactOptionalCloneNested[];
+}
+
+interface IExactOptionalCloneNested {
+  optional?: number;
+  optionalUndefined?: number | undefined;
+}

--- a/tests/test-typia-exact-optional/src/features/test_exact_optional_undefined_validators.ts
+++ b/tests/test-typia-exact-optional/src/features/test_exact_optional_undefined_validators.ts
@@ -1,0 +1,179 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { IValidation, TypeGuardError } from "typia";
+
+/**
+ * Verifies exact optional properties reject explicit undefined values.
+ *
+ * With `exactOptionalPropertyTypes` and typia's `"undefined": false` option,
+ * `optional?: T` means the key may be missing, not that the key may be present
+ * with `undefined`. Explicit `T | undefined` remains valid.
+ *
+ * 1. Validate missing optional keys and explicit `| undefined` values.
+ * 2. Reject explicit `undefined` for optional-only root, nested, array, and union
+ *    properties.
+ * 3. Exercise boolean, throwing, and collecting validator families.
+ */
+export const test_exact_optional_undefined_validators = (): void => {
+  const valid: IExactOptional = {
+    required: "value",
+    optionalUndefined: undefined,
+    requiredUndefined: undefined,
+    nested: {
+      optionalUndefined: undefined,
+    },
+    array: [
+      {
+        optionalUndefined: undefined,
+      },
+    ],
+    union: {
+      type: "a",
+      optionalUndefined: undefined,
+    },
+  };
+
+  TestValidator.equals(
+    "is accepts missing optional",
+    typia.is<IExactOptional>(valid),
+    true,
+  );
+  TestValidator.equals(
+    "equals accepts missing optional",
+    typia.equals<IExactOptional>(valid),
+    true,
+  );
+  TestValidator.equals(
+    "validate accepts missing optional",
+    typia.validate<IExactOptional>(valid).success,
+    true,
+  );
+  TestValidator.equals(
+    "validateEquals accepts missing optional",
+    typia.validateEquals<IExactOptional>(valid).success,
+    true,
+  );
+
+  const invalid: unknown = {
+    required: "value",
+    optional: undefined,
+    optionalUndefined: undefined,
+    requiredUndefined: undefined,
+    nested: {
+      optional: undefined,
+      optionalUndefined: undefined,
+    },
+    array: [
+      {
+        optional: undefined,
+        optionalUndefined: undefined,
+      },
+    ],
+    union: {
+      type: "a",
+      optional: undefined,
+      optionalUndefined: undefined,
+    },
+  };
+
+  TestValidator.equals(
+    "is rejects explicit optional undefined",
+    typia.is<IExactOptional>(invalid),
+    false,
+  );
+  TestValidator.equals(
+    "equals rejects explicit optional undefined",
+    typia.equals<IExactOptional>(invalid),
+    false,
+  );
+
+  assertTypeGuardError("assert", () => typia.assert<IExactOptional>(invalid));
+  assertTypeGuardError("assertGuard", () => {
+    const input: unknown = invalid;
+    typia.assertGuard<IExactOptional>(input);
+  });
+  assertTypeGuardError("assertEquals", () =>
+    typia.assertEquals<IExactOptional>(invalid),
+  );
+  assertTypeGuardError("assertGuardEquals", () => {
+    const input: unknown = invalid;
+    typia.assertGuardEquals<IExactOptional>(input);
+  });
+
+  assertValidationPaths("validate", typia.validate<IExactOptional>(invalid));
+  assertValidationPaths(
+    "validateEquals",
+    typia.validateEquals<IExactOptional>(invalid),
+  );
+
+  TestValidator.equals(
+    "union rejects optional-only undefined",
+    typia.is<IExactOptionalUnion>({
+      type: "a",
+      optional: undefined,
+      optionalUndefined: undefined,
+    }),
+    false,
+  );
+};
+
+const assertTypeGuardError = (name: string, closure: () => unknown): void => {
+  try {
+    closure();
+    throw new Error(`${name} should throw`);
+  } catch (exp) {
+    if (exp instanceof Error && exp.message === `${name} should throw`)
+      throw exp;
+    TestValidator.equals(
+      `${name} root path`,
+      (exp as TypeGuardError).path,
+      "$input.optional",
+    );
+    TestValidator.equals(
+      `${name} root value`,
+      (exp as TypeGuardError).value,
+      undefined,
+    );
+  }
+};
+
+const assertValidationPaths = (
+  name: string,
+  result: IValidation<IExactOptional>,
+): void => {
+  TestValidator.equals(`${name} success`, result.success, false);
+  if (result.success === true) return;
+
+  const paths: string[] = result.errors.map((error) => error.path);
+  for (const path of [
+    "$input.optional",
+    "$input.nested.optional",
+    "$input.array[0].optional",
+  ])
+    TestValidator.predicate(`${name} has ${path}`, () => paths.includes(path));
+};
+
+interface IExactOptional {
+  required: string;
+  optional?: string;
+  optionalUndefined?: string | undefined;
+  requiredUndefined: string | undefined;
+  nested?: IExactOptionalNested;
+  array: IExactOptionalNested[];
+  union: IExactOptionalUnion;
+}
+
+interface IExactOptionalNested {
+  optional?: number;
+  optionalUndefined?: number | undefined;
+}
+
+type IExactOptionalUnion =
+  | {
+      type: "a";
+      optional?: string;
+      optionalUndefined?: string | undefined;
+    }
+  | {
+      type: "b";
+      value: string;
+    };

--- a/tests/test-typia-exact-optional/src/index.ts
+++ b/tests/test-typia-exact-optional/src/index.ts
@@ -1,0 +1,37 @@
+import { test_exact_optional_undefined_clone_random } from "./features/test_exact_optional_undefined_clone_random";
+import { test_exact_optional_undefined_validators } from "./features/test_exact_optional_undefined_validators";
+
+const main = (): void => {
+  const tests: Array<[string, () => void]> = [
+    [
+      "test_exact_optional_undefined_validators",
+      test_exact_optional_undefined_validators,
+    ],
+    [
+      "test_exact_optional_undefined_clone_random",
+      test_exact_optional_undefined_clone_random,
+    ],
+  ];
+
+  const exceptions: Error[] = [];
+  for (const [name, test] of tests) {
+    const started: number = Date.now();
+    try {
+      test();
+      console.log(`  - ${name}: ${(Date.now() - started).toLocaleString()} ms`);
+    } catch (error) {
+      console.log(`  - ${name}: ${(error as Error).name}`);
+      exceptions.push(error as Error);
+    }
+  }
+
+  if (exceptions.length === 0) {
+    console.log("Success");
+  } else {
+    for (const exp of exceptions) console.log(exp);
+    console.log("Failed");
+    process.exit(-1);
+  }
+};
+
+main();

--- a/tests/test-typia-exact-optional/tsconfig.json
+++ b/tests/test-typia-exact-optional/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../config/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "exactOptionalPropertyTypes": true,
+    "plugins": [
+      { "transform": "typia/lib/transform", "undefined": false }
+    ]
+  }
+}

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_application_qualified_param.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_application_qualified_param.ts
@@ -12,9 +12,9 @@ import typia from "typia";
  *
  * 1. Declare a controller method with `@param input.value` documentation.
  * 2. Generate the LLM application schema for that controller.
- * 3. Assert the function exists and its single object parameter was inlined,
- *    so the parameter schema's `properties` carry the object's own keys
- *    (`value`), exactly as published typia emits.
+ * 3. Assert the function exists and its single object parameter was inlined, so
+ *    the parameter schema's `properties` carry the object's own keys (`value`),
+ *    exactly as published typia emits.
  */
 export const test_llm_application_qualified_param = (): void => {
   interface IRequest {

--- a/website/src/compiler/index.ts
+++ b/website/src/compiler/index.ts
@@ -13,7 +13,10 @@
 // the string-enum tsconfig override; the in-page Execute lane resolves typia's
 // runtime from a prebuilt pack in `PlaygroundMovie`'s `executeBundle`.
 
-import { createTypiaSourcePackMount, createWorkerCompiler } from "@ttsc/playground";
+import {
+  createTypiaSourcePackMount,
+  createWorkerCompiler,
+} from "@ttsc/playground";
 import { WorkerServer } from "tgrid";
 
 const service = createWorkerCompiler({


### PR DESCRIPTION
## Summary

- Respect the transform option for explicit undefined handling under exact optional property semantics.
- Propagate the undefined option through native validator, clone, random, and equality generation paths.
- Add native/plugin option coverage and an exact optional test package.

Fixes #1617

## Validation

- pnpm format
- git diff --check

## Release

This fix will ship with the official typia 13 release after the official TypeScript-Go release.