### PR TITLE
fix(typia): read protobuf sequence tags from native metadata

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/protobuf_sequence_field_numbers_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/protobuf_sequence_field_numbers_transform_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestProtobufSequenceFieldNumbersTransform verifies Sequence tag consumption.
+//
+// typescript-go materializes the `Sequence<N>` schema literal as its internal
+// jsnum number type, which the previous closed type switches never matched, so
+// explicit protobuf field numbers were silently replaced by auto-numbering and
+// duplicate-sequence validation never fired.
+//
+//  1. Transform a message fixture carrying explicit `Sequence<5>` / `Sequence<7>`
+//     field numbers plus an untagged property (auto-numbered after the highest
+//     explicit number).
+//  2. Require the emitted proto message to carry the explicit numbers.
+//  3. Require a message whose two properties share `Sequence<1>` to fail the
+//     transform, leaving the call untransformed.
+func TestProtobufSequenceFieldNumbersTransform(t *testing.T) {
+  project := protobufSequenceFieldNumbersProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("protobuf sequence transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  for _, line := range []string{
+    "required string id = 5;",
+    "required double age = 7;",
+    "required bool flag = 8;",
+  } {
+    if !strings.Contains(out, line) {
+      t.Fatalf("emitted proto message should contain %q:\n%s", line, out)
+    }
+  }
+  if !strings.Contains(out, ".protobuf.message()") {
+    t.Fatalf("duplicated sequence message should stay untransformed:\n%s", out)
+  }
+}
+
+func protobufSequenceFieldNumbersProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "protobuf-sequence-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(protobufSequenceFieldNumbersTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(protobufSequenceFieldNumbersSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+const protobufSequenceFieldNumbersTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const protobufSequenceFieldNumbersSource = `import typia, { tags } from "typia";
+
+interface Sequenced {
+  id: string & tags.Sequence<5>;
+  age: number & tags.Sequence<7>;
+  flag: boolean;
+}
+
+interface Duplicated {
+  id: string & tags.Sequence<1>;
+  age: number & tags.Sequence<1>;
+}
+
+export const sequenced = typia.protobuf.message<Sequenced>();
+export const duplicated = typia.protobuf.message<Duplicated>();
+`

--- a/packages/typia/native/core/factories/ProtobufFactory.go
+++ b/packages/typia/native/core/factories/ProtobufFactory.go
@@ -767,31 +767,8 @@ func protobufFactory_firstTagRow(tags [][]schemametadata.IMetadataTypeTag) []sch
 
 func protobufFactory_getSequence(tags []schemametadata.IMetadataTypeTag) *int {
   for _, tag := range tags {
-    if tag.Kind != "sequence" {
-      continue
-    }
-    schema, ok := tag.Schema.(map[string]any)
-    if ok == false {
-      continue
-    }
-    raw, ok := schema["x-protobuf-sequence"]
-    if ok == false {
-      continue
-    }
-    switch value := raw.(type) {
-    case int:
-      return &value
-    case int64:
-      next := int(value)
-      return &next
-    case float64:
-      next := int(value)
-      return &next
-    case string:
-      next := 0
-      if _, err := fmt.Sscan(value, &next); err == nil {
-        return &next
-      }
+    if sequence := schemametadata.IMetadataTypeTag_getSequence(tag); sequence != nil {
+      return sequence
     }
   }
   return nil

--- a/packages/typia/native/core/programmers/helpers/ProtobufUtil.go
+++ b/packages/typia/native/core/programmers/helpers/ProtobufUtil.go
@@ -36,19 +36,8 @@ func (protobufUtilNamespace) Size(meta *nativemetadata.MetadataSchema) int {
 
 func (protobufUtilNamespace) GetSequence(tags []nativemetadata.IMetadataTypeTag) *int {
   for _, tag := range tags {
-    if tag.Kind != "sequence" {
-      continue
-    }
-    schema, ok := tag.Schema.(map[string]any)
-    if ok == false {
-      continue
-    }
-    value, ok := schema["x-protobuf-sequence"]
-    if ok == false {
-      continue
-    }
-    if parsed, ok := protobufUtil_toInt(value); ok {
-      return &parsed
+    if sequence := nativemetadata.IMetadataTypeTag_getSequence(tag); sequence != nil {
+      return sequence
     }
   }
   return nil
@@ -240,32 +229,6 @@ func protobufUtil_decode_number(output map[string]*int, tags [][]nativemetadata.
       }
     }
     output[value] = ProtobufUtil.GetSequence(row)
-  }
-}
-
-func protobufUtil_toInt(value any) (int, bool) {
-  switch v := value.(type) {
-  case int:
-    return v, true
-  case int32:
-    return int(v), true
-  case int64:
-    return int(v), true
-  case uint:
-    return int(v), true
-  case uint32:
-    return int(v), true
-  case uint64:
-    return int(v), true
-  case float64:
-    return int(v), true
-  case float32:
-    return int(v), true
-  case string:
-    parsed, err := strconv.Atoi(v)
-    return parsed, err == nil
-  default:
-    return 0, false
   }
 }
 

--- a/packages/typia/native/core/schemas/metadata/IMetadataTypeTagSequence.go
+++ b/packages/typia/native/core/schemas/metadata/IMetadataTypeTagSequence.go
@@ -1,0 +1,53 @@
+package metadata
+
+import (
+  "reflect"
+  "strconv"
+)
+
+// IMetadataTypeTag_getSequence extracts the protobuf field number carried by a
+// `Sequence<N>` type tag, or nil when the tag is not a sequence tag.
+//
+// typescript-go materializes the tag's numeric literal as its internal
+// `jsnum.Number` — a defined float64 type living under `typescript-go/internal`
+// that typia cannot import — so the conversion must go through reflection
+// kinds instead of a closed type switch.
+func IMetadataTypeTag_getSequence(tag IMetadataTypeTag) *int {
+  if tag.Kind != "sequence" {
+    return nil
+  }
+  schema, ok := tag.Schema.(map[string]any)
+  if ok == false {
+    return nil
+  }
+  raw, ok := schema["x-protobuf-sequence"]
+  if ok == false {
+    return nil
+  }
+  if value, ok := IMetadataTypeTag_toInt(raw); ok {
+    return &value
+  }
+  return nil
+}
+
+// IMetadataTypeTag_toInt coerces a tag schema value to an int, accepting any
+// defined integer, float, or numeric-string type by reflection kind.
+func IMetadataTypeTag_toInt(value any) (int, bool) {
+  if value == nil {
+    return 0, false
+  }
+  rv := reflect.ValueOf(value)
+  switch rv.Kind() {
+  case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+    return int(rv.Int()), true
+  case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+    return int(rv.Uint()), true
+  case reflect.Float32, reflect.Float64:
+    return int(rv.Float()), true
+  case reflect.String:
+    parsed, err := strconv.Atoi(rv.String())
+    return parsed, err == nil
+  default:
+    return 0, false
+  }
+}

--- a/packages/typia/native/core/schemas/metadata/MetadataSchema.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataSchema.go
@@ -358,17 +358,7 @@ func (obj *MetadataSchema) IsSequence() bool {
   exists := func(tags [][]IMetadataTypeTag) bool {
     for _, row := range tags {
       for _, t := range row {
-        if t.Kind != "sequence" {
-          continue
-        }
-        schema, ok := t.Schema.(map[string]any)
-        if ok == false {
-          continue
-        }
-        if _, ok := schema["x-protobuf-sequence"].(float64); ok {
-          return true
-        }
-        if _, ok := schema["x-protobuf-sequence"].(int); ok {
+        if IMetadataTypeTag_getSequence(t) != nil {
           return true
         }
       }

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.12",
+  "version": "13.0.0-dev.20260605.13",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/test/metadata/schema/metadata_type_tag_reads_defined_number_sequences_test.go
+++ b/packages/typia/test/metadata/schema/metadata_type_tag_reads_defined_number_sequences_test.go
@@ -1,0 +1,61 @@
+package typia_test
+
+import (
+  "testing"
+
+  metadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// definedNumber mimics typescript-go's internal jsnum.Number: a defined
+// float64 type that a closed `case float64:` switch never matches.
+type definedNumber float64
+
+// TestMetadataTypeTagReadsDefinedNumberSequences verifies sequence coercion.
+//
+// typescript-go materializes `Sequence<N>` schema literals as its internal
+// defined number type, not a plain float64, so the sequence reader must coerce
+// values by reflection kind. A closed type switch silently dropped every
+// sequence tag, disabling explicit protobuf field numbers and their
+// duplicate-detection validators.
+//
+// 1. Read a sequence tag whose schema value is a defined float64 type.
+// 2. Read plain int, float64, and numeric-string values the old switch knew.
+// 3. Reject non-sequence kinds, malformed schemas, and non-numeric values.
+func TestMetadataTypeTagReadsDefinedNumberSequences(t *testing.T) {
+  tag := func(value any) metadata.IMetadataTypeTag {
+    return metadata.IMetadataTypeTag{
+      Kind:   "sequence",
+      Name:   "Sequence",
+      Schema: map[string]any{"x-protobuf-sequence": value},
+    }
+  }
+  for name, value := range map[string]any{
+    "defined-float64": definedNumber(7),
+    "int":             7,
+    "float64":         float64(7),
+    "string":          "7",
+  } {
+    sequence := metadata.IMetadataTypeTag_getSequence(tag(value))
+    if sequence == nil || *sequence != 7 {
+      t.Fatalf("%s sequence value should coerce to 7, got %v", name, sequence)
+    }
+  }
+  if metadata.IMetadataTypeTag_getSequence(metadata.IMetadataTypeTag{
+    Kind:   "type",
+    Schema: map[string]any{"x-protobuf-sequence": 7},
+  }) != nil {
+    t.Fatal("non-sequence tag kinds should not produce a sequence")
+  }
+  if metadata.IMetadataTypeTag_getSequence(metadata.IMetadataTypeTag{Kind: "sequence"}) != nil {
+    t.Fatal("sequence tag without schema should not produce a sequence")
+  }
+  if metadata.IMetadataTypeTag_getSequence(tag(nil)) != nil {
+    t.Fatal("nil schema value should not produce a sequence")
+  }
+  if metadata.IMetadataTypeTag_getSequence(tag("seven")) != nil {
+    t.Fatal("non-numeric string should not produce a sequence")
+  }
+  if metadata.IMetadataTypeTag_getSequence(tag(true)) != nil {
+    t.Fatal("boolean schema value should not produce a sequence")
+  }
+}


### PR DESCRIPTION
## Intent

Fix #1916: `tags.Sequence<N>` had no effect in the Go native transform — explicit protobuf field numbers were replaced by auto-numbering and the duplicate/union sequence validators never fired.

## Root cause

typescript-go materializes the tag's schema literal as its internal `jsnum.Number` (a defined float64 type under `typescript-go/internal` that typia cannot import). Every `x-protobuf-sequence` reader used a closed `int`/`int64`/`float64`/`string` type switch, which a defined type never matches, so every sequence tag was silently dropped. (`protobufUtil_toFloat` already had a string-roundtrip fallback, which is why only the sequence path was broken.)

## Changes

- Add `IMetadataTypeTag_getSequence` / `IMetadataTypeTag_toInt` to the metadata package: schema values are coerced by reflection kind (any defined integer/float/numeric-string type).
- Route the three readers through it: `protobufFactory_getSequence`, `ProtobufUtil.GetSequence` (drives encode/decode wire numbering), and `MetadataSchema.IsSequence`; drop the now-unused `protobufUtil_toInt`.
- Regression tests:
  - `TestProtobufSequenceFieldNumbersTransform`: `Sequence<5>`/`Sequence<7>` appear verbatim in the emitted proto message (untagged sibling auto-numbers after the highest explicit number, matching typia v12), and a message whose two properties share `Sequence<1>` fails the transform.
  - `TestMetadataTypeTagReadsDefinedNumberSequences`: defined-float64 coercion plus the negative cases.
- Bump `typia` to `13.0.0-dev.20260605.13` (native source ships in the npm package).

## Validation

- `pnpm format`, `pnpm run test:go` (public + native trees, all ok)
- Reference check against npm `typia@12.1.1` (ts-patch v3 + TS 5.9.3): explicit numbers, auto-number-after-highest, and duplicate rejection all match the pre-Go transform.
- `tests/test-error` protobuf sequence fixtures re-simulated through the Go transform: `error_protobuf_sequence_property_duplicated` and `error_protobuf_sequence_union_duplicated` now error on every call as v12 does. (The remaining stale fixtures are #1912's scope.)

## Review

Self-review, 3 rounds (per operator instruction; no multi-agent workflow): diff read-through with import/caller audit, semantic edge cases (PseudoBigInt not reachable for tag literals, pointer/struct kinds rejected), test-as-specification pass.

Fixes #1916.

🤖 Generated with [Claude Code](https://claude.com/claude-code)