### PR TITLE
fix(typia): preserve underscore prefix in snake/kebab without word separation

### DIFF
--- a/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
+++ b/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
@@ -1366,7 +1366,7 @@ func notationGeneralProgrammer_snake(str string) string {
     indexes = indexes[1:]
   }
   if len(indexes) == 0 {
-    return strings.ToLower(str)
+    return out(strings.ToLower(str))
   }
   ret := ""
   for i, last := range indexes {

--- a/packages/typia/native/core/programmers/notations/notation_general_programmer_snake_prefix_test.go
+++ b/packages/typia/native/core/programmers/notations/notation_general_programmer_snake_prefix_test.go
@@ -1,0 +1,44 @@
+package notations
+
+import "testing"
+
+// TestNotationGeneralProgrammerSnakePrefix verifies underscore preservation.
+//
+// Issue #1926: the no-word-separation fallback of the snake derivation
+// returned early without the `out()` prefix wrapper, so `snake("_foo")`
+// produced `"foo"` and `snake("___")` produced `""`, diverging from the
+// `SnakeCase<T>` typing which preserves such keys verbatim. The kebab
+// derivation composes over snake and must inherit the corrected behavior.
+func TestNotationGeneralProgrammerSnakePrefix(t *testing.T) {
+  snake := []struct{ input, expected string }{
+    {"userId", "user_id"},
+    {"UserId", "user_id"},
+    {"user_name", "user_name"},
+    {"_privateValue", "_private_value"},
+    {"__doublePrefix", "__double_prefix"},
+    {"_solo", "_solo"},
+    {"_FOO", "_foo"},
+    {"___", "___"},
+    {"XMLParser", "xmlparser"},
+    {"toHTML", "to_html"},
+    {"", ""},
+    {"word", "word"},
+  }
+  for _, c := range snake {
+    if actual := notationGeneralProgrammer_snake(c.input); actual != c.expected {
+      t.Errorf("snake(%q) == %q, expected %q", c.input, actual, c.expected)
+    }
+  }
+  kebab := []struct{ input, expected string }{
+    {"_privateValue", "_private-value"},
+    {"_solo", "_solo"},
+    {"_XML", "_xml"},
+    {"___", "___"},
+    {"toHTML", "to-html"},
+  }
+  for _, c := range kebab {
+    if actual := notationGeneralProgrammer_kebab(c.input); actual != c.expected {
+      t.Errorf("kebab(%q) == %q, expected %q", c.input, actual, c.expected)
+    }
+  }
+}

--- a/packages/typia/src/internal/_notationSnake.ts
+++ b/packages/typia/src/internal/_notationSnake.ts
@@ -28,7 +28,7 @@ export const _notationSnake = (str: string): string => {
     if (now - prev === 1) indexes.splice(i, 1);
   }
   if (indexes.length !== 0 && indexes[0] === 0) indexes.splice(0, 1);
-  if (indexes.length === 0) return str.toLowerCase();
+  if (indexes.length === 0) return out(str.toLowerCase());
 
   let ret: string = "";
   for (let i: number = 0; i < indexes.length; i++) {

--- a/packages/utils/src/utils/NamingConvention.ts
+++ b/packages/utils/src/utils/NamingConvention.ts
@@ -87,7 +87,7 @@ export namespace NamingConvention {
       if (now - prev === 1) indexes.splice(i, 1);
     }
     if (indexes.length !== 0 && indexes[0] === 0) indexes.splice(0, 1);
-    if (indexes.length === 0) return str.toLowerCase();
+    if (indexes.length === 0) return out(str.toLowerCase());
 
     let ret: string = "";
     for (let i: number = 0; i < indexes.length; i++) {

--- a/tests/test-utils/src/features/naming/test_naming_convention_kebab.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_kebab.ts
@@ -8,7 +8,8 @@ import { NamingConvention } from "@typia/utils";
  * separators, keeping leading underscores untouched. The same composition
  * drives the `typia.notations.kebab` transform and the `KebabCase<T>` typing,
  * so this utility must stay byte-identical to that contract — including the
- * acronym-run collapse the snake derivation performs.
+ * acronym-run collapse the snake derivation performs and the
+ * leading-underscore preservation on inputs without word separation (#1926).
  *
  * 1. Convert camelCase, PascalCase, and snake_case inputs.
  * 2. Convert leading-underscore and acronym-run inputs.
@@ -25,9 +26,9 @@ export const test_naming_convention_kebab = (): void => {
     ["toHTML", "to-html"],
     ["already-plain", "already-plain"],
     ["", ""],
-    // The snake derivation drops the prefix when no word separation occurs
-    // (a long-standing snake quirk); kebab inherits it by composition.
-    ["___", ""],
+    ["___", "___"],
+    ["_solo", "_solo"],
+    ["_XML", "_xml"],
     ["word", "word"],
   ];
   for (const [input, expected] of expectations)

--- a/tests/test-utils/src/features/naming/test_naming_convention_snake.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_snake.ts
@@ -1,0 +1,38 @@
+import { TestValidator } from "@nestia/e2e";
+import { NamingConvention } from "@typia/utils";
+
+/**
+ * Verifies NamingConvention.snake derives underscored names.
+ *
+ * The snake derivation drives the `typia.notations.snake` transform and the
+ * `SnakeCase<T>` typing, so this utility must stay byte-identical to that
+ * contract. Issue #1926: the no-word-separation fallback used to drop the
+ * leading underscores (`snake("_foo")` returned `"foo"`) while the typing
+ * preserves them — the prefix must survive on every path.
+ *
+ * 1. Convert camelCase, PascalCase, and snake_case inputs.
+ * 2. Convert leading-underscore inputs with and without word separation.
+ * 3. Convert degenerate inputs (empty, underscores only, acronym runs).
+ */
+export const test_naming_convention_snake = (): void => {
+  const expectations: [string, string][] = [
+    ["userId", "user_id"],
+    ["UserId", "user_id"],
+    ["user_name", "user_name"],
+    ["_privateValue", "_private_value"],
+    ["__doublePrefix", "__double_prefix"],
+    ["_solo", "_solo"],
+    ["_FOO", "_foo"],
+    ["___", "___"],
+    ["XMLParser", "xmlparser"],
+    ["toHTML", "to_html"],
+    ["", ""],
+    ["word", "word"],
+  ];
+  for (const [input, expected] of expectations)
+    TestValidator.equals(
+      `snake(${JSON.stringify(input)})`,
+      NamingConvention.snake(input),
+      expected,
+    );
+};


### PR DESCRIPTION
## Summary

Closes #1926.

The snake_case runtime derivation preserved leading underscores through its `out()` prefix wrapper on every path except the no-word-separation fallback, which returned early without it:

```ts
if (indexes.length === 0) return str.toLowerCase(); // prefix dropped
```

So `snake("_foo")` produced `"foo"` and `snake("___")` produced `""`, while the `SnakeCase<T>` typing preserves such keys verbatim (`"_foo"` / `"___"`) — `typia.notations.snake<{ _foo: string }>` declared the key `_foo` but the produced object carried `foo`. `kebab` inherited the quirk by composition.

## Fix

Route the fallback through `out()` in all three mirrored implementations, exactly as sketched on the issue:

- `packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go` (`notationGeneralProgrammer_snake` — the v13 transform)
- `packages/utils/src/utils/NamingConvention.ts` (`snake`)
- `packages/typia/src/internal/_notationSnake.ts` (legacy runtime)

`camel` / `pascal` already preserve the prefix through their shared `unsnake` wrapper, so the runtime family is now uniformly aligned with the typings.

## Testing

- New Go unit test pins the snake/kebab matrix in the notations package, including `_solo`, `_FOO`, `___`, and the acronym-run collapse.
- New `test_naming_convention_snake.ts` pins the same matrix against `NamingConvention.snake`.
- The kebab expectations updated: `["___", ""]` (the pinned quirk) becomes `["___", "___"]`, plus `_solo` / `_XML` cases.

Full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
