### PR TITLE
feat(typia): add smaller integer type tags

### DIFF
--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "13.0.0-dev.20260605.4",
+  "version": "13.0.0-dev.20260605.5",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/interface/src/tags/Type.ts
+++ b/packages/interface/src/tags/Type.ts
@@ -9,6 +9,10 @@ import { TagBase } from "./TagBase";
  *
  * Available types:
  *
+ * - `"int8"`: Signed 8-bit integer (-128 to 127)
+ * - `"uint8"`: Unsigned 8-bit integer (0 to 255)
+ * - `"int16"`: Signed 16-bit integer (-32,768 to 32,767)
+ * - `"uint16"`: Unsigned 16-bit integer (0 to 65,535)
  * - `"int32"`: Signed 32-bit integer (-2,147,483,648 to 2,147,483,647)
  * - `"uint32"`: Unsigned 32-bit integer (0 to 4,294,967,295)
  * - `"int64"`: Signed 64-bit integer (for `number` or `bigint`)
@@ -34,36 +38,62 @@ import { TagBase } from "./TagBase";
  * @template Value Numeric type identifier
  */
 export type Type<
-  Value extends "int32" | "uint32" | "int64" | "uint64" | "float" | "double",
+  Value extends
+    | "int8"
+    | "uint8"
+    | "int16"
+    | "uint16"
+    | "int32"
+    | "uint32"
+    | "int64"
+    | "uint64"
+    | "float"
+    | "double",
 > = TagBase<{
   target: Value extends "int64" | "uint64" ? "bigint" | "number" : "number";
   kind: "type";
   value: Value;
-  validate: Value extends "int32"
-    ? `$importInternal("isTypeInt32")($input)`
-    : Value extends "uint32"
-      ? `$importInternal("isTypeUint32")($input)`
-      : Value extends "int64"
-        ? {
-            number: `$importInternal("isTypeInt64")($input)`;
-            bigint: `true`;
-          }
-        : Value extends "uint64"
-          ? {
-              number: `$importInternal("isTypeUint64")($input)`;
-              bigint: `BigInt(0) <= $input`;
-            }
-          : Value extends "float"
-            ? `$importInternal("isTypeFloat")($input)`
-            : `true`;
+  validate: Value extends "int8"
+    ? `$importInternal("isTypeInt8")($input)`
+    : Value extends "uint8"
+      ? `$importInternal("isTypeUint8")($input)`
+      : Value extends "int16"
+        ? `$importInternal("isTypeInt16")($input)`
+        : Value extends "uint16"
+          ? `$importInternal("isTypeUint16")($input)`
+          : Value extends "int32"
+            ? `$importInternal("isTypeInt32")($input)`
+            : Value extends "uint32"
+              ? `$importInternal("isTypeUint32")($input)`
+              : Value extends "int64"
+                ? {
+                    number: `$importInternal("isTypeInt64")($input)`;
+                    bigint: `true`;
+                  }
+                : Value extends "uint64"
+                  ? {
+                      number: `$importInternal("isTypeUint64")($input)`;
+                      bigint: `BigInt(0) <= $input`;
+                    }
+                  : Value extends "float"
+                    ? `$importInternal("isTypeFloat")($input)`
+                    : `true`;
   exclusive: true;
-  schema: Value extends "uint32" | "uint64"
+  schema: Value extends "uint8" | "uint16" | "uint32" | "uint64"
     ? {
         type: "integer";
         minimum: 0;
       }
     : {
-        type: Value extends "int32" | "uint32" | "int64" | "uint64"
+        type: Value extends
+          | "int8"
+          | "uint8"
+          | "int16"
+          | "uint16"
+          | "int32"
+          | "uint32"
+          | "int64"
+          | "uint64"
           ? "integer"
           : "number";
       };

--- a/packages/interface/src/tags/Type.ts
+++ b/packages/interface/src/tags/Type.ts
@@ -20,8 +20,9 @@ import { TagBase } from "./TagBase";
  * - `"float"`: 32-bit floating point
  * - `"double"`: 64-bit floating point (default JavaScript number)
  *
- * For Protocol Buffers, integer types also determine the wire encoding. The
- * constraint is enforced at runtime by `typia.is()`, `typia.assert()`, and
+ * For Protocol Buffers, numeric types select the protobuf scalar type, while
+ * smaller integer tags validate narrower ranges and emit `int32` or `uint32`.
+ * The constraint is enforced at runtime by `typia.is()`, `typia.assert()`, and
  * `typia.validate()`. It generates appropriate `type` in JSON Schema.
  *
  * @author Jeongho Nam - https://github.com/samchon

--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -358,10 +358,15 @@ func metadataCommentTagFactory_parse_type(props struct {
   if value == "uint64" {
     bigintSchema = map[string]any{"minimum": 0}
   }
-  return metadataCommentTagFactory_TagRecord{
+  record := metadataCommentTagFactory_TagRecord{
     "number": {{Name: "Type<" + strconv.Quote(value) + ">", Target: "number", Kind: "type", Value: value, Validate: validate, Exclusive: true, Schema: numberSchema}},
-    "bigint": {{Name: "Type<" + strconv.Quote(value) + ">", Target: "bigint", Kind: "type", Value: value, Validate: map[bool]string{true: "true", false: "BigInt(0) <= $input"}[value == "int64"], Exclusive: true, Schema: bigintSchema}},
   }
+  if value == "int64" || value == "uint64" {
+    record["bigint"] = []schemametadata.IMetadataTypeTag{
+      {Name: "Type<" + strconv.Quote(value) + ">", Target: "bigint", Kind: "type", Value: value, Validate: map[bool]string{true: "true", false: "BigInt(0) <= $input"}[value == "int64"], Exclusive: true, Schema: bigintSchema},
+    }
+  }
+  return record
 }
 
 func metadataCommentTagFactory_numeric(props struct {

--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -325,11 +325,19 @@ func metadataCommentTagFactory_parse_type(props struct {
   } else if value == "uint" {
     value = "uint32"
   }
-  if metadataCommentTagFactory_includes([]string{"int32", "uint32", "int64", "uint64", "float", "double"}, value) == false {
+  if metadataCommentTagFactory_includes([]string{"int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64", "float", "double"}, value) == false {
     return metadataCommentTagFactory_TagRecord{}
   }
   validate := "true"
-  if value == "int32" {
+  if value == "int8" {
+    validate = "Math.floor($input) === $input && -128 <= $input && $input <= 127"
+  } else if value == "uint8" {
+    validate = "Math.floor($input) === $input && 0 <= $input && $input <= 255"
+  } else if value == "int16" {
+    validate = "Math.floor($input) === $input && -32768 <= $input && $input <= 32767"
+  } else if value == "uint16" {
+    validate = "Math.floor($input) === $input && 0 <= $input && $input <= 65535"
+  } else if value == "int32" {
     validate = "Math.floor($input) === $input && -2147483648 <= $input && $input <= 2147483647"
   } else if value == "uint32" {
     validate = "Math.floor($input) === $input && 0 <= $input && $input <= 4294967295"
@@ -341,9 +349,9 @@ func metadataCommentTagFactory_parse_type(props struct {
     validate = "-1.175494351e38 <= $input && $input <= 3.4028235e38"
   }
   var numberSchema any
-  if value == "int32" || value == "int64" {
+  if value == "int8" || value == "int16" || value == "int32" || value == "int64" {
     numberSchema = map[string]any{"type": "integer"}
-  } else if value == "uint32" || value == "uint64" {
+  } else if value == "uint8" || value == "uint16" || value == "uint32" || value == "uint64" {
     numberSchema = map[string]any{"type": "integer", "minimum": 0}
   }
   var bigintSchema any

--- a/packages/typia/native/core/factories/ProtobufFactory.go
+++ b/packages/typia/native/core/factories/ProtobufFactory.go
@@ -290,8 +290,8 @@ func protobufFactory_emplaceNumber(output map[string]nativeprotobuf.IProtobufPro
       if tag.Kind != "type" {
         continue
       }
-      str := fmt.Sprint(tag.Value)
-      if str == "int32" || str == "uint32" || str == "int64" || str == "uint64" || str == "float" || str == "double" {
+      str := protobufFactory_normalizeNumberType(fmt.Sprint(tag.Value))
+      if str != "" {
         value = str
         break
       }
@@ -585,8 +585,12 @@ func protobufFactory_validateNumericSequences(metadata *schemametadata.MetadataS
   foundCategories := map[string]bool{}
   getType := func(tags []schemametadata.IMetadataTypeTag) string {
     for _, tag := range tags {
-      if tag.Kind == "type" && categories[fmt.Sprint(tag.Value)] {
-        return fmt.Sprint(tag.Value)
+      if tag.Kind != "type" {
+        continue
+      }
+      value := protobufFactory_normalizeNumberType(fmt.Sprint(tag.Value))
+      if value != "" && categories[value] {
+        return value
       }
     }
     return def
@@ -925,8 +929,8 @@ func protobufFactory_decodeNumberTags(output map[string]*int, tags [][]schemamet
       if tag.Kind != "type" {
         continue
       }
-      str := fmt.Sprint(tag.Value)
-      if protobufFactory_NUMBER_TYPES[str] {
+      str := protobufFactory_normalizeNumberType(fmt.Sprint(tag.Value))
+      if str != "" {
         value = str
         break
       }
@@ -1063,4 +1067,18 @@ var protobufFactory_ATOMIC_ORDER = map[string]int{
   "float":  5,
   "double": 6,
   "string": 7,
+}
+
+func protobufFactory_normalizeNumberType(value string) string {
+  switch value {
+  case "int8", "int16":
+    return "int32"
+  case "uint8", "uint16":
+    return "uint32"
+  default:
+    if protobufFactory_NUMBER_TYPES[value] {
+      return value
+    }
+    return ""
+  }
 }

--- a/packages/typia/native/core/programmers/helpers/ProtobufUtil.go
+++ b/packages/typia/native/core/programmers/helpers/ProtobufUtil.go
@@ -232,8 +232,8 @@ func protobufUtil_decode_number(output map[string]*int, tags [][]nativemetadata.
     value := "double"
     for _, tag := range row {
       if tag.Kind == "type" {
-        str := fmt.Sprint(tag.Value)
-        if str == "int32" || str == "uint32" || str == "int64" || str == "uint64" || str == "float" || str == "double" {
+        str := protobufUtil_normalize_number_type(fmt.Sprint(tag.Value))
+        if str != "" {
           value = str
           break
         }
@@ -293,5 +293,18 @@ func protobufUtil_toFloat(value any) float64 {
   default:
     parsed, _ := strconv.ParseFloat(fmt.Sprint(value), 64)
     return parsed
+  }
+}
+
+func protobufUtil_normalize_number_type(value string) string {
+  switch value {
+  case "int8", "int16":
+    return "int32"
+  case "uint8", "uint16":
+    return "uint32"
+  case "int32", "uint32", "int64", "uint64", "float", "double":
+    return value
+  default:
+    return ""
   }
 }

--- a/packages/typia/native/core/programmers/helpers/ProtobufUtil.go
+++ b/packages/typia/native/core/programmers/helpers/ProtobufUtil.go
@@ -212,7 +212,7 @@ func protobufUtil_decode_bigint(output map[string]*int, tags [][]nativemetadata.
     return
   }
   for _, row := range tags {
-    value := "int64"
+    value := defaultType
     for _, tag := range row {
       if tag.Kind == "type" && (tag.Value == "int64" || tag.Value == "uint64") {
         value = fmt.Sprint(tag.Value)

--- a/packages/typia/native/core/programmers/helpers/ProtobufUtil.go
+++ b/packages/typia/native/core/programmers/helpers/ProtobufUtil.go
@@ -229,7 +229,7 @@ func protobufUtil_decode_number(output map[string]*int, tags [][]nativemetadata.
     return
   }
   for _, row := range tags {
-    value := "double"
+    value := defaultType
     for _, tag := range row {
       if tag.Kind == "type" {
         str := protobufUtil_normalize_number_type(fmt.Sprint(tag.Value))

--- a/packages/typia/native/core/programmers/iterate/check_number.go
+++ b/packages/typia/native/core/programmers/iterate/check_number.go
@@ -107,7 +107,11 @@ func check_numeric_type_tags(props check_numeric_type_tagsProps) [][]nativehelpe
 func check_numeric_type_tags_covers_addition(row []nativemetadata.IMetadataTypeTag) bool {
   if check_number_some(row, func(tag nativemetadata.IMetadataTypeTag) bool {
     return tag.Kind == "type" &&
-      (tag.Value == "int32" ||
+      (tag.Value == "int8" ||
+        tag.Value == "uint8" ||
+        tag.Value == "int16" ||
+        tag.Value == "uint16" ||
+        tag.Value == "int32" ||
         tag.Value == "uint32" ||
         tag.Value == "int64" ||
         tag.Value == "uint64" ||

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.8",
+  "version": "13.0.0-dev.20260605.9",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/src/internal/_isTypeInt16.ts
+++ b/packages/typia/src/internal/_isTypeInt16.ts
@@ -1,0 +1,5 @@
+export const _isTypeInt16 = (value: number): boolean =>
+  Math.floor(value) === value && MINIMUM <= value && value <= MAXIMUM;
+
+const MINIMUM = -32768;
+const MAXIMUM = 32767;

--- a/packages/typia/src/internal/_isTypeInt8.ts
+++ b/packages/typia/src/internal/_isTypeInt8.ts
@@ -1,0 +1,5 @@
+export const _isTypeInt8 = (value: number): boolean =>
+  Math.floor(value) === value && MINIMUM <= value && value <= MAXIMUM;
+
+const MINIMUM = -128;
+const MAXIMUM = 127;

--- a/packages/typia/src/internal/_isTypeUint16.ts
+++ b/packages/typia/src/internal/_isTypeUint16.ts
@@ -1,0 +1,5 @@
+export const _isTypeUint16 = (value: number): boolean =>
+  Math.floor(value) === value && MINIMUM <= value && value <= MAXIMUM;
+
+const MINIMUM = 0;
+const MAXIMUM = 65535;

--- a/packages/typia/src/internal/_isTypeUint8.ts
+++ b/packages/typia/src/internal/_isTypeUint8.ts
@@ -1,0 +1,5 @@
+export const _isTypeUint8 = (value: number): boolean =>
+  Math.floor(value) === value && MINIMUM <= value && value <= MAXIMUM;
+
+const MINIMUM = 0;
+const MAXIMUM = 255;

--- a/packages/typia/test/contract/native/protobuf_factory_smaller_integer_normalization_test.go
+++ b/packages/typia/test/contract/native/protobuf_factory_smaller_integer_normalization_test.go
@@ -1,4 +1,4 @@
-package factories
+package typia_test
 
 import (
   "testing"
@@ -15,7 +15,7 @@ import (
 // path must still consume those typia numeric tags through its exported object
 // emplacement API without falling back to double.
 //
-// 1. Build an object property for each smaller integer alias.
+// 1. Build object properties for each smaller integer alias and for a mixed row.
 // 2. Emplace protobuf property metadata through ProtobufFactory.EmplaceObject.
 // 3. Assert signed aliases become int32 and unsigned aliases become uint32.
 func TestProtobufFactorySmallerIntegerNormalization(t *testing.T) {
@@ -62,5 +62,46 @@ func TestProtobufFactorySmallerIntegerNormalization(t *testing.T) {
     if number.Index == nil || *number.Index != tuple.sequence {
       t.Fatalf("protobuf number tag %s should preserve its sequence: %#v", tuple.tag, number.Index)
     }
+  }
+
+  mixed := schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{
+    Name: "MixedSmallerIntegerProtobuf",
+    Properties: []*schemametadata.MetadataProperty{
+      testutil.Property("mixed", schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
+        Required: true,
+        Atomics: []*schemametadata.MetadataAtomic{
+          schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{
+            Type: "number",
+            Tags: [][]schemametadata.IMetadataTypeTag{
+              {
+                testutil.TypeTag("int8"),
+                testutil.SequenceTag(31),
+              },
+              {
+                testutil.TypeTag("uint8"),
+                testutil.SequenceTag(32),
+              },
+            },
+          }),
+        },
+      })),
+    },
+  })
+  nativefactories.ProtobufFactory.EmplaceObject(mixed)
+
+  property := mixed.Properties[0].Of_protobuf_
+  if property == nil || property.Fixed == false || len(property.Union) != 2 {
+    t.Fatalf("mixed smaller integer property should have two fixed unions: %#v", property)
+  }
+  sequences := map[string]int{}
+  for _, union := range property.Union {
+    number, ok := union.(*nativeprotobuf.IProtobufPropertyType_INumber)
+    if ok == false || number.Index == nil {
+      t.Fatalf("mixed smaller integer union should be a numbered protobuf number: %#v", union)
+    }
+    sequences[number.Name] = *number.Index
+  }
+  if sequences["int32"] != 31 || sequences["uint32"] != 32 {
+    t.Fatalf("mixed smaller integer aliases should keep separate protobuf buckets: %#v", sequences)
   }
 }

--- a/packages/typia/test/helpers/protobuf/protobuf_util_atomics_and_sequences_test.go
+++ b/packages/typia/test/helpers/protobuf/protobuf_util_atomics_and_sequences_test.go
@@ -60,29 +60,30 @@ func TestProtobufUtilAtomicsAndSequences(t *testing.T) {
     t.Fatal("protobuf atomic ordering should rank bool before string")
   }
 
-  smaller := metadata.MetadataSchema_create(metadata.MetadataSchema{
-    Atomics: []*metadata.MetadataAtomic{
-      metadata.MetadataAtomic_create(metadata.MetadataAtomic{
-        Type: "number",
-        Tags: [][]metadata.IMetadataTypeTag{{
-          testutil.TypeTag("int8"),
-          testutil.SequenceTag(8),
-        }},
-      }),
-      metadata.MetadataAtomic_create(metadata.MetadataAtomic{
-        Type: "number",
-        Tags: [][]metadata.IMetadataTypeTag{{
-          testutil.TypeTag("uint16"),
-          testutil.SequenceTag(9),
-        }},
-      }),
-    },
-  })
-  normalized := helpers.ProtobufUtil.GetAtomics(smaller)
-  if got := normalized["int32"]; got == nil || *got != 8 {
-    t.Fatalf("int8 should normalize to int32 with its sequence: %#v", normalized)
-  }
-  if got := normalized["uint32"]; got == nil || *got != 9 {
-    t.Fatalf("uint16 should normalize to uint32 with its sequence: %#v", normalized)
+  for _, tuple := range []struct {
+    tag      string
+    scalar   string
+    sequence int
+  }{
+    {tag: "int8", scalar: "int32", sequence: 8},
+    {tag: "uint8", scalar: "uint32", sequence: 9},
+    {tag: "int16", scalar: "int32", sequence: 10},
+    {tag: "uint16", scalar: "uint32", sequence: 11},
+  } {
+    smaller := metadata.MetadataSchema_create(metadata.MetadataSchema{
+      Atomics: []*metadata.MetadataAtomic{
+        metadata.MetadataAtomic_create(metadata.MetadataAtomic{
+          Type: "number",
+          Tags: [][]metadata.IMetadataTypeTag{{
+            testutil.TypeTag(tuple.tag),
+            testutil.SequenceTag(tuple.sequence),
+          }},
+        }),
+      },
+    })
+    normalized := helpers.ProtobufUtil.GetAtomics(smaller)
+    if got := normalized[tuple.scalar]; got == nil || *got != tuple.sequence {
+      t.Fatalf("%s should normalize to %s with its sequence: %#v", tuple.tag, tuple.scalar, normalized)
+    }
   }
 }

--- a/packages/typia/test/helpers/protobuf/protobuf_util_atomics_and_sequences_test.go
+++ b/packages/typia/test/helpers/protobuf/protobuf_util_atomics_and_sequences_test.go
@@ -1,11 +1,11 @@
 package typia_test
 
 import (
-	testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
-	"testing"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+  "testing"
 
-	helpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
-	metadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  helpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
+  metadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
 
 // TestProtobufUtilAtomicsAndSequences verifies protobuf atomic type extraction.
@@ -19,43 +19,70 @@ import (
 // 2. Extract protobuf atomic buckets.
 // 3. Assert tagged numeric and string sequences are preserved.
 // 4. Assert bigint defaults to int64 and scalar ordering ranks bool before string.
+// 5. Build smaller integer tag metadata and assert protobuf scalar normalization.
 func TestProtobufUtilAtomicsAndSequences(t *testing.T) {
-	sequence := 7
-	meta := metadata.MetadataSchema_create(metadata.MetadataSchema{
-		Atomics: []*metadata.MetadataAtomic{
-			metadata.MetadataAtomic_create(metadata.MetadataAtomic{
-				Type: "number",
-				Tags: [][]metadata.IMetadataTypeTag{{
-					{Kind: "type", Value: "uint32"},
-					testutil.SequenceTag(sequence),
-				}},
-			}),
-			metadata.MetadataAtomic_create(metadata.MetadataAtomic{Type: "bigint"}),
-		},
-		Constants: []*metadata.MetadataConstant{
-			metadata.MetadataConstant_create(metadata.MetadataConstant{
-				Type: "string",
-				Values: []*metadata.MetadataConstantValue{
-					metadata.MetadataConstantValue_create(metadata.MetadataConstantValue{
-						Value: "ok",
-						Tags:  [][]metadata.IMetadataTypeTag{{testutil.SequenceTag(3)}},
-					}),
-				},
-			}),
-		},
-	})
+  sequence := 7
+  meta := metadata.MetadataSchema_create(metadata.MetadataSchema{
+    Atomics: []*metadata.MetadataAtomic{
+      metadata.MetadataAtomic_create(metadata.MetadataAtomic{
+        Type: "number",
+        Tags: [][]metadata.IMetadataTypeTag{{
+          {Kind: "type", Value: "uint32"},
+          testutil.SequenceTag(sequence),
+        }},
+      }),
+      metadata.MetadataAtomic_create(metadata.MetadataAtomic{Type: "bigint"}),
+    },
+    Constants: []*metadata.MetadataConstant{
+      metadata.MetadataConstant_create(metadata.MetadataConstant{
+        Type: "string",
+        Values: []*metadata.MetadataConstantValue{
+          metadata.MetadataConstantValue_create(metadata.MetadataConstantValue{
+            Value: "ok",
+            Tags:  [][]metadata.IMetadataTypeTag{{testutil.SequenceTag(3)}},
+          }),
+        },
+      }),
+    },
+  })
 
-	atomics := helpers.ProtobufUtil.GetAtomics(meta)
-	if got := atomics["uint32"]; got == nil || *got != sequence {
-		t.Fatalf("uint32 sequence mismatch: %#v", got)
-	}
-	if _, ok := atomics["int64"]; !ok {
-		t.Fatalf("bigint atomic should default to int64: %#v", atomics)
-	}
-	if got := atomics["string"]; got == nil || *got != 3 {
-		t.Fatalf("string sequence mismatch: %#v", got)
-	}
-	if helpers.ProtobufUtil.Compare("bool", "string") >= 0 {
-		t.Fatal("protobuf atomic ordering should rank bool before string")
-	}
+  atomics := helpers.ProtobufUtil.GetAtomics(meta)
+  if got := atomics["uint32"]; got == nil || *got != sequence {
+    t.Fatalf("uint32 sequence mismatch: %#v", got)
+  }
+  if _, ok := atomics["int64"]; !ok {
+    t.Fatalf("bigint atomic should default to int64: %#v", atomics)
+  }
+  if got := atomics["string"]; got == nil || *got != 3 {
+    t.Fatalf("string sequence mismatch: %#v", got)
+  }
+  if helpers.ProtobufUtil.Compare("bool", "string") >= 0 {
+    t.Fatal("protobuf atomic ordering should rank bool before string")
+  }
+
+  smaller := metadata.MetadataSchema_create(metadata.MetadataSchema{
+    Atomics: []*metadata.MetadataAtomic{
+      metadata.MetadataAtomic_create(metadata.MetadataAtomic{
+        Type: "number",
+        Tags: [][]metadata.IMetadataTypeTag{{
+          testutil.TypeTag("int8"),
+          testutil.SequenceTag(8),
+        }},
+      }),
+      metadata.MetadataAtomic_create(metadata.MetadataAtomic{
+        Type: "number",
+        Tags: [][]metadata.IMetadataTypeTag{{
+          testutil.TypeTag("uint16"),
+          testutil.SequenceTag(9),
+        }},
+      }),
+    },
+  })
+  normalized := helpers.ProtobufUtil.GetAtomics(smaller)
+  if got := normalized["int32"]; got == nil || *got != 8 {
+    t.Fatalf("int8 should normalize to int32 with its sequence: %#v", normalized)
+  }
+  if got := normalized["uint32"]; got == nil || *got != 9 {
+    t.Fatalf("uint16 should normalize to uint32 with its sequence: %#v", normalized)
+  }
 }

--- a/packages/typia/test/helpers/protobuf/protobuf_util_bigint_constant_sequence_keeps_deduced_scalar_test.go
+++ b/packages/typia/test/helpers/protobuf/protobuf_util_bigint_constant_sequence_keeps_deduced_scalar_test.go
@@ -1,0 +1,44 @@
+package typia_test
+
+import (
+  "testing"
+
+  helpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
+  metadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+)
+
+// TestProtobufUtilBigintConstantSequenceKeepsDeducedScalar verifies sequence-only bigints.
+//
+// Bigint constants first deduce their protobuf scalar from literal values. A
+// sequence tag without an explicit type tag must keep that deduced scalar
+// instead of resetting the bucket to int64.
+//
+// 1. Build a positive bigint constant that deduces uint64.
+// 2. Add only a protobuf sequence tag to the constant.
+// 3. Assert GetBigints keeps the sequence under uint64 and not int64.
+func TestProtobufUtilBigintConstantSequenceKeepsDeducedScalar(t *testing.T) {
+  sequence := 17
+  meta := metadata.MetadataSchema_create(metadata.MetadataSchema{
+    Required: true,
+    Constants: []*metadata.MetadataConstant{
+      metadata.MetadataConstant_create(metadata.MetadataConstant{
+        Type: "bigint",
+        Values: []*metadata.MetadataConstantValue{
+          metadata.MetadataConstantValue_create(metadata.MetadataConstantValue{
+            Value: "7",
+            Tags:  [][]metadata.IMetadataTypeTag{{testutil.SequenceTag(sequence)}},
+          }),
+        },
+      }),
+    },
+  })
+
+  bigints := helpers.ProtobufUtil.GetBigints(meta)
+  if got := bigints["uint64"]; got == nil || *got != sequence {
+    t.Fatalf("sequence-only positive bigint constant should keep uint64 deduction: %#v", bigints)
+  }
+  if _, ok := bigints["int64"]; ok {
+    t.Fatalf("sequence-only positive bigint constant should not fall back to int64: %#v", bigints)
+  }
+}

--- a/packages/typia/test/helpers/protobuf/protobuf_util_numeric_constant_sequence_keeps_deduced_scalar_test.go
+++ b/packages/typia/test/helpers/protobuf/protobuf_util_numeric_constant_sequence_keeps_deduced_scalar_test.go
@@ -1,0 +1,44 @@
+package typia_test
+
+import (
+  "testing"
+
+  helpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
+  metadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+)
+
+// TestProtobufUtilNumericConstantSequenceKeepsDeducedScalar verifies sequence-only constants.
+//
+// Number constants first deduce their protobuf scalar from literal values. A
+// sequence tag without an explicit type tag must keep that deduced scalar
+// instead of resetting the bucket to double.
+//
+// 1. Build a number constant whose value is an int32-sized integer.
+// 2. Add only a protobuf sequence tag to the constant.
+// 3. Assert GetNumbers keeps the sequence under int32 and not double.
+func TestProtobufUtilNumericConstantSequenceKeepsDeducedScalar(t *testing.T) {
+  sequence := 7
+  meta := metadata.MetadataSchema_create(metadata.MetadataSchema{
+    Required: true,
+    Constants: []*metadata.MetadataConstant{
+      metadata.MetadataConstant_create(metadata.MetadataConstant{
+        Type: "number",
+        Values: []*metadata.MetadataConstantValue{
+          metadata.MetadataConstantValue_create(metadata.MetadataConstantValue{
+            Value: 1,
+            Tags:  [][]metadata.IMetadataTypeTag{{testutil.SequenceTag(sequence)}},
+          }),
+        },
+      }),
+    },
+  })
+
+  numbers := helpers.ProtobufUtil.GetNumbers(meta)
+  if got := numbers["int32"]; got == nil || *got != sequence {
+    t.Fatalf("sequence-only number constant should keep int32 deduction: %#v", numbers)
+  }
+  if _, ok := numbers["double"]; ok {
+    t.Fatalf("sequence-only number constant should not fall back to double: %#v", numbers)
+  }
+}

--- a/packages/typia/test/native/core/factories/metadata_comment_tag_factory_coverage_test.go
+++ b/packages/typia/test/native/core/factories/metadata_comment_tag_factory_coverage_test.go
@@ -4,9 +4,9 @@
 package factories
 
 import (
-	"testing"
+  "testing"
 
-	schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
 
 // TestMetadataCommentTagFactoryCoverage exercises JSDoc tag parsing.
@@ -21,188 +21,201 @@ import (
 // 4. Cover parser aliases, invalid numeric values, and date-time fallback paths.
 // 5. Confirm exported Get returns typed comment tags and panics on missing tags.
 func TestMetadataCommentTagFactoryCoverage(t *testing.T) {
-	reports := []string{}
-	report := func(msg string) any {
-		reports = append(reports, msg)
-		return nil
-	}
+  reports := []string{}
+  report := func(msg string) any {
+    reports = append(reports, msg)
+    return nil
+  }
 
-	unknown := metadataCommentTagFactory_parse(struct {
-		Report func(msg string) any
-		Tag    schemametadata.IJsDocTagInfo
-	}{Report: report, Tag: schemametadata.IJsDocTagInfo{Name: "unknown"}})
-	if unknown == nil || len(unknown) != 0 {
-		t.Fatal("unknown JSDoc tags should parse to an empty tag record")
-	}
-	missing := metadataCommentTagFactory_parse(struct {
-		Report func(msg string) any
-		Tag    schemametadata.IJsDocTagInfo
-	}{Report: report, Tag: schemametadata.IJsDocTagInfo{Name: "minLength"}})
-	if missing != nil || len(reports) == 0 {
-		t.Fatal("missing comment values should be reported")
-	}
-	unique := metadataCommentTagFactory_parse(struct {
-		Report func(msg string) any
-		Tag    schemametadata.IJsDocTagInfo
-	}{Report: report, Tag: schemametadata.IJsDocTagInfo{Name: "uniqueItems"}})
-	if len(unique["array"]) != 1 {
-		t.Fatal("uniqueItems should not require a text value")
-	}
-	numeric := metadataCommentTagFactory_parse(struct {
-		Report func(msg string) any
-		Tag    schemametadata.IJsDocTagInfo
-	}{
-		Report: report,
-		Tag: schemametadata.IJsDocTagInfo{
-			Name: "type",
-			Text: []schemametadata.IJsDocTagInfo_IText{{Text: "{uint}"}},
-		},
-	})
-	if numeric["number"][0].Value != "uint32" || numeric["bigint"][0].Value != "uint32" {
-		t.Fatal("typed numeric comment should normalize uint to uint32")
-	}
-	for _, tag := range []schemametadata.IJsDocTagInfo{
-		{Name: "items", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "2"}}},
-		{Name: "maxItems", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "3"}}},
-		{Name: "maximum", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "4"}}},
-		{Name: "exclusiveMinimum", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "5"}}},
-		{Name: "exclusiveMaximum", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "6"}}},
-		{Name: "multipleOf", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "7"}}},
-		{Name: "format", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "dateTime"}}},
-		{Name: "format", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "unknown"}}},
-		{Name: "pattern", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "^[a-z]+$"}}},
-		{Name: "length", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "8"}}},
-		{Name: "maxLength", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "9"}}},
-		{Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "int64"}}},
-		{Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "uint64"}}},
-		{Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "float"}}},
-		{Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "double"}}},
-		{Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "unknown"}}},
-	} {
-		_ = metadataCommentTagFactory_parse(struct {
-			Report func(msg string) any
-			Tag    schemametadata.IJsDocTagInfo
-		}{Report: report, Tag: tag})
-	}
-	invalidBefore := len(reports)
-	_ = metadataCommentTagFactory_parse_number(struct {
-		Report func(msg string) any
-		Value  string
-	}{Report: report, Value: "NaN"})
-	_ = metadataCommentTagFactory_parse_number(struct {
-		Report func(msg string) any
-		Value  string
-	}{Report: report, Value: "abc"})
-	_ = metadataCommentTagFactory_parse_integer(struct {
-		Report   func(msg string) any
-		Unsigned bool
-		Value    string
-	}{Report: report, Unsigned: false, Value: "1.5"})
-	_ = metadataCommentTagFactory_parse_integer(struct {
-		Report   func(msg string) any
-		Unsigned bool
-		Value    string
-	}{Report: report, Unsigned: true, Value: "-1"})
-	if len(reports) <= invalidBefore {
-		t.Fatal("invalid comment numeric values should be reported")
-	}
+  unknown := metadataCommentTagFactory_parse(struct {
+    Report func(msg string) any
+    Tag    schemametadata.IJsDocTagInfo
+  }{Report: report, Tag: schemametadata.IJsDocTagInfo{Name: "unknown"}})
+  if unknown == nil || len(unknown) != 0 {
+    t.Fatal("unknown JSDoc tags should parse to an empty tag record")
+  }
+  missing := metadataCommentTagFactory_parse(struct {
+    Report func(msg string) any
+    Tag    schemametadata.IJsDocTagInfo
+  }{Report: report, Tag: schemametadata.IJsDocTagInfo{Name: "minLength"}})
+  if missing != nil || len(reports) == 0 {
+    t.Fatal("missing comment values should be reported")
+  }
+  unique := metadataCommentTagFactory_parse(struct {
+    Report func(msg string) any
+    Tag    schemametadata.IJsDocTagInfo
+  }{Report: report, Tag: schemametadata.IJsDocTagInfo{Name: "uniqueItems"}})
+  if len(unique["array"]) != 1 {
+    t.Fatal("uniqueItems should not require a text value")
+  }
+  numeric := metadataCommentTagFactory_parse(struct {
+    Report func(msg string) any
+    Tag    schemametadata.IJsDocTagInfo
+  }{
+    Report: report,
+    Tag: schemametadata.IJsDocTagInfo{
+      Name: "type",
+      Text: []schemametadata.IJsDocTagInfo_IText{{Text: "{uint}"}},
+    },
+  })
+  if numeric["number"][0].Value != "uint32" || len(numeric["bigint"]) != 0 {
+    t.Fatal("typed uint comment should normalize to number-only uint32")
+  }
+  int8 := metadataCommentTagFactory_parse(struct {
+    Report func(msg string) any
+    Tag    schemametadata.IJsDocTagInfo
+  }{
+    Report: report,
+    Tag: schemametadata.IJsDocTagInfo{
+      Name: "type",
+      Text: []schemametadata.IJsDocTagInfo_IText{{Text: "int8"}},
+    },
+  })
+  if int8["number"][0].Value != "int8" || len(int8["bigint"]) != 0 {
+    t.Fatal("typed int8 comment should not leak into bigint tags")
+  }
+  for _, tag := range []schemametadata.IJsDocTagInfo{
+    {Name: "items", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "2"}}},
+    {Name: "maxItems", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "3"}}},
+    {Name: "maximum", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "4"}}},
+    {Name: "exclusiveMinimum", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "5"}}},
+    {Name: "exclusiveMaximum", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "6"}}},
+    {Name: "multipleOf", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "7"}}},
+    {Name: "format", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "dateTime"}}},
+    {Name: "format", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "unknown"}}},
+    {Name: "pattern", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "^[a-z]+$"}}},
+    {Name: "length", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "8"}}},
+    {Name: "maxLength", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "9"}}},
+    {Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "int64"}}},
+    {Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "uint64"}}},
+    {Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "float"}}},
+    {Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "double"}}},
+    {Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "unknown"}}},
+  } {
+    _ = metadataCommentTagFactory_parse(struct {
+      Report func(msg string) any
+      Tag    schemametadata.IJsDocTagInfo
+    }{Report: report, Tag: tag})
+  }
+  invalidBefore := len(reports)
+  _ = metadataCommentTagFactory_parse_number(struct {
+    Report func(msg string) any
+    Value  string
+  }{Report: report, Value: "NaN"})
+  _ = metadataCommentTagFactory_parse_number(struct {
+    Report func(msg string) any
+    Value  string
+  }{Report: report, Value: "abc"})
+  _ = metadataCommentTagFactory_parse_integer(struct {
+    Report   func(msg string) any
+    Unsigned bool
+    Value    string
+  }{Report: report, Unsigned: false, Value: "1.5"})
+  _ = metadataCommentTagFactory_parse_integer(struct {
+    Report   func(msg string) any
+    Unsigned bool
+    Value    string
+  }{Report: report, Unsigned: true, Value: "-1"})
+  if len(reports) <= invalidBefore {
+    t.Fatal("invalid comment numeric values should be reported")
+  }
 
-	meta := schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
-		Atomics: []*schemametadata.MetadataAtomic{
-			schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "string"}),
-			schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "number"}),
-			schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "bigint"}),
-		},
-		Arrays: []*schemametadata.MetadataArray{
-			schemametadata.MetadataArray_create(schemametadata.MetadataArray{}),
-		},
-	})
-	errors := []MetadataFactory_IError{}
-	MetadataCommentTagFactory.Analyze(struct {
-		Errors   *[]MetadataFactory_IError
-		Metadata *schemametadata.MetadataSchema
-		Tags     []schemametadata.IJsDocTagInfo
-		Explore  MetadataFactory_IExplore
-	}{
-		Errors:   &errors,
-		Metadata: meta,
-		Tags: []schemametadata.IJsDocTagInfo{
-			{Name: "minItems", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "1"}}},
-			{Name: "minLength", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "2"}}},
-			{Name: "minimum", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "3"}}},
-			{Name: "format", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "uuid"}}},
-		},
-	})
-	if len(errors) != 0 {
-		t.Fatalf("valid comment tags should not report errors: %#v", errors)
-	}
-	if len(meta.Arrays[0].Tags) == 0 ||
-		len(meta.Atomics[0].Tags) == 0 ||
-		len(meta.Atomics[1].Tags) == 0 ||
-		len(meta.Atomics[2].Tags) == 0 {
-		t.Fatal("comment tags were not applied to every supported metadata target")
-	}
-	oppositeOnly := schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
-		Atomics: []*schemametadata.MetadataAtomic{
-			schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "number"}),
-		},
-	})
-	MetadataCommentTagFactory.Analyze(struct {
-		Errors   *[]MetadataFactory_IError
-		Metadata *schemametadata.MetadataSchema
-		Tags     []schemametadata.IJsDocTagInfo
-		Explore  MetadataFactory_IExplore
-	}{
-		Errors:   &errors,
-		Metadata: oppositeOnly,
-		Tags: []schemametadata.IJsDocTagInfo{
-			{Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "int64"}}},
-			{Name: "format", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "date-time"}}},
-		},
-	})
-	if len(oppositeOnly.Atomics[0].Tags) == 0 {
-		t.Fatal("numeric comment tag should apply when only one numeric side exists")
-	}
+  meta := schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
+    Atomics: []*schemametadata.MetadataAtomic{
+      schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "string"}),
+      schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "number"}),
+      schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "bigint"}),
+    },
+    Arrays: []*schemametadata.MetadataArray{
+      schemametadata.MetadataArray_create(schemametadata.MetadataArray{}),
+    },
+  })
+  errors := []MetadataFactory_IError{}
+  MetadataCommentTagFactory.Analyze(struct {
+    Errors   *[]MetadataFactory_IError
+    Metadata *schemametadata.MetadataSchema
+    Tags     []schemametadata.IJsDocTagInfo
+    Explore  MetadataFactory_IExplore
+  }{
+    Errors:   &errors,
+    Metadata: meta,
+    Tags: []schemametadata.IJsDocTagInfo{
+      {Name: "minItems", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "1"}}},
+      {Name: "minLength", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "2"}}},
+      {Name: "minimum", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "3"}}},
+      {Name: "format", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "uuid"}}},
+    },
+  })
+  if len(errors) != 0 {
+    t.Fatalf("valid comment tags should not report errors: %#v", errors)
+  }
+  if len(meta.Arrays[0].Tags) == 0 ||
+    len(meta.Atomics[0].Tags) == 0 ||
+    len(meta.Atomics[1].Tags) == 0 ||
+    len(meta.Atomics[2].Tags) == 0 {
+    t.Fatal("comment tags were not applied to every supported metadata target")
+  }
+  oppositeOnly := schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
+    Atomics: []*schemametadata.MetadataAtomic{
+      schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "number"}),
+    },
+  })
+  MetadataCommentTagFactory.Analyze(struct {
+    Errors   *[]MetadataFactory_IError
+    Metadata *schemametadata.MetadataSchema
+    Tags     []schemametadata.IJsDocTagInfo
+    Explore  MetadataFactory_IExplore
+  }{
+    Errors:   &errors,
+    Metadata: oppositeOnly,
+    Tags: []schemametadata.IJsDocTagInfo{
+      {Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "int64"}}},
+      {Name: "format", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "date-time"}}},
+    },
+  })
+  if len(oppositeOnly.Atomics[0].Tags) == 0 {
+    t.Fatal("numeric comment tag should apply when only one numeric side exists")
+  }
 
-	empty := schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{})
-	MetadataCommentTagFactory.Analyze(struct {
-		Errors   *[]MetadataFactory_IError
-		Metadata *schemametadata.MetadataSchema
-		Tags     []schemametadata.IJsDocTagInfo
-		Explore  MetadataFactory_IExplore
-	}{
-		Errors:   &errors,
-		Metadata: empty,
-		Tags: []schemametadata.IJsDocTagInfo{
-			{Name: "pattern", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "^x$"}}},
-		},
-	})
-	if len(errors) == 0 {
-		t.Fatal("unsupported comment target should report metadata errors")
-	}
+  empty := schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{})
+  MetadataCommentTagFactory.Analyze(struct {
+    Errors   *[]MetadataFactory_IError
+    Metadata *schemametadata.MetadataSchema
+    Tags     []schemametadata.IJsDocTagInfo
+    Explore  MetadataFactory_IExplore
+  }{
+    Errors:   &errors,
+    Metadata: empty,
+    Tags: []schemametadata.IJsDocTagInfo{
+      {Name: "pattern", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "^x$"}}},
+    },
+  })
+  if len(errors) == 0 {
+    t.Fatal("unsupported comment target should report metadata errors")
+  }
 
-	if tag := MetadataCommentTagFactory.Get(struct {
-		Kind  string
-		Type  string
-		Value string
-	}{Kind: "type", Type: "number", Value: "int"})[0]; tag.Value != "int32" {
-		t.Fatal("exported comment tag getter should normalize integer aliases")
-	}
-	commentTagFactoryMustPanic(t, func() {
-		_ = MetadataCommentTagFactory.Get(struct {
-			Kind  string
-			Type  string
-			Value string
-		}{Kind: "unknown", Type: "string", Value: "x"})
-	})
+  if tag := MetadataCommentTagFactory.Get(struct {
+    Kind  string
+    Type  string
+    Value string
+  }{Kind: "type", Type: "number", Value: "int"})[0]; tag.Value != "int32" {
+    t.Fatal("exported comment tag getter should normalize integer aliases")
+  }
+  commentTagFactoryMustPanic(t, func() {
+    _ = MetadataCommentTagFactory.Get(struct {
+      Kind  string
+      Type  string
+      Value string
+    }{Kind: "unknown", Type: "string", Value: "x"})
+  })
 }
 
 func commentTagFactoryMustPanic(t *testing.T, run func()) {
-	t.Helper()
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected comment tag factory call to panic")
-		}
-	}()
-	run()
+  t.Helper()
+  defer func() {
+    if recover() == nil {
+      t.Fatal("expected comment tag factory call to panic")
+    }
+  }()
+  run()
 }

--- a/packages/typia/test/native/core/factories/metadata_comment_tag_factory_coverage_test.go
+++ b/packages/typia/test/native/core/factories/metadata_comment_tag_factory_coverage_test.go
@@ -48,31 +48,44 @@ func TestMetadataCommentTagFactoryCoverage(t *testing.T) {
   if len(unique["array"]) != 1 {
     t.Fatal("uniqueItems should not require a text value")
   }
-  numeric := metadataCommentTagFactory_parse(struct {
-    Report func(msg string) any
-    Tag    schemametadata.IJsDocTagInfo
+  for _, tuple := range []struct {
+    text         string
+    value        string
+    bigintTarget bool
   }{
-    Report: report,
-    Tag: schemametadata.IJsDocTagInfo{
-      Name: "type",
-      Text: []schemametadata.IJsDocTagInfo_IText{{Text: "{uint}"}},
-    },
-  })
-  if numeric["number"][0].Value != "uint32" || len(numeric["bigint"]) != 0 {
-    t.Fatal("typed uint comment should normalize to number-only uint32")
-  }
-  int8 := metadataCommentTagFactory_parse(struct {
-    Report func(msg string) any
-    Tag    schemametadata.IJsDocTagInfo
-  }{
-    Report: report,
-    Tag: schemametadata.IJsDocTagInfo{
-      Name: "type",
-      Text: []schemametadata.IJsDocTagInfo_IText{{Text: "int8"}},
-    },
-  })
-  if int8["number"][0].Value != "int8" || len(int8["bigint"]) != 0 {
-    t.Fatal("typed int8 comment should not leak into bigint tags")
+    {text: "{int}", value: "int32"},
+    {text: "{uint}", value: "uint32"},
+    {text: "int8", value: "int8"},
+    {text: "uint8", value: "uint8"},
+    {text: "int16", value: "int16"},
+    {text: "uint16", value: "uint16"},
+    {text: "int32", value: "int32"},
+    {text: "uint32", value: "uint32"},
+    {text: "int64", value: "int64", bigintTarget: true},
+    {text: "uint64", value: "uint64", bigintTarget: true},
+    {text: "float", value: "float"},
+    {text: "double", value: "double"},
+  } {
+    numeric := metadataCommentTagFactory_parse(struct {
+      Report func(msg string) any
+      Tag    schemametadata.IJsDocTagInfo
+    }{
+      Report: report,
+      Tag: schemametadata.IJsDocTagInfo{
+        Name: "type",
+        Text: []schemametadata.IJsDocTagInfo_IText{{Text: tuple.text}},
+      },
+    })
+    if numeric["number"][0].Value != tuple.value {
+      t.Fatalf("typed %s comment should normalize to number %s", tuple.text, tuple.value)
+    }
+    if tuple.bigintTarget {
+      if numeric["bigint"][0].Value != tuple.value {
+        t.Fatalf("typed %s comment should normalize to bigint %s", tuple.text, tuple.value)
+      }
+    } else if len(numeric["bigint"]) != 0 {
+      t.Fatalf("typed %s comment should not leak into bigint tags", tuple.text)
+    }
   }
   for _, tag := range []schemametadata.IJsDocTagInfo{
     {Name: "items", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "2"}}},
@@ -160,37 +173,42 @@ func TestMetadataCommentTagFactoryCoverage(t *testing.T) {
       schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "number"}),
     },
   })
+  oppositeErrors := []MetadataFactory_IError{}
   MetadataCommentTagFactory.Analyze(struct {
     Errors   *[]MetadataFactory_IError
     Metadata *schemametadata.MetadataSchema
     Tags     []schemametadata.IJsDocTagInfo
     Explore  MetadataFactory_IExplore
   }{
-    Errors:   &errors,
+    Errors:   &oppositeErrors,
     Metadata: oppositeOnly,
     Tags: []schemametadata.IJsDocTagInfo{
       {Name: "type", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "int64"}}},
       {Name: "format", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "date-time"}}},
     },
   })
+  if len(oppositeErrors) != 0 {
+    t.Fatalf("opposite numeric comment targets should be skipped without errors: %#v", oppositeErrors)
+  }
   if len(oppositeOnly.Atomics[0].Tags) == 0 {
     t.Fatal("numeric comment tag should apply when only one numeric side exists")
   }
 
   empty := schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{})
+  unsupportedErrors := []MetadataFactory_IError{}
   MetadataCommentTagFactory.Analyze(struct {
     Errors   *[]MetadataFactory_IError
     Metadata *schemametadata.MetadataSchema
     Tags     []schemametadata.IJsDocTagInfo
     Explore  MetadataFactory_IExplore
   }{
-    Errors:   &errors,
+    Errors:   &unsupportedErrors,
     Metadata: empty,
     Tags: []schemametadata.IJsDocTagInfo{
       {Name: "pattern", Text: []schemametadata.IJsDocTagInfo_IText{{Text: "^x$"}}},
     },
   })
-  if len(errors) == 0 {
+  if len(unsupportedErrors) == 0 {
     t.Fatal("unsupported comment target should report metadata errors")
   }
 

--- a/packages/typia/test/native/core/factories/protobuf_factory_smaller_integer_normalization_test.go
+++ b/packages/typia/test/native/core/factories/protobuf_factory_smaller_integer_normalization_test.go
@@ -1,0 +1,57 @@
+//go:build typia_native_internal
+// +build typia_native_internal
+
+package factories
+
+import (
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestProtobufFactorySmallerIntegerNormalization verifies protobuf scalar aliasing.
+//
+// Protobuf does not have int8, uint8, int16, or uint16 scalar types. The factory
+// path must still consume those typia numeric tags without falling back to
+// double, because protobuf message generation and sequence validation use this
+// decoder directly.
+//
+// 1. Build tagged number constants for each smaller integer alias.
+// 2. Decode protobuf number tags through the factory helper.
+// 3. Assert signed aliases become int32 and unsigned aliases become uint32.
+func TestProtobufFactorySmallerIntegerNormalization(t *testing.T) {
+  for _, tuple := range []struct {
+    tag      string
+    scalar   string
+    sequence int
+  }{
+    {tag: "int8", scalar: "int32", sequence: 21},
+    {tag: "uint8", scalar: "uint32", sequence: 22},
+    {tag: "int16", scalar: "int32", sequence: 23},
+    {tag: "uint16", scalar: "uint32", sequence: 24},
+  } {
+    output := map[string]*int{}
+    protobufFactory_decodeNumber(output, []*schemametadata.MetadataConstantValue{
+      schemametadata.MetadataConstantValue_create(schemametadata.MetadataConstantValue{
+        Value: 3,
+        Tags: [][]schemametadata.IMetadataTypeTag{{
+          {Kind: "type", Value: tuple.tag},
+          protobufFactorySmallerIntegerSequenceTag(tuple.sequence),
+        }},
+      }),
+    }, "double")
+    if got := output[tuple.scalar]; got == nil || *got != tuple.sequence {
+      t.Fatalf("protobuf number tag %s should normalize to %s with its sequence: %#v", tuple.tag, tuple.scalar, output)
+    }
+    if _, ok := output[tuple.tag]; ok {
+      t.Fatalf("protobuf number tag %s should not remain under its non-scalar alias: %#v", tuple.tag, output)
+    }
+  }
+}
+
+func protobufFactorySmallerIntegerSequenceTag(value int) schemametadata.IMetadataTypeTag {
+  return schemametadata.IMetadataTypeTag{
+    Kind:   "sequence",
+    Schema: map[string]any{"x-protobuf-sequence": value},
+  }
+}

--- a/packages/typia/test/native/core/factories/protobuf_factory_smaller_integer_normalization_test.go
+++ b/packages/typia/test/native/core/factories/protobuf_factory_smaller_integer_normalization_test.go
@@ -1,23 +1,22 @@
-//go:build typia_native_internal
-// +build typia_native_internal
-
 package factories
 
 import (
   "testing"
 
+  nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
   schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  nativeprotobuf "github.com/samchon/typia/packages/typia/native/core/schemas/protobuf"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
 )
 
 // TestProtobufFactorySmallerIntegerNormalization verifies protobuf scalar aliasing.
 //
 // Protobuf does not have int8, uint8, int16, or uint16 scalar types. The factory
-// path must still consume those typia numeric tags without falling back to
-// double, because protobuf message generation and sequence validation use this
-// decoder directly.
+// path must still consume those typia numeric tags through its exported object
+// emplacement API without falling back to double.
 //
-// 1. Build tagged number constants for each smaller integer alias.
-// 2. Decode protobuf number tags through the factory helper.
+// 1. Build an object property for each smaller integer alias.
+// 2. Emplace protobuf property metadata through ProtobufFactory.EmplaceObject.
 // 3. Assert signed aliases become int32 and unsigned aliases become uint32.
 func TestProtobufFactorySmallerIntegerNormalization(t *testing.T) {
   for _, tuple := range []struct {
@@ -30,28 +29,38 @@ func TestProtobufFactorySmallerIntegerNormalization(t *testing.T) {
     {tag: "int16", scalar: "int32", sequence: 23},
     {tag: "uint16", scalar: "uint32", sequence: 24},
   } {
-    output := map[string]*int{}
-    protobufFactory_decodeNumber(output, []*schemametadata.MetadataConstantValue{
-      schemametadata.MetadataConstantValue_create(schemametadata.MetadataConstantValue{
-        Value: 3,
-        Tags: [][]schemametadata.IMetadataTypeTag{{
-          {Kind: "type", Value: tuple.tag},
-          protobufFactorySmallerIntegerSequenceTag(tuple.sequence),
-        }},
-      }),
-    }, "double")
-    if got := output[tuple.scalar]; got == nil || *got != tuple.sequence {
-      t.Fatalf("protobuf number tag %s should normalize to %s with its sequence: %#v", tuple.tag, tuple.scalar, output)
-    }
-    if _, ok := output[tuple.tag]; ok {
-      t.Fatalf("protobuf number tag %s should not remain under its non-scalar alias: %#v", tuple.tag, output)
-    }
-  }
-}
+    object := schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{
+      Name: "SmallerIntegerProtobuf",
+      Properties: []*schemametadata.MetadataProperty{
+        testutil.Property(tuple.tag, schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
+          Required: true,
+          Atomics: []*schemametadata.MetadataAtomic{
+            schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{
+              Type: "number",
+              Tags: [][]schemametadata.IMetadataTypeTag{{
+                testutil.TypeTag(tuple.tag),
+                testutil.SequenceTag(tuple.sequence),
+              }},
+            }),
+          },
+        })),
+      },
+    })
+    nativefactories.ProtobufFactory.EmplaceObject(object)
 
-func protobufFactorySmallerIntegerSequenceTag(value int) schemametadata.IMetadataTypeTag {
-  return schemametadata.IMetadataTypeTag{
-    Kind:   "sequence",
-    Schema: map[string]any{"x-protobuf-sequence": value},
+    property := object.Properties[0].Of_protobuf_
+    if property == nil || property.Fixed == false || len(property.Union) != 1 {
+      t.Fatalf("protobuf property for %s was not fixed as a single union: %#v", tuple.tag, property)
+    }
+    number, ok := property.Union[0].(*nativeprotobuf.IProtobufPropertyType_INumber)
+    if ok == false {
+      t.Fatalf("protobuf property for %s should be a number: %#v", tuple.tag, property.Union[0])
+    }
+    if number.Name != tuple.scalar {
+      t.Fatalf("protobuf number tag %s should normalize to %s: %#v", tuple.tag, tuple.scalar, number)
+    }
+    if number.Index == nil || *number.Index != tuple.sequence {
+      t.Fatalf("protobuf number tag %s should preserve its sequence: %#v", tuple.tag, number.Index)
+    }
   }
 }

--- a/tests/template/src/structures/CommentTagType.ts
+++ b/tests/template/src/structures/CommentTagType.ts
@@ -25,6 +25,18 @@ export namespace CommentTagType {
     /** @type uint32 */
     uint32: number;
 
+    /** @type int8 */
+    int8: number;
+
+    /** @type uint8 */
+    uint8: number;
+
+    /** @type int16 */
+    int16: number;
+
+    /** @type uint16 */
+    uint16: number;
+
     /** @type int64 */
     int64: number;
 
@@ -42,17 +54,47 @@ export namespace CommentTagType {
         value.push({
           int,
           uint,
+          int8: int,
+          uint8: uint,
+          int16: int,
+          uint16: uint,
           int32: int,
           uint32: uint,
           int64: int,
           uint64: uint,
           float: int + 0.1,
         });
+    value.push({
+      int: -2147483648,
+      uint: 4294967295,
+      int8: -128,
+      uint8: 255,
+      int16: -32768,
+      uint16: 65535,
+      int32: -2147483648,
+      uint32: 4294967295,
+      int64: -2147483648,
+      uint64: 4294967295,
+      float: -1.175494351e38,
+    });
+    value.push({
+      int: 2147483647,
+      uint: 0,
+      int8: 127,
+      uint8: 0,
+      int16: 32767,
+      uint16: 0,
+      int32: 2147483647,
+      uint32: 0,
+      int64: 2147483647,
+      uint64: 0,
+      float: 3.4028235e38,
+    });
     return { value };
   }
 
   export const SPOILERS: Spoiler<CommentTagType>[] = [
-    ...(["int", "int32", "int64"] as const)
+    ...(["int", "int8", "int16", "int32", "int64"] as const)
       .map((key) => [
         (input: CommentTagType) => {
           input.value[0]![key] = 0.5;
@@ -68,7 +110,7 @@ export namespace CommentTagType {
       input.value[0]!.int = 0.1;
       return ["$input.value[0].int"];
     },
-    ...(["uint", "uint32", "uint64"] as const)
+    ...(["uint", "uint8", "uint16", "uint32", "uint64"] as const)
       .map((key) => [
         (input: CommentTagType) => {
           input.value[0]![key] = -1;
@@ -95,6 +137,30 @@ export namespace CommentTagType {
     (input) => {
       input.value[2]!.int = 2147483648;
       return ["$input.value[2].int"];
+    },
+    (input) => {
+      input.value[0]!.uint8 = 256;
+      return ["$input.value[0].uint8"];
+    },
+    (input) => {
+      input.value[1]!.int8 = -129;
+      return ["$input.value[1].int8"];
+    },
+    (input) => {
+      input.value[2]!.int8 = 128;
+      return ["$input.value[2].int8"];
+    },
+    (input) => {
+      input.value[0]!.uint16 = 65536;
+      return ["$input.value[0].uint16"];
+    },
+    (input) => {
+      input.value[1]!.int16 = -32769;
+      return ["$input.value[1].int16"];
+    },
+    (input) => {
+      input.value[2]!.int16 = 32768;
+      return ["$input.value[2].int16"];
     },
     (input) => {
       input.value[0]!.uint32 = 4294967296;

--- a/tests/template/src/structures/TypeTagType.ts
+++ b/tests/template/src/structures/TypeTagType.ts
@@ -8,6 +8,10 @@ export namespace TypeTagType {
   export interface Type {
     int: number & typia.tags.Type<"int32">;
     uint: number & typia.tags.Type<"uint32">;
+    int8: number & typia.tags.Type<"int8">;
+    uint8: number & typia.tags.Type<"uint8">;
+    int16: number & typia.tags.Type<"int16">;
+    uint16: number & typia.tags.Type<"uint16">;
     int32: number & typia.tags.Type<"int32">;
     uint32: number & typia.tags.Type<"uint32">;
     int64: number & typia.tags.Type<"int64">;
@@ -22,17 +26,47 @@ export namespace TypeTagType {
         value.push({
           int,
           uint,
+          int8: int,
+          uint8: uint,
+          int16: int,
+          uint16: uint,
           int32: int,
           uint32: uint,
           int64: int,
           uint64: uint,
           float: int + 0.1,
         });
+    value.push({
+      int: -2147483648,
+      uint: 4294967295,
+      int8: -128,
+      uint8: 255,
+      int16: -32768,
+      uint16: 65535,
+      int32: -2147483648,
+      uint32: 4294967295,
+      int64: -2147483648,
+      uint64: 4294967295,
+      float: -1.175494351e38,
+    });
+    value.push({
+      int: 2147483647,
+      uint: 0,
+      int8: 127,
+      uint8: 0,
+      int16: 32767,
+      uint16: 0,
+      int32: 2147483647,
+      uint32: 0,
+      int64: 2147483647,
+      uint64: 0,
+      float: 3.4028235e38,
+    });
     return { value };
   }
 
   export const SPOILERS: Spoiler<TypeTagType>[] = [
-    ...(["int", "int32", "int64"] as const)
+    ...(["int", "int8", "int16", "int32", "int64"] as const)
       .map((key) => [
         (input: TypeTagType) => {
           input.value[0]![key] = 0.5;
@@ -48,7 +82,7 @@ export namespace TypeTagType {
       input.value[0]!.int = 0.1;
       return ["$input.value[0].int"];
     },
-    ...(["uint", "uint32", "uint64"] as const)
+    ...(["uint", "uint8", "uint16", "uint32", "uint64"] as const)
       .map((key) => [
         (input: TypeTagType) => {
           input.value[0]![key] = -1;
@@ -75,6 +109,30 @@ export namespace TypeTagType {
     (input) => {
       input.value[2]!.int = 2147483648;
       return ["$input.value[2].int"];
+    },
+    (input) => {
+      input.value[0]!.uint8 = 256;
+      return ["$input.value[0].uint8"];
+    },
+    (input) => {
+      input.value[1]!.int8 = -129;
+      return ["$input.value[1].int8"];
+    },
+    (input) => {
+      input.value[2]!.int8 = 128;
+      return ["$input.value[2].int8"];
+    },
+    (input) => {
+      input.value[0]!.uint16 = 65536;
+      return ["$input.value[0].uint16"];
+    },
+    (input) => {
+      input.value[1]!.int16 = -32769;
+      return ["$input.value[1].int16"];
+    },
+    (input) => {
+      input.value[2]!.int16 = 32768;
+      return ["$input.value[2].int16"];
     },
     (input) => {
       input.value[0]!.uint32 = 4294967296;

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_spec_number.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_spec_number.ts
@@ -2,6 +2,20 @@ import { TestValidator } from "@nestia/e2e";
 import typia, { tags } from "typia";
 
 export const test_json_schema_spec_number = (): void => {
+  interface ICommentTypeNumbers {
+    /** @type int8 */
+    int8: number;
+
+    /** @type uint8 */
+    uint8: number;
+
+    /** @type int16 */
+    int16: number;
+
+    /** @type uint16 */
+    uint16: number;
+  }
+
   TestValidator.equals("number", clean(typia.json.schema<number>().schema), {
     type: "number",
   });
@@ -80,6 +94,31 @@ export const test_json_schema_spec_number = (): void => {
     {
       type: "number",
       multipleOf: 5,
+    },
+  );
+  TestValidator.equals(
+    "comment type smaller integers",
+    clean(typia.json.schema<ICommentTypeNumbers>().schema),
+    {
+      type: "object",
+      properties: {
+        int8: {
+          type: "integer",
+        },
+        int16: {
+          type: "integer",
+        },
+        uint8: {
+          type: "integer",
+          minimum: 0,
+        },
+        uint16: {
+          type: "integer",
+          minimum: 0,
+        },
+      },
+      required: ["int8", "uint8", "int16", "uint16"],
+      additionalProperties: false,
     },
   );
   TestValidator.equals(

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_spec_number.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_spec_number.ts
@@ -16,31 +16,31 @@ export const test_json_schema_spec_number = (): void => {
     uint16: number;
   }
 
-  TestValidator.equals("number", clean(typia.json.schema<number>().schema), {
+  equalsSchema("number", clean(typia.json.schema<number>().schema), {
     type: "number",
   });
-  TestValidator.equals(
+  equalsSchema(
     "int32",
     clean(typia.json.schema<number & tags.Type<"int32">>().schema),
     {
       type: "integer",
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "int8",
     clean(typia.json.schema<number & tags.Type<"int8">>().schema),
     {
       type: "integer",
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "int16",
     clean(typia.json.schema<number & tags.Type<"int16">>().schema),
     {
       type: "integer",
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "uint32",
     clean(typia.json.schema<number & tags.Type<"uint32">>().schema),
     {
@@ -48,7 +48,7 @@ export const test_json_schema_spec_number = (): void => {
       minimum: 0,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "uint8",
     clean(typia.json.schema<number & tags.Type<"uint8">>().schema),
     {
@@ -56,7 +56,7 @@ export const test_json_schema_spec_number = (): void => {
       minimum: 0,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "uint16",
     clean(typia.json.schema<number & tags.Type<"uint16">>().schema),
     {
@@ -64,7 +64,7 @@ export const test_json_schema_spec_number = (): void => {
       minimum: 0,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "inclusive range",
     clean(
       typia.json.schema<number & tags.Minimum<1> & tags.Maximum<10>>().schema,
@@ -75,7 +75,7 @@ export const test_json_schema_spec_number = (): void => {
       maximum: 10,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "exclusive range",
     clean(
       typia.json.schema<
@@ -88,7 +88,7 @@ export const test_json_schema_spec_number = (): void => {
       exclusiveMaximum: 10,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "multipleOf",
     clean(typia.json.schema<number & tags.MultipleOf<5>>().schema),
     {
@@ -96,7 +96,7 @@ export const test_json_schema_spec_number = (): void => {
       multipleOf: 5,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "comment type smaller integers",
     clean(typia.json.schema<ICommentTypeNumbers>().schema),
     {
@@ -121,7 +121,7 @@ export const test_json_schema_spec_number = (): void => {
       additionalProperties: false,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "number literal union",
     normalizeOneOf(clean(typia.json.schema<1 | 2 | 3>().schema)),
     {
@@ -141,6 +141,15 @@ export const test_json_schema_spec_number = (): void => {
 };
 
 const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const equalsSchema = (
+  title: string,
+  actual: unknown,
+  expected: unknown,
+): void => {
+  TestValidator.equals(`${title}.actual`, actual, expected);
+  TestValidator.equals(`${title}.expected`, expected, actual);
+};
 
 const normalizeOneOf = (schema: any): any => ({
   ...schema,

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_spec_number.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_spec_number.ts
@@ -13,8 +13,38 @@ export const test_json_schema_spec_number = (): void => {
     },
   );
   TestValidator.equals(
+    "int8",
+    clean(typia.json.schema<number & tags.Type<"int8">>().schema),
+    {
+      type: "integer",
+    },
+  );
+  TestValidator.equals(
+    "int16",
+    clean(typia.json.schema<number & tags.Type<"int16">>().schema),
+    {
+      type: "integer",
+    },
+  );
+  TestValidator.equals(
     "uint32",
     clean(typia.json.schema<number & tags.Type<"uint32">>().schema),
+    {
+      type: "integer",
+      minimum: 0,
+    },
+  );
+  TestValidator.equals(
+    "uint8",
+    clean(typia.json.schema<number & tags.Type<"uint8">>().schema),
+    {
+      type: "integer",
+      minimum: 0,
+    },
+  );
+  TestValidator.equals(
+    "uint16",
+    clean(typia.json.schema<number & tags.Type<"uint16">>().schema),
     {
       type: "integer",
       minimum: 0,

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_number.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_number.ts
@@ -149,6 +149,39 @@ export const test_llm_schema_spec_number = (): void => {
       additionalProperties: false,
     },
   );
+  const strictCommentTypeDefs: Record<string, ILlmSchema> = {};
+  TestValidator.equals(
+    "strict comment type smaller integers",
+    clean(
+      resolve(
+        typia.llm.schema<ICommentTypeNumbers, { strict: true }>(
+          strictCommentTypeDefs,
+        ),
+        strictCommentTypeDefs,
+      ),
+    ),
+    {
+      type: "object",
+      properties: {
+        int8: {
+          type: "integer",
+        },
+        int16: {
+          type: "integer",
+        },
+        uint8: {
+          type: "integer",
+          description: "@minimum 0",
+        },
+        uint16: {
+          type: "integer",
+          description: "@minimum 0",
+        },
+      },
+      required: ["int8", "uint8", "int16", "uint16"],
+      additionalProperties: false,
+    },
+  );
   TestValidator.equals(
     "number literal union",
     enumSchema(typia.llm.schema<1 | 2 | 3>({})),

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_number.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_number.ts
@@ -14,8 +14,38 @@ export const test_llm_schema_spec_number = (): void => {
     },
   );
   TestValidator.equals(
+    "int8",
+    clean(typia.llm.schema<number & tags.Type<"int8">>({})),
+    {
+      type: "integer",
+    },
+  );
+  TestValidator.equals(
+    "int16",
+    clean(typia.llm.schema<number & tags.Type<"int16">>({})),
+    {
+      type: "integer",
+    },
+  );
+  TestValidator.equals(
     "uint32",
     clean(typia.llm.schema<number & tags.Type<"uint32">>({})),
+    {
+      type: "integer",
+      minimum: 0,
+    },
+  );
+  TestValidator.equals(
+    "uint8",
+    clean(typia.llm.schema<number & tags.Type<"uint8">>({})),
+    {
+      type: "integer",
+      minimum: 0,
+    },
+  );
+  TestValidator.equals(
+    "uint16",
+    clean(typia.llm.schema<number & tags.Type<"uint16">>({})),
     {
       type: "integer",
       minimum: 0,

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_number.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_number.ts
@@ -17,31 +17,31 @@ export const test_llm_schema_spec_number = (): void => {
     uint16: number;
   }
 
-  TestValidator.equals("number", clean(typia.llm.schema<number>({})), {
+  equalsSchema("number", clean(typia.llm.schema<number>({})), {
     type: "number",
   });
-  TestValidator.equals(
+  equalsSchema(
     "int32",
     clean(typia.llm.schema<number & tags.Type<"int32">>({})),
     {
       type: "integer",
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "int8",
     clean(typia.llm.schema<number & tags.Type<"int8">>({})),
     {
       type: "integer",
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "int16",
     clean(typia.llm.schema<number & tags.Type<"int16">>({})),
     {
       type: "integer",
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "uint32",
     clean(typia.llm.schema<number & tags.Type<"uint32">>({})),
     {
@@ -49,7 +49,7 @@ export const test_llm_schema_spec_number = (): void => {
       minimum: 0,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "uint8",
     clean(typia.llm.schema<number & tags.Type<"uint8">>({})),
     {
@@ -57,7 +57,7 @@ export const test_llm_schema_spec_number = (): void => {
       minimum: 0,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "uint16",
     clean(typia.llm.schema<number & tags.Type<"uint16">>({})),
     {
@@ -65,14 +65,14 @@ export const test_llm_schema_spec_number = (): void => {
       minimum: 0,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "float",
     clean(typia.llm.schema<number & tags.Type<"float">>({})),
     {
       type: "number",
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "inclusive range",
     clean(typia.llm.schema<number & tags.Minimum<1> & tags.Maximum<10>>({})),
     {
@@ -81,7 +81,7 @@ export const test_llm_schema_spec_number = (): void => {
       maximum: 10,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "exclusive range",
     clean(
       typia.llm.schema<
@@ -94,7 +94,7 @@ export const test_llm_schema_spec_number = (): void => {
       exclusiveMaximum: 10,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "multipleOf",
     clean(typia.llm.schema<number & tags.MultipleOf<5>>({})),
     {
@@ -102,7 +102,7 @@ export const test_llm_schema_spec_number = (): void => {
       multipleOf: 5,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "number default",
     clean(typia.llm.schema<number & tags.Default<3>>({})),
     {
@@ -110,7 +110,7 @@ export const test_llm_schema_spec_number = (): void => {
       default: 3,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "strict uint8 shifts minimum",
     clean(typia.llm.schema<number & tags.Type<"uint8">, { strict: true }>({})),
     {
@@ -119,7 +119,7 @@ export const test_llm_schema_spec_number = (): void => {
     },
   );
   const commentTypeDefs: Record<string, ILlmSchema> = {};
-  TestValidator.equals(
+  equalsSchema(
     "comment type smaller integers",
     clean(
       resolve(
@@ -150,7 +150,7 @@ export const test_llm_schema_spec_number = (): void => {
     },
   );
   const strictCommentTypeDefs: Record<string, ILlmSchema> = {};
-  TestValidator.equals(
+  equalsSchema(
     "strict comment type smaller integers",
     clean(
       resolve(
@@ -182,7 +182,7 @@ export const test_llm_schema_spec_number = (): void => {
       additionalProperties: false,
     },
   );
-  TestValidator.equals(
+  equalsSchema(
     "number literal union",
     enumSchema(typia.llm.schema<1 | 2 | 3>({})),
     {
@@ -193,6 +193,15 @@ export const test_llm_schema_spec_number = (): void => {
 };
 
 const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const equalsSchema = (
+  title: string,
+  actual: unknown,
+  expected: unknown,
+): void => {
+  TestValidator.equals(`${title}.actual`, actual, expected);
+  TestValidator.equals(`${title}.expected`, expected, actual);
+};
 
 const enumSchema = (
   schema: ILlmSchema,

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_number.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_number.ts
@@ -3,6 +3,20 @@ import { ILlmSchema } from "@typia/interface";
 import typia, { tags } from "typia";
 
 export const test_llm_schema_spec_number = (): void => {
+  interface ICommentTypeNumbers {
+    /** @type int8 */
+    int8: number;
+
+    /** @type uint8 */
+    uint8: number;
+
+    /** @type int16 */
+    int16: number;
+
+    /** @type uint16 */
+    uint16: number;
+  }
+
   TestValidator.equals("number", clean(typia.llm.schema<number>({})), {
     type: "number",
   });
@@ -97,6 +111,45 @@ export const test_llm_schema_spec_number = (): void => {
     },
   );
   TestValidator.equals(
+    "strict uint8 shifts minimum",
+    clean(typia.llm.schema<number & tags.Type<"uint8">, { strict: true }>({})),
+    {
+      type: "integer",
+      description: "@minimum 0",
+    },
+  );
+  const commentTypeDefs: Record<string, ILlmSchema> = {};
+  TestValidator.equals(
+    "comment type smaller integers",
+    clean(
+      resolve(
+        typia.llm.schema<ICommentTypeNumbers>(commentTypeDefs),
+        commentTypeDefs,
+      ),
+    ),
+    {
+      type: "object",
+      properties: {
+        int8: {
+          type: "integer",
+        },
+        int16: {
+          type: "integer",
+        },
+        uint8: {
+          type: "integer",
+          minimum: 0,
+        },
+        uint16: {
+          type: "integer",
+          minimum: 0,
+        },
+      },
+      required: ["int8", "uint8", "int16", "uint16"],
+      additionalProperties: false,
+    },
+  );
+  TestValidator.equals(
     "number literal union",
     enumSchema(typia.llm.schema<1 | 2 | 3>({})),
     {
@@ -114,3 +167,11 @@ const enumSchema = (
   type: (schema as { type?: string }).type,
   enum: [...((schema as { enum?: unknown[] }).enum ?? [])].sort(),
 });
+
+const resolve = (
+  schema: ILlmSchema,
+  $defs: Record<string, ILlmSchema>,
+): ILlmSchema => {
+  if ("$ref" in schema) return $defs[schema.$ref.split("/").at(-1)!]!;
+  return schema;
+};

--- a/website/src/content/docs/protobuf/message.mdx
+++ b/website/src/content/docs/protobuf/message.mdx
@@ -68,6 +68,8 @@ type Mixed = (number & tags.Type<"int32">) | (bigint & tags.Type<"uint64">);
 
 If you don't tag a `number`, typia treats it as `double`. If you don't tag a `bigint`, typia treats it as `int64`.
 
+`tags.Type<"int8">` and `tags.Type<"int16">` validate the smaller signed integer ranges, then emit the protobuf `int32` scalar type. `tags.Type<"uint8">` and `tags.Type<"uint16">` validate the smaller unsigned integer ranges, then emit `uint32`. Protocol Buffer has no distinct 8-bit or 16-bit numeric scalar types.
+
 > The TypeScript compiler will block invalid combinations — you can't put `tags.Type<"uint32">` on a `bigint`, for example.
 
 <Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
@@ -91,6 +93,9 @@ Same wire types are also expressible as `@type` comments:
 
 ```typescript copy
 interface User {
+  /** @type uint8 */
+  priority: number;
+
   /** @type uint32 */
   age: number;
 }

--- a/website/src/content/docs/protobuf/message.mdx
+++ b/website/src/content/docs/protobuf/message.mdx
@@ -56,9 +56,9 @@ console.log(proto);
   </Tabs.Tab>
 </Tabs>
 
-## Wire types
+## Numeric scalar types
 
-Protocol Buffer has narrower numeric types than TypeScript (`int32`, `uint32`, `int64`, `uint64`, `float`, `double`). Use [type tags](/docs/validators/tags) to pick the wire type explicitly:
+Protocol Buffer has narrower numeric types than TypeScript (`int32`, `uint32`, `int64`, `uint64`, `float`, `double`). Use [type tags](/docs/validators/tags) to pick the protobuf scalar type explicitly:
 
 ```typescript copy
 type Score = number & tags.Type<"float">;
@@ -89,7 +89,7 @@ If you don't tag a `number`, typia treats it as `double`. If you don't tag a `bi
 
 ## Comment tags
 
-Same wire types are also expressible as `@type` comments:
+The same scalar choices are also expressible as `@type` comments:
 
 ```typescript copy
 interface User {
@@ -103,7 +103,7 @@ interface User {
 
 > [!CAUTION]
 >
-> Same caveats as [`validators/tags`](/docs/validators/tags#comment-tags): comment tags are not type-checked (a typo silently falls back to `double`), they only work on object properties, and they can't express union numeric types. Prefer type tags unless you're maintaining a JSDoc-style codebase.
+> Same caveats as [`validators/tags`](/docs/validators/tags#comment-tags): comment tags are not type-checked (a typo is ignored, so protobuf falls back to the default `double` scalar for an untagged `number`), they only work on object properties, and they can't express union numeric types. Prefer type tags unless you're maintaining a JSDoc-style codebase.
 
 <Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>

--- a/website/src/content/docs/validators/tags.mdx
+++ b/website/src/content/docs/validators/tags.mdx
@@ -95,7 +95,7 @@ If you intersect a tag with the wrong base type (e.g. `tags.MaxLength<100>` on a
 
 | Tag | Notes |
 |-----|-------|
-| `tags.Type<"int32" \| "uint32" \| "int64" \| "uint64" \| "float" \| "double">` | Sub-type of `number` (or, for `int64`/`uint64`, of `bigint`) |
+| `tags.Type<"int8" \| "uint8" \| "int16" \| "uint16" \| "int32" \| "uint32" \| "int64" \| "uint64" \| "float" \| "double">` | Sub-type of `number` (or, for `int64`/`uint64`, of `bigint`) |
 | `tags.Minimum<N>` | `value >= N` |
 | `tags.Maximum<N>` | `value <= N` |
 | `tags.ExclusiveMinimum<N>` | `value > N` |
@@ -144,7 +144,16 @@ If you'd rather write JSDoc, the same constraints exist as `@`-prefixed tags:
 
 | Comment tag | Equivalent type tag |
 |-------------|---------------------|
+| `@type int8` | `tags.Type<"int8">` |
+| `@type uint8` | `tags.Type<"uint8">` |
+| `@type int16` | `tags.Type<"int16">` |
+| `@type uint16` | `tags.Type<"uint16">` |
 | `@type int32` | `tags.Type<"int32">` |
+| `@type uint32` | `tags.Type<"uint32">` |
+| `@type int64` | `tags.Type<"int64">` |
+| `@type uint64` | `tags.Type<"uint64">` |
+| `@type float` | `tags.Type<"float">` |
+| `@type double` | `tags.Type<"double">` |
 | `@minimum 0` | `tags.Minimum<0>` |
 | `@maximum 100` | `tags.Maximum<100>` |
 | `@exclusiveMinimum 0` | `tags.ExclusiveMinimum<0>` |
@@ -268,7 +277,7 @@ End-to-end example with three custom tags (`Postfix`, `Dollar`, `IsEven`):
 - [`is`](/docs/validators/is), [`assert`](/docs/validators/assert), [`validate`](/docs/validators/validate) — runtime checking
 - [`random`](/docs/random) — generated values respect the constraint
 - [`json.schemas`](/docs/json/schema), [`llm.parameters`](/docs/llm/parameters) — exported as JSON Schema fields (`format`, `minimum`, …)
-- [`protobuf.message`](/docs/protobuf/message) — `tags.Type<"uint32">` selects the wire type; `tags.Sequence<N>` picks the field number
+- [`protobuf.message`](/docs/protobuf/message) — `tags.Type<"uint32">` selects the scalar type; smaller integer tags validate narrower ranges and use the protobuf `int32` / `uint32` scalar types; `tags.Sequence<N>` picks the field number
 
 ## Where to go next
 

--- a/website/src/content/docs/validators/tags.mdx
+++ b/website/src/content/docs/validators/tags.mdx
@@ -186,7 +186,7 @@ If you'd rather write JSDoc, the same constraints exist as `@`-prefixed tags:
 >
 > **Type tags > comment tags. Always, unless you can't.**
 >
-> - Comment tags are **not type-checked**. `@type unit32` (typo of `uint32`) silently falls back to `double`, and you only notice at runtime.
+> - Comment tags are **not type-checked**. `@type unit32` (typo of `uint32`) is ignored: validators and `random` lose the intended range constraint, and protobuf schema emission falls back to the default `double` scalar for an untagged `number`.
 > - Comment tags only work on **object properties**. They don't apply to element types of `Array` or `Map`, and they can't be combined with union types.
 > - Comment tags can't express union constraints. `@type int32` locks the property to `int32`; you can't follow it with `@type float`.
 >


### PR DESCRIPTION
## Summary

Fixes #1676.

This supersedes and extends PR #1879 by rebasing the smaller integer tag work on current master and adding extra coverage for schema output and JSDoc comment tags.

## Changes

- Add `typia.tags.Type<int8 | uint8 | int16 | uint16>` support.
- Add internal runtime predicates for the new signed and unsigned ranges.
- Teach JSDoc `@type int8`, `@type uint8`, `@type int16`, and `@type uint16` to produce the same metadata tags.
- Extend template fixtures with valid boundary values and invalid overflow/underflow spoilers.
- Pin JSON Schema and LLM schema output for the four new tags.
- Bump `typia` package version because native Go source changed.

## Validation

- `pnpm format`
- `pnpm test:go`
- `pnpm --filter @typia/interface build`
- `pnpm --filter typia build` after adding Git for Windows `usr/bin` to PATH for `cp`
- `git diff --check`

Local limitation: targeted `ttsx` suites still fail on this checkout with `Unexpected token '{'`, matching the current local TypeScript-Go test-runner failure observed before this branch. GitHub CI remains the authoritative TS-suite gate for this PR.