### PR TITLE
feat(typia): add exclude type tag

### DIFF
--- a/packages/interface/src/tags/Exclude.ts
+++ b/packages/interface/src/tags/Exclude.ts
@@ -1,0 +1,37 @@
+import { TagBase } from "./TagBase";
+
+/**
+ * Excluded literal values.
+ *
+ * `Exclude<Values>` is a type tag that rejects the listed literal values while
+ * keeping the rest of the base type valid. List every excluded value in one
+ * tuple — the tag is exclusive, so a second `Exclude` on the same type is a
+ * compile error (their JSON schema fragments could not merge).
+ *
+ * In JSON schema the constraint appears as `not: { enum: [...] }`. Note that
+ * OpenAI strict mode (and therefore `typia.llm.*` with a strict model
+ * configuration) cannot express `not`, so strict LLM schemas reject this tag.
+ * `typia.random` does not consult it either: generated values may collide with
+ * the excluded list.
+ *
+ * @author Jeongho Nam - https://github.com/samchon
+ * @example
+ *   interface IConfig {
+ *     port: number & tags.Exclude<[0, 22, 80]>;
+ *     name: string & tags.Exclude<["admin", "root"]>;
+ *   }
+ *
+ * @template Values Tuple of excluded literal values
+ */
+export type Exclude<Values extends readonly (bigint | number | string)[]> =
+  TagBase<{
+    target: "bigint" | "number" | "string";
+    kind: "exclude";
+    value: undefined;
+    exclusive: true;
+    schema: {
+      not: {
+        enum: Values;
+      };
+    };
+  }>;

--- a/packages/interface/src/tags/index.ts
+++ b/packages/interface/src/tags/index.ts
@@ -3,6 +3,7 @@ export * from "./ContentMediaType";
 export * from "./Default";
 export * from "./Example";
 export * from "./Examples";
+export * from "./Exclude";
 export * from "./ExclusiveMaximum";
 export * from "./ExclusiveMinimum";
 export * from "./Format";

--- a/packages/typia/native/cmd/ttsc-typia/exclude_type_tag_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/exclude_type_tag_transform_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestExcludeTypeTagTransform verifies the exclude type tag.
+//
+// `tags.Exclude<Values>` rejects listed literal values. The excluded
+// literals travel in the tag's JSON schema fragment (`not.enum`) because a
+// tuple of values cannot be templated into a single validate literal, so the
+// checker synthesizes the `!==` chain itself and the JSON schema emitter
+// merges the fragment untouched (#1630).
+//
+//  1. Transform a fixture excluding number, string, bigint, and
+//     template-literal values.
+//  2. Require the emitted JSON schema to carry `not: { enum: [...] }`.
+//  3. Execute is/validate runtime cases: excluded values fail with the tag
+//     named in the error, all other values of the base type pass.
+func TestExcludeTypeTagTransform(t *testing.T) {
+  project := excludeTypeTagProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("exclude tag transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  for _, needle := range []string{"not:", `"enum"`, "input.port !== 0", `input.name !== "admin"`} {
+    if !strings.Contains(out, needle) {
+      t.Fatalf("emitted output should contain %q:\n%s", needle, out)
+    }
+  }
+  excludeTypeTagRunRuntimeCases(t, project, out)
+}
+
+func excludeTypeTagProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "exclude-tag-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(excludeTypeTagTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(excludeTypeTagSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func excludeTypeTagRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(excludeTypeTagRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("exclude tag runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const excludeTypeTagTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const excludeTypeTagSource = `import typia, { tags } from "typia";
+
+interface IConfig {
+  port: number & tags.Exclude<[0, 22, 80]>;
+  name: string & tags.Exclude<["admin", "root"]>;
+  serial: bigint & tags.Exclude<[0n]>;
+  account: ` + "`user-${string}`" + ` & tags.Exclude<["user-admin"]>;
+}
+
+export const isConfig = typia.createIs<IConfig>();
+export const validateConfig = typia.createValidate<IConfig>();
+export const schema = typia.json.schemas<[{ port: number & tags.Exclude<[0, 22, 80]> }]>();
+`
+
+const excludeTypeTagRuntimeRunner = `const mod = require("./main.cjs");
+
+const valid = { port: 8080, name: "user", serial: 1n, account: "user-one" };
+if (mod.isConfig(valid) !== true) {
+  throw new Error("non-excluded values should pass is");
+}
+for (const port of [0, 22, 80]) {
+  if (mod.isConfig({ ...valid, port }) !== false) {
+    throw new Error("excluded port " + port + " should fail is");
+  }
+}
+for (const name of ["admin", "root"]) {
+  if (mod.isConfig({ ...valid, name }) !== false) {
+    throw new Error("excluded name " + name + " should fail is");
+  }
+}
+if (mod.isConfig({ ...valid, serial: 0n }) !== false) {
+  throw new Error("excluded bigint serial should fail is");
+}
+if (mod.isConfig({ ...valid, serial: 2n }) !== true) {
+  throw new Error("non-excluded bigint serial should pass is");
+}
+if (mod.isConfig({ ...valid, account: "user-admin" }) !== false) {
+  throw new Error("excluded template literal value should fail is");
+}
+if (mod.isConfig({ ...valid, account: "nomatch" }) !== false) {
+  throw new Error("template pattern should still be enforced next to exclude");
+}
+
+const failure = mod.validateConfig({ ...valid, port: 22 });
+if (failure.success !== false) {
+  throw new Error("excluded port should fail validate");
+}
+if (!failure.errors.some((e) => e.path === "$input.port" && e.expected.includes("Exclude"))) {
+  throw new Error("validate error should name the exclude tag: " + JSON.stringify(failure.errors));
+}
+if (mod.validateConfig(valid).success !== true) {
+  throw new Error("valid input should pass validate");
+}
+
+const unit = mod.schema.schemas[0];
+const resolved = unit.$ref
+  ? mod.schema.components.schemas[unit.$ref.split("/").pop()]
+  : unit;
+const port = resolved.properties.port;
+if (!port.not || JSON.stringify(port.not["enum"]) !== "[0,22,80]") {
+  throw new Error("JSON schema should carry not.enum: " + JSON.stringify(port));
+}
+`

--- a/packages/typia/native/core/programmers/iterate/check_bigint.go
+++ b/packages/typia/native/core/programmers/iterate/check_bigint.go
@@ -34,15 +34,20 @@ func check_bigint_type_tags(props Check_bigintProps) [][]nativehelpers.ICheckEnt
   output := [][]nativehelpers.ICheckEntry_ICondition{}
   for _, row := range props.Atomic.Tags {
     tags := check_bigint_filter_validate(row)
-    if len(tags) == 0 {
-      continue
-    }
     conditions := make([]nativehelpers.ICheckEntry_ICondition, 0, len(tags))
     for _, tag := range tags {
       conditions = append(conditions, nativehelpers.ICheckEntry_ICondition{
         Expected:   "bigint & " + tag.Name,
         Expression: check_bigint_transpile(props.Context, tag.Validate)(props.Input),
       })
+    }
+    for _, tag := range row {
+      if condition := check_exclude_condition("bigint", tag, props.Input, props.Context.Emit); condition != nil {
+        conditions = append(conditions, *condition)
+      }
+    }
+    if len(conditions) == 0 {
+      continue
     }
     output = append(output, conditions)
   }

--- a/packages/typia/native/core/programmers/iterate/check_exclude.go
+++ b/packages/typia/native/core/programmers/iterate/check_exclude.go
@@ -1,0 +1,88 @@
+package iterate
+
+import (
+  "fmt"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimprinter "github.com/microsoft/typescript-go/shim/printer"
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+  nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
+  nativehelpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
+  nativemetadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// check_exclude_condition synthesizes the runtime condition of an `exclude`
+// kind type tag. Excluded literals travel in the tag's JSON schema fragment
+// (`schema.not.enum`) instead of a validate script, because the tag accepts a
+// tuple of values that no single validate literal could template, so the
+// checker builds the `!==` chain itself.
+func check_exclude_condition(
+  typ string,
+  tag nativemetadata.IMetadataTypeTag,
+  input *shimast.Expression,
+  emit *shimprinter.EmitContext,
+) *nativehelpers.ICheckEntry_ICondition {
+  if tag.Kind != "exclude" {
+    return nil
+  }
+  values := check_exclude_values(tag)
+  if len(values) == 0 {
+    return nil
+  }
+  f := nativecontext.EmitFactoryOf(check_exclude_factory, emit)
+  var expression *shimast.Node
+  for _, value := range values {
+    comparison := f.NewBinaryExpression(
+      nil,
+      input,
+      nil,
+      f.NewToken(shimast.KindExclamationEqualsEqualsToken),
+      check_exclude_literal(typ, value, emit),
+    )
+    if expression == nil {
+      expression = comparison
+    } else {
+      expression = f.NewBinaryExpression(
+        nil,
+        expression,
+        nil,
+        f.NewToken(shimast.KindAmpersandAmpersandToken),
+        comparison,
+      )
+    }
+  }
+  return &nativehelpers.ICheckEntry_ICondition{
+    Expected:   typ + " & " + tag.Name,
+    Expression: expression,
+  }
+}
+
+func check_exclude_values(tag nativemetadata.IMetadataTypeTag) []any {
+  schema, ok := tag.Schema.(map[string]any)
+  if ok == false {
+    return nil
+  }
+  not, ok := schema["not"].(map[string]any)
+  if ok == false {
+    return nil
+  }
+  enum, ok := not["enum"].([]any)
+  if ok == false {
+    return nil
+  }
+  return enum
+}
+
+func check_exclude_literal(typ string, value any, emit *shimprinter.EmitContext) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(check_exclude_factory, emit)
+  switch typ {
+  case "string":
+    return f.NewStringLiteral(fmt.Sprint(value), shimast.TokenFlagsNone)
+  case "bigint":
+    return nativefactories.ExpressionFactory.Bigint(value, emit)
+  default:
+    return f.NewIdentifier(fmt.Sprint(value))
+  }
+}
+
+var check_exclude_factory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{})

--- a/packages/typia/native/core/programmers/iterate/check_number.go
+++ b/packages/typia/native/core/programmers/iterate/check_number.go
@@ -83,7 +83,13 @@ func check_numeric_type_tags(props check_numeric_type_tagsProps) [][]nativehelpe
   output := [][]nativehelpers.ICheckEntry_ICondition{}
   for _, row := range props.Atomic.Tags {
     tags := check_number_filter_validate(row)
-    if len(tags) == 0 {
+    excludes := []nativehelpers.ICheckEntry_ICondition{}
+    for _, tag := range row {
+      if condition := check_exclude_condition("number", tag, props.Input, props.Context.Emit); condition != nil {
+        excludes = append(excludes, *condition)
+      }
+    }
+    if len(tags) == 0 && len(excludes) == 0 {
       continue
     }
     conditions := []nativehelpers.ICheckEntry_ICondition{}
@@ -99,6 +105,7 @@ func check_numeric_type_tags(props check_numeric_type_tagsProps) [][]nativehelpe
         Expression: check_number_transpile(props.Context, tag.Validate)(props.Input),
       })
     }
+    conditions = append(conditions, excludes...)
     output = append(output, conditions)
   }
   return output

--- a/packages/typia/native/core/programmers/iterate/check_string.go
+++ b/packages/typia/native/core/programmers/iterate/check_string.go
@@ -34,15 +34,20 @@ func check_string_type_tags(props Check_stringProps) [][]nativehelpers.ICheckEnt
   output := [][]nativehelpers.ICheckEntry_ICondition{}
   for _, row := range props.Atomic.Tags {
     tags := check_string_filter_validate(row)
-    if len(tags) == 0 {
-      continue
-    }
     conditions := make([]nativehelpers.ICheckEntry_ICondition, 0, len(tags))
     for _, tag := range tags {
       conditions = append(conditions, nativehelpers.ICheckEntry_ICondition{
         Expected:   "string & " + tag.Name,
         Expression: check_string_transpile(props.Context, tag.Validate)(props.Input),
       })
+    }
+    for _, tag := range row {
+      if condition := check_exclude_condition("string", tag, props.Input, props.Context.Emit); condition != nil {
+        conditions = append(conditions, *condition)
+      }
+    }
+    if len(conditions) == 0 {
+      continue
     }
     output = append(output, conditions)
   }

--- a/packages/typia/native/core/programmers/iterate/check_template.go
+++ b/packages/typia/native/core/programmers/iterate/check_template.go
@@ -83,15 +83,20 @@ func check_template_type_tags(props Check_templateProps, tpl *nativemetadata.Met
   output := [][]nativehelpers.ICheckEntry_ICondition{}
   for _, row := range tpl.Tags {
     tags := check_string_filter_validate(row)
-    if len(tags) == 0 {
-      continue
-    }
     conditions := make([]nativehelpers.ICheckEntry_ICondition, 0, len(tags))
     for _, tag := range tags {
       conditions = append(conditions, nativehelpers.ICheckEntry_ICondition{
         Expected:   tpl.GetBaseName() + " & " + tag.Name,
         Expression: check_string_transpile(props.Context, tag.Validate)(props.Input),
       })
+    }
+    for _, tag := range row {
+      if condition := check_exclude_condition("string", tag, props.Input, props.Emit); condition != nil {
+        conditions = append(conditions, *condition)
+      }
+    }
+    if len(conditions) == 0 {
+      continue
     }
     output = append(output, conditions)
   }
@@ -104,12 +109,17 @@ func check_template_inline_tags(props Check_templateProps, tpl *nativemetadata.M
   rows := make([]*shimast.Node, 0, len(tpl.Tags))
   for _, row := range tpl.Tags {
     tags := check_string_filter_validate(row)
-    if len(tags) == 0 {
-      continue
-    }
     expressions := make([]*shimast.Node, 0, len(tags))
     for _, tag := range tags {
       expressions = append(expressions, check_string_transpile(props.Context, tag.Validate)(props.Input))
+    }
+    for _, tag := range row {
+      if condition := check_exclude_condition("string", tag, props.Input, props.Emit); condition != nil {
+        expressions = append(expressions, condition.Expression)
+      }
+    }
+    if len(expressions) == 0 {
+      continue
     }
     rows = append(rows, check_template_reduce(expressions, shimast.KindAmpersandAmpersandToken, props.Emit))
   }

--- a/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
+++ b/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
@@ -154,6 +154,27 @@ func (llmSchemaProgrammerNamespace) Validate(props struct {
         }
       }
     }
+    // OpenAI strict structured outputs cannot express the `not` keyword the
+    // exclude tag compiles to (supported subset: types, enum, anyOf, $defs).
+    excluded := false
+    scan := func(matrix [][]schemametadata.IMetadataTypeTag) {
+      for _, row := range matrix {
+        for _, tag := range row {
+          if tag.Kind == "exclude" {
+            excluded = true
+          }
+        }
+      }
+    }
+    for _, atomic := range props.Metadata.Atomics {
+      scan(atomic.Tags)
+    }
+    for _, template := range props.Metadata.Templates {
+      scan(template.Tags)
+    }
+    if excluded {
+      output = append(output, "Strict mode does not support exclude type tag.")
+    }
   }
   if schemametadata.MetadataSchema_hasBigint(props.Metadata) {
     output = append(output, "LLM schema does not support bigint type.")

--- a/packages/typia/native/core/programmers/llm/llm_schema_programmer_rejects_exclude_tag_in_strict_test.go
+++ b/packages/typia/native/core/programmers/llm/llm_schema_programmer_rejects_exclude_tag_in_strict_test.go
@@ -1,0 +1,52 @@
+package llm
+
+import (
+  "testing"
+
+  nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestLlmSchemaProgrammerRejectsExcludeTagInStrict verifies strict exclusion.
+//
+// The exclude type tag compiles to `not: { enum: [...] }` in JSON schema, but
+// OpenAI strict structured outputs support no `not` keyword (only types,
+// enum, anyOf, and $defs). A strict LLM schema configuration must therefore
+// reject the tag instead of silently emitting an unenforceable schema, while
+// non-strict configurations keep accepting it.
+//
+// 1. Build metadata with a number atomic carrying an exclude-kind tag.
+// 2. Validate with strict config and require the rejection diagnostic.
+// 3. Validate without strict config and require no diagnostic.
+func TestLlmSchemaProgrammerRejectsExcludeTagInStrict(t *testing.T) {
+  build := func() *schemametadata.MetadataSchema {
+    meta := schemametadata.MetadataSchema_initialize()
+    meta.Atomics = append(meta.Atomics, schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{
+      Type: "number",
+      Tags: [][]schemametadata.IMetadataTypeTag{{
+        {
+          Kind:   "exclude",
+          Name:   "Exclude<[0, 22]>",
+          Schema: map[string]any{"not": map[string]any{"enum": []any{0, 22}}},
+        },
+      }},
+    }))
+    return meta
+  }
+  strict := LlmSchemaProgrammer.Validate(struct {
+    Config   map[string]any
+    Metadata *schemametadata.MetadataSchema
+    Explore  nativefactories.MetadataFactory_IExplore
+  }{Config: map[string]any{"strict": true}, Metadata: build()})
+  if len(strict) != 1 || strict[0] != "Strict mode does not support exclude type tag." {
+    t.Fatalf("strict config should reject the exclude tag, got %v", strict)
+  }
+  loose := LlmSchemaProgrammer.Validate(struct {
+    Config   map[string]any
+    Metadata *schemametadata.MetadataSchema
+    Explore  nativefactories.MetadataFactory_IExplore
+  }{Metadata: build()})
+  if len(loose) != 0 {
+    t.Fatalf("non-strict config should accept the exclude tag, got %v", loose)
+  }
+}

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.16",
+  "version": "13.0.0-dev.20260605.17",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.17",
+  "version": "13.0.0-dev.20260605.18",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/website/src/content/docs/validators/tags.mdx
+++ b/website/src/content/docs/validators/tags.mdx
@@ -101,6 +101,7 @@ If you intersect a tag with the wrong base type (e.g. `tags.MaxLength<100>` on a
 | `tags.ExclusiveMinimum<N>` | `value > N` |
 | `tags.ExclusiveMaximum<N>` | `value < N` |
 | `tags.MultipleOf<N>` | `value % N === 0` |
+| `tags.Exclude<[V1, V2, …]>` | `value` is none of the listed literals (`not: { enum: [...] }` in JSON Schema) |
 
 For `bigint`, `tags.Type<...>` accepts `"int64"` or `"uint64"`; range tags accept `bigint` literals.
 
@@ -113,12 +114,15 @@ For `bigint`, `tags.Type<...>` accepts `"int64"` or `"uint64"`; range tags accep
 | `tags.Pattern<R>` | regex (passed as a string literal) |
 | `tags.Format<F>` | one of the formats below |
 | `tags.ContentMediaType<MT>` | OpenAPI `contentMediaType` (e.g. `"image/png"`) |
+| `tags.Exclude<[V1, V2, …]>` | `value` is none of the listed literals (`not: { enum: [...] }` in JSON Schema) |
 
 `Format` accepts: `byte`, `password`, `regex`, `uuid`, `email`, `hostname`, `idn-email`, `idn-hostname`, `iri`, `iri-reference`, `ipv4`, `ipv6`, `uri`, `uri-reference`, `uri-template`, `url`, `date-time`, `date`, `time`, `duration`, `json-pointer`, `relative-json-pointer`.
 
 For `url`, DNS host labels may contain interior hyphen runs such as `example--example`, but leading or trailing label hyphens and private IPv4 hosts are rejected.
 
 > `Format` and `Pattern` are mutually exclusive on the same string — pick one.
+
+> `Exclude` lists every rejected literal in one tuple (a second `Exclude` on the same type is a compile error). OpenAI strict mode cannot express the `not` keyword, so strict `typia.llm.*` schemas reject this tag, and `typia.random` does not consult it.
 
 #### `Array<T>`
 


### PR DESCRIPTION
## Intent

Implement #1630: `tags.Exclude<Values>` — a type tag rejecting listed literal values, for `bigint` / `number` / `string` and template-literal bases.

```typescript
interface IConfig {
  port: number & tags.Exclude<[0, 22, 80]>;
  name: string & tags.Exclude<["admin", "root"]>;
}
// runtime: input.port !== 0 && input.port !== 22 && input.port !== 80 && ...
// JSON schema: { type: "number", not: { enum: [0, 22, 80] } }
```

## Design

A tuple of excluded values cannot be templated into the single validate-script literal that standard tags use, so the excluded literals travel in the tag's **JSON schema fragment** (`not: { enum: Values }`) and:

- the tag stays a *pure interface definition* (`value: undefined`; `exclusive: true`, so a second `Exclude` on the same type — whose schema fragments could not merge — is a compile error);
- a new `check_exclude_condition` in the iterate package synthesizes the `!==` chain from the fragment, hooked into the bigint/number/string atomic builders and the template-literal entry (both the sole-template conditions path and the union-member inline path from #1921);
- the JSON schema emitter merges the fragment untouched — `not: { enum: [...] }` appears with zero schema-side changes.

## Function calling / OpenAI strict (the issue's key question)

Verified against the current structured-outputs documentation: the strict subset supports only types / `enum` / `anyOf` / `$defs` — **`not` is not expressible** (even `minimum`/`pattern` are listed unsupported). Accordingly `typia.llm.*` with a strict model configuration rejects the tag with `Strict mode does not support exclude type tag.` (atomics and templates both scanned), while non-strict 3.1-class schemas pass it through.

## Known limitation

`typia.random` does not consult the tag (generated values may collide with the excluded list) — documented on the tag's jsdoc and in the guide. Constants-bucket intersections (`(0 | 8080) & Exclude<[0]>`) are out of scope as type-level contradictions.

## Tests

- `TestExcludeTypeTagTransform`: number/string/bigint/template excludes — emission asserts (`!==` chains, `not.enum` in JSON schema), runtime is/validate accept+reject matrix per base, validate error naming (`expected` includes the tag), template-pattern-still-enforced case.
- `TestLlmSchemaProgrammerRejectsExcludeTagInStrict`: strict rejects with the exact diagnostic; non-strict accepts.
- Docs: `validators/tags.mdx` catalogue rows (number/bigint and string tables) + strict-mode/random caveat note.
- Bump `typia` to `13.0.0-dev.20260605.17` (will rebase if #1927 lands first with the same number).

## Validation

- `pnpm format`, `pnpm run test:go` (public + native trees, all ok)

## Review

Self-review, 3 rounds (per operator instruction): design alternatives audit (validate-string templating vs schema-fragment carriage), semantic edges (negative numbers, jsnum literals, empty tuple no-op, quote escaping via the string literal factory), adversarial pass that surfaced and closed the template-literal gap.

Fixes #1630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)