### PR TITLE
fix(typia): restore exact optional undefined handling

### DIFF
--- a/packages/typia/native/core/programmers/helpers/CloneJoiner.go
+++ b/packages/typia/native/core/programmers/helpers/CloneJoiner.go
@@ -65,7 +65,7 @@ func (cloneJoinerNamespace) Object(props CloneJoiner_ObjectProps) *shimast.Node 
     if entry.OptionalProperty {
       properties = append(properties, f.NewSpreadAssignment(
         f.NewParenthesizedExpression(nativefactories.ExpressionFactory.Conditional(
-          nativefactories.ExpressionFactory.IsRequired(entry.Input, props.Emit),
+          cloneJoiner_optional_condition(entry, props.Input, props.Emit),
           f.NewObjectLiteralExpression(f.NewNodeList([]*shimast.Node{property}), false),
           f.NewObjectLiteralExpression(f.NewNodeList(nil), false),
           props.Emit,
@@ -145,6 +145,30 @@ func (cloneJoinerNamespace) Object(props CloneJoiner_ObjectProps) *shimast.Node 
       f.NewReturnStatement(output),
     }),
     false,
+  )
+}
+
+func cloneJoiner_optional_condition(entry IExpressionEntry, input *shimast.Expression, emit ...*shimprinter.EmitContext) *shimast.Node {
+  if entry.StrictOptionalUndefined {
+    return nativefactories.ExpressionFactory.IsRequired(entry.Input, emit...)
+  }
+  key := entry.Key.GetSoleLiteral()
+  if key == nil {
+    return nativefactories.ExpressionFactory.IsRequired(entry.Input, emit...)
+  }
+  f := nativecontext.EmitFactoryOf(cloneJoiner_factory, emit...)
+  return f.NewBinaryExpression(
+    nil,
+    nativefactories.ExpressionFactory.IsRequired(entry.Input, emit...),
+    nil,
+    f.NewToken(shimast.KindBarBarToken),
+    f.NewBinaryExpression(
+      nil,
+      f.NewStringLiteral(*key, shimast.TokenFlagsNone),
+      nil,
+      f.NewToken(shimast.KindInKeyword),
+      input,
+    ),
   )
 }
 

--- a/packages/typia/native/core/programmers/helpers/OptionPredicator.go
+++ b/packages/typia/native/core/programmers/helpers/OptionPredicator.go
@@ -27,7 +27,7 @@ func (optionPredicatorNamespace) Undefined(options nativecontext.ITransformOptio
 
 func (optionPredicatorNamespace) StrictOptionalUndefined(context nativecontext.ITypiaContext, metadata *schemametadata.MetadataSchema) bool {
   return OptionPredicator.ExactOptionalProperty(context, metadata) &&
-    metadata.Required
+    metadata.Required == false
 }
 
 func (optionPredicatorNamespace) ExactOptionalProperty(context nativecontext.ITypiaContext, metadata *schemametadata.MetadataSchema) bool {

--- a/packages/typia/native/core/programmers/helpers/OptionPredicator.go
+++ b/packages/typia/native/core/programmers/helpers/OptionPredicator.go
@@ -27,7 +27,7 @@ func (optionPredicatorNamespace) Undefined(options nativecontext.ITransformOptio
 
 func (optionPredicatorNamespace) StrictOptionalUndefined(context nativecontext.ITypiaContext, metadata *schemametadata.MetadataSchema) bool {
   return OptionPredicator.ExactOptionalProperty(context, metadata) &&
-    metadata.Required == false
+    metadata.Required
 }
 
 func (optionPredicatorNamespace) ExactOptionalProperty(context nativecontext.ITypiaContext, metadata *schemametadata.MetadataSchema) bool {

--- a/packages/typia/native/core/programmers/helpers/clone_joiner_optional_condition_test.go
+++ b/packages/typia/native/core/programmers/helpers/clone_joiner_optional_condition_test.go
@@ -1,0 +1,62 @@
+package helpers
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  nativemetadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestCloneJoinerOptionalConditionDistinguishesExplicitUndefined verifies optional clone guards.
+//
+// Exact optional properties use two runtime branches: `optional?: T` must only
+// emit the property when the decoded value is not undefined, while
+// `optional?: T | undefined` must also preserve a present own `undefined`
+// property.
+//
+//  1. Build a strict optional clone entry and assert it uses only value presence.
+//  2. Build an explicit undefined-union optional entry and assert it also checks
+//     property presence with the `in` operator.
+func TestCloneJoinerOptionalConditionDistinguishesExplicitUndefined(t *testing.T) {
+  factory := shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+  input := factory.NewIdentifier("input")
+  key := cloneJoinerTestLiteralKey("optionalUndefined")
+  property := factory.NewPropertyAccessExpression(
+    input,
+    nil,
+    factory.NewIdentifier("optionalUndefined"),
+    shimast.NodeFlagsNone,
+  )
+
+  strict := cloneJoiner_optional_condition(IExpressionEntry{
+    Input:                   property,
+    Key:                     key,
+    StrictOptionalUndefined: true,
+  }, input)
+  if strict.AsBinaryExpression().OperatorToken.Kind != shimast.KindExclamationEqualsEqualsToken {
+    t.Fatal("strict optional condition should only test value presence")
+  }
+
+  explicit := cloneJoiner_optional_condition(IExpressionEntry{
+    Input: property,
+    Key:   key,
+  }, input)
+  outer := explicit.AsBinaryExpression()
+  if outer.OperatorToken.Kind != shimast.KindBarBarToken {
+    t.Fatal("explicit undefined union should add a property-presence branch")
+  }
+  if outer.Right.AsBinaryExpression().OperatorToken.Kind != shimast.KindInKeyword {
+    t.Fatal("explicit undefined union should use the in operator")
+  }
+}
+
+func cloneJoinerTestLiteralKey(value string) *nativemetadata.MetadataSchema {
+  meta := nativemetadata.MetadataSchema_initialize()
+  meta.Constants = append(meta.Constants, nativemetadata.MetadataConstant_create(nativemetadata.MetadataConstant{
+    Type: "string",
+    Values: []*nativemetadata.MetadataConstantValue{
+      nativemetadata.MetadataConstantValue_create(nativemetadata.MetadataConstantValue{Value: value}),
+    },
+  }))
+  return meta
+}

--- a/packages/typia/native/core/programmers/helpers/clone_joiner_optional_condition_test.go
+++ b/packages/typia/native/core/programmers/helpers/clone_joiner_optional_condition_test.go
@@ -48,6 +48,14 @@ func TestCloneJoinerOptionalConditionDistinguishesExplicitUndefined(t *testing.T
   if outer.Right.AsBinaryExpression().OperatorToken.Kind != shimast.KindInKeyword {
     t.Fatal("explicit undefined union should use the in operator")
   }
+  presence := outer.Right.AsBinaryExpression()
+  if presence.Left.Kind != shimast.KindStringLiteral ||
+    shimast.NodeText(presence.Left) != "optionalUndefined" {
+    t.Fatal("explicit undefined union should test the literal property key")
+  }
+  if presence.Right != input {
+    t.Fatal("explicit undefined union should test presence on the original input")
+  }
 }
 
 func cloneJoinerTestLiteralKey(value string) *nativemetadata.MetadataSchema {

--- a/packages/typia/native/core/programmers/iterate/check_object.go
+++ b/packages/typia/native/core/programmers/iterate/check_object.go
@@ -37,7 +37,7 @@ func Check_object(props Check_objectProps) *shimast.Node {
   }
   flags := make([]*shimast.Node, 0, len(regular)+1)
   for _, entry := range regular {
-    flags = append(flags, entry.Expression)
+    flags = append(flags, check_object_regular_expression(props, entry))
   }
 
   if props.Config.Equals == false && len(dynamic) == 0 {
@@ -61,6 +61,28 @@ func Check_object(props Check_objectProps) *shimast.Node {
     Config:      props.Config,
     Expressions: flags,
   }, props.Context.Emit)
+}
+
+func check_object_regular_expression(props Check_objectProps, entry nativehelpers.IExpressionEntry) *shimast.Node {
+  key := entry.Key.GetSoleLiteral()
+  if !entry.StrictOptionalUndefined || key == nil {
+    return entry.Expression
+  }
+  f := nativecontext.EmitFactoryOf(check_object_factory, props.Context.Emit)
+  present := f.NewBinaryExpression(
+    nil,
+    f.NewStringLiteral(*key, shimast.TokenFlagsNone),
+    nil,
+    f.NewToken(shimast.KindInKeyword),
+    props.Input,
+  )
+  return f.NewBinaryExpression(
+    nil,
+    f.NewPrefixUnaryExpression(shimast.KindExclamationToken, present),
+    nil,
+    f.NewToken(shimast.KindBarBarToken),
+    entry.Expression,
+  )
 }
 
 type check_object_reduceProps struct {

--- a/packages/typia/native/core/programmers/iterate/check_object_strict_optional_undefined_test.go
+++ b/packages/typia/native/core/programmers/iterate/check_object_strict_optional_undefined_test.go
@@ -1,0 +1,62 @@
+package iterate
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+  nativehelpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
+  nativemetadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestCheckObjectStrictOptionalUndefinedAllowsMissingKey verifies strict optional guards.
+//
+// Exact optional properties must reject a present own `undefined` value without
+// rejecting a missing optional key. The object checker therefore wraps strict
+// optional property expressions with a key-presence short circuit.
+//
+// 1. Build a strict optional regular entry.
+// 2. Assert its object-check expression first tests property absence.
+// 3. Assert the original strict property expression stays on the right branch.
+func TestCheckObjectStrictOptionalUndefinedAllowsMissingKey(t *testing.T) {
+  factory := shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+  input := factory.NewIdentifier("input")
+  expression := factory.NewIdentifier("strict")
+  entry := nativehelpers.IExpressionEntry{
+    Input:                   factory.NewPropertyAccessExpression(input, nil, factory.NewIdentifier("optional"), shimast.NodeFlagsNone),
+    Key:                     checkObjectLiteralKey("optional"),
+    Meta:                    nativemetadata.MetadataSchema_initialize(),
+    Expression:              expression,
+    StrictOptionalUndefined: true,
+  }
+
+  wrapped := check_object_regular_expression(Check_objectProps{
+    Config:  Check_object_IConfig{Positive: factory.NewKeywordExpression(shimast.KindTrueKeyword)},
+    Context: nativecontext.ITypiaContext{},
+    Input:   input,
+  }, entry)
+  outer := wrapped.AsBinaryExpression()
+  if outer.OperatorToken.Kind != shimast.KindBarBarToken {
+    t.Fatal("strict optional expression should short-circuit with ||")
+  }
+  if outer.Left.Kind != shimast.KindPrefixUnaryExpression {
+    t.Fatal("left branch should negate property presence")
+  }
+  if outer.Left.AsPrefixUnaryExpression().Operand.AsBinaryExpression().OperatorToken.Kind != shimast.KindInKeyword {
+    t.Fatal("left branch should use the in operator")
+  }
+  if outer.Right != expression {
+    t.Fatal("right branch should be the original strict decoder expression")
+  }
+}
+
+func checkObjectLiteralKey(value string) *nativemetadata.MetadataSchema {
+  meta := nativemetadata.MetadataSchema_initialize()
+  meta.Constants = append(meta.Constants, nativemetadata.MetadataConstant_create(nativemetadata.MetadataConstant{
+    Type: "string",
+    Values: []*nativemetadata.MetadataConstantValue{
+      nativemetadata.MetadataConstantValue_create(nativemetadata.MetadataConstantValue{Value: value}),
+    },
+  }))
+  return meta
+}

--- a/packages/typia/native/core/programmers/iterate/check_object_strict_optional_undefined_test.go
+++ b/packages/typia/native/core/programmers/iterate/check_object_strict_optional_undefined_test.go
@@ -42,8 +42,20 @@ func TestCheckObjectStrictOptionalUndefinedAllowsMissingKey(t *testing.T) {
   if outer.Left.Kind != shimast.KindPrefixUnaryExpression {
     t.Fatal("left branch should negate property presence")
   }
-  if outer.Left.AsPrefixUnaryExpression().Operand.AsBinaryExpression().OperatorToken.Kind != shimast.KindInKeyword {
+  prefix := outer.Left.AsPrefixUnaryExpression()
+  if prefix.Operator != shimast.KindExclamationToken {
+    t.Fatal("left branch should use a ! prefix")
+  }
+  presence := prefix.Operand.AsBinaryExpression()
+  if presence.OperatorToken.Kind != shimast.KindInKeyword {
     t.Fatal("left branch should use the in operator")
+  }
+  if presence.Left.Kind != shimast.KindStringLiteral ||
+    shimast.NodeText(presence.Left) != "optional" {
+    t.Fatal("left branch should test the literal property key")
+  }
+  if presence.Right != input {
+    t.Fatal("left branch should test presence on the original input")
   }
   if outer.Right != expression {
     t.Fatal("right branch should be the original strict decoder expression")

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.6",
+  "version": "13.0.0-dev.20260605.7",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/test/helpers/predicator/option_predicator_strict_optional_undefined_test.go
+++ b/packages/typia/test/helpers/predicator/option_predicator_strict_optional_undefined_test.go
@@ -1,0 +1,44 @@
+package typia_test
+
+import (
+  "testing"
+
+  shimcore "github.com/microsoft/typescript-go/shim/core"
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+  helpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestOptionPredicatorStrictOptionalUndefinedDistinguishesExplicitUnion verifies exact optional undefined handling.
+//
+// With exact optional properties and typia's `"undefined": false` option,
+// `optional?: T` must reject an own `undefined` value, but
+// `optional?: T | undefined` must still accept one because the undefined union
+// is explicit.
+//
+// 1. Enable exact optional property types and disable typia undefined checks.
+// 2. Assert `optional?: T` is strict.
+// 3. Assert `optional?: T | undefined` is not strict.
+func TestOptionPredicatorStrictOptionalUndefinedDistinguishesExplicitUnion(t *testing.T) {
+  disabled := false
+  context := nativecontext.ITypiaContext{
+    CompilerOptions: &shimcore.CompilerOptions{
+      ExactOptionalPropertyTypes: shimcore.TSTrue,
+    },
+    Options: nativecontext.ITransformOptions{Undefined: &disabled},
+  }
+
+  implicit := schemametadata.MetadataSchema_initialize()
+  implicit.Required = false
+  implicit.Optional = true
+  if !helpers.OptionPredicator.StrictOptionalUndefined(context, implicit) {
+    t.Fatal("optional?: T should reject explicit undefined")
+  }
+
+  explicit := schemametadata.MetadataSchema_initialize()
+  explicit.Required = true
+  explicit.Optional = true
+  if helpers.OptionPredicator.StrictOptionalUndefined(context, explicit) {
+    t.Fatal("optional?: T | undefined should allow explicit undefined")
+  }
+}

--- a/packages/typia/test/helpers/predicator/option_predicator_strict_optional_undefined_test.go
+++ b/packages/typia/test/helpers/predicator/option_predicator_strict_optional_undefined_test.go
@@ -29,14 +29,13 @@ func TestOptionPredicatorStrictOptionalUndefinedDistinguishesExplicitUnion(t *te
   }
 
   implicit := schemametadata.MetadataSchema_initialize()
-  implicit.Required = false
   implicit.Optional = true
   if !helpers.OptionPredicator.StrictOptionalUndefined(context, implicit) {
     t.Fatal("optional?: T should reject explicit undefined")
   }
 
   explicit := schemametadata.MetadataSchema_initialize()
-  explicit.Required = true
+  explicit.Required = false
   explicit.Optional = true
   if helpers.OptionPredicator.StrictOptionalUndefined(context, explicit) {
     t.Fatal("optional?: T | undefined should allow explicit undefined")

--- a/website/compiler/cmd/playground/typia_plugin.go
+++ b/website/compiler/cmd/playground/typia_plugin.go
@@ -435,6 +435,15 @@ func readTypiaPluginOptions(cwd, tsconfigPath string) typiaadapter.PluginOptions
     Functional: regexp.MustCompile(`(?s)"functional"\s*:\s*true`).MatchString(text),
     Numeric:    regexp.MustCompile(`(?s)"numeric"\s*:\s*true`).MatchString(text),
     Finite:     regexp.MustCompile(`(?s)"finite"\s*:\s*true`).MatchString(text),
-    Undefined:  regexp.MustCompile(`(?s)"undefined"\s*:\s*true`).MatchString(text),
+    Undefined:  readBooleanTypiaPluginOption(text, "undefined"),
   }
+}
+
+func readBooleanTypiaPluginOption(text string, name string) *bool {
+  matched := regexp.MustCompile(`(?s)"` + regexp.QuoteMeta(name) + `"\s*:\s*(true|false)`).FindStringSubmatch(text)
+  if matched == nil {
+    return nil
+  }
+  value := matched[1] == "true"
+  return &value
 }

--- a/website/compiler/cmd/playground/typia_plugin_undefined_false_test.go
+++ b/website/compiler/cmd/playground/typia_plugin_undefined_false_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestPlaygroundPluginOptionsUndefinedFalsePreservesExplicitFalse verifies playground option parsing.
@@ -17,20 +17,20 @@ import (
 // 2. Read plugin options through the playground helper.
 // 3. Assert the undefined option is a non-nil false pointer.
 func TestPlaygroundPluginOptionsUndefinedFalsePreservesExplicitFalse(t *testing.T) {
-	root := t.TempDir()
-	path := filepath.Join(root, "tsconfig.json")
-	if err := os.WriteFile(path, []byte(`{
+  root := t.TempDir()
+  path := filepath.Join(root, "tsconfig.json")
+  if err := os.WriteFile(path, []byte(`{
   "compilerOptions": {
     "plugins": [
       { "transform": "typia/lib/transform", "undefined": false }
     ]
   }
 }`), 0o644); err != nil {
-		t.Fatal(err)
-	}
+    t.Fatal(err)
+  }
 
-	options := readTypiaPluginOptions(root, path)
-	if options.Undefined == nil || *options.Undefined {
-		t.Fatalf("undefined=false should be preserved: %#v", options.Undefined)
-	}
+  options := readTypiaPluginOptions(root, path)
+  if options.Undefined == nil || *options.Undefined {
+    t.Fatalf("undefined=false should be preserved: %#v", options.Undefined)
+  }
 }

--- a/website/compiler/cmd/playground/typia_plugin_undefined_false_test.go
+++ b/website/compiler/cmd/playground/typia_plugin_undefined_false_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPlaygroundPluginOptionsUndefinedFalsePreservesExplicitFalse verifies playground option parsing.
+//
+// The playground mirrors typia's native CLI option reader, so it must preserve
+// an explicit `"undefined": false` transformer option instead of treating it as
+// an omitted nil option. Otherwise the exact optional-property behavior would
+// diverge between the website compiler and the packaged CLI.
+//
+// 1. Write a tsconfig with the typia transformer and `"undefined": false`.
+// 2. Read plugin options through the playground helper.
+// 3. Assert the undefined option is a non-nil false pointer.
+func TestPlaygroundPluginOptionsUndefinedFalsePreservesExplicitFalse(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "tsconfig.json")
+	if err := os.WriteFile(path, []byte(`{
+  "compilerOptions": {
+    "plugins": [
+      { "transform": "typia/lib/transform", "undefined": false }
+    ]
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	options := readTypiaPluginOptions(root, path)
+	if options.Undefined == nil || *options.Undefined {
+		t.Fatalf("undefined=false should be preserved: %#v", options.Undefined)
+	}
+}

--- a/website/src/compiler/createTypiaWorkerCompiler.ts
+++ b/website/src/compiler/createTypiaWorkerCompiler.ts
@@ -1,0 +1,255 @@
+import {
+  bootTtsc,
+  parseResult,
+  type IBootResult,
+  type ITtscCompileResult,
+} from "@ttsc/wasm";
+import {
+  buildTsconfigJSON,
+  DEFAULT_ENTRY_FILE,
+  DEFAULT_TSCONFIG_PATH,
+  DEFAULT_TYPIA_PLUGIN_NAME,
+  DEFAULT_WORK_DIR,
+  installDependenciesIntoMemFS,
+  mapDiagnostic,
+  normalizeError,
+  pickEmittedJS,
+  type ICompilerService,
+  type ICreateWorkerCompilerOptions,
+  type ITransformOptions,
+} from "@ttsc/playground";
+
+const TYPIA_OPTION_KEYS = [
+  "finite",
+  "numeric",
+  "functional",
+  "undefined",
+] as const;
+
+type ModuleKind = "ESNext" | "CommonJS";
+type TypiaPluginEntry = {
+  transform: string;
+} & Partial<Record<(typeof TYPIA_OPTION_KEYS)[number], boolean>>;
+
+interface ITypiaTransformOutput {
+  typescript: Record<string, string>;
+}
+
+export function createTypiaWorkerCompiler(
+  options: ICreateWorkerCompilerOptions,
+): ICompilerService {
+  const workDir = options.workDir ?? DEFAULT_WORK_DIR;
+  const tsconfigPath = options.tsconfigPath ?? DEFAULT_TSCONFIG_PATH;
+  const entryFile = options.entryFile ?? DEFAULT_ENTRY_FILE;
+
+  const typiaPlugin =
+    options.typiaPlugin === false ? null : (options.typiaPlugin ?? {});
+  const typiaPluginName = typiaPlugin?.name ?? DEFAULT_TYPIA_PLUGIN_NAME;
+  const typiaTransformModule =
+    typiaPlugin?.transformModule ?? "typia/lib/transform";
+
+  let boot: Promise<IBootResult> | null = null;
+  function getBoot(): Promise<IBootResult> {
+    if (boot) return boot;
+    boot = (async () => {
+      const result = await bootTtsc({
+        wasmUrl: options.wasmUrl,
+        wasmExecUrl: options.wasmExecUrl,
+        apiName: options.apiName,
+      });
+      if (typiaPlugin?.mount) await typiaPlugin.mount(result.host, workDir);
+      return result;
+    })().catch((err) => {
+      boot = null;
+      throw err;
+    });
+    return boot;
+  }
+
+  let busy: Promise<unknown> = Promise.resolve();
+  const enqueue = <T>(fn: () => Promise<T>): Promise<T> => {
+    const next = busy.then(fn, fn);
+    busy = next.catch(() => {});
+    return next;
+  };
+
+  const buildTsconfig = (
+    module: ModuleKind,
+    transformOptions: ITransformOptions | undefined,
+  ): string =>
+    buildTsconfigJSON({
+      module,
+      compilerOptions: {
+        ...(options.extraCompilerOptions ?? {}),
+        ...(typiaPlugin
+          ? {
+              plugins: [
+                createTypiaPluginEntry(typiaTransformModule, transformOptions),
+              ],
+            }
+          : {}),
+      },
+    });
+
+  const projectFiles = (
+    source: string,
+    tsconfigText: string,
+  ): Record<string, string> => ({
+    [`${workDir}/${tsconfigPath}`]: tsconfigText,
+    [`${workDir}/${entryFile}`]: source,
+  });
+
+  const writeProject = (
+    host: IBootResult["host"],
+    files: Record<string, string>,
+  ): void => {
+    for (const [path, text] of Object.entries(files))
+      host.writeFile(path, text);
+  };
+
+  const applyTypiaTransform = async (
+    api: IBootResult["api"],
+    host: IBootResult["host"],
+  ): Promise<void> => {
+    if (!typiaPlugin) return;
+    try {
+      const raw = await api.plugin({
+        name: typiaPluginName,
+        command: "transform",
+        cwd: workDir,
+        tsconfig: tsconfigPath,
+        output: "ts",
+      });
+      if (!raw.stdout) return;
+      const transformed = safeParseTypiaTransform(raw.stdout);
+      if (!transformed) return;
+      for (const [rel, text] of Object.entries(transformed.typescript)) {
+        host.writeFile(joinUnder(workDir, rel), text);
+      }
+    } catch {
+      // Keep the playground usable; the following build still reports tsgo
+      // diagnostics for the user's source.
+    }
+  };
+
+  const runBuildPipeline = async (
+    source: string,
+    runTypia: boolean,
+    module: ModuleKind,
+    transformOptions: ITransformOptions | undefined,
+  ): Promise<ICompilerService.IResult> => {
+    try {
+      const { api, host } = await getBoot();
+      writeProject(
+        host,
+        projectFiles(source, buildTsconfig(module, transformOptions)),
+      );
+      if (runTypia) await applyTypiaTransform(api, host);
+      const raw = await api.build({
+        cwd: workDir,
+        tsconfig: tsconfigPath,
+      });
+      if (raw.code !== 0 && !raw.result) {
+        return {
+          type: "error",
+          target: "javascript",
+          value: {
+            message:
+              raw.stderr || "ttsc: build failed without a result payload",
+          },
+        };
+      }
+      const parsed = parseResult<ITtscCompileResult>(raw);
+      if (!parsed) {
+        return {
+          type: "error",
+          target: "javascript",
+          value: { message: "ttsc: result JSON could not be parsed" },
+        };
+      }
+      const diagnostics = (parsed.diagnostics ?? []).map((d) =>
+        mapDiagnostic(d, source),
+      );
+      const js = pickEmittedJS(parsed.output ?? {}, entryFile);
+      const errors = diagnostics.filter((d) => d.severity === "error");
+      if (errors.length > 0) {
+        return {
+          type: "failure",
+          target: "javascript",
+          value: js ?? "",
+          diagnostics,
+        };
+      }
+      return { type: "success", target: "javascript", value: js ?? "" };
+    } catch (error) {
+      return {
+        type: "error",
+        target: "javascript",
+        value: normalizeError(error),
+      };
+    }
+  };
+
+  return {
+    installDependencies: (props) =>
+      enqueue(async () => {
+        const { host } = await getBoot();
+        return installDependenciesIntoMemFS(host, workDir, props);
+      }),
+    compile: (props) =>
+      enqueue(() =>
+        runBuildPipeline(
+          props.source,
+          shouldRunTypia(props.options),
+          "ESNext",
+          props.options,
+        ),
+      ),
+    bundle: (props) =>
+      enqueue(() =>
+        runBuildPipeline(
+          props.source,
+          shouldRunTypia(props.options),
+          "CommonJS",
+          props.options,
+        ),
+      ),
+    lint: () => enqueue(async () => ({ diagnostics: [] })),
+  };
+}
+
+export function createTypiaPluginEntry(
+  transformModule: string,
+  options: ITransformOptions | undefined,
+): TypiaPluginEntry {
+  const entry: TypiaPluginEntry = { transform: transformModule };
+  for (const key of TYPIA_OPTION_KEYS) {
+    const value = options?.[key];
+    if (value !== undefined) entry[key] = value;
+  }
+  return entry;
+}
+
+function shouldRunTypia(options?: ITransformOptions): boolean {
+  return options?.typia !== false;
+}
+
+function safeParseTypiaTransform(text: string): ITypiaTransformOutput | null {
+  try {
+    const parsed = JSON.parse(text) as ITypiaTransformOutput;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      parsed.typescript &&
+      typeof parsed.typescript === "object"
+    )
+      return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function joinUnder(root: string, rel: string): string {
+  return `${root.replace(/\/+$/, "")}/${rel.replace(/^\/+/, "")}`;
+}

--- a/website/src/compiler/index.ts
+++ b/website/src/compiler/index.ts
@@ -6,20 +6,18 @@
 // `@ttsc/wasm`'s `host.Expose` — which registers a single `host.Plugin` named
 // `"typia"` that dispatches `transform` / `build` into typia's native runners.
 //
-// All shared playground scaffolding (worker race guards, MemFS layout, tsconfig
-// builder, npm dependency installer, ESM/CJS compile lanes) lives inside
-// `@ttsc/playground` and is invoked through `createWorkerCompiler`. This file
-// only supplies the typia-specific wasm URL, plugin id, source-pack mount, and
-// the string-enum tsconfig override; the in-page Execute lane resolves typia's
-// runtime from a prebuilt pack in `PlaygroundMovie`'s `executeBundle`.
+// Most shared playground scaffolding lives inside `@ttsc/playground`. The
+// website worker uses a typia-specific compiler wrapper so each compile can
+// serialize the current transform toggles into `compilerOptions.plugins`; the
+// in-page Execute lane resolves typia's runtime from a prebuilt pack in
+// `PlaygroundMovie`'s `executeBundle`.
 
-import {
-  createTypiaSourcePackMount,
-  createWorkerCompiler,
-} from "@ttsc/playground";
+import { createTypiaSourcePackMount } from "@ttsc/playground";
 import { WorkerServer } from "tgrid";
 
-const service = createWorkerCompiler({
+import { createTypiaWorkerCompiler } from "./createTypiaWorkerCompiler";
+
+const service = createTypiaWorkerCompiler({
   wasmUrl: "/compiler/ttsc-typia.wasm",
   wasmExecUrl: "/compiler/wasm_exec.js",
   apiName: "ttscTypia",


### PR DESCRIPTION
## Summary
- restores exact optional handling so `optional?: T` rejects an own `undefined` value while `optional?: T | undefined` keeps accepting explicit undefined
- mirrors the native CLI boolean plugin-option parser in the website playground so `undefined` is a `*bool`, including explicit `false`
- bumps `packages/typia` to `13.0.0-dev.20260605.7` because native source changed

## Validation
- `node scripts/format-go.cjs`
- `go -C packages/typia/test test ./helpers/predicator`
- `go -C packages/typia/test test ./...`
- `go -C website/compiler test ./...`
- `go -C website/compiler build ./cmd/playground`
- `git diff --check`

## Local limitations
- `pnpm --filter ./tests/test-typia-exact-optional start` still exits on Windows before assertions with `Unexpected token '{'`; Linux CI is expected to validate this suite.