### PR TITLE
chore(typia): tidy bigint native cosmetics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules/
 
 tests/test-typia-ttsc/fixtures/*/build/output/
 
+# transform test fixture scratch space (inside the npm-packed native tree)
+packages/typia/native/.tmp-ttsc-typia-tests/
+
 package-lock.json
 !experiments/setup/package-lock.json
 

--- a/packages/typia/native/core/factories/JsonMetadataFactory.go
+++ b/packages/typia/native/core/factories/JsonMetadataFactory.go
@@ -72,17 +72,8 @@ func (jsonMetadataFactoryNamespace) Validate(props struct {
   Explore  MetadataFactory_IExplore
 }) []string {
   output := []string{}
-  for _, atomic := range props.Metadata.Atomics {
-    if atomic.Type == "bigint" {
-      output = append(output, "JSON does not support bigint type.")
-      break
-    }
-  }
-  for _, constant := range props.Metadata.Constants {
-    if constant.Type == "bigint" {
-      output = append(output, "JSON does not support bigint type.")
-      break
-    }
+  if schemametadata.MetadataSchema_hasBigint(props.Metadata) {
+    output = append(output, "JSON does not support bigint type.")
   }
   tupleInvalid := false
   for _, tuple := range props.Metadata.Tuples {
@@ -114,7 +105,6 @@ func (jsonMetadataFactoryNamespace) Validate(props struct {
   }
   for _, native := range props.Metadata.Natives {
     if native.Name == "BigInt" {
-      output = append(output, "JSON does not support bigint type.")
       continue
     }
     if jsonMetadataFactory_atomic_predicator_native(native.Name) == false && native.Name != "Date" {

--- a/packages/typia/native/core/factories/json_metadata_factory_dedupes_bigint_diagnostics_test.go
+++ b/packages/typia/native/core/factories/json_metadata_factory_dedupes_bigint_diagnostics_test.go
@@ -1,0 +1,36 @@
+package factories
+
+import (
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestJsonMetadataFactoryDedupesBigintDiagnostics verifies single bigint report.
+//
+// A union like `bigint | 1n | BigInt` fills the atomic, constant, and native
+// buckets at once. Each bucket used to append its own copy of the identical
+// "JSON does not support bigint type." message; the validator must report the
+// unsupported type exactly once.
+//
+// 1. Build metadata holding atomic bigint, a bigint constant, and native BigInt.
+// 2. Validate it through `JsonMetadataFactory`.
+// 3. Require exactly one bigint diagnostic.
+func TestJsonMetadataFactoryDedupesBigintDiagnostics(t *testing.T) {
+  meta := schemametadata.MetadataSchema_initialize()
+  meta.Atomics = append(meta.Atomics, schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "bigint"}))
+  meta.Constants = append(meta.Constants, schemametadata.MetadataConstant_create(schemametadata.MetadataConstant{
+    Type: "bigint",
+    Values: []*schemametadata.MetadataConstantValue{
+      schemametadata.MetadataConstantValue_create(schemametadata.MetadataConstantValue{Value: "1"}),
+    },
+  }))
+  meta.Natives = append(meta.Natives, schemametadata.MetadataNative_create(schemametadata.MetadataNative{Name: "BigInt"}))
+  messages := JsonMetadataFactory.Validate(struct {
+    Metadata *schemametadata.MetadataSchema
+    Explore  MetadataFactory_IExplore
+  }{Metadata: meta})
+  if len(messages) != 1 || messages[0] != "JSON does not support bigint type." {
+    t.Fatalf("expected exactly one JSON bigint diagnostic, got %v", messages)
+  }
+}

--- a/packages/typia/native/core/programmers/RandomProgrammer.go
+++ b/packages/typia/native/core/programmers/RandomProgrammer.go
@@ -811,11 +811,7 @@ func randomProgrammer_decode_native(props struct {
   Explore randomProgrammer_IExplore
   Name    string
 }) *shimast.Node {
-  if props.Name == "Boolean" || props.Name == "Number" || props.Name == "BigInt" || props.Name == "String" {
-    atomic := strings.ToLower(props.Name)
-    if atomic == "bigint" {
-      atomic = "bigint"
-    }
+  if atomic, ok := schemametadata.MetadataSchema_atomicLikeNative(props.Name); ok {
     return randomProgrammer_first(randomProgrammer_decode_atomic(randomProgrammer_decodeAtomicProps{
       Context: props.Context,
       Atomic: schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{

--- a/packages/typia/native/core/programmers/json/JsonSchemasProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonSchemasProgrammer.go
@@ -32,17 +32,8 @@ func (jsonSchemasProgrammerNamespace) Validate(props struct {
   Explore  nativefactories.MetadataFactory_IExplore
 }) []string {
   output := []string{}
-  for _, atomic := range props.Metadata.Atomics {
-    if atomic.Type == "bigint" {
-      output = append(output, "JSON schema does not support bigint type.")
-      break
-    }
-  }
-  for _, constant := range props.Metadata.Constants {
-    if constant.Type == "bigint" {
-      output = append(output, "JSON schema does not support bigint type.")
-      break
-    }
+  if nativemetadata.MetadataSchema_hasBigint(props.Metadata) {
+    output = append(output, "JSON schema does not support bigint type.")
   }
   tupleInvalid := false
   for _, tuple := range props.Metadata.Tuples {
@@ -74,7 +65,6 @@ func (jsonSchemasProgrammerNamespace) Validate(props struct {
   }
   for _, native := range props.Metadata.Natives {
     if native.Name == "BigInt" {
-      output = append(output, "JSON schema does not support bigint type.")
       continue
     }
     if nativehelpers.AtomicPredicator.Native(native.Name) == false &&

--- a/packages/typia/native/core/programmers/json/json_schemas_programmer_dedupes_bigint_diagnostics_test.go
+++ b/packages/typia/native/core/programmers/json/json_schemas_programmer_dedupes_bigint_diagnostics_test.go
@@ -1,0 +1,37 @@
+package json
+
+import (
+  "testing"
+
+  nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestJsonSchemasProgrammerDedupesBigintDiagnostics verifies single bigint report.
+//
+// A union like `bigint | 1n | BigInt` fills the atomic, constant, and native
+// buckets at once. Each bucket used to append its own copy of the identical
+// "JSON schema does not support bigint type." message; the schema validator
+// must report the unsupported type exactly once.
+//
+// 1. Build metadata holding atomic bigint, a bigint constant, and native BigInt.
+// 2. Validate it through `JsonSchemasProgrammer`.
+// 3. Require exactly one bigint diagnostic.
+func TestJsonSchemasProgrammerDedupesBigintDiagnostics(t *testing.T) {
+  meta := schemametadata.MetadataSchema_initialize()
+  meta.Atomics = append(meta.Atomics, schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "bigint"}))
+  meta.Constants = append(meta.Constants, schemametadata.MetadataConstant_create(schemametadata.MetadataConstant{
+    Type: "bigint",
+    Values: []*schemametadata.MetadataConstantValue{
+      schemametadata.MetadataConstantValue_create(schemametadata.MetadataConstantValue{Value: "1"}),
+    },
+  }))
+  meta.Natives = append(meta.Natives, schemametadata.MetadataNative_create(schemametadata.MetadataNative{Name: "BigInt"}))
+  messages := JsonSchemasProgrammer.Validate(struct {
+    Metadata *schemametadata.MetadataSchema
+    Explore  nativefactories.MetadataFactory_IExplore
+  }{Metadata: meta})
+  if len(messages) != 1 || messages[0] != "JSON schema does not support bigint type." {
+    t.Fatalf("expected exactly one JSON schema bigint diagnostic, got %v", messages)
+  }
+}

--- a/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
+++ b/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
@@ -155,17 +155,8 @@ func (llmSchemaProgrammerNamespace) Validate(props struct {
       }
     }
   }
-  for _, atomic := range props.Metadata.Atomics {
-    if atomic.Type == "bigint" {
-      output = append(output, "LLM schema does not support bigint type.")
-      break
-    }
-  }
-  for _, constant := range props.Metadata.Constants {
-    if constant.Type == "bigint" {
-      output = append(output, "LLM schema does not support bigint type.")
-      break
-    }
+  if schemametadata.MetadataSchema_hasBigint(props.Metadata) {
+    output = append(output, "LLM schema does not support bigint type.")
   }
   if len(props.Metadata.Tuples) != 0 {
     output = append(output, "LLM schema does not support tuple type.")
@@ -184,7 +175,6 @@ func (llmSchemaProgrammerNamespace) Validate(props struct {
   }
   for _, native := range props.Metadata.Natives {
     if native.Name == "BigInt" {
-      output = append(output, "LLM schema does not support bigint type.")
       continue
     }
     if nativehelpers.AtomicPredicator.Native(native.Name) == false &&

--- a/packages/typia/native/core/programmers/llm/llm_schema_programmer_dedupes_bigint_diagnostics_test.go
+++ b/packages/typia/native/core/programmers/llm/llm_schema_programmer_dedupes_bigint_diagnostics_test.go
@@ -1,0 +1,38 @@
+package llm
+
+import (
+  "testing"
+
+  nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestLlmSchemaProgrammerDedupesBigintDiagnostics verifies single bigint report.
+//
+// A union like `bigint | 1n | BigInt` fills the atomic, constant, and native
+// buckets at once. Each bucket used to append its own copy of the identical
+// "LLM schema does not support bigint type." message; the schema validator
+// must report the unsupported type exactly once.
+//
+// 1. Build metadata holding atomic bigint, a bigint constant, and native BigInt.
+// 2. Validate it through `LlmSchemaProgrammer`.
+// 3. Require exactly one bigint diagnostic.
+func TestLlmSchemaProgrammerDedupesBigintDiagnostics(t *testing.T) {
+  meta := schemametadata.MetadataSchema_initialize()
+  meta.Atomics = append(meta.Atomics, schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "bigint"}))
+  meta.Constants = append(meta.Constants, schemametadata.MetadataConstant_create(schemametadata.MetadataConstant{
+    Type: "bigint",
+    Values: []*schemametadata.MetadataConstantValue{
+      schemametadata.MetadataConstantValue_create(schemametadata.MetadataConstantValue{Value: "1"}),
+    },
+  }))
+  meta.Natives = append(meta.Natives, schemametadata.MetadataNative_create(schemametadata.MetadataNative{Name: "BigInt"}))
+  messages := LlmSchemaProgrammer.Validate(struct {
+    Config   map[string]any
+    Metadata *schemametadata.MetadataSchema
+    Explore  nativefactories.MetadataFactory_IExplore
+  }{Metadata: meta})
+  if len(messages) != 1 || messages[0] != "LLM schema does not support bigint type." {
+    t.Fatalf("expected exactly one LLM schema bigint diagnostic, got %v", messages)
+  }
+}

--- a/packages/typia/native/core/schemas/metadata/MetadataSchema.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataSchema.go
@@ -897,6 +897,16 @@ func metadataSchema_hasAtomicLikeNative(meta *MetadataSchema, atomic string) boo
   })
 }
 
+// MetadataSchema_hasBigint reports whether the schema can hold bigint values
+// through its atomic, constant, or wrapper-native buckets. JSON-derived
+// validators use it to emit a single bigint diagnostic instead of one per
+// bucket.
+func MetadataSchema_hasBigint(meta *MetadataSchema) bool {
+  return metadataSchema_hasAtomic(meta, "bigint") ||
+    metadataSchema_hasConstant(meta, "bigint") ||
+    metadataSchema_hasAtomicLikeNative(meta, "bigint")
+}
+
 func MetadataSchema_atomicLikeNative(name string) (string, bool) {
   switch name {
   case "Boolean":

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.11",
+  "version": "13.0.0-dev.20260605.12",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Intent

Resolve the cosmetic cleanups collected in #1914 around the bigint native handling introduced by #1909.

## Changes

- Emit the "does not support bigint type." diagnostic once per metadata node in `JsonMetadataFactory.Validate`, `JsonSchemasProgrammer.Validate`, and `LlmSchemaProgrammer.Validate`, via a shared `MetadataSchema_hasBigint` helper covering the atomic, constant, and wrapper-native buckets. Previously a union like `bigint | 1n | BigInt` produced up to three identical messages.
- Key `randomProgrammer_decode_native`'s wrapper branch on `MetadataSchema_atomicLikeNative`, removing the no-op `if atomic == "bigint" { atomic = "bigint" }` and aligning with the clone/notation programmers.
- Add `packages/typia/native/.tmp-ttsc-typia-tests/` to `.gitignore` so a crashed transform-test run cannot leak fixture litter into the npm-packed `native` tree.
- Bump `typia` to `13.0.0-dev.20260605.12` (native source changes ship in the npm package).

## Behavior notes

- For metadata combining a `BigInt` native with `Map`/`Set` buckets, the bigint message now appears before the Map/Set messages (it used to be appended by the native loop after them). Nothing pins that order — purely cosmetic.
- `random<BigInt>()` emission is provably identical (the four wrapper names map to the same lowercase atomics).

## Validation

- `pnpm format`
- `pnpm run test:go` (public + native trees, all ok)
- New per-surface regression tests: `Test(JsonMetadataFactory|JsonSchemasProgrammer|LlmSchemaProgrammer)DedupesBigintDiagnostics` assert exactly one diagnostic for the triple-bucket union.
- `git check-ignore packages/typia/native/.tmp-ttsc-typia-tests/foo.txt` confirms the ignore entry.

## Review

Self-review, 3 rounds (per operator instruction; no multi-agent workflow): full diff read-through, bucket-combination equivalence table, adversarial pass (message-order change found and documented above).

Fixes #1914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)