### PR TITLE
fix(typia): tighten metadata containment and intersection

### DIFF
--- a/packages/typia/native/core/schemas/metadata/MetadataSchema.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataSchema.go
@@ -460,9 +460,13 @@ func MetadataSchema_intersects(x *MetadataSchema, y *MetadataSchema) bool {
   if metadataSchema_intersectsAtomicLikeNative(x, y) || metadataSchema_intersectsAtomicLikeNative(y, x) {
     return true
   }
-  if x.Escaped != nil && y.Escaped != nil {
-    return MetadataSchema_intersects(x.Escaped.Original, y.Escaped.Original) ||
-      MetadataSchema_intersects(x.Escaped.Returns, y.Escaped.Returns)
+  // Escaped buckets may coexist with primitive buckets, so an escaped match is
+  // sufficient but not necessary — fall through to the remaining comparisons
+  // instead of returning their result.
+  if x.Escaped != nil && y.Escaped != nil &&
+    (MetadataSchema_intersects(x.Escaped.Original, y.Escaped.Original) ||
+      MetadataSchema_intersects(x.Escaped.Returns, y.Escaped.Returns)) {
+    return true
   }
   for _, atomic := range x.Atomics {
     if anyOf(y.Atomics, func(ya *MetadataAtomic) bool { return atomic.Type == ya.Type }) {
@@ -553,6 +557,12 @@ func metadataSchema_covers(x *MetadataSchema, y *MetadataSchema, escaped bool, v
     return true
   }
   if y.Any {
+    return false
+  }
+  if y.Nullable && x.Nullable == false {
+    return false
+  }
+  if y.IsRequired() == false && x.IsRequired() {
     return false
   }
   if escaped == false {
@@ -653,7 +663,8 @@ func metadataSchema_covers(x *MetadataSchema, y *MetadataSchema, escaped bool, v
   }
   if anyOf(y.Atomics, func(ya *MetadataAtomic) bool {
     return metadataSchema_hasAtomic(x, ya.Type) == false &&
-      metadataSchema_hasAtomicLikeNative(x, ya.Type) == false
+      metadataSchema_hasAtomicLikeNative(x, ya.Type) == false &&
+      (ya.Type != "boolean" || metadataSchema_hasBooleanLiteralPair(x) == false)
   }) {
     return false
   }
@@ -878,6 +889,21 @@ func metadataSchema_hasAtomic(meta *MetadataSchema, atomic string) bool {
 
 func metadataSchema_hasConstant(meta *MetadataSchema, atomic string) bool {
   return anyOf(meta.Constants, func(elem *MetadataConstant) bool { return elem.Type == atomic })
+}
+
+// metadataSchema_hasBooleanLiteralPair reports whether the schema holds both
+// boolean literals, which together accept exactly what the boolean atomic does.
+func metadataSchema_hasBooleanLiteralPair(meta *MetadataSchema) bool {
+  hasLiteral := func(expected bool) bool {
+    return anyOf(meta.Constants, func(constant *MetadataConstant) bool {
+      return constant.Type == "boolean" &&
+        anyOf(constant.Values, func(value *MetadataConstantValue) bool {
+          actual, ok := value.Value.(bool)
+          return ok && actual == expected
+        })
+    })
+  }
+  return hasLiteral(true) && hasLiteral(false)
 }
 
 func metadataSchema_hasAtomicLikeNative(meta *MetadataSchema, atomic string) bool {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.14",
+  "version": "13.0.0-dev.20260605.15",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/test/metadata/schema/metadata_schema_covers_boolean_literal_pair_test.go
+++ b/packages/typia/test/metadata/schema/metadata_schema_covers_boolean_literal_pair_test.go
@@ -1,0 +1,38 @@
+package typia_test
+
+import (
+  "testing"
+
+  metadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+)
+
+// TestMetadataSchemaCoversBooleanLiteralPair verifies exhaustive literal pairs.
+//
+// `true | false` accepts exactly the same runtime values as atomic `boolean`,
+// so the literal pair must cover the atomic. A sole literal keeps rejecting
+// the atomic, and the atomic keeps covering its literals.
+//
+// 1. Assert the {true, false} constant pair covers atomic boolean.
+// 2. Assert a sole boolean literal does not cover atomic boolean.
+// 3. Assert atomic boolean still covers the literal pair.
+func TestMetadataSchemaCoversBooleanLiteralPair(t *testing.T) {
+  if !metadata.MetadataSchema_covers(
+    testutil.ConstantMetadata("boolean", true, false),
+    testutil.AtomicMetadata("boolean"),
+  ) {
+    t.Fatal("the {true, false} literal pair should cover atomic boolean")
+  }
+  if metadata.MetadataSchema_covers(
+    testutil.ConstantMetadata("boolean", true),
+    testutil.AtomicMetadata("boolean"),
+  ) {
+    t.Fatal("a sole boolean literal should not cover atomic boolean")
+  }
+  if !metadata.MetadataSchema_covers(
+    testutil.AtomicMetadata("boolean"),
+    testutil.ConstantMetadata("boolean", true, false),
+  ) {
+    t.Fatal("atomic boolean should cover the literal pair")
+  }
+}

--- a/packages/typia/test/metadata/schema/metadata_schema_covers_nullability_test.go
+++ b/packages/typia/test/metadata/schema/metadata_schema_covers_nullability_test.go
@@ -1,0 +1,37 @@
+package typia_test
+
+import (
+  "testing"
+
+  metadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+)
+
+// TestMetadataSchemaCoversNullability verifies null/undefined containment.
+//
+// Coverage ignored nullability and optionality entirely, so `number` covered
+// `number | null` and vice versa — a non-antisymmetric comparator that made
+// the union sort order of nullable-vs-plain pairs arbitrary.
+//
+// 1. Assert a non-nullable source does not cover a nullable target.
+// 2. Assert a nullable source still covers the plain target.
+// 3. Assert a required source does not cover an optional target.
+// 4. Assert an optional source still covers the required target.
+func TestMetadataSchemaCoversNullability(t *testing.T) {
+  nullable := testutil.AtomicMetadata("number")
+  nullable.Nullable = true
+  if metadata.MetadataSchema_covers(testutil.AtomicMetadata("number"), nullable) {
+    t.Fatal("plain number should not cover nullable number")
+  }
+  if !metadata.MetadataSchema_covers(nullable, testutil.AtomicMetadata("number")) {
+    t.Fatal("nullable number should cover plain number")
+  }
+  optional := testutil.AtomicMetadata("number")
+  optional.Optional = true
+  if metadata.MetadataSchema_covers(testutil.AtomicMetadata("number"), optional) {
+    t.Fatal("required number should not cover optional number")
+  }
+  if !metadata.MetadataSchema_covers(optional, testutil.AtomicMetadata("number")) {
+    t.Fatal("optional number should cover required number")
+  }
+}

--- a/packages/typia/test/metadata/schema/metadata_schema_intersects_escaped_neighbors_test.go
+++ b/packages/typia/test/metadata/schema/metadata_schema_intersects_escaped_neighbors_test.go
@@ -1,0 +1,53 @@
+package typia_test
+
+import (
+  "testing"
+
+  metadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+)
+
+// TestMetadataSchemaIntersectsEscapedNeighbors verifies escaped coexistence.
+//
+// A schema can carry an escaped (toJSON) bucket next to primitive buckets.
+// The intersection check used to return the escaped-only comparison whenever
+// both sides carried an escaped bucket, hiding shared primitives — an unsafe
+// discriminator for unions mixing toJSON classes with primitives.
+//
+// 1. Build two schemas with disjoint escaped pairs but a shared number atomic.
+// 2. Assert they intersect through the shared primitive bucket.
+// 3. Assert matching escaped pairs still intersect on their own.
+// 4. Assert fully disjoint escaped schemas still do not intersect.
+func TestMetadataSchemaIntersectsEscapedNeighbors(t *testing.T) {
+  escaped := func(original *metadata.MetadataSchema, returns *metadata.MetadataSchema, atomic string) *metadata.MetadataSchema {
+    schema := metadata.MetadataSchema_create(metadata.MetadataSchema{
+      Required: true,
+      Escaped: metadata.MetadataEscaped_create(metadata.MetadataEscaped{
+        Original: original,
+        Returns:  returns,
+      }),
+    })
+    if atomic != "" {
+      schema.Atomics = append(schema.Atomics, metadata.MetadataAtomic_create(metadata.MetadataAtomic{Type: atomic}))
+    }
+    return schema
+  }
+  if !metadata.MetadataSchema_intersects(
+    escaped(testutil.NativeMetadata("Date"), testutil.AtomicMetadata("string"), "number"),
+    escaped(testutil.NativeMetadata("Uint8Array"), testutil.AtomicMetadata("boolean"), "number"),
+  ) {
+    t.Fatal("shared number atomic should intersect despite disjoint escaped buckets")
+  }
+  if !metadata.MetadataSchema_intersects(
+    escaped(testutil.NativeMetadata("Date"), testutil.AtomicMetadata("string"), ""),
+    escaped(testutil.NativeMetadata("Date"), testutil.AtomicMetadata("number"), ""),
+  ) {
+    t.Fatal("matching escaped originals should intersect on their own")
+  }
+  if metadata.MetadataSchema_intersects(
+    escaped(testutil.NativeMetadata("Date"), testutil.AtomicMetadata("string"), ""),
+    escaped(testutil.NativeMetadata("Uint8Array"), testutil.AtomicMetadata("boolean"), ""),
+  ) {
+    t.Fatal("fully disjoint escaped schemas should not intersect")
+  }
+}


### PR DESCRIPTION
## Intent

Advance #1913 (the safely-fixable subset): three precision gaps in `MetadataSchema_intersects` / `MetadataSchema_covers` found during the #1909 review rounds.

## Changes

- **intersects, both-sides-Escaped early return**: when both schemas carried an `Escaped` (toJSON) bucket, the function returned the escaped-only comparison, hiding shared primitive buckets — `{Escaped(Blob→boolean), number}` vs `{Escaped(Date→string), number}` reported no intersection, an unsafe union discriminator for types mixing toJSON classes with primitives. The escaped match is now sufficient-but-not-necessary (strictly conservative: only adds `true` outcomes, so `UnionPredicator` can only get safer).
- **covers nullability/optionality**: `covers(number, number | null)` and `covers(number, number | undefined)` returned true, making the union sort comparator non-antisymmetric (arbitrary order for nullable-vs-plain pairs). A non-nullable/required source no longer covers a nullable/optional target; the reverse stays covered.
- **covers boolean literal pair**: `true | false` accepts exactly what atomic `boolean` does, so the exhaustive pair now covers the atomic (a sole literal still does not).
- Three regression tests pin each change with positive and negative directions.
- Bump `typia` to `13.0.0-dev.20260605.14` (native source ships in the npm package).

## Deferred (stay tracked on #1913)

- Cross-bucket overlap absence (natives×objects, arrays×objects): an unconditional `intersects=true` would discard genuinely-safe discriminators (object types with required properties are runtime-disjoint from `Date` instances); needs a precise rule, not a blanket one.
- Tag-matrix containment in `covers`: sound tag implication needs a real design; sort-only impact.

## Impact

`covers` feeds only the union sort comparator (runtime consumers re-validate per branch, so sort changes cannot flip a validation boolean); `intersects` feeds only discriminator selection and only gains conservative `true`s.

## Validation

- `pnpm format`, `pnpm run test:go` (public + native trees, all ok)

## Review

Self-review, 3 rounds (per operator instruction; no multi-agent workflow): recursion-context audit for the new top checks, sort-tie determinism for the both-cover boolean pair case, conservative-degradation check for non-bool constant values.

Advances #1913.

🤖 Generated with [Claude Code](https://claude.com/claude-code)