### PR TITLE
fix(typia): validate type tags on template literal types

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/template_literal_type_tags_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/template_literal_type_tags_transform_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestTemplateLiteralTypeTagsTransform verifies tags on template literals.
+//
+// Type tags intersected with a template literal type reached the metadata
+// (JSON schema emitted them correctly) but the runtime checker's template
+// entry ignored its tag matrix, so `MaxLength`/`Pattern` and every other
+// validate-able tag silently vanished from `is`/`assert`/`validate` whenever
+// the base type was a template literal instead of plain `string` (#1635).
+//
+//  1. Transform fixtures intersecting tags with a sole template literal and
+//     with a union of differently-tagged template literals.
+//  2. Require the emitted checker to carry the tag predicates.
+//  3. Execute runtime cases: tag-violating strings must fail even when they
+//     match the template pattern, per union member.
+func TestTemplateLiteralTypeTagsTransform(t *testing.T) {
+  project := templateLiteralTypeTagsProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("template literal tags transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  if !strings.Contains(out, "length <= 30") || !strings.Contains(out, "RegExp(/^prefix(.*)postfix$/)") {
+    t.Fatalf("emitted checker should combine the template pattern with its tags:\n%s", out)
+  }
+  templateLiteralTypeTagsRunRuntimeCases(t, project, out)
+}
+
+func templateLiteralTypeTagsProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "template-tags-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(templateLiteralTypeTagsTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(templateLiteralTypeTagsSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func templateLiteralTypeTagsRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(templateLiteralTypeTagsRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("template literal tags runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const templateLiteralTypeTagsTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const templateLiteralTypeTagsSource = `import typia, { tags } from "typia";
+
+type Tagged = tags.MaxLength<30> & tags.Pattern<"^[a-zA-Z0-9_]+$"> & ` + "`prefix${string}postfix`" + `;
+type TaggedUnion =
+  | (` + "`a${string}`" + ` & tags.MinLength<3>)
+  | (` + "`b${string}`" + ` & tags.MaxLength<5>);
+
+export const isTagged = typia.createIs<Tagged>();
+export const validateTagged = typia.createValidate<Tagged>();
+export const isTaggedUnion = typia.createIs<TaggedUnion>();
+`
+
+const templateLiteralTypeTagsRuntimeRunner = `const mod = require("./main.cjs");
+
+if (mod.isTagged("prefix_0123_postfix") !== true) {
+  throw new Error("tag-conforming template string should pass is");
+}
+if (mod.isTagged('prefix;"+,df0123456789postfix') !== false) {
+  throw new Error("pattern/length-violating template string should fail is");
+}
+if (mod.isTagged("prefix_basically_way_too_long_for_max_postfix") !== false) {
+  throw new Error("over-length template string should fail is");
+}
+if (mod.isTagged("nomatch") !== false) {
+  throw new Error("non-template string should keep failing is");
+}
+
+const invalid = mod.validateTagged('prefix;"+,df0123456789postfix');
+if (invalid.success !== false) {
+  throw new Error("validate should reject the tag-violating template string");
+}
+if (!invalid.errors.some((e) => e.expected.includes("Pattern") || e.expected.includes("MaxLength"))) {
+  throw new Error("validate error should name the violated tag: " + JSON.stringify(invalid.errors));
+}
+if (mod.validateTagged("prefix_0123_postfix").success !== true) {
+  throw new Error("validate should accept the tag-conforming template string");
+}
+
+if (mod.isTaggedUnion("abc") !== true) {
+  throw new Error("a-branch string meeting MinLength should pass");
+}
+if (mod.isTaggedUnion("ab") !== false) {
+  throw new Error("a-branch string violating MinLength should fail");
+}
+if (mod.isTaggedUnion("bcdef") !== true) {
+  throw new Error("b-branch string meeting MaxLength should pass");
+}
+if (mod.isTaggedUnion("bcdefgh") !== false) {
+  throw new Error("b-branch string violating MaxLength should fail");
+}
+`

--- a/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
@@ -707,6 +707,7 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
       Expression: props.Config.Atomist(CheckerProgrammer_AtomistProps{
         Explore: props.Explore,
         Entry: nativeiterate.Check_template(nativeiterate.Check_templateProps{
+          Context:   props.Context,
           Templates: props.Metadata.Templates,
           Input:     props.Input,
         }),

--- a/packages/typia/native/core/programmers/iterate/check_dynamic_key.go
+++ b/packages/typia/native/core/programmers/iterate/check_dynamic_key.go
@@ -116,6 +116,7 @@ func Check_dynamic_key(props Check_dynamic_keyProps) *shimast.Node {
 
   if len(props.Metadata.Templates) != 0 {
     conditions = append(conditions, check_dynamic_key_atomist(Check_template(Check_templateProps{
+      Context:   props.Context,
       Templates: props.Metadata.Templates,
       Input:     props.Input,
     }), props.Context.Emit))

--- a/packages/typia/native/core/programmers/iterate/check_template.go
+++ b/packages/typia/native/core/programmers/iterate/check_template.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Check_templateProps struct {
+  Context   nativecontext.ITypiaContext
   Templates []*nativemetadata.MetadataTemplate
   Input     *shimast.Expression
   Emit      *shimprinter.EmitContext
@@ -29,7 +30,7 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
   }
   internal := make([]*shimast.Node, 0, len(props.Templates))
   for _, tpl := range props.Templates {
-    internal = append(internal, f.NewCallExpression(
+    expression := f.NewCallExpression(
       f.NewIdentifier("RegExp(/"+template_to_pattern(struct {
         top      bool
         template []*nativemetadata.MetadataSchema
@@ -41,7 +42,22 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
       nil,
       f.NewNodeList([]*shimast.Node{props.Input}),
       shimast.NodeFlagsNone,
-    ))
+    )
+    // A template with more than one neighbor cannot route its type tags
+    // through the entry conditions (those gate the whole entry), so inline
+    // them into the member expression instead.
+    if len(props.Templates) > 1 {
+      if tags := check_template_inline_tags(props, tpl); tags != nil {
+        expression = f.NewBinaryExpression(
+          nil,
+          expression,
+          nil,
+          f.NewToken(shimast.KindAmpersandAmpersandToken),
+          tags,
+        )
+      }
+    }
+    internal = append(internal, expression)
   }
   if len(internal) != 0 {
     conditions = append(conditions, check_template_reduce(internal, shimast.KindBarBarToken, props.Emit))
@@ -50,11 +66,57 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
   for _, tpl := range props.Templates {
     names = append(names, tpl.GetName())
   }
-  return nativehelpers.ICheckEntry{
+  entry := nativehelpers.ICheckEntry{
     Expression: check_template_reduce(conditions, shimast.KindAmpersandAmpersandToken, props.Emit),
     Conditions: nil,
     Expected:   strings.Join(names, " | "),
   }
+  if len(props.Templates) == 1 {
+    entry.Conditions = check_template_type_tags(props, props.Templates[0])
+  }
+  return entry
+}
+
+// check_template_type_tags mirrors check_string_type_tags: a sole template
+// reports each violated type tag individually through the entry conditions.
+func check_template_type_tags(props Check_templateProps, tpl *nativemetadata.MetadataTemplate) [][]nativehelpers.ICheckEntry_ICondition {
+  output := [][]nativehelpers.ICheckEntry_ICondition{}
+  for _, row := range tpl.Tags {
+    tags := check_string_filter_validate(row)
+    if len(tags) == 0 {
+      continue
+    }
+    conditions := make([]nativehelpers.ICheckEntry_ICondition, 0, len(tags))
+    for _, tag := range tags {
+      conditions = append(conditions, nativehelpers.ICheckEntry_ICondition{
+        Expected:   tpl.GetBaseName() + " & " + tag.Name,
+        Expression: check_string_transpile(props.Context, tag.Validate)(props.Input),
+      })
+    }
+    output = append(output, conditions)
+  }
+  return output
+}
+
+// check_template_inline_tags folds a template's tag matrix (OR of AND rows)
+// into a single expression for union members that cannot carry conditions.
+func check_template_inline_tags(props Check_templateProps, tpl *nativemetadata.MetadataTemplate) *shimast.Node {
+  rows := make([]*shimast.Node, 0, len(tpl.Tags))
+  for _, row := range tpl.Tags {
+    tags := check_string_filter_validate(row)
+    if len(tags) == 0 {
+      continue
+    }
+    expressions := make([]*shimast.Node, 0, len(tags))
+    for _, tag := range tags {
+      expressions = append(expressions, check_string_transpile(props.Context, tag.Validate)(props.Input))
+    }
+    rows = append(rows, check_template_reduce(expressions, shimast.KindAmpersandAmpersandToken, props.Emit))
+  }
+  if len(rows) == 0 {
+    return nil
+  }
+  return check_template_reduce(rows, shimast.KindBarBarToken, props.Emit)
 }
 
 func check_template_reduce(expressions []*shimast.Node, operator shimast.Kind, emit ...*shimprinter.EmitContext) *shimast.Node {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.13",
+  "version": "13.0.0-dev.20260605.14",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Intent

Fix #1635: type tags (`MaxLength`, `Pattern`, …) intersected with a template literal type were silently dropped by `is` / `assert` / `validate`, while plain `string` bases applied them correctly.

```typescript
typia.is<tags.MaxLength<10> & `prefix${string}postfix`>("prefix...way-too-long...postfix");
// before: true (MaxLength ignored)   after: false
```

## Root cause

The tags were collected into the metadata correctly (JSON schema already emitted `maxLength`/`pattern`), but `Check_template` — the checker entry builder for the Templates bucket — never read `MetadataTemplate.Tags`. This is a faithful port of the pre-Go behavior (npm `typia@12.1.1` drops the tags identically), so this is an upstream bug fix rather than a port regression.

## Changes

- `Check_template` now consumes each template's tag matrix:
  - a sole template routes its tags through the entry conditions like string atomics do, with granular expected names built from the template base name (`` `prefix${string}postfix` & MaxLength<30> ``);
  - a template union inlines each member's tag matrix (OR of AND rows) into that member's regex expression, so tags bind to the correct branch;
  - dynamic-key templates (`Record<` template `, T>`) gain the same enforcement through the shared entry builder.
- Both call sites (`CheckerProgrammer`, `check_dynamic_key`) now pass the typia context required for tag predicate transpilation.
- Regression test `TestTemplateLiteralTypeTagsTransform`: emission assertion plus runtime cases covering the issue's exact failing value, a conforming value, per-tag validate error naming, and per-branch tag binding in a template union.
- Bump `typia` to `13.0.0-dev.20260605.14` (native source ships in the npm package).

## Validation

- `pnpm format`, `pnpm run test:go` (public + native trees, all ok)
- JSON schema output unchanged (verified before/after — it already carried the tags).

## Review

Self-review, 3 rounds (per operator instruction; no multi-agent workflow): call-site/Context audit, edge semantics (empty tag matrices, mixed tagged/untagged union members, atomic-string + template coexistence untouched), runtime proof of union branch binding.

Fixes #1635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)