### PR TITLE
fix(typia): reject non-trailing tuple rest elements at compile time

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/non_trailing_rest_tuple_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/non_trailing_rest_tuple_transform_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestNonTrailingRestTupleTransform verifies non-trailing rest rejection.
+//
+// Issue #1932: tuples whose rest element is not in the trailing position
+// compiled into positionally wrong validators — `[...unknown[], Status]`
+// checked the post-rest element at the fixed index 1 and emitted an exact
+// length comparison, so only length-2 inputs could ever pass, and then only
+// by coincidence. Every programmer (checker, stringify, clone, random)
+// addresses tuples by fixed leading positions, so the honest resolution is
+// a compile-time rejection, mirroring the json.schemas bigint precedent.
+//
+//  1. Require leading-rest and middle-rest tuples to be rejected: the call
+//     stays untransformed and a transform diagnostic is recorded (the same
+//     convention the duplicate-Sequence protobuf fixture pins; in build and
+//     project modes these diagnostics fail the compilation).
+//  2. Require trailing-rest tuples to keep compiling and validating
+//     correctly at every length.
+func TestNonTrailingRestTupleTransform(t *testing.T) {
+  t.Run("leading rest rejected", func(t *testing.T) {
+    nonTrailingRestExpectRejection(t, "leading-",
+      "export const validate = typia.createValidate<[...unknown[], string]>();")
+  })
+  t.Run("middle rest rejected", func(t *testing.T) {
+    nonTrailingRestExpectRejection(t, "middle-",
+      "export const validate = typia.createValidate<[number, ...boolean[], string]>();")
+  })
+  t.Run("trailing rest keeps working", func(t *testing.T) {
+    nonTrailingRestTrailingControl(t)
+  })
+}
+
+func nonTrailingRestProject(t *testing.T, prefix string, body string) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "rest-tuple-"+prefix)
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(nonTrailingRestTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  source := "import typia from \"typia\";\n\n" + body + "\n"
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func nonTrailingRestExpectRejection(t *testing.T, prefix string, body string) {
+  t.Helper()
+  project := nonTrailingRestProject(t, prefix, body)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("single-file transform should stay inspectable: code=%d stderr=\n%s", code, errText)
+  }
+  if !strings.Contains(out, ".createValidate()") {
+    t.Fatalf("non-trailing rest tuple call should stay untransformed:\n%s", out)
+  }
+}
+
+func nonTrailingRestTrailingControl(t *testing.T) {
+  t.Helper()
+  project := nonTrailingRestProject(t, "trailing-",
+    "export const validate = typia.createValidate<[string, ...number[]]>();")
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("trailing rest tuple failed to compile: %s", errText)
+  }
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, out)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(nonTrailingRestRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("trailing rest runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const nonTrailingRestTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const nonTrailingRestRuntimeRunner = `const mod = require("./main.cjs");
+
+const expect = (label, result, success) => {
+  if (result.success !== success) {
+    throw new Error(label + " expected success=" + success + ": " + JSON.stringify(result.errors));
+  }
+};
+
+expect("solo head", mod.validate(["head"]), true);
+expect("head + numbers", mod.validate(["head", 1, 2, 3]), true);
+expect("empty", mod.validate([]), false);
+expect("wrong head", mod.validate([1, 2]), false);
+expect("wrong rest element", mod.validate(["head", 1, "x"]), false);
+`

--- a/packages/typia/native/core/factories/internal/metadata/emplace_metadata_tuple.go
+++ b/packages/typia/native/core/factories/internal/metadata/emplace_metadata_tuple.go
@@ -49,6 +49,17 @@ func Emplace_metadata_tuple(props IMetadataIteratorProps) *schemametadata.Metada
       elements = append(elements, child)
       continue
     }
+    // Every programmer addresses tuple elements by their fixed leading
+    // position and slices the rest segment off the end, so a rest element
+    // anywhere but the trailing position would compile into positionally
+    // wrong checks (issue #1932). Reject it honestly instead.
+    if i != len(args)-1 && props.Errors != nil {
+      *props.Errors = append(*props.Errors, MetadataFactory_IError{
+        Name:     tuple.Name,
+        Explore:  props.Explore,
+        Messages: []string{"non-trailing rest element in tuple type is not supported."},
+      })
+    }
     wrapper := schemametadata.MetadataSchema_initialize()
     wrapper.Rest = child
     elements = append(elements, wrapper)


### PR DESCRIPTION
## Summary

Closes #1932.

Tuples whose rest element is not in the trailing position compiled into positionally wrong validators: `[...unknown[], Status]` checked the post-rest element at the fixed index 1 and emitted an exact length comparison, so only length-2 inputs could pass — and then only by coincidence (`["SUCCESS"]` was rejected, `["a","b","SUCCESS"]` was rejected, `["stuff","SUCCESS"]` passed).

## Resolution: compile-time rejection

Of the two candidates on the issue, this PR takes the prohibition route. Every programmer (checker, stringify, clone/prune, random) addresses tuple elements by fixed leading positions and slices the rest segment off the end — supporting non-trailing rest means end-relative addressing replicated across all of them, for a type shape with near-zero practical demand and no JSON-schema representation. A silently wrong validator is the worst outcome for a validation library, so the honest behavior is an upfront error, mirroring the `json.schemas` bigint precedent (and the direction already suggested in #1299).

`Emplace_metadata_tuple` now reports `non-trailing rest element in tuple type is not supported.` through the standard `MetadataFactory` error channel when a `Rest`-flagged element is not last, which fails the compilation in build/project modes. End-relative support can still be implemented later behind this error if real demand appears.

## Testing

New `non_trailing_rest_tuple_transform_test.go`:

- leading-rest (`[...unknown[], string]`) and middle-rest (`[number, ...boolean[], string]`) tuples are rejected — the call stays untransformed, following the same single-file-mode convention the duplicate-`Sequence` protobuf fixture pins;
- trailing-rest (`[string, ...number[]]`) keeps compiling, with runtime checks exercised at lengths 1/2/4, an empty array, a wrong head, and a wrong rest element.

Full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
