### PR TITLE
ci(release): build the website job through the pnpm workspace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,21 @@ jobs:
         with:
           go-version: 1.26.x
       - uses: pnpm/action-setup@v4
+
+      # Mirror website.yml: the wasm playground links against samchon/ttsc
+      # through packages/typia/native/go.work, and the website is a pnpm
+      # workspace member consuming catalog: versions, so it must be installed
+      # from the workspace root (a standalone npm install cannot resolve it).
+      - name: Checkout ttsc sibling
+        run: git clone --depth 1 https://github.com/samchon/ttsc.git ../ttsc
       - name: Build Packages
-        run: pnpm install && pnpm run package:tgz
-      - name: Website Setup
-        working-directory: website
         run: |
-          npm cache clean --force
-          npm install
-          npm run build
+          pnpm install
+          pnpm run build
+          pnpm run package:tgz
+      - name: Website Build
+        working-directory: website
+        run: pnpm run build
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:


### PR DESCRIPTION
## Intent

Follow-up to #1923: the release workflow's `website` job still ran a standalone `npm install` inside `website/`, which cannot resolve the `catalog:typescript` version the website now consumes — the next tag push would have failed at the website deploy stage. The job also lacked the `ttsc` sibling checkout that the wasm playground build resolves through `packages/typia/native/go.work` (the PR-time `website.yml` has it; the release copy predates it).

## Changes

Mirror the proven `website.yml` deploy steps in `release.yml`'s website job: clone the ttsc sibling, root `pnpm install`, `pnpm run build` + `pnpm run package:tgz`, then `pnpm run build` inside `website/`. Deploy step unchanged.

## Validation

- Step-by-step parity check against `website.yml`, which runs green on every PR (most recently on #1923 itself).
- Release workflows only run on tag pushes, so the real proof lands with the next release; this PR removes a guaranteed failure, not a speculative one.

## Review

Self-review, 3 rounds (per operator instruction): YAML structure/indent audit, parity diff against website.yml, blast-radius check (publish/release jobs untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)