### PR TITLE
fix(typia): reject invalid protobuf field names

### DIFF
--- a/packages/typia/native/core/factories/ProtobufFactory.go
+++ b/packages/typia/native/core/factories/ProtobufFactory.go
@@ -481,6 +481,11 @@ func protobufFactory_validateShape(metadata *schemametadata.MetadataSchema, noSu
 
 func protobufFactory_validateObject(object *schemametadata.MetadataObjectType, errors *[]string) {
   for _, property := range object.Properties {
+    // Dynamic keys (template/string typed) become protobuf maps and carry no
+    // field name; only sole-literal keys reach the emitted message text.
+    if name := property.Key.GetSoleLiteral(); name != nil && protobufFactory_isFieldName(*name) == false {
+      *errors = append(*errors, fmt.Sprintf("property name %q is not a valid Protocol Buffer field name", *name))
+    }
     protobufFactory_validateProperty(property.Value, errors)
   }
   entire := map[int]string{}
@@ -756,6 +761,30 @@ func protobufFactory_setPropertyIndex(prop nativeprotobuf.IProtobufPropertyType,
   case *nativeprotobuf.IProtobufPropertyType_IMap:
     v.Index = &index
   }
+}
+
+// protobufFactory_isFieldName reports whether the property name is a valid
+// proto3 field identifier: letters, digits, and underscores, not starting
+// with a digit. Anything else cannot appear in the emitted message text.
+func protobufFactory_isFieldName(name string) bool {
+  if len(name) == 0 {
+    return false
+  }
+  for i := 0; i < len(name); i++ {
+    ch := name[i]
+    switch {
+    case ch == '_':
+    case 'a' <= ch && ch <= 'z':
+    case 'A' <= ch && ch <= 'Z':
+    case '0' <= ch && ch <= '9':
+      if i == 0 {
+        return false
+      }
+    default:
+      return false
+    }
+  }
+  return true
 }
 
 func protobufFactory_firstTagRow(tags [][]schemametadata.IMetadataTypeTag) []schemametadata.IMetadataTypeTag {

--- a/packages/typia/native/core/factories/protobuf_factory_rejects_invalid_field_names_test.go
+++ b/packages/typia/native/core/factories/protobuf_factory_rejects_invalid_field_names_test.go
@@ -1,0 +1,75 @@
+package factories
+
+import (
+  "strings"
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestProtobufFactoryRejectsInvalidFieldNames verifies proto3 identifier rules.
+//
+// The emitted message text writes property names verbatim, so a quoted key
+// like "something-strange" produced a .proto file protoc cannot parse. The
+// object validator must reject any sole-literal property key that is not a
+// proto3 identifier, while dynamic (non-literal) keys stay exempt because
+// they compile to protobuf maps without field names.
+//
+//  1. Validate objects whose keys are valid identifiers and assert no error.
+//  2. Validate keys with dashes, leading digits, spaces, and empty names and
+//     assert each is rejected.
+//  3. Assert a dynamic string-typed key passes the name rule untouched.
+func TestProtobufFactoryRejectsInvalidFieldNames(t *testing.T) {
+  literal := func(value string) *schemametadata.MetadataSchema {
+    return schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
+      Required: true,
+      Constants: []*schemametadata.MetadataConstant{
+        schemametadata.MetadataConstant_create(schemametadata.MetadataConstant{
+          Type: "string",
+          Values: []*schemametadata.MetadataConstantValue{
+            schemametadata.MetadataConstantValue_create(schemametadata.MetadataConstantValue{Value: value}),
+          },
+        }),
+      },
+    })
+  }
+  atomic := func(kind string) *schemametadata.MetadataSchema {
+    return schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
+      Required: true,
+      Atomics: []*schemametadata.MetadataAtomic{
+        schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: kind}),
+      },
+    })
+  }
+  object := func(key *schemametadata.MetadataSchema) *schemametadata.MetadataObjectType {
+    return schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{
+      Name: "Something",
+      Properties: []*schemametadata.MetadataProperty{
+        schemametadata.MetadataProperty_create(schemametadata.MetadataProperty{
+          Key:   key,
+          Value: atomic("string"),
+        }),
+      },
+    })
+  }
+  validate := func(key *schemametadata.MetadataSchema) []string {
+    errors := []string{}
+    protobufFactory_validateObject(object(key), &errors)
+    return errors
+  }
+
+  for _, name := range []string{"id", "_private", "snake_case", "camelCase", "v2"} {
+    if errors := validate(literal(name)); len(errors) != 0 {
+      t.Fatalf("identifier key %q should be accepted, got %v", name, errors)
+    }
+  }
+  for _, name := range []string{"something-strange", "1leading", "has space", "", "emojié"} {
+    errors := validate(literal(name))
+    if len(errors) != 1 || strings.Contains(errors[0], "not a valid Protocol Buffer field name") == false {
+      t.Fatalf("key %q should be rejected as an invalid field name, got %v", name, errors)
+    }
+  }
+  if errors := validate(atomic("string")); len(errors) != 0 {
+    t.Fatalf("dynamic string key should be exempt from the field name rule, got %v", errors)
+  }
+}

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.15",
+  "version": "13.0.0-dev.20260605.16",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/tests/test-error/src/protobuf/error_protobuf_object_non_variable_key_name.ts
+++ b/tests/test-error/src/protobuf/error_protobuf_object_non_variable_key_name.ts
@@ -1,0 +1,24 @@
+import typia from "typia";
+
+interface IPointer<T> {
+  value: T;
+}
+interface Something {
+  id: string;
+  "something-strange": boolean;
+}
+
+// MESSAGE
+typia.protobuf.message<Something>();
+typia.protobuf.message<IPointer<Something>>();
+typia.protobuf.message<IPointer<Something>[]>();
+
+// DECODE
+typia.protobuf.createDecode<Something>();
+typia.protobuf.createDecode<IPointer<Something>>();
+typia.protobuf.createDecode<IPointer<Something>[]>();
+
+// ENCODE
+typia.protobuf.createEncode<Something>();
+typia.protobuf.createEncode<IPointer<Something>>();
+typia.protobuf.createEncode<IPointer<Something>[]>();


### PR DESCRIPTION
## Intent

Fix #1919: `typia.protobuf.message<T>()` emitted quoted object keys verbatim as proto3 field names, producing `.proto` text protoc cannot parse (`required bool something-strange = 2;`). Per the owner's decision on the issue, this is now a compile error.

## Changes

- `protobufFactory_validateObject` rejects any sole-literal property key that is not a proto3 identifier (`[A-Za-z_][A-Za-z0-9_]*`), with the diagnostic `property name "..." is not a valid Protocol Buffer field name`. The validator is shared by `message`, `createEncode`, and `createDecode`, so all protobuf entry points agree on what is expressible (the original fixture expected exactly that).
- Dynamic (template/string typed) keys stay exempt — they compile to protobuf maps and never appear as field names.
- Restores `tests/test-error/src/protobuf/error_protobuf_object_non_variable_key_name.ts` (removed in #1920 because the validation it pinned never existed — pre-Go `typia@12.1.1` accepted 4 of its 9 calls). With the validation now real, all 9 calls fail.
- Unit test `TestProtobufFactoryRejectsInvalidFieldNames` covers the identifier matrix (valid names, dash/leading-digit/space/empty/non-ASCII rejections, dynamic-key exemption).
- Bump `typia` to `13.0.0-dev.20260605.16` (native source ships in the npm package).

## Behavior note

This is intentionally stricter than pre-Go typia (v12 silently emitted the invalid `.proto`). Existing code using identifier keys is unaffected; code using quoted non-identifier keys with protobuf was already broken at the protoc boundary.

## Validation

- `pnpm format`, `pnpm run test:go` (public + native trees, all ok)
- Full test-error simulation through the Go transform CLI: 51/51 fixtures pass (the restored fixture errors on every call).

## Review

Self-review, 3 rounds (per operator instruction): byte-loop correctness incl. multi-byte input safety, dynamic-object/map exemption audit, blast-radius check over existing fixtures and suites.

Fixes #1919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)