### PR TITLE
feat(typia): add kebab-case notations

### DIFF
--- a/examples/src/notations/kebab.ts
+++ b/examples/src/notations/kebab.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+interface IPerson {
+  isMyNameSamchon?: boolean;
+  HelloTheNewWorld: string;
+  ToHTML: string;
+}
+typia.notations.createKebab<IPerson>();

--- a/packages/interface/src/typings/KebabCase.ts
+++ b/packages/interface/src/typings/KebabCase.ts
@@ -1,0 +1,136 @@
+import { Equal } from "./internal/Equal";
+import { NativeClass } from "./internal/NativeClass";
+import { ValueOf } from "./internal/ValueOf";
+
+/**
+ * Converts all object keys to kebab-case.
+ *
+ * `KebabCase<T>` transforms object property names to kebab-case format and
+ * erases methods like {@link Resolved}. Recursively processes nested
+ * structures.
+ *
+ * The conversion first derives the snake_case form of each key (matching
+ * {@link SnakeCase}), then rewrites the word separators to hyphens while keeping
+ * any leading underscores untouched.
+ *
+ * @author Jeongho Nam - https://github.com/samchon
+ * @template T Target type to transform
+ */
+export type KebabCase<T> =
+  Equal<T, KebabageMain<T>> extends true ? T : KebabageMain<T>;
+
+/* -----------------------------------------------------------
+    OBJECT CONVERSION
+----------------------------------------------------------- */
+
+type KebabageMain<T> = T extends [never]
+  ? never // special trick for (jsonable | null) type
+  : T extends { valueOf(): boolean | bigint | number | string }
+    ? ValueOf<T>
+    : T extends Function
+      ? never
+      : T extends object
+        ? KebabageObject<T>
+        : T;
+
+type KebabageObject<T extends object> =
+  T extends Array<infer U>
+    ? IsTuple<T> extends true
+      ? KebabageTuple<T>
+      : KebabageMain<U>[]
+    : T extends Set<infer U>
+      ? Set<KebabageMain<U>>
+      : T extends Map<infer K, infer V>
+        ? Map<KebabageMain<K>, KebabageMain<V>>
+        : T extends WeakSet<any> | WeakMap<any, any>
+          ? never
+          : T extends NativeClass
+            ? T
+            : {
+                [Key in keyof T as KebabageString<Key & string>]: KebabageMain<
+                  T[Key]
+                >;
+              };
+
+/* -----------------------------------------------------------
+    SPECIAL CASES
+----------------------------------------------------------- */
+type IsTuple<T extends readonly any[] | { length: number }> = [T] extends [
+  never,
+]
+  ? false
+  : T extends readonly any[]
+    ? number extends T["length"]
+      ? false
+      : true
+    : false;
+type KebabageTuple<T extends readonly any[]> = T extends []
+  ? []
+  : T extends [infer F]
+    ? [KebabageMain<F>]
+    : T extends [infer F, ...infer Rest extends readonly any[]]
+      ? [KebabageMain<F>, ...KebabageTuple<Rest>]
+      : T extends [(infer F)?]
+        ? [KebabageMain<F>?]
+        : T extends [(infer F)?, ...infer Rest extends readonly any[]]
+          ? [KebabageMain<F>?, ...KebabageTuple<Rest>]
+          : [];
+
+/* -----------------------------------------------------------
+    STRING CONVERTER
+----------------------------------------------------------- */
+type KebabageString<Key extends string> = Key extends `${infer _}`
+  ? KebabagePrefix<SnakageStringRepeatedly<Key, "">>
+  : Key;
+type KebabagePrefix<S extends string> = S extends `_${infer Rest}`
+  ? `_${KebabagePrefix<Rest>}`
+  : KebabageBody<S>;
+type KebabageBody<S extends string> = S extends `${infer Head}_${infer Tail}`
+  ? `${Head}-${KebabageBody<Tail>}`
+  : S;
+type SnakageStringRepeatedly<
+  S extends string,
+  Previous extends string,
+> = S extends `${infer First}${infer Second}${infer Rest}`
+  ? `${Underscore<Previous, First>}${Lowercase<First>}${Underscore<
+      First,
+      Second
+    >}${Lowercase<Second>}${SnakageStringRepeatedly<Rest, Second>}`
+  : S extends `${infer First}`
+    ? `${Underscore<Previous, First>}${Lowercase<First>}`
+    : "";
+type Underscore<First extends string, Second extends string> = First extends
+  | UpperAlphabetic
+  | ""
+  | "_"
+  ? ""
+  : Second extends UpperAlphabetic
+    ? "_"
+    : "";
+type UpperAlphabetic =
+  | "A"
+  | "B"
+  | "C"
+  | "D"
+  | "E"
+  | "F"
+  | "G"
+  | "H"
+  | "I"
+  | "J"
+  | "K"
+  | "L"
+  | "M"
+  | "N"
+  | "O"
+  | "P"
+  | "Q"
+  | "R"
+  | "S"
+  | "T"
+  | "U"
+  | "V"
+  | "W"
+  | "X"
+  | "Y"
+  | "Z";

--- a/packages/interface/src/typings/index.ts
+++ b/packages/interface/src/typings/index.ts
@@ -1,5 +1,6 @@
 export * from "./AssertionGuard";
 export * from "./CamelCase";
+export * from "./KebabCase";
 export * from "./PascalCase";
 export * from "./Primitive";
 export * from "./Resolved";

--- a/packages/typia/native/cmd/ttsc-typia/notation_kebab_case_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/notation_kebab_case_transform_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestNotationKebabCaseTransform verifies kebab-case notation conversion.
+//
+// `notations.kebab` derives the snake_case form of every property name and
+// rewrites the word separators to hyphens, keeping leading underscores. The
+// type-level `KebabCase<T>` must agree with the runtime rename exactly, or
+// the declared result type lies about the produced keys.
+//
+//  1. Transform a fixture covering camelCase, snake_case, leading-underscore,
+//     consecutive-uppercase (the acronym run collapses, so `XMLParser` becomes
+//     `xmlparser`), and nested property names. The matching compile-time
+//     `KebabCase<T>` assertions live in the test-typia-generate fixture, where
+//     ttsc enforces type diagnostics.
+//  2. Require the emitted converter to reference the kebab-case keys.
+//  3. Execute kebab, isKebab, assertKebab, and validateKebab runtime cases
+//     over valid and invalid inputs.
+func TestNotationKebabCaseTransform(t *testing.T) {
+  project := notationKebabCaseProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("kebab notation transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  for _, key := range []string{`"user-id"`, `"user-name"`, `"_private-value"`, `xmlparser:`, `"inner-value"`} {
+    if !strings.Contains(out, key) {
+      t.Fatalf("emitted converter should contain kebab key %s:\n%s", key, out)
+    }
+  }
+  notationKebabCaseRunRuntimeCases(t, project, out)
+}
+
+func notationKebabCaseProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "notation-kebab-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(notationKebabCaseTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(notationKebabCaseSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func notationKebabCaseRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(notationKebabCaseRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("kebab notation runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const notationKebabCaseTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const notationKebabCaseSource = `import typia from "typia";
+
+interface SourceRecord {
+  userId: string;
+  user_name: string;
+  _privateValue: number;
+  XMLParser: boolean;
+  nested: { innerValue: string };
+}
+
+export const toKebab = typia.notations.createKebab<SourceRecord>();
+export const isKebab = typia.notations.createIsKebab<SourceRecord>();
+export const assertKebab = typia.notations.createAssertKebab<SourceRecord>();
+export const validateKebab =
+  typia.notations.createValidateKebab<SourceRecord>();
+`
+
+const notationKebabCaseRuntimeRunner = `const mod = require("./main.cjs");
+
+const valid = {
+  userId: "u-1",
+  user_name: "John",
+  _privateValue: 3,
+  XMLParser: true,
+  nested: { innerValue: "deep" },
+};
+const expectedKeys = ["user-id", "user-name", "_private-value", "xmlparser", "nested"];
+
+const converted = mod.toKebab(valid);
+const keys = Object.keys(converted).sort();
+if (JSON.stringify(keys) !== JSON.stringify([...expectedKeys].sort())) {
+  throw new Error("kebab conversion produced unexpected keys: " + JSON.stringify(keys));
+}
+if (converted["user-id"] !== "u-1" || converted["user-name"] !== "John") {
+  throw new Error("kebab conversion lost property values: " + JSON.stringify(converted));
+}
+if (converted["_private-value"] !== 3 || converted["xmlparser"] !== true) {
+  throw new Error("prefix/acronym keys converted incorrectly: " + JSON.stringify(converted));
+}
+if (JSON.stringify(Object.keys(converted.nested)) !== JSON.stringify(["inner-value"])) {
+  throw new Error("nested keys should be kebab-cased: " + JSON.stringify(converted.nested));
+}
+
+if (mod.isKebab(valid) === null) {
+  throw new Error("isKebab should accept the valid input");
+}
+if (mod.isKebab({ ...valid, userId: 1 }) !== null) {
+  throw new Error("isKebab should reject an invalid property type");
+}
+if (mod.assertKebab(valid)["user-id"] !== "u-1") {
+  throw new Error("assertKebab should return the converted object");
+}
+let thrown = null;
+try {
+  mod.assertKebab({ ...valid, nested: { innerValue: 1 } });
+} catch (error) {
+  thrown = error;
+}
+if (thrown === null) {
+  throw new Error("assertKebab should throw on invalid nested input");
+}
+
+const success = mod.validateKebab(valid);
+if (success.success !== true || success.data["user-name"] !== "John") {
+  throw new Error("validateKebab should succeed with converted data: " + JSON.stringify(success));
+}
+const failure = mod.validateKebab({ ...valid, XMLParser: "yes" });
+if (failure.success !== false || failure.errors.length === 0) {
+  throw new Error("validateKebab should collect errors for invalid input: " + JSON.stringify(failure));
+}
+`

--- a/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
+++ b/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
@@ -1301,6 +1301,7 @@ func notationGeneralProgrammer_capitalize(str string) string {
 var NotationGeneralProgrammer_Camel = NotationGeneralProgrammer_IRename{Name: "camel", Func: notationGeneralProgrammer_camel}
 var NotationGeneralProgrammer_Pascal = NotationGeneralProgrammer_IRename{Name: "pascal", Func: notationGeneralProgrammer_pascal}
 var NotationGeneralProgrammer_Snake = NotationGeneralProgrammer_IRename{Name: "snake", Func: notationGeneralProgrammer_snake}
+var NotationGeneralProgrammer_Kebab = NotationGeneralProgrammer_IRename{Name: "kebab", Func: notationGeneralProgrammer_kebab}
 
 func notationGeneralProgrammer_camel(str string) string {
   return notationGeneralProgrammer_unsnake(str, func(value string) string {
@@ -1378,6 +1379,19 @@ func notationGeneralProgrammer_snake(str string) string {
   }
   ret += strings.ToLower(str[indexes[len(indexes)-1]:])
   return out(ret)
+}
+
+// notationGeneralProgrammer_kebab derives the snake_case form first and then
+// rewrites the word separators to hyphens, keeping any leading underscores
+// untouched — the exact composition mirrored by the `KebabCase<T>` typing.
+func notationGeneralProgrammer_kebab(str string) string {
+  snaked := notationGeneralProgrammer_snake(str)
+  prefix := ""
+  for len(snaked) != 0 && snaked[0] == '_' {
+    prefix += "_"
+    snaked = snaked[1:]
+  }
+  return prefix + strings.ReplaceAll(snaked, "_", "-")
 }
 
 func notationGeneralProgrammer_unsnake(str string, plain func(string) string, snake func(string, int) string) string {

--- a/packages/typia/native/transform/CallExpressionTransformer.go
+++ b/packages/typia/native/transform/CallExpressionTransformer.go
@@ -507,6 +507,7 @@ func callExpressionTransformer_notations() map[string]callExpressionTransformerF
   camel := nativenotationprogrammers.NotationGeneralProgrammer_Camel
   pascal := nativenotationprogrammers.NotationGeneralProgrammer_Pascal
   snake := nativenotationprogrammers.NotationGeneralProgrammer_Snake
+  kebab := nativenotationprogrammers.NotationGeneralProgrammer_Kebab
   return map[string]callExpressionTransformerFunctor{
     "camel": func() callExpressionTransformerTask {
       return nativenotationtransformers.NotationGeneralTransformer.Transform(camel)
@@ -544,6 +545,18 @@ func callExpressionTransformer_notations() map[string]callExpressionTransformerF
     "validateSnake": func() callExpressionTransformerTask {
       return nativenotationtransformers.NotationValidateGeneralTransformer.Transform(snake)
     },
+    "kebab": func() callExpressionTransformerTask {
+      return nativenotationtransformers.NotationGeneralTransformer.Transform(kebab)
+    },
+    "assertKebab": func() callExpressionTransformerTask {
+      return nativenotationtransformers.NotationAssertGeneralTransformer.Transform(kebab)
+    },
+    "isKebab": func() callExpressionTransformerTask {
+      return nativenotationtransformers.NotationIsGeneralTransformer.Transform(kebab)
+    },
+    "validateKebab": func() callExpressionTransformerTask {
+      return nativenotationtransformers.NotationValidateGeneralTransformer.Transform(kebab)
+    },
     "createCamel": func() callExpressionTransformerTask {
       return nativenotationtransformers.NotationCreateGeneralTransformer.Transform(camel)
     },
@@ -579,6 +592,18 @@ func callExpressionTransformer_notations() map[string]callExpressionTransformerF
     },
     "createValidateSnake": func() callExpressionTransformerTask {
       return nativenotationtransformers.NotationCreateValidateGeneralTransformer.Transform(snake)
+    },
+    "createKebab": func() callExpressionTransformerTask {
+      return nativenotationtransformers.NotationCreateGeneralTransformer.Transform(kebab)
+    },
+    "createAssertKebab": func() callExpressionTransformerTask {
+      return nativenotationtransformers.NotationCreateAssertGeneralTransformer.Transform(kebab)
+    },
+    "createIsKebab": func() callExpressionTransformerTask {
+      return nativenotationtransformers.NotationCreateIsGeneralTransformer.Transform(kebab)
+    },
+    "createValidateKebab": func() callExpressionTransformerTask {
+      return nativenotationtransformers.NotationCreateValidateGeneralTransformer.Transform(kebab)
     },
   }
 }

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.16",
+  "version": "13.0.0-dev.20260605.17",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/src/notations.ts
+++ b/packages/typia/src/notations.ts
@@ -1,6 +1,7 @@
 import {
   CamelCase,
   IValidation,
+  KebabCase,
   PascalCase,
   SnakeCase,
 } from "@typia/interface";
@@ -13,6 +14,7 @@ import { NoTransformConfigurationError } from "./transformers/NoTransformConfigu
       - CAMEL CASE
       - PASCAL CASE
       - SNAKE CASE
+      - KEBAB CASE
       - FACTORY FUNCTIONS
 ==============================================================
     CAMEL CASE
@@ -357,6 +359,120 @@ export function validateSnake(): never {
 }
 
 /* -----------------------------------------------------------
+    KEBAB CASE
+----------------------------------------------------------- */
+/**
+ * Converts property names to kebab-case.
+ *
+ * Transforms all property names in the object (including nested) to kebab-case
+ * convention. Creates a new object with renamed properties.
+ *
+ * Does not validate the input. For validation, use:
+ *
+ * - {@link assertKebab} — Throws on type mismatch
+ * - {@link isKebab} — Returns `null` on type mismatch
+ * - {@link validateKebab} — Returns detailed validation errors
+ *
+ * @template T Type of input value
+ * @param input Object to convert
+ * @returns New object with kebab-case property names
+ */
+export function kebab<T>(input: T): KebabCase<T>;
+
+/** @internal */
+export function kebab(): never {
+  return NoTransformConfigurationError("notations.kebab");
+}
+
+/**
+ * Converts property names to kebab-case with assertion.
+ *
+ * Transforms all property names to kebab-case with {@link assert} validation.
+ * Throws {@link TypeGuardError} on type mismatch.
+ *
+ * Related functions:
+ *
+ * - {@link kebab} — No validation
+ * - {@link isKebab} — Returns `null` instead of throwing
+ * - {@link validateKebab} — Returns detailed validation errors
+ *
+ * @template T Type of input value
+ * @param input Object to convert
+ * @param errorFactory Custom error factory receiving
+ *   {@link TypeGuardError.IProps}
+ * @returns New object with kebab-case property names
+ * @throws {TypeGuardError} When input doesn't conform to type `T`
+ */
+export function assertKebab<T>(
+  input: T,
+  errorFactory?: undefined | ((props: TypeGuardError.IProps) => Error),
+): KebabCase<T>;
+
+/** @internal */
+export function assertKebab<T>(
+  input: unknown,
+  errorFactory?: undefined | ((props: TypeGuardError.IProps) => Error),
+): KebabCase<T>;
+
+/** @internal */
+export function assertKebab(): never {
+  return NoTransformConfigurationError("notations.assertKebab");
+}
+
+/**
+ * Converts property names to kebab-case with type checking.
+ *
+ * Transforms all property names to kebab-case with {@link is} validation.
+ * Returns `null` on type mismatch.
+ *
+ * Related functions:
+ *
+ * - {@link kebab} — No validation
+ * - {@link assertKebab} — Throws instead of returning `null`
+ * - {@link validateKebab} — Returns detailed validation errors
+ *
+ * @template T Type of input value
+ * @param input Object to convert
+ * @returns New object with kebab-case property names, or `null` if invalid
+ */
+export function isKebab<T>(input: T): KebabCase<T> | null;
+
+/** @internal */
+export function isKebab<T>(input: unknown): KebabCase<T> | null;
+
+/** @internal */
+export function isKebab(): never {
+  return NoTransformConfigurationError("notations.isKebab");
+}
+
+/**
+ * Converts property names to kebab-case with validation.
+ *
+ * Transforms all property names to kebab-case with {@link validate} validation.
+ * Returns {@link IValidation.IFailure} with all errors on mismatch, or
+ * {@link IValidation.ISuccess} with converted object.
+ *
+ * Related functions:
+ *
+ * - {@link kebab} — No validation
+ * - {@link assertKebab} — Throws on first error
+ * - {@link isKebab} — Returns `null` instead of error details
+ *
+ * @template T Type of input value
+ * @param input Object to convert
+ * @returns Validation result containing converted object or errors
+ */
+export function validateKebab<T>(input: T): IValidation<KebabCase<T>>;
+
+/** @internal */
+export function validateKebab<T>(input: unknown): IValidation<KebabCase<T>>;
+
+/** @internal */
+export function validateKebab(): never {
+  return NoTransformConfigurationError("notations.validateKebab");
+}
+
+/* -----------------------------------------------------------
     FACTORY FUNCTIONS
 ----------------------------------------------------------- */
 /**
@@ -621,4 +737,92 @@ export function createValidateSnake<T>(): (
 /** @internal */
 export function createValidateSnake(): never {
   NoTransformConfigurationError("notations.createValidateSnake");
+}
+
+/**
+ * Creates reusable {@link kebab} function.
+ *
+ * @danger You must configure the generic argument `T`
+ */
+export function createKebab(): never;
+
+/**
+ * Creates reusable {@link kebab} function.
+ *
+ * @template T Type of input value
+ * @returns Reusable conversion function
+ */
+export function createKebab<T>(): (input: T) => KebabCase<T>;
+
+/** @internal */
+export function createKebab(): never {
+  NoTransformConfigurationError("notations.createKebab");
+}
+
+/**
+ * Creates reusable {@link assertKebab} function.
+ *
+ * @danger You must configure the generic argument `T`
+ */
+export function createAssertKebab(
+  errorFactory?: undefined | ((props: TypeGuardError.IProps) => Error),
+): never;
+
+/**
+ * Creates reusable {@link assertKebab} function.
+ *
+ * @template T Type of input value
+ * @param errorFactory Custom error factory receiving
+ *   {@link TypeGuardError.IProps}
+ * @returns Reusable conversion function
+ */
+export function createAssertKebab<T>(
+  errorFactory?: undefined | ((props: TypeGuardError.IProps) => Error),
+): (input: T) => KebabCase<T>;
+
+/** @internal */
+export function createAssertKebab(): never {
+  NoTransformConfigurationError("notations.createAssertKebab");
+}
+
+/**
+ * Creates reusable {@link isKebab} function.
+ *
+ * @danger You must configure the generic argument `T`
+ */
+export function createIsKebab(): never;
+
+/**
+ * Creates reusable {@link isKebab} function.
+ *
+ * @template T Type of input value
+ * @returns Reusable conversion function
+ */
+export function createIsKebab<T>(): (input: T) => KebabCase<T> | null;
+
+/** @internal */
+export function createIsKebab(): never {
+  NoTransformConfigurationError("notations.createIsKebab");
+}
+
+/**
+ * Creates reusable {@link validateKebab} function.
+ *
+ * @danger You must configure the generic argument `T`
+ */
+export function createValidateKebab(): never;
+
+/**
+ * Creates reusable {@link validateKebab} function.
+ *
+ * @template T Type of input value
+ * @returns Reusable conversion function
+ */
+export function createValidateKebab<T>(): (
+  input: T,
+) => IValidation<KebabCase<T>>;
+
+/** @internal */
+export function createValidateKebab(): never {
+  NoTransformConfigurationError("notations.createValidateKebab");
 }

--- a/packages/typia/src/re-exports.ts
+++ b/packages/typia/src/re-exports.ts
@@ -25,6 +25,7 @@ export {
   Primitive,
   Resolved,
   CamelCase,
+  KebabCase,
   PascalCase,
   SnakeCase,
   // http

--- a/packages/utils/src/utils/NamingConvention.ts
+++ b/packages/utils/src/utils/NamingConvention.ts
@@ -11,6 +11,7 @@
  * - {@link camel}: Convert to camelCase (`fooBar`)
  * - {@link pascal}: Convert to PascalCase (`FooBar`)
  * - {@link snake}: Convert to snake_case (`foo_bar`)
+ * - {@link kebab}: Convert to kebab-case (`foo-bar`)
  * - {@link variable}: Test if string is valid JavaScript variable name
  *
  * @author Jeongho Nam - https://github.com/samchon
@@ -98,6 +99,25 @@ export namespace NamingConvention {
     }
     ret += str.substring(indexes[indexes.length - 1]!).toLowerCase();
     return out(ret);
+  }
+
+  /**
+   * Convert to kebab-case.
+   *
+   * Derives the snake_case form first and then rewrites the word separators to
+   * hyphens, keeping any leading underscores untouched.
+   *
+   * @param str Input string
+   * @returns Kebab-case string
+   */
+  export function kebab(str: string): string {
+    const snaked: string = snake(str);
+    let prefix: string = "";
+    for (let i: number = 0; i < snaked.length; i++) {
+      if (snaked[i] === "_") prefix += "_";
+      else break;
+    }
+    return prefix + snaked.substring(prefix.length).split("_").join("-");
   }
 
   /**

--- a/tests/test-typia-generate/src/input/generate_notations.ts
+++ b/tests/test-typia-generate/src/input/generate_notations.ts
@@ -30,3 +30,31 @@ export const createAssertSnake = typia.notations.createAssertSnake<ICitizen>();
 export const createIsSnake = typia.notations.createIsSnake<ICitizen>();
 export const createValidateSnake =
   typia.notations.createValidateSnake<ICitizen>();
+
+export const createKebab = typia.notations.createKebab<ICitizen>();
+export const createAssertKebab = typia.notations.createAssertKebab<ICitizen>();
+export const createIsKebab = typia.notations.createIsKebab<ICitizen>();
+export const createValidateKebab =
+  typia.notations.createValidateKebab<ICitizen>();
+
+interface IKebabSource {
+  userId: string;
+  user_name: string;
+  _privateValue: number;
+  XMLParser: boolean;
+  nested: { innerValue: string };
+}
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
+const kebabKeyAssertion: Equal<
+  keyof typia.KebabCase<IKebabSource>,
+  "user-id" | "user-name" | "_private-value" | "xmlparser" | "nested"
+> = true;
+const kebabNestedKeyAssertion: Equal<
+  keyof typia.KebabCase<IKebabSource>["nested"],
+  "inner-value"
+> = true;
+void kebabKeyAssertion;
+void kebabNestedKeyAssertion;

--- a/tests/test-utils/src/features/naming/test_naming_convention_kebab.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_kebab.ts
@@ -1,0 +1,37 @@
+import { TestValidator } from "@nestia/e2e";
+import { NamingConvention } from "@typia/utils";
+
+/**
+ * Verifies NamingConvention.kebab derives hyphenated names.
+ *
+ * Kebab conversion is defined as the snake_case derivation with hyphen word
+ * separators, keeping leading underscores untouched. The same composition
+ * drives the `typia.notations.kebab` transform and the `KebabCase<T>` typing,
+ * so this utility must stay byte-identical to that contract — including the
+ * acronym-run collapse the snake derivation performs.
+ *
+ * 1. Convert camelCase, PascalCase, and snake_case inputs.
+ * 2. Convert leading-underscore and acronym-run inputs.
+ * 3. Convert degenerate inputs (empty, underscores only, single word).
+ */
+export const test_naming_convention_kebab = (): void => {
+  const expectations: [string, string][] = [
+    ["userId", "user-id"],
+    ["UserId", "user-id"],
+    ["user_name", "user-name"],
+    ["_privateValue", "_private-value"],
+    ["__doublePrefix", "__double-prefix"],
+    ["XMLParser", "xmlparser"],
+    ["toHTML", "to-html"],
+    ["already-plain", "already-plain"],
+    ["", ""],
+    // The snake derivation drops the prefix when no word separation occurs
+    // (a long-standing snake quirk); kebab inherits it by composition.
+    ["___", ""],
+    ["word", "word"],
+  ];
+  for (const [input, expected] of expectations)
+    TestValidator.equals(`kebab(${JSON.stringify(input)})`)(
+      NamingConvention.kebab(input),
+    )(expected);
+};

--- a/tests/test-utils/src/features/naming/test_naming_convention_kebab.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_kebab.ts
@@ -31,7 +31,9 @@ export const test_naming_convention_kebab = (): void => {
     ["word", "word"],
   ];
   for (const [input, expected] of expectations)
-    TestValidator.equals(`kebab(${JSON.stringify(input)})`)(
+    TestValidator.equals(
+      `kebab(${JSON.stringify(input)})`,
       NamingConvention.kebab(input),
-    )(expected);
+      expected,
+    );
 };

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -169,7 +169,7 @@ Handy for select-box options, discriminated-union test matrices, etc.
 
 ## `notations`
 
-Three case converters: `camel`, `pascal`, `snake`. Each one walks the object and rewrites property names to that case at type *and* runtime. Same four-variant family as everywhere else (`name`, `assertName`, `isName`, `validateName`, plus `create*` factories).
+Four case converters: `camel`, `pascal`, `snake`, `kebab`. Each one walks the object and rewrites property names to that case at type *and* runtime. Same four-variant family as everywhere else (`name`, `assertName`, `isName`, `validateName`, plus `create*` factories).
 
 ### `camel`
 
@@ -261,6 +261,42 @@ typia.notations.snake<{ userId: string; userName: string }>({
     <LocalSource
       path="examples/bin/notations/snake.js"
       filename="examples/bin/notations/snake.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+### `kebab`
+
+```typescript copy filename="signatures"
+namespace notations {
+  function kebab<T>(input: T): KebabCase<T>;
+  function assertKebab<T>(input: unknown): KebabCase<T>;
+  function isKebab<T>(input: unknown): KebabCase<T> | null;
+  function validateKebab<T>(input: unknown): IValidation<KebabCase<T>>;
+}
+```
+
+```typescript copy
+typia.notations.kebab<{ userId: string; user_name: string }>({
+  userId: "1",
+  user_name: "John",
+});
+// → { "user-id": "1", "user-name": "John" }
+```
+
+`kebab` derives the snake_case form first and then rewrites the word separators to hyphens, keeping leading underscores untouched.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/notations/kebab.ts"
+      filename="examples/src/notations/kebab.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/notations/kebab.js"
+      filename="examples/bin/notations/kebab.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>


### PR DESCRIPTION
## Intent

Implement #1548: the kebab-case member of the notations family, alongside camel/pascal/snake.

## Design

kebab is defined as **the snake_case derivation with hyphen word separators** (leading underscores preserved). Both the type level and every runtime implementation are built as that exact composition, so they stay equivalent by construction:

- `KebabCase<T>` (`@typia/interface`, self-contained like its siblings, re-exported from `typia`): snake string machinery → hyphenate body, keep `_` prefix.
- `NotationGeneralProgrammer_Kebab` (Go transform): `notationGeneralProgrammer_snake(str)` → keep `_` prefix → replace `_` with `-`.
- `NamingConvention.kebab` (`@typia/utils`): `snake(str)` → same post-processing.

## API surface

`typia.notations.kebab` / `assertKebab` / `isKebab` / `validateKebab` + the four `create*` factories, wired through the existing notation transformers; `typia.KebabCase<T>` re-export; `NamingConvention.kebab`; docs section in `misc.mdx` with the `examples/src/notations/kebab.ts` example.

## Tests

- `TestNotationKebabCaseTransform` (Go, cmd): camelCase / snake_case / leading-underscore / acronym-run / nested keys; runtime cases for kebab, isKebab (accept + reject), assertKebab (return + throw), validateKebab (success + error collection); emitted-key assertions.
- Compile-time `Equal` assertions on the `KebabCase<T>` key set live in the `test-typia-generate` fixture (where ttsc enforces type diagnostics — the cmd transform harness does not), including the nested key.
- `test_naming_convention_kebab` in `tests/test-utils` (new `naming` feature group) pinning the conversion matrix; verified locally against a standalone tsc compile (`ALL PASS`, plus a negative-control type assertion).

## Notes found while implementing

- Acronym runs collapse (`XMLParser` → `xmlparser`): this is the existing snake semantics at both type and runtime; kebab inherits it consistently and the tests pin it.
- The snake runtime drops the `_` prefix when no word separation occurs (`snake("_foo")` → `"foo"`, diverging from `SnakeCase<T>`); kebab inherits that family quirk by composition. Filed separately as #1926 rather than changing snake behavior inside a feature PR.
- Bump `typia` to `13.0.0-dev.20260605.17` (native source ships in the npm package).

## Validation

- `pnpm format`, `pnpm run test:go` (public + native trees, all ok)
- Standalone tsc typecheck of the `KebabCase` assertions and the `NamingConvention.kebab` matrix.

## Review

Self-review, 3 rounds (per operator instruction): surface-parity audit against the snake family (8 functions, transformer entries, re-exports), type/runtime equivalence trace per input class, adversarial pass that surfaced the acronym-collapse expectation and the #1926 prefix quirk.

Fixes #1548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)