### PR TITLE
fix(typia): render inline types structurally in validator expected strings

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/inline_type_display_name_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/inline_type_display_name_transform_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestInlineTypeDisplayNameTransform verifies expected strings of inline types.
+//
+// Issue #1667: validators reported anonymous (inline) type literals through
+// their synthetic identifier names — `__type`, `__type.o1`, `Array<__type>` —
+// which tell the user nothing about the violated type. Human-facing expected
+// strings must instead render the structural form (`{ property: string; }`),
+// while the synthetic identifiers stay everywhere identity matters: JSON
+// schema component keys and generated-function deduplication.
+//
+//  1. Transform a fixture mixing inline objects, named interfaces, inline
+//     array elements, inline unions, and Set/Map of inline values.
+//  2. Execute validate entrypoints against violating inputs and require every
+//     reported `expected` to use the structural rendering, never `__type`.
+//  3. Require named interfaces to keep reporting their identifier names.
+//  4. Require the emitted artifact to carry no `__type` leak at all: inline
+//     literal objects are inlined by `typia.json.schemas` (never referenced
+//     as components), so with display names in place the synthetic
+//     identifiers must vanish from the output entirely.
+func TestInlineTypeDisplayNameTransform(t *testing.T) {
+  project := inlineTypeDisplayNameProject(t)
+  js := inlineTypeDisplayNameTransform(t, project)
+  if strings.Contains(js, "__type") {
+    t.Fatalf("emitted JavaScript leaked an anonymous __type identifier:\n%s", js)
+  }
+  if !strings.Contains(js, `"inline"`) {
+    t.Fatalf("json.schemas literal lost the inline property:\n%s", js)
+  }
+  inlineTypeDisplayNameRunRuntimeCases(t, project, js)
+}
+
+func inlineTypeDisplayNameProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "inline-display-name-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(inlineTypeDisplayNameTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(inlineTypeDisplayNameSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func inlineTypeDisplayNameTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("inline display name transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func inlineTypeDisplayNameRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(inlineTypeDisplayNameRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("inline display name runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const inlineTypeDisplayNameTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const inlineTypeDisplayNameSource = `import typia from "typia";
+
+// The issue #1667 playground shape: nested inline type literals.
+export const validateNested = typia.createValidate<{
+  property: { property: string };
+}>();
+
+// Named interfaces must keep reporting their identifier names.
+interface INamed {
+  value: string;
+}
+export const validateNamed = typia.createValidate<{ child: INamed }>();
+
+// Inline element types of arrays previously surfaced by synthetic names.
+export const validateInlineArray = typia.createValidate<{
+  list: { value: number }[];
+}>();
+
+// Inline unions previously surfaced as a pair of synthetic names.
+export const validateInlineUnion = typia.createValidate<{
+  union: { kind: "a"; a: string } | { kind: "b"; b: number };
+}>();
+
+// Containers of inline values previously wrapped the synthetic names.
+export const validateInlineSet = typia.createValidate<{
+  entries: Set<{ flag: boolean }>;
+}>();
+
+// Component keys are identifiers and must stay on the synthetic names.
+export const schemas = typia.json.schemas<[{ inline: { id: string } }]>();
+`
+
+const inlineTypeDisplayNameRuntimeRunner = `const mod = require("./main.cjs");
+
+const expectError = (label, result, path, expected) => {
+  if (result.success !== false) {
+    throw new Error(label + " unexpectedly passed");
+  }
+  const entry = result.errors.find((error) => error.path === path);
+  if (entry === undefined) {
+    throw new Error(label + " did not report " + path + ": " + JSON.stringify(result.errors));
+  }
+  if (entry.expected !== expected) {
+    throw new Error(
+      label + " reported wrong expected string.\n  wanted: " + expected + "\n  actual: " + entry.expected,
+    );
+  }
+};
+
+const forbidAnonymous = (label, result) => {
+  for (const entry of result.errors) {
+    if (entry.expected.includes("__type")) {
+      throw new Error(label + " leaked an anonymous identifier: " + JSON.stringify(entry));
+    }
+  }
+};
+
+// 1. Nested inline object: the inner property is undefined.
+const nested = mod.validateNested({ property: { property: undefined } });
+expectError(
+  "nested inline (missing leaf)",
+  nested,
+  "$input.property.property",
+  "string",
+);
+forbidAnonymous("nested inline (missing leaf)", nested);
+
+// 2. Nested inline object: the intermediate object is undefined. The expected
+//    string must render the structural form, not __type.
+const intermediate = mod.validateNested({ property: undefined });
+expectError(
+  "nested inline (missing branch)",
+  intermediate,
+  "$input.property",
+  "{ property: string; }",
+);
+forbidAnonymous("nested inline (missing branch)", intermediate);
+
+// 3. Named interfaces keep their identifier names.
+const named = mod.validateNamed({ child: undefined });
+expectError("named interface", named, "$input.child", "INamed");
+
+// 4. Inline array element type.
+const arrayElement = mod.validateInlineArray({ list: [{ value: "1" }] });
+expectError(
+  "inline array (element violation)",
+  arrayElement,
+  "$input.list[0].value",
+  "number",
+);
+forbidAnonymous("inline array (element violation)", arrayElement);
+
+const arrayBranch = mod.validateInlineArray({ list: undefined });
+expectError(
+  "inline array (missing list)",
+  arrayBranch,
+  "$input.list",
+  "{ value: number; }[]",
+);
+forbidAnonymous("inline array (missing list)", arrayBranch);
+
+// 5. Inline union: both branches must render structurally.
+const union = mod.validateInlineUnion({ union: { kind: "c" } });
+if (union.success !== false) {
+  throw new Error("inline union unexpectedly passed");
+}
+forbidAnonymous("inline union", union);
+
+const unionMissing = mod.validateInlineUnion({ union: undefined });
+if (unionMissing.success !== false) {
+  throw new Error("inline union (missing) unexpectedly passed");
+}
+const unionEntry = unionMissing.errors.find((error) => error.path === "$input.union");
+if (unionEntry === undefined) {
+  throw new Error("inline union (missing) did not report $input.union: " + JSON.stringify(unionMissing.errors));
+}
+if (unionEntry.expected.includes("__type")) {
+  throw new Error("inline union (missing) leaked an anonymous identifier: " + JSON.stringify(unionEntry));
+}
+if (!unionEntry.expected.includes("{ kind: \"a\"; a: string; }") || !unionEntry.expected.includes("{ kind: \"b\"; b: number; }")) {
+  throw new Error("inline union (missing) lost a structural branch: " + JSON.stringify(unionEntry));
+}
+
+// 6. Set of inline values.
+const set = mod.validateInlineSet({ entries: undefined });
+expectError(
+  "inline Set (missing entries)",
+  set,
+  "$input.entries",
+  "Set<{ flag: boolean; }>",
+);
+forbidAnonymous("inline Set (missing entries)", set);
+`

--- a/packages/typia/native/cmd/ttsc-typia/inline_type_display_name_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/inline_type_display_name_transform_test.go
@@ -151,6 +151,14 @@ export const validateInlineSet = typia.createValidate<{
   entries: Set<{ flag: boolean }>;
 }>();
 
+// Top-level inline types must render structurally at the "$input" root.
+export const validateTopLevel = typia.createValidate<{ id: string }>();
+
+// Tuples of inline objects must render each element structurally.
+export const validateInlineTuple = typia.createValidate<{
+  pair: [{ a: string }, { b: number }];
+}>();
+
 // Component keys are identifiers and must stay on the synthetic names.
 export const schemas = typia.json.schemas<[{ inline: { id: string } }]>();
 `
@@ -255,4 +263,28 @@ expectError(
   "Set<{ flag: boolean; }>",
 );
 forbidAnonymous("inline Set (missing entries)", set);
+
+// 7. Top-level inline type.
+const topLevel = mod.validateTopLevel(null);
+expectError("top-level inline", topLevel, "$input", "{ id: string; }");
+forbidAnonymous("top-level inline", topLevel);
+
+// 8. Tuple of inline objects.
+const tupleElement = mod.validateInlineTuple({ pair: [{ a: "x" }, { b: "1" }] });
+expectError(
+  "inline tuple (element violation)",
+  tupleElement,
+  "$input.pair[1].b",
+  "number",
+);
+forbidAnonymous("inline tuple (element violation)", tupleElement);
+
+const tupleMissing = mod.validateInlineTuple({ pair: undefined });
+expectError(
+  "inline tuple (missing pair)",
+  tupleMissing,
+  "$input.pair",
+  "[{ a: string; }, { b: number; }]",
+);
+forbidAnonymous("inline tuple (missing pair)", tupleMissing);
 `

--- a/packages/typia/native/core/programmers/helpers/UnionExplorer.go
+++ b/packages/typia/native/core/programmers/helpers/UnionExplorer.go
@@ -162,7 +162,7 @@ func (unionExplorerNamespace) Object(props UnionExplorer_ObjectProps) *shimast.N
 
   names := make([]string, 0, len(props.Objects))
   for _, obj := range props.Objects {
-    names = append(names, obj.Name)
+    names = append(names, obj.GetDisplayName())
   }
   expected := "(" + strings.Join(names, " | ") + ")"
 
@@ -310,7 +310,7 @@ func (unionExplorerNamespace) Tuple(props UnionExplorer_TupleProps) *shimast.Nod
       Front:     func(input *shimast.Expression) *shimast.Node { return input },
       Array:     func(input *shimast.Expression) *shimast.Node { return input },
       Name: func(t any, elem any) string {
-        return t.(*nativemetadata.MetadataTuple).Type.Name
+        return t.(*nativemetadata.MetadataTuple).Type.GetDisplayName()
       },
     },
     Parameters:  props.Parameters,
@@ -342,7 +342,7 @@ func (unionExplorerNamespace) Array(props UnionExplorer_ArrayProps) *shimast.Nod
       },
       Array: func(input *shimast.Expression) *shimast.Node { return input },
       Name: func(t any, elem any) string {
-        return t.(*nativemetadata.MetadataArray).Type.Name
+        return t.(*nativemetadata.MetadataArray).Type.GetDisplayName()
       },
     },
     Parameters:  props.Parameters,
@@ -375,9 +375,9 @@ func (unionExplorerNamespace) Array_or_tuple(props UnionExplorer_ArrayOrTuplePro
       Name: func(m any, elem any) string {
         switch v := m.(type) {
         case *nativemetadata.MetadataArray:
-          return v.Type.Name
+          return v.Type.GetDisplayName()
         case *nativemetadata.MetadataTuple:
-          return v.Type.Name
+          return v.Type.GetDisplayName()
         default:
           return "unknown"
         }
@@ -405,11 +405,12 @@ func (unionExplorerNamespace) Set(props UnionExplorer_SetProps) *shimast.Node {
         return nativemetadata.MetadataArray_create(nativemetadata.MetadataArray{
           Tags: [][]nativemetadata.IMetadataTypeTag{},
           Type: nativemetadata.MetadataArrayType_create(nativemetadata.MetadataArrayType{
-            Name:      "Set<" + meta.GetName() + ">",
-            Index:     nil,
-            Recursive: false,
-            Nullables: []bool{},
-            Value:     meta,
+            Name:        "Set<" + meta.GetName() + ">",
+            DisplayName: "Set<" + meta.GetDisplayName() + ">",
+            Index:       nil,
+            Recursive:   false,
+            Nullables:   []bool{},
+            Value:       meta,
           }),
         })
       },
@@ -445,7 +446,7 @@ func (unionExplorerNamespace) Set(props UnionExplorer_SetProps) *shimast.Node {
         )
       },
       Name: func(_m any, elem any) string {
-        return "Set<" + elem.(*nativemetadata.MetadataSchema).GetName() + ">"
+        return "Set<" + elem.(*nativemetadata.MetadataSchema).GetDisplayName() + ">"
       },
     },
     Parameters:  props.Parameters,
@@ -499,7 +500,7 @@ func (unionExplorerNamespace) Map(props UnionExplorer_MapProps) *shimast.Node {
       },
       Name: func(_m any, elem any) string {
         pair := elem.([]*nativemetadata.MetadataSchema)
-        return "Map<" + pair[0].GetName() + ", " + pair[1].GetName() + ">"
+        return "Map<" + pair[0].GetDisplayName() + ", " + pair[1].GetDisplayName() + ">"
       },
       Transform: func(origin any) any {
         m := origin.(*nativemetadata.MetadataMap)
@@ -507,21 +508,23 @@ func (unionExplorerNamespace) Map(props UnionExplorer_MapProps) *shimast.Node {
         tuple := nativemetadata.MetadataTuple_create(nativemetadata.MetadataTuple{
           Tags: [][]nativemetadata.IMetadataTypeTag{},
           Type: nativemetadata.MetadataTupleType_create(nativemetadata.MetadataTupleType{
-            Name:      "[" + m.Key.GetName() + ", " + m.Value.GetName() + "]",
-            Index:     nil,
-            Recursive: false,
-            Nullables: []bool{},
-            Elements:  []*nativemetadata.MetadataSchema{m.Key, m.Value},
+            Name:        "[" + m.Key.GetName() + ", " + m.Value.GetName() + "]",
+            DisplayName: "[" + m.Key.GetDisplayName() + ", " + m.Value.GetDisplayName() + "]",
+            Index:       nil,
+            Recursive:   false,
+            Nullables:   []bool{},
+            Elements:    []*nativemetadata.MetadataSchema{m.Key, m.Value},
           }),
         })
         tuple.Type.Of_map = &ofMap
         return nativemetadata.MetadataArray_create(nativemetadata.MetadataArray{
           Tags: [][]nativemetadata.IMetadataTypeTag{},
           Type: nativemetadata.MetadataArrayType_create(nativemetadata.MetadataArrayType{
-            Name:      "Map<" + m.Key.GetName() + ", " + m.Value.GetName() + ">",
-            Index:     nil,
-            Recursive: false,
-            Nullables: []bool{},
+            Name:        "Map<" + m.Key.GetName() + ", " + m.Value.GetName() + ">",
+            DisplayName: "Map<" + m.Key.GetDisplayName() + ", " + m.Value.GetDisplayName() + ">",
+            Index:       nil,
+            Recursive:   false,
+            Nullables:   []bool{},
             Value: nativemetadata.MetadataSchema_create(nativemetadata.MetadataSchema{
               Any:       false,
               Required:  true,

--- a/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
@@ -733,7 +733,7 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
     any := false
     names := []string{}
     for _, elem := range props.Metadata.Sets {
-      names = append(names, "Set<"+elem.Value.GetName()+">")
+      names = append(names, "Set<"+elem.Value.GetDisplayName()+">")
       if elem.Value.Any {
         any = true
       }
@@ -754,7 +754,7 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
     any := false
     names := []string{}
     for _, elem := range props.Metadata.Maps {
-      names = append(names, "Map<"+elem.Key.GetName()+", "+elem.Value.GetName()+">")
+      names = append(names, "Map<"+elem.Key.GetDisplayName()+", "+elem.Value.GetDisplayName()+">")
       if elem.Key.Any && elem.Value.Any {
         any = true
       }
@@ -775,10 +775,10 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
     body := (*shimast.Node)(nil)
     expected := []string{}
     for _, tuple := range props.Metadata.Tuples {
-      expected = append(expected, tuple.Type.Name)
+      expected = append(expected, tuple.Type.GetDisplayName())
     }
     for _, array := range props.Metadata.Arrays {
-      expected = append(expected, array.GetName())
+      expected = append(expected, array.GetDisplayName())
     }
     if len(props.Metadata.Arrays) == 0 {
       explore := props.Explore
@@ -833,7 +833,7 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
     }
     names := []string{}
     for _, obj := range props.Metadata.Objects {
-      names = append(names, obj.Type.Name)
+      names = append(names, obj.Type.GetDisplayName())
     }
     explore := props.Explore
     explore.From = "object"
@@ -872,7 +872,7 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
               {Expression: instance.Head, Combined: false},
               {Expression: instance.Body, Combined: true},
             },
-            Expected: props.Metadata.GetName(),
+            Expected: props.Metadata.GetDisplayName(),
           }),
           Combined: true,
         })
@@ -890,7 +890,7 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
           Logic:    "or",
           Input:    props.Input,
           Binaries: transformed,
-          Expected: props.Metadata.GetName(),
+          Expected: props.Metadata.GetDisplayName(),
         }),
         Combined: true,
       })
@@ -922,13 +922,13 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
   if len(top) != 0 && len(binaries) != 0 {
     next := append([]CheckerProgrammer_IBinary{}, top...)
     next = append(next, CheckerProgrammer_IBinary{
-      Expression: props.Config.Combiner(CheckerProgrammer_CombinerProps{Explore: props.Explore, Logic: "or", Input: props.Input, Binaries: binaries, Expected: props.Metadata.GetName()}),
+      Expression: props.Config.Combiner(CheckerProgrammer_CombinerProps{Explore: props.Explore, Logic: "or", Input: props.Input, Binaries: binaries, Expected: props.Metadata.GetDisplayName()}),
       Combined:   true,
     })
-    return props.Config.Combiner(CheckerProgrammer_CombinerProps{Explore: props.Explore, Logic: "and", Input: props.Input, Binaries: next, Expected: props.Metadata.GetName()})
+    return props.Config.Combiner(CheckerProgrammer_CombinerProps{Explore: props.Explore, Logic: "and", Input: props.Input, Binaries: next, Expected: props.Metadata.GetDisplayName()})
   }
   if len(binaries) != 0 {
-    return props.Config.Combiner(CheckerProgrammer_CombinerProps{Explore: props.Explore, Logic: "or", Input: props.Input, Binaries: binaries, Expected: props.Metadata.GetName()})
+    return props.Config.Combiner(CheckerProgrammer_CombinerProps{Explore: props.Explore, Logic: "or", Input: props.Input, Binaries: binaries, Expected: props.Metadata.GetDisplayName()})
   }
   return props.Config.Success
 }
@@ -987,7 +987,7 @@ func checkerProgrammer_decode_array(props checkerProgrammer_decodeArrayProps) *s
     ),
     props.Config.Joiner.Failure(CheckerProgrammer_JoinerFailureProps{
       Input:    props.Input,
-      Expected: props.Array.Type.Name,
+      Expected: props.Array.Type.GetDisplayName(),
       Explore:  &arrayExplore,
     }),
     props.Context.Emit,
@@ -1097,7 +1097,7 @@ func checkerProgrammer_decode_tuple(props checkerProgrammer_decodeTupleProps) *s
     ),
     props.Config.Joiner.Failure(CheckerProgrammer_JoinerFailureProps{
       Input:    props.Input,
-      Expected: props.Tuple.Type.Name,
+      Expected: props.Tuple.Type.GetDisplayName(),
       Explore:  &arrayExplore,
     }),
     props.Context.Emit,
@@ -1194,7 +1194,7 @@ func checkerProgrammer_decode_tuple_inline(props checkerProgrammer_decodeTupleIn
   }
   names := make([]string, 0, len(props.Tuple.Elements))
   for _, elem := range props.Tuple.Elements {
-    names = append(names, elem.GetName())
+    names = append(names, elem.GetDisplayName())
   }
   return props.Config.Combiner(CheckerProgrammer_CombinerProps{
     Explore:  props.Explore,
@@ -1460,9 +1460,9 @@ func checkerProgrammer_explore_arrays_and_tuples(props checkerProgrammer_explore
             for _, elem := range props.Definitions {
               switch x := elem.(type) {
               case *nativemetadata.MetadataArray:
-                expected = append(expected, x.GetName())
+                expected = append(expected, x.GetDisplayName())
               case *nativemetadata.MetadataTuple:
-                expected = append(expected, x.Type.Name)
+                expected = append(expected, x.Type.GetDisplayName())
               }
             }
             return props.Config.Atomist(CheckerProgrammer_AtomistProps{
@@ -1513,7 +1513,11 @@ func checkerProgrammer_explore_array_like_union_types(props checkerProgrammer_ex
   arrayExplore := props.Explore
   arrayExplore.Source = "function"
   arrayExplore.From = "array"
+  // EmplaceUnion deduplicates generated union functions by this key, so it
+  // must stay on the unique identifier names; only the human-facing failure
+  // message switches to the display rendering.
   names := checkerProgrammer_definition_names(props.Definitions)
+  displays := checkerProgrammer_definition_display_names(props.Definitions)
   return checkerProgrammer_or(
     f.NewCallExpression(
       f.NewIdentifier(
@@ -1549,7 +1553,7 @@ func checkerProgrammer_explore_array_like_union_types(props checkerProgrammer_ex
     ),
     props.Config.Joiner.Failure(CheckerProgrammer_JoinerFailureProps{
       Input:    props.Input,
-      Expected: strings.Join(names, " | "),
+      Expected: strings.Join(displays, " | "),
       Explore:  &arrayExplore,
     }),
     props.Emit,
@@ -1579,7 +1583,7 @@ func checkerProgrammer_explore_objects(props checkerProgrammer_exploreObjectsPro
   if checkerProgrammer_has_object_type_tags(props.Metadata.Objects) {
     names := make([]string, 0, len(props.Metadata.Objects))
     for _, object := range props.Metadata.Objects {
-      names = append(names, object.GetName())
+      names = append(names, object.GetDisplayName())
     }
     expected := "(" + strings.Join(names, " | ") + ")"
     f := nativecontext.EmitFactoryOf(checkerProgrammer_factory, props.Context.Emit)
@@ -1839,6 +1843,19 @@ func checkerProgrammer_definition_names(definitions []any) []string {
   return names
 }
 
+func checkerProgrammer_definition_display_names(definitions []any) []string {
+  names := make([]string, 0, len(definitions))
+  for _, elem := range definitions {
+    switch v := elem.(type) {
+    case *nativemetadata.MetadataArray:
+      names = append(names, v.Type.GetDisplayName())
+    case *nativemetadata.MetadataTuple:
+      names = append(names, v.Type.GetDisplayName())
+    }
+  }
+  return names
+}
+
 func checkerProgrammer_postfix_of_tuple(str string) string {
   if len(str) > 0 && str[len(str)-1] == '"' {
     return str[:len(str)-1]
@@ -1850,11 +1867,12 @@ func checkerProgrammer_wrap_metadata_rest_tuple(rest *nativemetadata.MetadataSch
   wrapper := nativemetadata.MetadataSchema_initialize()
   wrapper.Arrays = append(wrapper.Arrays, nativemetadata.MetadataArray_create(nativemetadata.MetadataArray{
     Type: nativemetadata.MetadataArrayType_create(nativemetadata.MetadataArrayType{
-      Name:      "..." + rest.GetName(),
-      Value:     rest,
-      Nullables: []bool{},
-      Recursive: false,
-      Index:     nil,
+      Name:        "..." + rest.GetName(),
+      DisplayName: "..." + rest.GetDisplayName(),
+      Value:       rest,
+      Nullables:   []bool{},
+      Recursive:   false,
+      Index:       nil,
     }),
     Tags: [][]nativemetadata.IMetadataTypeTag{},
   }))

--- a/packages/typia/native/core/programmers/iterate/check_array_length.go
+++ b/packages/typia/native/core/programmers/iterate/check_array_length.go
@@ -17,7 +17,7 @@ type Check_array_lengthProps struct {
 func Check_array_length(props Check_array_lengthProps) nativehelpers.ICheckEntry {
   conditions := check_array_type_tags(props)
   return nativehelpers.ICheckEntry{
-    Expected:   props.Array.GetName(),
+    Expected:   props.Array.GetDisplayName(),
     Expression: nil,
     Conditions: conditions,
   }

--- a/packages/typia/native/core/programmers/iterate/check_object_type_tags.go
+++ b/packages/typia/native/core/programmers/iterate/check_object_type_tags.go
@@ -17,7 +17,7 @@ type Check_object_type_tagsProps struct {
 func Check_object_type_tags(props Check_object_type_tagsProps) nativehelpers.ICheckEntry {
   conditions := check_object_type_tags(props)
   return nativehelpers.ICheckEntry{
-    Expected:   props.Object.GetName(),
+    Expected:   props.Object.GetDisplayName(),
     Expression: nil,
     Conditions: conditions,
   }

--- a/packages/typia/native/core/programmers/iterate/decode_union_object.go
+++ b/packages/typia/native/core/programmers/iterate/decode_union_object.go
@@ -36,7 +36,7 @@ func Decode_union_object(props Decode_union_objectProps) *shimast.Node {
   names := make([]string, 0, len(props.Objects))
   for _, object := range props.Objects {
     obj := object
-    names = append(names, obj.Name)
+    names = append(names, obj.GetDisplayName())
     unions = append(unions, decode_union_object_IUnion{
       Type: "object",
       Is: func() *shimast.Node {

--- a/packages/typia/native/core/programmers/iterate/wrap_metadata_rest_tuple.go
+++ b/packages/typia/native/core/programmers/iterate/wrap_metadata_rest_tuple.go
@@ -6,11 +6,12 @@ func wrap_metadata_rest_tuple(rest *nativemetadata.MetadataSchema) *nativemetada
   wrapper := nativemetadata.MetadataSchema_initialize()
   wrapper.Arrays = append(wrapper.Arrays, nativemetadata.MetadataArray_create(nativemetadata.MetadataArray{
     Type: nativemetadata.MetadataArrayType_create(nativemetadata.MetadataArrayType{
-      Name:      "..." + rest.GetName(),
-      Value:     rest,
-      Nullables: []bool{},
-      Recursive: false,
-      Index:     nil,
+      Name:        "..." + rest.GetName(),
+      DisplayName: "..." + rest.GetDisplayName(),
+      Value:       rest,
+      Nullables:   []bool{},
+      Recursive:   false,
+      Index:       nil,
     }),
     Tags: [][]nativemetadata.IMetadataTypeTag{},
   }))

--- a/packages/typia/native/core/programmers/json/JsonSchemasProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonSchemasProgrammer.go
@@ -129,7 +129,7 @@ func jsonSchemasProgrammer_writeV3_1(metadataList []*nativemetadata.MetadataSche
     if schema == nil {
       panic(nativecontext.NewTransformerError(nativecontext.TransformerError_IProps{
         Code:    "typia.json.schemas",
-        Message: fmt.Sprintf("invalid type on argument - (%s, %d)", meta.GetName(), i),
+        Message: fmt.Sprintf("invalid type on argument - (%s, %d)", meta.GetDisplayName(), i),
       }))
     }
     schemas = append(schemas, schema)

--- a/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
@@ -608,7 +608,7 @@ func jsonStringifyProgrammer_decode(props struct {
         Context:  props.Context,
         Functor:  props.Functor,
         Input:    props.Input,
-        Expected: props.Metadata.GetName(),
+        Expected: props.Metadata.GetDisplayName(),
         Unions:   unions,
       }),
     ),

--- a/packages/typia/native/core/schemas/metadata/MetadataAlias.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataAlias.go
@@ -1,9 +1,10 @@
 package metadata
 
 type MetadataAlias struct {
-  Type  *MetadataAliasType
-  Tags  [][]IMetadataTypeTag
-  name_ string
+  Type          *MetadataAliasType
+  Tags          [][]IMetadataTypeTag
+  name_         string
+  display_name_ string
 }
 
 func MetadataAlias_create(props MetadataAlias) *MetadataAlias {
@@ -18,6 +19,13 @@ func (obj *MetadataAlias) GetName() string {
     obj.name_ = taggedName(obj.Type.Name, obj.Tags)
   }
   return obj.name_
+}
+
+func (obj *MetadataAlias) GetDisplayName() string {
+  if obj.display_name_ == "" {
+    obj.display_name_ = taggedName(obj.Type.GetDisplayName(), obj.Tags)
+  }
+  return obj.display_name_
 }
 
 func (obj *MetadataAlias) ToJSON() IMetadataSchema_IReference {

--- a/packages/typia/native/core/schemas/metadata/MetadataAliasType.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataAliasType.go
@@ -11,6 +11,7 @@ type IMetadataSchema_IAliasType struct {
 
 type MetadataAliasType struct {
   Name        string
+  DisplayName string
   Value       *MetadataSchema
   Description *string
   JsDocTags   []IJsDocTagInfo
@@ -21,6 +22,7 @@ type MetadataAliasType struct {
 func MetadataAliasType_create(props MetadataAliasType) *MetadataAliasType {
   return &MetadataAliasType{
     Name:        props.Name,
+    DisplayName: props.DisplayName,
     Value:       props.Value,
     Description: props.Description,
     JsDocTags:   append([]IJsDocTagInfo{}, props.JsDocTags...),
@@ -38,6 +40,16 @@ func MetadataAliasType__From_without_value(props IMetadataSchema_IAliasType) *Me
     JsDocTags:   append([]IJsDocTagInfo{}, props.JsDocTags...),
     Nullables:   append([]bool{}, props.Nullables...),
   })
+}
+
+// GetDisplayName returns the human-facing rendering of the type: the
+// structural form for anonymous (inline) types, the identifier name otherwise.
+// Identity-sensitive logic (function keys, deduplication) must keep using Name.
+func (obj *MetadataAliasType) GetDisplayName() string {
+  if obj.DisplayName != "" {
+    return obj.DisplayName
+  }
+  return obj.Name
 }
 
 func (obj *MetadataAliasType) ToJSON() IMetadataSchema_IAliasType {

--- a/packages/typia/native/core/schemas/metadata/MetadataArray.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataArray.go
@@ -1,9 +1,10 @@
 package metadata
 
 type MetadataArray struct {
-  Type  *MetadataArrayType
-  Tags  [][]IMetadataTypeTag
-  name_ string
+  Type          *MetadataArrayType
+  Tags          [][]IMetadataTypeTag
+  name_         string
+  display_name_ string
 }
 
 func MetadataArray_create(props MetadataArray) *MetadataArray {
@@ -18,6 +19,13 @@ func (obj *MetadataArray) GetName() string {
     obj.name_ = taggedName(obj.Type.Name, obj.Tags)
   }
   return obj.name_
+}
+
+func (obj *MetadataArray) GetDisplayName() string {
+  if obj.display_name_ == "" {
+    obj.display_name_ = taggedName(obj.Type.GetDisplayName(), obj.Tags)
+  }
+  return obj.display_name_
 }
 
 func (obj *MetadataArray) ToJSON() IMetadataSchema_IReference {

--- a/packages/typia/native/core/schemas/metadata/MetadataArrayType.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataArrayType.go
@@ -9,11 +9,12 @@ type IMetadataSchema_IArrayType struct {
 }
 
 type MetadataArrayType struct {
-  Name      string
-  Value     *MetadataSchema
-  Nullables []bool
-  Recursive bool
-  Index     *int
+  Name        string
+  DisplayName string
+  Value       *MetadataSchema
+  Nullables   []bool
+  Recursive   bool
+  Index       *int
 }
 
 func MetadataArrayType__From_without_value(props IMetadataSchema_IArrayType) *MetadataArrayType {
@@ -28,12 +29,23 @@ func MetadataArrayType__From_without_value(props IMetadataSchema_IArrayType) *Me
 
 func MetadataArrayType_create(props MetadataArrayType) *MetadataArrayType {
   return &MetadataArrayType{
-    Name:      props.Name,
-    Value:     props.Value,
-    Index:     props.Index,
-    Recursive: props.Recursive,
-    Nullables: append([]bool{}, props.Nullables...),
+    Name:        props.Name,
+    DisplayName: props.DisplayName,
+    Value:       props.Value,
+    Index:       props.Index,
+    Recursive:   props.Recursive,
+    Nullables:   append([]bool{}, props.Nullables...),
   }
+}
+
+// GetDisplayName returns the human-facing rendering of the type: the
+// structural form for anonymous (inline) types, the identifier name otherwise.
+// Identity-sensitive logic (function keys, deduplication) must keep using Name.
+func (obj *MetadataArrayType) GetDisplayName() string {
+  if obj.DisplayName != "" {
+    return obj.DisplayName
+  }
+  return obj.Name
 }
 
 func (obj *MetadataArrayType) ToJSON() IMetadataSchema_IArrayType {

--- a/packages/typia/native/core/schemas/metadata/MetadataCollection.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataCollection.go
@@ -31,6 +31,7 @@ type MetadataCollection struct {
   names_                 map[string]map[*nativechecker.Type]string
   type_full_names_       map[*nativechecker.Type]string
   full_names_            map[*nativechecker.Type]string
+  display_names_         map[*nativechecker.Type]string
   object_index_          int
   recursive_array_index_ int
   recursive_tuple_index_ int
@@ -169,7 +170,7 @@ func (collection *MetadataCollection) Tuples() []*MetadataTupleType {
   return output
 }
 
-func (collection *MetadataCollection) getName(checker *nativechecker.Checker, typ *nativechecker.Type) string {
+func (collection *MetadataCollection) getName(checker *nativechecker.Checker, typ *nativechecker.Type) (string, string) {
   // metadataCollection_getFullName (checker.TypeToString, recursing generics and
   // unions) is pure for a given type pointer, but the duplicate-numbering logic
   // below calls getName again for the same type. Cache only the full-name
@@ -188,6 +189,10 @@ func (collection *MetadataCollection) getName(checker *nativechecker.Checker, ty
   name := fullName
   name = strings.ToValidUTF8(name, "__")
   name = strings.ReplaceAll(name, "\uFFFD", "__")
+  // The anonymous marker only reads "__type" after sanitization: the raw
+  // symbol name carries tsgo's internal prefix byte, which the lines above
+  // rewrite to "__". Gate the display rendering on the sanitized form.
+  display := collection.getDisplayName(checker, typ, name)
   if collection.Options != nil && collection.Options.Replace != nil {
     name = collection.Options.Replace(name)
   }
@@ -197,14 +202,41 @@ func (collection *MetadataCollection) getName(checker *nativechecker.Checker, ty
     collection.names_[name] = duplicates
   }
   if oldbie, ok := duplicates[typ]; ok {
-    return oldbie
+    return oldbie, display
   }
   addicted := name
   if len(duplicates) != 0 {
     addicted = name + ".o" + metadataCollection_itoa(len(duplicates))
   }
   duplicates[typ] = addicted
-  return addicted
+  return addicted, display
+}
+
+// getDisplayName renders the structural form (checker.TypeToString) of types
+// whose sanitized identifier name carries the anonymous "__type" marker, so
+// human-facing expected strings can show `{ id: string; name: string; }`
+// instead of `__type.o1`. Named types return "": their identifier name is
+// already the best display, and so is the degenerate case where the rendering
+// brings no extra information.
+func (collection *MetadataCollection) getDisplayName(checker *nativechecker.Checker, typ *nativechecker.Type, sanitized string) string {
+  if strings.Contains(sanitized, "__type") == false {
+    return ""
+  }
+  if checker == nil || typ == nil {
+    return ""
+  }
+  if display, ok := collection.display_names_[typ]; ok {
+    return display
+  }
+  display := metadataCollection_sanitizeName(checker.TypeToString(typ))
+  if display == sanitized {
+    display = ""
+  }
+  if collection.display_names_ == nil {
+    collection.display_names_ = map[*nativechecker.Type]string{}
+  }
+  collection.display_names_[typ] = display
+  return display
 }
 
 func (collection *MetadataCollection) GetUnionIndex(meta *MetadataSchema) int {
@@ -233,9 +265,10 @@ func (collection *MetadataCollection) Emplace(checker *nativechecker.Checker, ty
   if oldbie := collection.objects_[typ]; oldbie != nil {
     return oldbie, false
   }
-  id := collection.getName(checker, typ)
+  id, display := collection.getName(checker, typ)
   obj := MetadataObjectType_create(MetadataObjectType{
     Name:        id,
+    DisplayName: display,
     Properties:  []*MetadataProperty{},
     Description: metadataCollection_description(metadataCollection_symbol(typ)),
     JsDocTags:   metadataCollection_jsDocTags(metadataCollection_symbol(typ)),
@@ -258,9 +291,10 @@ func (collection *MetadataCollection) EmplaceAlias(
   if oldbie := collection.aliases_[typ]; oldbie != nil {
     return oldbie, false, func(meta *MetadataSchema) {}
   }
-  id := collection.getName(checker, typ)
+  id, display := collection.getName(checker, typ)
   alias := MetadataAliasType_create(MetadataAliasType{
     Name:        id,
+    DisplayName: display,
     Value:       nil,
     Description: metadataCollection_description(symbol),
     Recursive:   false,
@@ -281,13 +315,14 @@ func (collection *MetadataCollection) EmplaceArray(
   if oldbie := collection.arrays_[typ]; oldbie != nil {
     return oldbie, false, func(meta *MetadataSchema) {}
   }
-  id := collection.getName(checker, typ)
+  id, display := collection.getName(checker, typ)
   array := MetadataArrayType_create(MetadataArrayType{
-    Name:      id,
-    Value:     nil,
-    Index:     nil,
-    Recursive: false,
-    Nullables: []bool{},
+    Name:        id,
+    DisplayName: display,
+    Value:       nil,
+    Index:       nil,
+    Recursive:   false,
+    Nullables:   []bool{},
   })
   collection.arrays_[typ] = array
   collection.arrays_order_ = append(collection.arrays_order_, typ)
@@ -303,13 +338,14 @@ func (collection *MetadataCollection) EmplaceTuple(
   if oldbie := collection.tuples_[typ]; oldbie != nil {
     return oldbie, false, func(elements []*MetadataSchema) {}
   }
-  id := collection.getName(checker, typ)
+  id, display := collection.getName(checker, typ)
   tuple := MetadataTupleType_create(MetadataTupleType{
-    Name:      id,
-    Elements:  nil,
-    Index:     nil,
-    Recursive: false,
-    Nullables: []bool{},
+    Name:        id,
+    DisplayName: display,
+    Elements:    nil,
+    Index:       nil,
+    Recursive:   false,
+    Nullables:   []bool{},
   })
   collection.tuples_[typ] = tuple
   collection.tuples_order_ = append(collection.tuples_order_, typ)

--- a/packages/typia/native/core/schemas/metadata/MetadataEscaped.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataEscaped.go
@@ -28,6 +28,10 @@ func (obj *MetadataEscaped) GetName() string {
   return obj.Returns.GetName()
 }
 
+func (obj *MetadataEscaped) GetDisplayName() string {
+  return obj.Returns.GetDisplayName()
+}
+
 func (obj *MetadataEscaped) ToJSON() IMetadataSchema_IEscaped {
   return IMetadataSchema_IEscaped{
     Original: obj.Original.ToJSON(),

--- a/packages/typia/native/core/schemas/metadata/MetadataMap.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataMap.go
@@ -7,10 +7,11 @@ type IMetadataSchema_IMap struct {
 }
 
 type MetadataMap struct {
-  Key   *MetadataSchema
-  Value *MetadataSchema
-  Tags  [][]IMetadataTypeTag
-  name_ string
+  Key           *MetadataSchema
+  Value         *MetadataSchema
+  Tags          [][]IMetadataTypeTag
+  name_         string
+  display_name_ string
 }
 
 func MetadataMap_create(props MetadataMap) *MetadataMap {
@@ -26,6 +27,13 @@ func (obj *MetadataMap) GetName() string {
     obj.name_ = taggedName("Map<"+safeMetadataName(obj.Key)+", "+safeMetadataName(obj.Value)+">", obj.Tags)
   }
   return obj.name_
+}
+
+func (obj *MetadataMap) GetDisplayName() string {
+  if obj.display_name_ == "" {
+    obj.display_name_ = taggedName("Map<"+safeMetadataDisplayName(obj.Key)+", "+safeMetadataDisplayName(obj.Value)+">", obj.Tags)
+  }
+  return obj.display_name_
 }
 
 func (obj *MetadataMap) ToJSON() IMetadataSchema_IMap {

--- a/packages/typia/native/core/schemas/metadata/MetadataObject.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataObject.go
@@ -1,9 +1,10 @@
 package metadata
 
 type MetadataObject struct {
-  Type  *MetadataObjectType
-  Tags  [][]IMetadataTypeTag
-  name_ string
+  Type          *MetadataObjectType
+  Tags          [][]IMetadataTypeTag
+  name_         string
+  display_name_ string
 }
 
 func MetadataObject_create(props MetadataObject) *MetadataObject {
@@ -18,6 +19,13 @@ func (obj *MetadataObject) GetName() string {
     obj.name_ = taggedName(obj.Type.Name, obj.Tags)
   }
   return obj.name_
+}
+
+func (obj *MetadataObject) GetDisplayName() string {
+  if obj.display_name_ == "" {
+    obj.display_name_ = taggedName(obj.Type.GetDisplayName(), obj.Tags)
+  }
+  return obj.display_name_
 }
 
 func (obj *MetadataObject) ToJSON() IMetadataSchema_IReference {

--- a/packages/typia/native/core/schemas/metadata/MetadataObjectType.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataObjectType.go
@@ -14,6 +14,7 @@ type IMetadataSchema_IObjectType struct {
 
 type MetadataObjectType struct {
   Name        string
+  DisplayName string
   Properties  []*MetadataProperty
   Description *string
   JsDocTags   []IJsDocTagInfo
@@ -30,6 +31,7 @@ func MetadataObjectType_create(props MetadataObjectType) *MetadataObjectType {
   name = strings.ReplaceAll(name, "\uFFFD", "__")
   return &MetadataObjectType{
     Name:        name,
+    DisplayName: props.DisplayName,
     Properties:  props.Properties,
     Description: props.Description,
     JsDocTags:   append([]IJsDocTagInfo{}, props.JsDocTags...),
@@ -52,6 +54,16 @@ func MetadataObjectType__From_without_properties(obj IMetadataSchema_IObjectType
     Recursive:   obj.Recursive,
     Nullables:   obj.Nullables,
   })
+}
+
+// GetDisplayName returns the human-facing rendering of the type: the
+// structural form for anonymous (inline) types, the identifier name otherwise.
+// Identity-sensitive logic (function keys, deduplication) must keep using Name.
+func (obj *MetadataObjectType) GetDisplayName() string {
+  if obj.DisplayName != "" {
+    return obj.DisplayName
+  }
+  return obj.Name
 }
 
 func (obj *MetadataObjectType) IsPlain(level ...int) bool {

--- a/packages/typia/native/core/schemas/metadata/MetadataSchema.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataSchema.go
@@ -53,6 +53,7 @@ type MetadataSchema struct {
   Maps    []*MetadataMap
 
   name_                        string
+  display_name_                string
   parent_resolved_             bool
   Union_index                  *int
   Fixed_                       *int
@@ -274,9 +275,20 @@ func MetadataSchema_from(meta *IMetadataSchema, dict IMetadataDictionary) *Metad
 
 func (obj *MetadataSchema) GetName() string {
   if obj.name_ == "" {
-    obj.name_ = metadataSchema_getName(obj)
+    obj.name_ = metadataSchema_getName(obj, false)
   }
   return obj.name_
+}
+
+// GetDisplayName composes the same union notation as GetName, but renders
+// anonymous (inline) member types structurally instead of by their synthetic
+// "__type" identifiers. Use it for human-facing expected strings only;
+// identity-sensitive logic (function keys, deduplication) must keep GetName.
+func (obj *MetadataSchema) GetDisplayName() string {
+  if obj.display_name_ == "" {
+    obj.display_name_ = metadataSchema_getName(obj, true)
+  }
+  return obj.display_name_
 }
 
 func (obj *MetadataSchema) Empty() bool {
@@ -757,9 +769,17 @@ func MetadataSchema_unalias(w *MetadataSchema) *MetadataSchema {
   return w
 }
 
-func metadataSchema_getName(metadata *MetadataSchema) string {
+func metadataSchema_getName(metadata *MetadataSchema, display bool) string {
   if metadata.Any {
     return "any"
+  }
+  // Atomics, constants, templates, and natives never carry anonymous names,
+  // so only the container buckets distinguish display rendering.
+  choose := func(name string, displayName string) string {
+    if display {
+      return displayName
+    }
+    return name
   }
   elements := []string{}
   if metadata.Nullable {
@@ -783,28 +803,28 @@ func metadataSchema_getName(metadata *MetadataSchema) string {
     elements = append(elements, native.GetName())
   }
   for _, set := range metadata.Sets {
-    elements = append(elements, set.GetName())
+    elements = append(elements, choose(set.GetName(), set.GetDisplayName()))
   }
   for _, m := range metadata.Maps {
-    elements = append(elements, m.GetName())
+    elements = append(elements, choose(m.GetName(), m.GetDisplayName()))
   }
   if metadata.Rest != nil {
-    elements = append(elements, "..."+metadata.Rest.GetName())
+    elements = append(elements, "..."+choose(metadata.Rest.GetName(), metadata.Rest.GetDisplayName()))
   }
   for _, tuple := range metadata.Tuples {
-    elements = append(elements, tuple.Type.Name)
+    elements = append(elements, choose(tuple.Type.Name, tuple.Type.GetDisplayName()))
   }
   for _, array := range metadata.Arrays {
-    elements = append(elements, array.GetName())
+    elements = append(elements, choose(array.GetName(), array.GetDisplayName()))
   }
   for _, object := range metadata.Objects {
-    elements = append(elements, object.GetName())
+    elements = append(elements, choose(object.GetName(), object.GetDisplayName()))
   }
   for _, alias := range metadata.Aliases {
-    elements = append(elements, alias.GetName())
+    elements = append(elements, choose(alias.GetName(), alias.GetDisplayName()))
   }
   if metadata.Escaped != nil {
-    elements = append(elements, metadata.Escaped.GetName())
+    elements = append(elements, choose(metadata.Escaped.GetName(), metadata.Escaped.GetDisplayName()))
   }
   if len(elements) == 0 {
     return "unknown"
@@ -859,6 +879,13 @@ func safeMetadataName(meta *MetadataSchema) string {
     return "unknown"
   }
   return meta.GetName()
+}
+
+func safeMetadataDisplayName(meta *MetadataSchema) string {
+  if meta == nil {
+    return "unknown"
+  }
+  return meta.GetDisplayName()
 }
 
 func metadataSchema_intersectsAtomicLikeNative(nativeOwner *MetadataSchema, opposite *MetadataSchema) bool {

--- a/packages/typia/native/core/schemas/metadata/MetadataSet.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataSet.go
@@ -6,9 +6,10 @@ type IMetadataSchema_ISet struct {
 }
 
 type MetadataSet struct {
-  Value *MetadataSchema
-  Tags  [][]IMetadataTypeTag
-  name_ string
+  Value         *MetadataSchema
+  Tags          [][]IMetadataTypeTag
+  name_         string
+  display_name_ string
 }
 
 func MetadataSet_create(props MetadataSet) *MetadataSet {
@@ -23,6 +24,13 @@ func (obj *MetadataSet) GetName() string {
     obj.name_ = taggedName("Set<"+safeMetadataName(obj.Value)+">", obj.Tags)
   }
   return obj.name_
+}
+
+func (obj *MetadataSet) GetDisplayName() string {
+  if obj.display_name_ == "" {
+    obj.display_name_ = taggedName("Set<"+safeMetadataDisplayName(obj.Value)+">", obj.Tags)
+  }
+  return obj.display_name_
 }
 
 func (obj *MetadataSet) ToJSON() IMetadataSchema_ISet {

--- a/packages/typia/native/core/schemas/metadata/MetadataTupleType.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataTupleType.go
@@ -9,12 +9,13 @@ type IMetadataSchema_ITupleType struct {
 }
 
 type MetadataTupleType struct {
-  Name      string
-  Elements  []*MetadataSchema
-  Index     *int
-  Recursive bool
-  Nullables []bool
-  Of_map    *bool
+  Name        string
+  DisplayName string
+  Elements    []*MetadataSchema
+  Index       *int
+  Recursive   bool
+  Nullables   []bool
+  Of_map      *bool
 }
 
 func MetadataTupleType__From_without_elements(props IMetadataSchema_ITupleType) *MetadataTupleType {
@@ -29,13 +30,24 @@ func MetadataTupleType__From_without_elements(props IMetadataSchema_ITupleType) 
 
 func MetadataTupleType_create(props MetadataTupleType) *MetadataTupleType {
   return &MetadataTupleType{
-    Name:      props.Name,
-    Elements:  props.Elements,
-    Index:     props.Index,
-    Recursive: props.Recursive,
-    Nullables: append([]bool{}, props.Nullables...),
-    Of_map:    props.Of_map,
+    Name:        props.Name,
+    DisplayName: props.DisplayName,
+    Elements:    props.Elements,
+    Index:       props.Index,
+    Recursive:   props.Recursive,
+    Nullables:   append([]bool{}, props.Nullables...),
+    Of_map:      props.Of_map,
   }
+}
+
+// GetDisplayName returns the human-facing rendering of the type: the
+// structural form for anonymous (inline) types, the identifier name otherwise.
+// Identity-sensitive logic (function keys, deduplication) must keep using Name.
+func (obj *MetadataTupleType) GetDisplayName() string {
+  if obj.DisplayName != "" {
+    return obj.DisplayName
+  }
+  return obj.Name
 }
 
 func (obj *MetadataTupleType) IsRest() bool {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.18",
+  "version": "13.0.0-dev.20260605.19",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
﻿## Summary

Closes #1667.

`validate` / `assert` errors reported anonymous (inline) type literals through their synthetic identifier names — `expected: "__type"`, `"__type.o1"`, `"Array<__type>"` — which tell the user nothing about the violated type. This PR renders them structurally instead:

```typescript
const validate = typia.createValidate<{ property: { property: string } }>();
validate({ property: undefined });
// before: { path: "$input.property", expected: "__type" }
// after:  { path: "$input.property", expected: "{ property: string; }" }
```

## Design: a parallel display name, never a renamed identifier

The synthetic names cannot simply be replaced. They are identity keys: `.oN`-numbered names guarantee uniqueness for structurally different anonymous types, `FunctionProgrammer.EmplaceUnion` deduplicates generated union functions by name, JSON-schema component keys must stay OpenAPI-safe identifiers, and merge/discrimination logic compares buckets by name equality. Two distinct anonymous types can render to the same structural string, so display strings are not usable as keys.

The implementation therefore adds a parallel `DisplayName`:

- `MetadataCollection.getName` computes it once per checker type: when the sanitized identifier carries the anonymous `__type` marker, the display is `checker.TypeToString(typ)` — the same structural rendering TypeScript uses in its own diagnostics. Named types keep their identifier as display.
- `MetadataObjectType` / `MetadataAliasType` / `MetadataArrayType` / `MetadataTupleType` store it (internal field; `ToJSON()` and the public `IMetadataSchema` interface are unchanged, so `typia.reflect.metadata` output is untouched).
- `GetDisplayName()` accessors mirror `GetName()` through wrappers, `Set<...>` / `Map<...>` composition, rest tuples, and union notation in `MetadataSchema`.
- Only human-facing `expected` strings switch to the display variant: `CheckerProgrammer` combiners and failure joiners, `UnionExplorer` failure names, `check_array_length` / `check_object_type_tags` entries, `Decode_union_object` escapes, and `JsonStringifyProgrammer` union expected. Identity consumers — `EmplaceUnion` keys, JSON-schema component keys, union predicator and merge comparisons — stay on `GetName()` / `Name`, and the `EmplaceUnion` call site is explicitly split (`names` for the key, `displays` for the message).

## Testing

New `inline_type_display_name_transform_test.go` transforms a fixture and executes the emitted validators under node, pinning exact expected strings:

- nested inline object (the issue playground case): `{ property: string; }`
- top-level inline type at `$input`: `{ id: string; }`
- inline array element: `{ value: number; }[]`
- inline union: both `{ kind: "a"; a: string; }` and `{ kind: "b"; b: number; }` branches
- tuple of inline objects: `[{ a: string; }, { b: number; }]`
- `Set` of inline values: `Set<{ flag: boolean; }>`
- named interfaces still report `INamed`
- the whole emitted artifact carries no `__type` leak, while `typia.json.schemas` output is unchanged (inline literals were always inlined, never component-referenced)

No existing TS test fixture pins any `__type` string (verified by sweep), so no fixture regeneration is needed. Full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
