### PR TITLE
feat(typia): cycle-safe validators via visit tracking on recursive types

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/recursive_visit_tracking_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/recursive_visit_tracking_transform_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestRecursiveVisitTrackingTransform verifies cycle-safe validators.
+//
+// Issue #1820: generated validators walked recursive values without visit
+// tracking, so any runtime cycle overflowed the stack. Recursive type graphs
+// are the only way the generated function call graph can cycle, so the
+// transform now threads a per-invocation `_vctx` context through validators
+// of recursive types and guards each recursive function with a lazy WeakSet:
+// a value already being checked (or proven) short-circuits to true — the
+// coinductive reading — and a failed check removes its entry so union-branch
+// probing cannot poison sibling checks of the same value.
+//
+//  1. Self-recursive, mutually recursive, recursive-array, and
+//     recursive-tuple cycles validate successfully across is / assert /
+//     validate / equals.
+//  2. Cyclic but invalid values are rejected finitely with correct error
+//     paths, and assert throws instead of overflowing.
+//  3. Union probing of one shared cyclic value across recursive branches
+//     stays correct (delete-on-fail), and DAG aliases revalidate per path.
+//  4. Repeat invocations stay independent (per-invocation context).
+//  5. Non-recursive types keep their emission free of any `_vctx` text.
+func TestRecursiveVisitTrackingTransform(t *testing.T) {
+  project := recursiveVisitTrackingProject(t)
+  js := recursiveVisitTrackingTransform(t, project)
+  if !strings.Contains(js, "_vctx") {
+    t.Fatalf("recursive fixtures did not emit visit tracking:\n%s", js)
+  }
+  recursiveVisitTrackingRunRuntimeCases(t, project, js)
+
+  flat := recursiveVisitTrackingFlatControl(t)
+  if strings.Contains(flat, "_vctx") {
+    t.Fatalf("non-recursive emission must stay untouched by visit tracking:\n%s", flat)
+  }
+}
+
+func recursiveVisitTrackingProject(t *testing.T) string {
+  t.Helper()
+  return recursiveVisitTrackingWrite(t, "visit-", recursiveVisitTrackingSource)
+}
+
+func recursiveVisitTrackingFlatControl(t *testing.T) string {
+  t.Helper()
+  project := recursiveVisitTrackingWrite(t, "visit-flat-", recursiveVisitTrackingFlatSource)
+  return recursiveVisitTrackingTransform(t, project)
+}
+
+func recursiveVisitTrackingWrite(t *testing.T, prefix string, source string) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, prefix)
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(recursiveVisitTrackingTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func recursiveVisitTrackingTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("visit tracking transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func recursiveVisitTrackingRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(recursiveVisitTrackingRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("visit tracking runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const recursiveVisitTrackingTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const recursiveVisitTrackingSource = `import typia from "typia";
+
+// The issue #1820 case: self recursion.
+interface INode {
+  id: number;
+  parent: INode | null;
+}
+export const isNode = typia.createIs<INode>();
+export const assertNode = typia.createAssert<INode>();
+export const validateNode = typia.createValidate<INode>();
+export const equalsNode = typia.createEquals<INode>();
+
+// Mutual recursion.
+interface IAlpha {
+  a: string;
+  beta: IBeta | null;
+}
+interface IBeta {
+  b: number;
+  alpha: IAlpha | null;
+}
+export const isAlpha = typia.createIs<IAlpha>();
+export const validateAlpha = typia.createValidate<IAlpha>();
+
+// Recursion through an array property.
+interface ITree {
+  id: number;
+  children: ITree[];
+}
+export const isTree = typia.createIs<ITree>();
+export const validateTree = typia.createValidate<ITree>();
+
+// Recursion through a tuple.
+type TPair = [number, TPair | null];
+export const isPair = typia.createIs<TPair>();
+export const validatePair = typia.createValidate<TPair>();
+
+// Non-discriminated union of two recursive shapes: probing one branch with a
+// shared cyclic value must not poison the other branch (delete-on-fail).
+interface IUA {
+  next: IUA | null;
+  a: number;
+}
+interface IUB {
+  next: IUB | null;
+  b: number;
+}
+export const isUnion = typia.createIs<IUA | IUB>();
+
+// Recursion through dynamic record keys.
+interface IGraph {
+  name: string;
+  nodes: Record<string, IGraph>;
+}
+export const isGraph = typia.createIs<IGraph>();
+
+// A recursive array as one branch of a union: exercises the hoisted union
+// predicate path, which must thread the visit context as a parameter.
+export const isForest = typia.createIs<ITree[] | number>();
+export const validateForest = typia.createValidate<ITree[] | number>();
+`
+
+const recursiveVisitTrackingFlatSource = `import typia from "typia";
+
+interface IFlat {
+  id: number;
+  name: string;
+  tags: string[];
+}
+export const isFlat = typia.createIs<IFlat>();
+export const validateFlat = typia.createValidate<IFlat>();
+`
+
+const recursiveVisitTrackingRuntimeRunner = `const mod = require("./main.cjs");
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + expected + ", got " + actual);
+  }
+};
+const capture = (task) => {
+  try {
+    task();
+    return null;
+  } catch (error) {
+    return error;
+  }
+};
+
+// 1. Self recursion: the issue's exact case.
+const node = { id: 1, parent: null };
+node.parent = node;
+expect("cyclic is", mod.isNode(node), true);
+expect("cyclic validate", mod.validateNode(node).success, true);
+expect("cyclic assert", mod.assertNode(node), node);
+expect("cyclic equals", mod.equalsNode(node), true);
+
+// 2. Cyclic but invalid: finite rejection with correct paths.
+const bad = { id: 1, parent: null };
+bad.parent = { id: "x", parent: bad };
+expect("bad is", mod.isNode(bad), false);
+const badReport = mod.validateNode(bad);
+expect("bad validate", badReport.success, false);
+if (badReport.errors.every((e) => e.path !== "$input.parent.id")) {
+  throw new Error("bad validate lost the cycle-internal path: " +
+    badReport.errors.map((e) => e.path).join(", "));
+}
+const badAssert = capture(() => mod.assertNode(bad));
+if (badAssert === null) {
+  throw new Error("assert accepted a cyclic invalid value");
+}
+
+// 3. Equals: cyclic value with a superfluous property must still fail.
+const extra = { id: 1, parent: null, superfluous: true };
+extra.parent = extra;
+expect("cyclic equals superfluous", mod.equalsNode(extra), false);
+expect("cyclic is ignores superfluous", mod.isNode(extra), true);
+
+// 4. Mutual recursion.
+const alpha = { a: "a", beta: null };
+const beta = { b: 2, alpha: alpha };
+alpha.beta = beta;
+expect("mutual is", mod.isAlpha(alpha), true);
+expect("mutual validate", mod.validateAlpha(alpha).success, true);
+beta.b = "broken";
+expect("mutual broken is", mod.isAlpha(alpha), false);
+const mutualReport = mod.validateAlpha(alpha);
+expect("mutual broken validate", mutualReport.success, false);
+if (mutualReport.errors.every((e) => e.path !== "$input.beta.b")) {
+  throw new Error("mutual validate lost the path: " +
+    mutualReport.errors.map((e) => e.path).join(", "));
+}
+
+// 5. Recursion through arrays.
+const tree = { id: 1, children: [] };
+tree.children.push(tree, { id: 2, children: [] });
+expect("tree is", mod.isTree(tree), true);
+expect("tree validate", mod.validateTree(tree).success, true);
+tree.children.push({ id: "x", children: [] });
+expect("tree broken is", mod.isTree(tree), false);
+const treeReport = mod.validateTree(tree);
+expect("tree broken validate", treeReport.success, false);
+if (treeReport.errors.every((e) => e.path !== "$input.children[2].id")) {
+  throw new Error("tree validate lost the indexed path: " +
+    treeReport.errors.map((e) => e.path).join(", "));
+}
+
+// 6. Recursion through tuples.
+const pair = [1, null];
+pair[1] = pair;
+expect("pair is", mod.isPair(pair), true);
+expect("pair validate", mod.validatePair(pair).success, true);
+const badPair = [1, ["x", null]];
+expect("bad pair is", mod.isPair(badPair), false);
+
+// 7. Union probing with a shared cyclic value: a cyclic IUB must survive the
+//    IUA probe failing on it first.
+const ub = { next: null, b: 3 };
+ub.next = ub;
+expect("union cyclic b", mod.isUnion(ub), true);
+const ua = { next: null, a: 4 };
+ua.next = ua;
+expect("union cyclic a", mod.isUnion(ua), true);
+const neither = { next: null, c: 5 };
+neither.next = neither;
+expect("union cyclic neither", mod.isUnion(neither), false);
+
+// 8. Recursion through dynamic record keys.
+const graph = { name: "root", nodes: {} };
+graph.nodes.self = graph;
+graph.nodes.leaf = { name: "leaf", nodes: {} };
+expect("graph is", mod.isGraph(graph), true);
+graph.nodes.bad = { name: 9, nodes: {} };
+expect("graph broken is", mod.isGraph(graph), false);
+
+// 9. DAG aliases: valid shared subtrees pass; an invalid shared subtree is
+//    reported at every path it appears under (delete-on-fail re-walks).
+const shared = { id: 7, parent: null };
+expect("dag is", mod.isNode({ id: 1, parent: shared }), true);
+const wrongShared = { id: "broken", parent: null };
+const dagReport = mod.validateNode({ id: 1, parent: wrongShared });
+expect("dag broken validate", dagReport.success, false);
+
+// 10. Recursive array branch inside a union.
+expect("forest number", mod.isForest(8), true);
+const forest = [{ id: 1, children: [] }];
+forest[0].children.push(forest[0]);
+expect("forest cyclic", mod.isForest(forest), true);
+expect("forest cyclic validate", mod.validateForest(forest).success, true);
+forest.push({ id: "x", children: [] });
+expect("forest broken", mod.isForest(forest), false);
+
+// 11. Repeat invocations stay independent.
+expect("repeat 1", mod.isNode(node), true);
+expect("repeat 2", mod.isNode(node), true);
+expect("repeat bad", mod.isNode(bad), false);
+expect("repeat good after bad", mod.isNode(node), true);
+`

--- a/packages/typia/native/cmd/ttsc-typia/recursive_visit_tracking_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/recursive_visit_tracking_transform_test.go
@@ -107,6 +107,21 @@ func recursiveVisitTrackingRunRuntimeCases(t *testing.T, project string, js stri
     t.Fatalf("mkdir runtime dir: %v", err)
   }
   ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  extras := map[string]string{
+    "throw-type-guard-error-stub.cjs":   recursiveVisitTrackingThrowStub,
+    "protobuf-sizer-stub.cjs":           recursiveVisitTrackingProtobufSizerStub,
+    "protobuf-writer-stub.cjs":          recursiveVisitTrackingProtobufWriterStub,
+    "json-stringify-number-stub.cjs":    recursiveVisitTrackingNumberStub,
+  }
+  for name, content := range extras {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  js = strings.ReplaceAll(js, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
+  js = strings.ReplaceAll(js, `require("typia/lib/internal/_ProtobufSizer")`, `require("./protobuf-sizer-stub.cjs")`)
+  js = strings.ReplaceAll(js, `require("typia/lib/internal/_ProtobufWriter")`, `require("./protobuf-writer-stub.cjs")`)
+  js = strings.ReplaceAll(js, `require("typia/lib/internal/_jsonStringifyNumber")`, `require("./json-stringify-number-stub.cjs")`)
   runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
   if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
     t.Fatalf("write runtime module: %v", err)
@@ -198,6 +213,35 @@ export const isGraph = typia.createIs<IGraph>();
 // predicate path, which must thread the visit context as a parameter.
 export const isForest = typia.createIs<ITree[] | number>();
 export const validateForest = typia.createValidate<ITree[] | number>();
+
+// Rebuilders: clone must reproduce cycles (structured-clone style), and the
+// assert composition shares one functor with the clone emission.
+export const cloneNode = typia.misc.createClone<INode>();
+export const assertCloneNode = typia.misc.createAssertClone<INode>();
+export const cloneTree = typia.misc.createClone<ITree>();
+
+// In-place walker: prune must terminate on cycles while still erasing the
+// superfluous properties it reaches.
+export const pruneNode = typia.misc.createPrune<INode>();
+
+// Renaming rebuilder: notations must reproduce cycles under the new keys.
+interface IRenamed {
+  userId: number;
+  nextNode: IRenamed | null;
+}
+export const snakeRenamed = typia.notations.createSnake<IRenamed>();
+
+// Serializers: JSON and protobuf cannot represent cycles, so they must fail
+// fast with a TypeGuardError instead of overflowing the stack — while DAG
+// aliases keep serializing (duplicated output is legal).
+export const stringifyNode = typia.json.createStringify<INode>();
+export const assertStringifyNode = typia.json.createAssertStringify<INode>();
+
+interface IProtoNode {
+  id: number;
+  child: IProtoNode | null;
+}
+export const encodeNode = typia.protobuf.createEncode<IProtoNode>();
 `
 
 const recursiveVisitTrackingFlatSource = `import typia from "typia";
@@ -335,4 +379,95 @@ expect("repeat 1", mod.isNode(node), true);
 expect("repeat 2", mod.isNode(node), true);
 expect("repeat bad", mod.isNode(bad), false);
 expect("repeat good after bad", mod.isNode(node), true);
+
+// 12. Clone reproduces cycles with fresh identity (structured-clone style).
+const cloned = mod.cloneNode(node);
+expect("clone new identity", cloned !== node, true);
+expect("clone cycle reproduced", cloned.parent === cloned, true);
+expect("clone value", cloned.id, 1);
+const assertCloned = mod.assertCloneNode(node);
+expect("assertClone cycle", assertCloned.parent === assertCloned, true);
+const clonedTree = mod.cloneTree(tree2());
+expect("clone tree cycle", clonedTree.children[0] === clonedTree, true);
+expect("clone tree leaf identity", clonedTree.children[1].id, 2);
+function tree2() {
+  const value = { id: 1, children: [] };
+  value.children.push(value, { id: 2, children: [] });
+  return value;
+}
+
+// 13. Prune terminates on cycles and still erases superfluous properties.
+const prunable = { id: 1, parent: null, superfluous: "x" };
+prunable.parent = prunable;
+mod.pruneNode(prunable);
+expect("prune terminated and erased", "superfluous" in prunable, false);
+expect("prune kept cycle", prunable.parent === prunable, true);
+
+// 14. Notations reproduce cycles under the renamed keys.
+const renamed = { userId: 9, nextNode: null };
+renamed.nextNode = renamed;
+const snaked = mod.snakeRenamed(renamed);
+expect("snake renamed key", snaked.user_id, 9);
+expect("snake cycle reproduced", snaked.next_node === snaked, true);
+
+// 15. JSON stringify: cycles fail fast, DAG aliases keep serializing.
+const circularError = capture(() => mod.stringifyNode(node));
+if (circularError === null) {
+  throw new Error("stringify accepted a circular value");
+}
+if (String(circularError.expected).includes("non-circular") === false) {
+  throw new Error("stringify cycle error lost its expected text: " + circularError.expected);
+}
+const sharedLeaf = { id: 7, parent: null };
+expect(
+  "stringify DAG",
+  typeof mod.stringifyNode({ id: 1, parent: sharedLeaf }),
+  "string",
+);
+const assertStringifyError = capture(() => mod.assertStringifyNode(node));
+if (assertStringifyError === null) {
+  throw new Error("assertStringify accepted a circular value");
+}
+
+// 16. Protobuf encode: cycles fail fast, acyclic recursive values encode.
+const protoCycle = { id: 1, child: null };
+protoCycle.child = protoCycle;
+const protoError = capture(() => mod.encodeNode(protoCycle));
+if (protoError === null) {
+  throw new Error("protobuf encode accepted a circular value");
+}
+const protoOk = capture(() => mod.encodeNode({ id: 1, child: { id: 2, child: null } }));
+if (protoOk !== null) {
+  throw new Error("protobuf encode rejected an acyclic recursive value: " + protoOk);
+}
+`
+
+const recursiveVisitTrackingNumberStub = `module.exports._jsonStringifyNumber = (value) => String(value);
+`
+
+const recursiveVisitTrackingThrowStub = `module.exports._throwTypeGuardError = (props) => {
+  const error = new Error("typia.json.stringify: " + props.expected);
+  error.method = props.method;
+  error.expected = props.expected;
+  error.value = props.value;
+  throw error;
+};
+`
+
+const recursiveVisitTrackingProtobufSizerStub = `class ProtobufSizer {
+  constructor() {
+    return new Proxy(this, { get: () => () => 0 });
+  }
+}
+module.exports._ProtobufSizer = ProtobufSizer;
+module.exports.ProtobufSizer = ProtobufSizer;
+`
+
+const recursiveVisitTrackingProtobufWriterStub = `class ProtobufWriter {
+  constructor() {
+    return new Proxy(this, { get: () => () => new Uint8Array() });
+  }
+}
+module.exports._ProtobufWriter = ProtobufWriter;
+module.exports.ProtobufWriter = ProtobufWriter;
 `

--- a/packages/typia/native/core/programmers/helpers/FunctionProgrammer.go
+++ b/packages/typia/native/core/programmers/helpers/FunctionProgrammer.go
@@ -18,6 +18,12 @@ type FunctionProgrammer struct {
   variableOrder_ []string
   sequence_      int
   disableDeclare bool
+  // visited_ turns on per-invocation visit tracking: set after metadata
+  // analysis when the type graph carries a recursive component, so generated
+  // functions thread a `_vctx` context and recursive ones guard against
+  // runtime cycles (issue #1820). Read late (at emission) on purpose — the
+  // flag is unknown until the collection is analyzed.
+  visited_ bool
   // emit_ routes declaration/identifier creation through the emit context's
   // factory when present so generated `const` validators carry original-node
   // tracking; nil falls back to the standalone factory (legacy / test paths).
@@ -49,6 +55,14 @@ func NewFunctionProgrammer(method string, emit ...*shimprinter.EmitContext) *Fun
 func (p *FunctionProgrammer) UseLocal(name string) string {
   p.local_[name] = true
   return name
+}
+
+func (p *FunctionProgrammer) SetVisited(value bool) {
+  p.visited_ = value
+}
+
+func (p *FunctionProgrammer) Visited() bool {
+  return p.visited_
 }
 
 func (p *FunctionProgrammer) HasLocal(name string) bool {

--- a/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
@@ -196,7 +196,7 @@ func (checkerProgrammerNamespace) Write_array_functions(props CheckerProgrammer_
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        checkerProgrammer_visit_guard(fmt.Sprintf("a%d", i), checkerProgrammer_decode_array_inline(checkerProgrammer_decodeArrayInlineProps{
+        checkerProgrammer_visit_guard(FeatureProgrammer.VisitKey(props.Config.Prefix, "a", i), checkerProgrammer_decode_array_inline(checkerProgrammer_decodeArrayInlineProps{
           Config:  props.Config,
           Context: props.Context,
           Functor: props.Functor,
@@ -241,7 +241,7 @@ func (checkerProgrammerNamespace) Write_tuple_functions(props CheckerProgrammer_
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        checkerProgrammer_visit_guard(fmt.Sprintf("t%d", i), checkerProgrammer_decode_tuple_inline(checkerProgrammer_decodeTupleInlineProps{
+        checkerProgrammer_visit_guard(FeatureProgrammer.VisitKey(props.Config.Prefix, "t", i), checkerProgrammer_decode_tuple_inline(checkerProgrammer_decodeTupleInlineProps{
           Config:  props.Config,
           Context: props.Context,
           Functor: props.Functor,
@@ -318,7 +318,7 @@ func checkerProgrammer_configure(context nativecontext.ITypiaContext, config Che
       // Recursive type graphs are the only way the generated function call
       // graph can cycle, so visit tracking (issue #1820) turns on exactly
       // here; non-recursive types keep their emission byte-identical.
-      if checkerProgrammer_collection_recursive(collection) {
+      if FeatureProgrammer.CollectionRecursive(collection) {
         next.Functor.SetVisited(true)
       }
       return FeatureProgrammer_InitializerOutput{
@@ -1827,28 +1827,6 @@ func checkerProgrammer_reduce(expressions []*shimast.Node, operator shimast.Kind
 
 func checkerProgrammer_and(x *shimast.Expression, y *shimast.Expression, emit *shimprinter.EmitContext) *shimast.Node {
   return checkerProgrammer_binary(x, shimast.KindAmpersandAmpersandToken, y, emit)
-}
-
-// checkerProgrammer_collection_recursive reports whether the analyzed type
-// graph carries any recursive component — the precondition for a runtime
-// value to drive the generated function call graph into a cycle.
-func checkerProgrammer_collection_recursive(collection *nativemetadata.MetadataCollection) bool {
-  for _, object := range collection.Objects() {
-    if object.Recursive {
-      return true
-    }
-  }
-  for _, array := range collection.Arrays() {
-    if array.Recursive {
-      return true
-    }
-  }
-  for _, tuple := range collection.Tuples() {
-    if tuple.Recursive {
-      return true
-    }
-  }
-  return false
 }
 
 // checkerProgrammer_visit_guard wraps a recursive function body so a value

--- a/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
@@ -188,7 +188,7 @@ func (checkerProgrammerNamespace) Write_array_functions(props CheckerProgrammer_
         nil,
         nil,
         f.NewNodeList(FeatureProgrammer.ParameterDeclarations(FeatureProgrammer_ParameterDeclarationsProps{
-          Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any"),
           Input:  input,
           Emit:   props.Context.Emit,
@@ -196,7 +196,7 @@ func (checkerProgrammerNamespace) Write_array_functions(props CheckerProgrammer_
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        checkerProgrammer_decode_array_inline(checkerProgrammer_decodeArrayInlineProps{
+        checkerProgrammer_visit_guard(fmt.Sprintf("a%d", i), checkerProgrammer_decode_array_inline(checkerProgrammer_decodeArrayInlineProps{
           Config:  props.Config,
           Context: props.Context,
           Functor: props.Functor,
@@ -211,7 +211,7 @@ func (checkerProgrammerNamespace) Write_array_functions(props CheckerProgrammer_
             From:     "array",
             Postfix:  "",
           },
-        }),
+        }), props.Context.Emit),
       ),
     }, props.Context.Emit))
   }
@@ -233,7 +233,7 @@ func (checkerProgrammerNamespace) Write_tuple_functions(props CheckerProgrammer_
         nil,
         nil,
         f.NewNodeList(FeatureProgrammer.ParameterDeclarations(FeatureProgrammer_ParameterDeclarationsProps{
-          Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any"),
           Input:  input,
           Emit:   props.Context.Emit,
@@ -241,7 +241,7 @@ func (checkerProgrammerNamespace) Write_tuple_functions(props CheckerProgrammer_
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        checkerProgrammer_decode_tuple_inline(checkerProgrammer_decodeTupleInlineProps{
+        checkerProgrammer_visit_guard(fmt.Sprintf("t%d", i), checkerProgrammer_decode_tuple_inline(checkerProgrammer_decodeTupleInlineProps{
           Config:  props.Config,
           Context: props.Context,
           Functor: props.Functor,
@@ -253,7 +253,7 @@ func (checkerProgrammerNamespace) Write_tuple_functions(props CheckerProgrammer_
             From:     "array",
             Postfix:  "",
           },
-        }),
+        }), props.Context.Emit),
       ),
     }, props.Context.Emit))
   }
@@ -287,9 +287,13 @@ func checkerProgrammer_configure(context nativecontext.ITypiaContext, config Che
         )
       },
     },
-    Trace:  config.Trace,
-    Path:   config.Path,
-    Prefix: config.Prefix,
+    Trace:   config.Trace,
+    Path:    config.Path,
+    Prefix:  config.Prefix,
+    Visited: functor.Visited,
+    VisitGuard: func(next FeatureProgrammer_VisitGuardProps) *shimast.Node {
+      return checkerProgrammer_visit_guard(next.Key, next.Body, context.Emit)
+    },
     Initializer: func(next FeatureProgrammer_InitializerProps) FeatureProgrammer_InitializerOutput {
       collection := nativemetadata.NewMetadataCollection()
       result := nativefactories.MetadataFactory.Analyze(nativefactories.MetadataFactory_IProps{
@@ -310,6 +314,12 @@ func checkerProgrammer_configure(context nativecontext.ITypiaContext, config Che
           Code:   next.Functor.Method,
           Errors: checkerProgrammer_errors(result.Errors),
         }))
+      }
+      // Recursive type graphs are the only way the generated function call
+      // graph can cycle, so visit tracking (issue #1820) turns on exactly
+      // here; non-recursive types keep their emission byte-identical.
+      if checkerProgrammer_collection_recursive(collection) {
+        next.Functor.SetVisited(true)
       }
       return FeatureProgrammer_InitializerOutput{
         Collection: collection,
@@ -953,9 +963,10 @@ func (checkerProgrammerNamespace) Decode_object(props CheckerProgrammer_DecodeOb
   props.Object.Validated = true
   return FeatureProgrammer.Decode_object(FeatureProgrammer_DecodeObjectProps{
     Config: FeatureProgrammer_DecodeObjectConfig{
-      Prefix: props.Config.Prefix,
-      Path:   props.Config.Path,
-      Trace:  props.Config.Trace,
+      Prefix:  props.Config.Prefix,
+      Path:    props.Config.Path,
+      Trace:   props.Config.Trace,
+      Visited: props.Functor.Visited(),
     },
     Functor: props.Functor,
     Object:  props.Object,
@@ -994,7 +1005,7 @@ func checkerProgrammer_decode_array(props checkerProgrammer_decodeArrayProps) *s
       nil,
       nil,
       f.NewNodeList(FeatureProgrammer.ArgumentsArray(FeatureProgrammer_ArgumentsArrayProps{
-        Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Explore: arrayExplore,
         Input:   props.Input,
         Emit:    props.Context.Emit,
@@ -1104,7 +1115,7 @@ func checkerProgrammer_decode_tuple(props checkerProgrammer_decodeTupleProps) *s
       nil,
       nil,
       f.NewNodeList(FeatureProgrammer.ArgumentsArray(FeatureProgrammer_ArgumentsArrayProps{
-        Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Explore: arrayExplore,
         Input:   props.Input,
         Emit:    props.Context.Emit,
@@ -1545,7 +1556,7 @@ func checkerProgrammer_explore_array_like_union_types(props checkerProgrammer_ex
             nextExplore.Postfix = ""
             return props.Factory(checkerProgrammer_exploreArrayLikeUnionTypesFactoryProps{
               Parameters: FeatureProgrammer.ParameterDeclarations(FeatureProgrammer_ParameterDeclarationsProps{
-                Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+                Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
                 Type:   nativefactories.TypeFactory.Keyword("any"),
                 Input:  f.NewIdentifier("input"),
                 Emit:   props.Emit,
@@ -1560,7 +1571,7 @@ func checkerProgrammer_explore_array_like_union_types(props checkerProgrammer_ex
       nil,
       nil,
       f.NewNodeList(FeatureProgrammer.ArgumentsArray(FeatureProgrammer_ArgumentsArrayProps{
-        Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Input:   props.Input,
         Explore: props.Explore,
         Emit:    props.Emit,
@@ -1649,7 +1660,7 @@ func checkerProgrammer_explore_objects(props checkerProgrammer_exploreObjectsPro
     nil,
     nil,
     f.NewNodeList(FeatureProgrammer.ArgumentsArray(FeatureProgrammer_ArgumentsArrayProps{
-      Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
       Input:   props.Input,
       Explore: props.Explore,
       Emit:    props.Context.Emit,
@@ -1816,6 +1827,60 @@ func checkerProgrammer_reduce(expressions []*shimast.Node, operator shimast.Kind
 
 func checkerProgrammer_and(x *shimast.Expression, y *shimast.Expression, emit *shimprinter.EmitContext) *shimast.Node {
   return checkerProgrammer_binary(x, shimast.KindAmpersandAmpersandToken, y, emit)
+}
+
+// checkerProgrammer_collection_recursive reports whether the analyzed type
+// graph carries any recursive component — the precondition for a runtime
+// value to drive the generated function call graph into a cycle.
+func checkerProgrammer_collection_recursive(collection *nativemetadata.MetadataCollection) bool {
+  for _, object := range collection.Objects() {
+    if object.Recursive {
+      return true
+    }
+  }
+  for _, array := range collection.Arrays() {
+    if array.Recursive {
+      return true
+    }
+  }
+  for _, tuple := range collection.Tuples() {
+    if tuple.Recursive {
+      return true
+    }
+  }
+  return false
+}
+
+// checkerProgrammer_visit_guard wraps a recursive function body so a value
+// already being checked (or already proven) by this function short-circuits
+// to true — the coinductive reading that makes runtime cycles validate
+// instead of overflowing the stack, and deduplicates aliased subtrees. The
+// entry is removed when the body fails, so union-branch probing of the same
+// value cannot poison sibling checks; each recursive function owns its own
+// `_vctx` slot for the same reason.
+func checkerProgrammer_visit_guard(key string, body *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(checkerProgrammer_factory, emit)
+  slot := "_vctx." + key
+  return nativefactories.ExpressionFactory.Conditional(
+    f.NewIdentifier("("+slot+" || ("+slot+" = new WeakSet())).has(input)"),
+    f.NewKeywordExpression(shimast.KindTrueKeyword),
+    f.NewParenthesizedExpression(
+      f.NewBinaryExpression(
+        nil,
+        f.NewIdentifier(slot+".add(input)"),
+        nil,
+        f.NewToken(shimast.KindCommaToken),
+        f.NewBinaryExpression(
+          nil,
+          f.NewParenthesizedExpression(body),
+          nil,
+          f.NewToken(shimast.KindBarBarToken),
+          f.NewIdentifier("("+slot+".delete(input), false)"),
+        ),
+      ),
+    ),
+    emit,
+  )
 }
 
 func checkerProgrammer_or(x *shimast.Expression, y *shimast.Expression, emit *shimprinter.EmitContext) *shimast.Node {

--- a/packages/typia/native/core/programmers/internal/FeatureProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/FeatureProgrammer.go
@@ -3,6 +3,7 @@ package internal
 import (
   "fmt"
   "sort"
+  "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimchecker "github.com/microsoft/typescript-go/shim/checker"
@@ -262,6 +263,177 @@ type FeatureProgrammer_ParameterConfig struct {
 // closure is nil for features that do not participate in visit tracking.
 func featureProgrammer_visited(config FeatureProgrammer_IConfig) bool {
   return config.Visited != nil && config.Visited()
+}
+
+// VisitKey names a recursive function's `_vctx` slot after the function
+// itself (its prefixed name minus the leading underscore, e.g. "io0", "co2").
+// Composed features share one context object — clone embeds is-checks for
+// union discrimination, for instance — so the slot must carry the feature
+// prefix or two families would clash on the same key with different
+// container kinds.
+func (featureProgrammerNamespace) VisitKey(prefix string, kind string, index int) string {
+  return strings.TrimPrefix(fmt.Sprintf("%s%s%d", prefix, kind, index), "_")
+}
+
+// CollectionRecursive reports whether the analyzed type graph carries any
+// recursive component — the precondition for a runtime value to drive the
+// generated function call graph into a cycle (issue #1820).
+func (featureProgrammerNamespace) CollectionRecursive(collection *nativemetadata.MetadataCollection) bool {
+  for _, object := range collection.Objects() {
+    if object.Recursive {
+      return true
+    }
+  }
+  for _, array := range collection.Arrays() {
+    if array.Recursive {
+      return true
+    }
+  }
+  for _, tuple := range collection.Tuples() {
+    if tuple.Recursive {
+      return true
+    }
+  }
+  return false
+}
+
+// VisitGuardSkip wraps a recursive in-place walker (prune) so a revisited
+// object is simply skipped: pruning is idempotent per instance, which makes
+// the skip both the cycle breaker and the DAG deduplication. Handles the
+// block bodies the prune joiner produces as well as expression bodies.
+func (featureProgrammerNamespace) VisitGuardSkip(key string, body *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(featureProgrammer_factory, emit)
+  slot := "_vctx." + key
+  has := f.NewIdentifier("(" + slot + " || (" + slot + " = new WeakSet())).has(input)")
+  add := f.NewIdentifier(slot + ".add(input)")
+  if body != nil && body.Kind == shimast.KindBlock {
+    statements := []*shimast.Node{
+      f.NewIfStatement(has, f.NewReturnStatement(nil), nil),
+      f.NewExpressionStatement(add),
+    }
+    statements = append(statements, body.Statements()...)
+    return f.NewBlock(f.NewNodeList(statements), true)
+  }
+  return nativefactories.ExpressionFactory.Conditional(
+    has,
+    f.NewIdentifier("undefined"),
+    f.NewParenthesizedExpression(
+      f.NewBinaryExpression(
+        nil,
+        add,
+        nil,
+        f.NewToken(shimast.KindCommaToken),
+        f.NewParenthesizedExpression(body),
+      ),
+    ),
+    emit,
+  )
+}
+
+// VisitGuardSerialize wraps a recursive serializer function (json.stringify,
+// protobuf.encode) with on-stack cycle detection: JSON and protobuf cannot
+// represent cycles, so a value met again while still being serialized raises
+// the feature's thrower instead of overflowing the stack. Unlike the checker
+// and rebuilder guards the entry is removed after the body finishes either
+// way, because re-serializing a DAG alias at another position is legal and
+// must keep working.
+func (featureProgrammerNamespace) VisitGuardSerialize(key string, thrower *shimast.Node, body *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(featureProgrammer_factory, emit)
+  slot := "_vctx." + key
+  finisher := f.NewArrowFunction(
+    nil,
+    nil,
+    f.NewNodeList([]*shimast.Node{
+      nativefactories.IdentifierFactory.Parameter("_vout", nativefactories.TypeFactory.Keyword("any"), nil),
+    }),
+    nil,
+    nil,
+    f.NewToken(shimast.KindEqualsGreaterThanToken),
+    f.NewParenthesizedExpression(
+      f.NewBinaryExpression(
+        nil,
+        f.NewIdentifier(slot+".delete(input)"),
+        nil,
+        f.NewToken(shimast.KindCommaToken),
+        f.NewIdentifier("_vout"),
+      ),
+    ),
+  )
+  return nativefactories.ExpressionFactory.Conditional(
+    f.NewIdentifier("("+slot+" || ("+slot+" = new WeakSet())).has(input)"),
+    thrower,
+    f.NewParenthesizedExpression(
+      f.NewBinaryExpression(
+        nil,
+        f.NewIdentifier(slot+".add(input)"),
+        nil,
+        f.NewToken(shimast.KindCommaToken),
+        f.NewCallExpression(
+          f.NewParenthesizedExpression(finisher),
+          nil,
+          nil,
+          f.NewNodeList([]*shimast.Node{body}),
+          shimast.NodeFlagsNone,
+        ),
+      ),
+    ),
+    emit,
+  )
+}
+
+// VisitGuardRebuild wraps a recursive rebuilder function (clone, notations)
+// so a revisited source object returns the output instance allocated on its
+// first visit — reproducing runtime cycles and deduplicating DAG aliases.
+// The output container registers in the WeakMap BEFORE the body evaluates,
+// so recursive references inside the body resolve to the same (still
+// filling) instance, exactly like the structured-clone algorithm.
+func (featureProgrammerNamespace) VisitGuardRebuild(key string, array bool, body *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(featureProgrammer_factory, emit)
+  slot := "_vctx." + key
+  allocator := f.NewObjectLiteralExpression(f.NewNodeList(nil), false)
+  if array {
+    allocator = f.NewArrayLiteralExpression(f.NewNodeList(nil), false)
+  }
+  filler := f.NewArrowFunction(
+    nil,
+    nil,
+    f.NewNodeList([]*shimast.Node{
+      nativefactories.IdentifierFactory.Parameter("_vout", nativefactories.TypeFactory.Keyword("any"), nil),
+    }),
+    nil,
+    nil,
+    f.NewToken(shimast.KindEqualsGreaterThanToken),
+    f.NewParenthesizedExpression(
+      f.NewBinaryExpression(
+        nil,
+        f.NewIdentifier(slot+".set(input, _vout)"),
+        nil,
+        f.NewToken(shimast.KindCommaToken),
+        f.NewCallExpression(
+          f.NewIdentifier("Object.assign"),
+          nil,
+          nil,
+          f.NewNodeList([]*shimast.Node{
+            f.NewIdentifier("_vout"),
+            body,
+          }),
+          shimast.NodeFlagsNone,
+        ),
+      ),
+    ),
+  )
+  return nativefactories.ExpressionFactory.Conditional(
+    f.NewIdentifier("("+slot+" || ("+slot+" = new WeakMap())).has(input)"),
+    f.NewIdentifier(slot+".get(input)"),
+    f.NewCallExpression(
+      f.NewParenthesizedExpression(filler),
+      nil,
+      nil,
+      f.NewNodeList([]*shimast.Node{allocator}),
+      shimast.NodeFlagsNone,
+    ),
+    emit,
+  )
 }
 
 var featureProgrammer_factory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
@@ -661,7 +833,7 @@ func featureProgrammer_write_object_functions(config FeatureProgrammer_IConfig, 
     })
     if object.Recursive && config.VisitGuard != nil && featureProgrammer_visited(config) {
       body = config.VisitGuard(FeatureProgrammer_VisitGuardProps{
-        Key:   fmt.Sprintf("o%d", object.Index),
+        Key:   FeatureProgrammer.VisitKey(config.Prefix, "o", object.Index),
         Input: input,
         Body:  body,
       })

--- a/packages/typia/native/core/programmers/internal/FeatureProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/FeatureProgrammer.go
@@ -28,6 +28,25 @@ type FeatureProgrammer_IConfig struct {
   Decoder     func(props FeatureProgrammer_DecoderProps) *shimast.Node
   Objector    FeatureProgrammer_IConfig_IObjector
   Generator   FeatureProgrammer_IConfig_IGenerator
+  // Visited reports whether the analyzed type graph carries a recursive
+  // component (issue #1820). It is a closure (usually the functor's Visited
+  // method) because the answer is unknown until metadata analysis runs,
+  // which happens after the config is constructed. When true, generated
+  // functions thread a per-invocation `_vctx` visit context.
+  Visited func() bool
+  // VisitGuard wraps a recursive function's body with the feature's own
+  // cycle handling (e.g. checkers report a revisited object as valid). Nil
+  // keeps the body untouched even when Visited is on.
+  VisitGuard func(props FeatureProgrammer_VisitGuardProps) *shimast.Node
+}
+
+type FeatureProgrammer_VisitGuardProps struct {
+  // Key names the `_vctx` slot of the guarded function (e.g. "o3" for the
+  // object function of index 3), so each recursive function tracks its own
+  // visit set and union-branch probing cannot pollute sibling checks.
+  Key   string
+  Input *shimast.Expression
+  Body  *shimast.Node
 }
 
 type FeatureProgrammer_IConfig_ITypes struct {
@@ -190,6 +209,12 @@ type FeatureProgrammer_DecodeObjectConfig struct {
   Trace  bool
   Path   bool
   Prefix string
+  // Visited threads the per-invocation `_vctx` argument to the called object
+  // function. It must come from the calling feature's own config — not from
+  // the (possibly shared) functor — so a visit-tracking feature composed with
+  // a non-tracking one (e.g. assert + clone) cannot leak the argument into
+  // functions that do not declare it.
+  Visited bool
 }
 
 type FeatureProgrammer_DecodeObjectProps struct {
@@ -215,8 +240,9 @@ type FeatureProgrammer_ArgumentsArrayProps struct {
 }
 
 type FeatureProgrammer_ArgumentsArrayConfig struct {
-  Path  bool
-  Trace bool
+  Path    bool
+  Trace   bool
+  Visited bool
 }
 
 type FeatureProgrammer_ParameterDeclarationsProps struct {
@@ -227,8 +253,15 @@ type FeatureProgrammer_ParameterDeclarationsProps struct {
 }
 
 type FeatureProgrammer_ParameterConfig struct {
-  Path  bool
-  Trace bool
+  Path    bool
+  Trace   bool
+  Visited bool
+}
+
+// featureProgrammer_visited resolves the late-bound recursion flag; the
+// closure is nil for features that do not participate in visit tracking.
+func featureProgrammer_visited(config FeatureProgrammer_IConfig) bool {
+  return config.Visited != nil && config.Visited()
 }
 
 var featureProgrammer_factory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
@@ -272,7 +305,7 @@ func (featureProgrammerNamespace) Compose(props FeatureProgrammer_ComposeProps) 
     Statements: statements,
     Functions:  functions,
     Parameters: FeatureProgrammer.ParameterDeclarations(FeatureProgrammer_ParameterDeclarationsProps{
-      Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: featureProgrammer_visited(props.Config)},
       Type:   props.Config.Types.Input(props.Type, props.Name),
       Input:  nativefactories.ValueFactory.INPUT(props.Context.Emit),
       Emit:   props.Context.Emit,
@@ -374,7 +407,7 @@ func (featureProgrammerNamespace) Write(props FeatureProgrammer_WriteProps) *shi
     nil,
     nil,
     f.NewNodeList(FeatureProgrammer.ParameterDeclarations(FeatureProgrammer_ParameterDeclarationsProps{
-      Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: featureProgrammer_visited(props.Config)},
       Type:   props.Config.Types.Input(props.Type, props.Name),
       Input:  nativefactories.ValueFactory.INPUT(props.Context.Emit),
       Emit:   props.Context.Emit,
@@ -442,7 +475,7 @@ func (featureProgrammerNamespace) Decode_object(props FeatureProgrammer_DecodeOb
     nil,
     nil,
     f.NewNodeList(FeatureProgrammer.ArgumentsArray(FeatureProgrammer_ArgumentsArrayProps{
-      Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config:  FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Config.Visited},
       Input:   props.Input,
       Explore: props.Explore,
       Emit:    props.Emit,
@@ -498,6 +531,9 @@ func (featureProgrammerNamespace) ArgumentsArray(props FeatureProgrammer_Argumen
       tail = append(tail, f.NewKeywordExpression(shimast.KindFalseKeyword))
     }
   }
+  if props.Config.Visited {
+    tail = append(tail, f.NewIdentifier("_vctx"))
+  }
   return append([]*shimast.Node{props.Input}, tail...)
 }
 
@@ -512,6 +548,15 @@ func (featureProgrammerNamespace) ParameterDeclarations(props FeatureProgrammer_
       "_exceptionable",
       nativefactories.TypeFactory.Keyword("boolean"),
       f.NewKeywordExpression(shimast.KindTrueKeyword),
+    ))
+  }
+  if props.Config.Visited {
+    // The per-invocation visit context: internal calls always pass it along,
+    // so the default object literal only materializes at the public entry.
+    tail = append(tail, nativefactories.IdentifierFactory.Parameter(
+      "_vctx",
+      nativefactories.TypeFactory.Keyword("any"),
+      f.NewObjectLiteralExpression(f.NewNodeList(nil), false),
     ))
   }
   return append([]*shimast.Node{
@@ -594,13 +639,40 @@ func featureProgrammer_write_object_functions(config FeatureProgrammer_IConfig, 
     if objectType == nil {
       objectType = nativefactories.TypeFactory.Keyword("any", context.Emit)
     }
+    body := config.Objector.Joiner(FeatureProgrammer_ObjectorJoinerProps{
+      Input: input,
+      Entries: nativeiterate.Feature_object_entries(nativeiterate.Feature_object_entriesProps{
+        Config: nativeiterate.Feature_object_entriesConfig{
+          Path:  config.Path,
+          Trace: config.Trace,
+          Decoder: func(next nativeiterate.Feature_object_entriesDecoderProps) *shimast.Node {
+            return config.Decoder(FeatureProgrammer_DecoderProps{
+              Input:    next.Input,
+              Metadata: next.Metadata,
+              Explore:  featureProgrammer_from_iterate_explore(next.Explore),
+            })
+          },
+        },
+        Context: context,
+        Input:   input,
+        Object:  object,
+      }),
+      Object: object,
+    })
+    if object.Recursive && config.VisitGuard != nil && featureProgrammer_visited(config) {
+      body = config.VisitGuard(FeatureProgrammer_VisitGuardProps{
+        Key:   fmt.Sprintf("o%d", object.Index),
+        Input: input,
+        Body:  body,
+      })
+    }
     output = append(output, nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
       Name: fmt.Sprintf("%so%d", config.Prefix, object.Index),
       Value: f.NewArrowFunction(
         nil,
         nil,
         f.NewNodeList(FeatureProgrammer.ParameterDeclarations(FeatureProgrammer_ParameterDeclarationsProps{
-          Config: FeatureProgrammer_ParameterConfig{Path: config.Path, Trace: config.Trace},
+          Config: FeatureProgrammer_ParameterConfig{Path: config.Path, Trace: config.Trace, Visited: featureProgrammer_visited(config)},
           Type:   nativefactories.TypeFactory.Keyword("any"),
           Input:  nativefactories.ValueFactory.INPUT(context.Emit),
           Emit:   context.Emit,
@@ -608,26 +680,7 @@ func featureProgrammer_write_object_functions(config FeatureProgrammer_IConfig, 
         objectType,
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        config.Objector.Joiner(FeatureProgrammer_ObjectorJoinerProps{
-          Input: input,
-          Entries: nativeiterate.Feature_object_entries(nativeiterate.Feature_object_entriesProps{
-            Config: nativeiterate.Feature_object_entriesConfig{
-              Path:  config.Path,
-              Trace: config.Trace,
-              Decoder: func(next nativeiterate.Feature_object_entriesDecoderProps) *shimast.Node {
-                return config.Decoder(FeatureProgrammer_DecoderProps{
-                  Input:    next.Input,
-                  Metadata: next.Metadata,
-                  Explore:  featureProgrammer_from_iterate_explore(next.Explore),
-                })
-              },
-            },
-            Context: context,
-            Input:   input,
-            Object:  object,
-          }),
-          Object: object,
-        }),
+        body,
       ),
     }, context.Emit))
   }
@@ -658,7 +711,7 @@ func featureProgrammer_write_union(props struct {
     nil,
     nil,
     f.NewNodeList(FeatureProgrammer.ParameterDeclarations(FeatureProgrammer_ParameterDeclarationsProps{
-      Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: featureProgrammer_visited(props.Config)},
       Type:   nativefactories.TypeFactory.Keyword("any"),
       Input:  nativefactories.ValueFactory.INPUT(nil),
       Emit:   emit,

--- a/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
@@ -108,29 +108,34 @@ func jsonStringifyProgrammer_write_array_functions(props struct {
         nil,
         nil,
         f.NewNodeList(nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         })),
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        jsonStringifyProgrammer_decode_array_inline(jsonStringifyProgrammer_decodeArrayProps{
-          Context: props.Context,
-          Config:  props.Config,
-          Functor: props.Functor,
-          Input:   f.NewIdentifier("input"),
-          Array: schemametadata.MetadataArray_create(schemametadata.MetadataArray{
-            Type: typ,
-            Tags: [][]schemametadata.IMetadataTypeTag{},
+        nativeinternal.FeatureProgrammer.VisitGuardSerialize(
+          nativeinternal.FeatureProgrammer.VisitKey(props.Config.Prefix, "a", i),
+          jsonStringifyProgrammer_circular_thrower(props.Context, props.Functor),
+          jsonStringifyProgrammer_decode_array_inline(jsonStringifyProgrammer_decodeArrayProps{
+            Context: props.Context,
+            Config:  props.Config,
+            Functor: props.Functor,
+            Input:   f.NewIdentifier("input"),
+            Array: schemametadata.MetadataArray_create(schemametadata.MetadataArray{
+              Type: typ,
+              Tags: [][]schemametadata.IMetadataTypeTag{},
+            }),
+            Explore: nativeinternal.FeatureProgrammer_IExplore{
+              Tracable: props.Config.Trace,
+              Source:   "function",
+              From:     "array",
+              Postfix:  "",
+            },
           }),
-          Explore: nativeinternal.FeatureProgrammer_IExplore{
-            Tracable: props.Config.Trace,
-            Source:   "function",
-            From:     "array",
-            Postfix:  "",
-          },
-        }),
+          props.Context.Emit,
+        ),
       ),
     }, props.Context.Emit))
   }
@@ -156,22 +161,27 @@ func jsonStringifyProgrammer_write_tuple_functions(props struct {
         nil,
         nil,
         f.NewNodeList(nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         })),
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        jsonStringifyProgrammer_decode_tuple_inline(jsonStringifyProgrammer_decodeTupleInlineProps{
-          Context:   props.Context,
-          Config:    props.Config,
-          Functor:   props.Functor,
-          Input:     f.NewIdentifier("input"),
-          Tuple:     tuple,
-          Explore:   nativeinternal.FeatureProgrammer_IExplore{Tracable: props.Config.Trace, Source: "function", From: "array", Postfix: ""},
-          Validated: props.Validated,
-        }),
+        nativeinternal.FeatureProgrammer.VisitGuardSerialize(
+          nativeinternal.FeatureProgrammer.VisitKey(props.Config.Prefix, "t", i),
+          jsonStringifyProgrammer_circular_thrower(props.Context, props.Functor),
+          jsonStringifyProgrammer_decode_tuple_inline(jsonStringifyProgrammer_decodeTupleInlineProps{
+            Context:   props.Context,
+            Config:    props.Config,
+            Functor:   props.Functor,
+            Input:     f.NewIdentifier("input"),
+            Tuple:     tuple,
+            Explore:   nativeinternal.FeatureProgrammer_IExplore{Tracable: props.Config.Trace, Source: "function", From: "array", Postfix: ""},
+            Validated: props.Validated,
+          }),
+          props.Context.Emit,
+        ),
       ),
     }, props.Context.Emit))
   }
@@ -626,7 +636,7 @@ func jsonStringifyProgrammer_decode_object(props struct {
   Explore nativeinternal.FeatureProgrammer_IExplore
 }) *shimast.Node {
   return nativeinternal.FeatureProgrammer.Decode_object(nativeinternal.FeatureProgrammer_DecodeObjectProps{
-    Config:  nativeinternal.FeatureProgrammer_DecodeObjectConfig{Trace: false, Path: false, Prefix: jsonStringifyProgrammer_PREFIX},
+    Config:  nativeinternal.FeatureProgrammer_DecodeObjectConfig{Trace: false, Path: false, Prefix: jsonStringifyProgrammer_PREFIX, Visited: props.Functor.Visited()},
     Functor: props.Functor,
     Object:  props.Object,
     Input:   props.Input,
@@ -655,7 +665,7 @@ func jsonStringifyProgrammer_decode_array(props jsonStringifyProgrammer_decodeAr
       nil,
       nil,
       f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Input:   props.Input,
         Explore: jsonStringifyProgrammer_explore_with(props.Explore, "function", "array"),
       })),
@@ -712,7 +722,7 @@ func jsonStringifyProgrammer_decode_tuple(props jsonStringifyProgrammer_decodeTu
       nil,
       nil,
       f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Explore: jsonStringifyProgrammer_explore_with(props.Explore, "function", props.Explore.From),
         Input:   props.Input,
       })),
@@ -950,7 +960,7 @@ func jsonStringifyProgrammer_explore_objects(props jsonStringifyProgrammer_explo
     nil,
     nil,
     f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
       Input:   props.Input,
       Explore: props.Explore,
     })),
@@ -1067,7 +1077,7 @@ func jsonStringifyProgrammer_explore_array_like_union_types[T interface {
         Input      *shimast.Node
       }{
         Parameters: nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         }),
@@ -1078,7 +1088,7 @@ func jsonStringifyProgrammer_explore_array_like_union_types[T interface {
     nil,
     nil,
     f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
       Explore: arrayExplore,
       Input:   props.Input,
     })),
@@ -1199,6 +1209,15 @@ func jsonStringifyProgrammer_configure(props struct {
     Trace:       false,
     Path:        false,
     Initializer: jsonStringifyProgrammer_initializer,
+    Visited:     props.Functor.Visited,
+    VisitGuard: func(next nativeinternal.FeatureProgrammer_VisitGuardProps) *shimast.Node {
+      return nativeinternal.FeatureProgrammer.VisitGuardSerialize(
+        next.Key,
+        jsonStringifyProgrammer_circular_thrower(props.Context, props.Functor),
+        next.Body,
+        props.Context.Emit,
+      )
+    },
     Decoder: func(next nativeinternal.FeatureProgrammer_DecoderProps) *shimast.Node {
       return jsonStringifyProgrammer_decode(struct {
         Context   nativecontext.ITypiaContext
@@ -1315,10 +1334,37 @@ func jsonStringifyProgrammer_initializer(props nativeinternal.FeatureProgrammer_
     Checker: props.Context.Checker,
     Type:    props.Type,
   })
+  if nativeinternal.FeatureProgrammer.CollectionRecursive(result.Collection) {
+    props.Functor.SetVisited(true)
+  }
   return nativeinternal.FeatureProgrammer_InitializerOutput{
     Collection: result.Collection,
     Metadata:   result.Metadata,
   }
+}
+
+// jsonStringifyProgrammer_circular_thrower raises the cycle error used by the
+// on-stack visit guard: JSON cannot represent circular references, so meeting
+// a value again while it is still being serialized must fail fast instead of
+// overflowing the stack.
+func jsonStringifyProgrammer_circular_thrower(context nativecontext.ITypiaContext, functor *nativehelpers.FunctionProgrammer) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(jsonStringifyProgrammer_factory, context.Emit)
+  return f.NewCallExpression(
+    jsonStringifyProgrammer_internal(context, "throwTypeGuardError"),
+    nil,
+    f.NewNodeList(nil),
+    f.NewNodeList([]*shimast.Node{
+      f.NewObjectLiteralExpression(
+        f.NewNodeList([]*shimast.Node{
+          f.NewPropertyAssignment(nil, nativefactories.IdentifierFactory.Identifier("method", context.Emit), nil, nil, f.NewStringLiteral(functor.Method, shimast.TokenFlagsNone)),
+          f.NewPropertyAssignment(nil, nativefactories.IdentifierFactory.Identifier("expected", context.Emit), nil, nil, f.NewStringLiteral("non-circular reference", shimast.TokenFlagsNone)),
+          f.NewPropertyAssignment(nil, nativefactories.IdentifierFactory.Identifier("value", context.Emit), nil, nil, f.NewIdentifier("input")),
+        }),
+        true,
+      ),
+    }),
+    shimast.NodeFlagsNone,
+  )
 }
 
 type jsonStringifyProgrammer_throwProps struct {

--- a/packages/typia/native/core/programmers/misc/MiscCloneProgrammer.go
+++ b/packages/typia/native/core/programmers/misc/MiscCloneProgrammer.go
@@ -106,29 +106,34 @@ func miscCloneProgrammer_write_array_functions(props struct {
         nil,
         nil,
         f.NewNodeList(nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         })),
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        miscCloneProgrammer_decode_array_inline(miscCloneProgrammer_decodeArrayProps{
-          Context: props.Context,
-          Config:  props.Config,
-          Functor: props.Functor,
-          Input:   f.NewIdentifier("input"),
-          Array: schemametadata.MetadataArray_create(schemametadata.MetadataArray{
-            Type: typ,
-            Tags: [][]schemametadata.IMetadataTypeTag{},
+        nativeinternal.FeatureProgrammer.VisitGuardRebuild(
+          nativeinternal.FeatureProgrammer.VisitKey(props.Config.Prefix, "a", i),
+          true,
+          miscCloneProgrammer_decode_array_inline(miscCloneProgrammer_decodeArrayProps{
+            Context: props.Context,
+            Config:  props.Config,
+            Functor: props.Functor,
+            Input:   f.NewIdentifier("input"),
+            Array: schemametadata.MetadataArray_create(schemametadata.MetadataArray{
+              Type: typ,
+              Tags: [][]schemametadata.IMetadataTypeTag{},
+            }),
+            Explore: nativeinternal.FeatureProgrammer_IExplore{
+              Tracable: props.Config.Trace,
+              Source:   "function",
+              From:     "array",
+              Postfix:  "",
+            },
           }),
-          Explore: nativeinternal.FeatureProgrammer_IExplore{
-            Tracable: props.Config.Trace,
-            Source:   "function",
-            From:     "array",
-            Postfix:  "",
-          },
-        }),
+          props.Context.Emit,
+        ),
       ),
     }, props.Context.Emit))
   }
@@ -153,26 +158,31 @@ func miscCloneProgrammer_write_tuple_functions(props struct {
         nil,
         nil,
         f.NewNodeList(nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         })),
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        miscCloneProgrammer_decode_tuple_inline(miscCloneProgrammer_decodeTupleInlineProps{
-          Context: props.Context,
-          Config:  props.Config,
-          Functor: props.Functor,
-          Input:   f.NewIdentifier("input"),
-          Tuple:   tuple,
-          Explore: nativeinternal.FeatureProgrammer_IExplore{
-            Tracable: props.Config.Trace,
-            Source:   "function",
-            From:     "array",
-            Postfix:  "",
-          },
-        }),
+        nativeinternal.FeatureProgrammer.VisitGuardRebuild(
+          nativeinternal.FeatureProgrammer.VisitKey(props.Config.Prefix, "t", i),
+          true,
+          miscCloneProgrammer_decode_tuple_inline(miscCloneProgrammer_decodeTupleInlineProps{
+            Context: props.Context,
+            Config:  props.Config,
+            Functor: props.Functor,
+            Input:   f.NewIdentifier("input"),
+            Tuple:   tuple,
+            Explore: nativeinternal.FeatureProgrammer_IExplore{
+              Tracable: props.Config.Trace,
+              Source:   "function",
+              From:     "array",
+              Postfix:  "",
+            },
+          }),
+          props.Context.Emit,
+        ),
       ),
     }, props.Context.Emit))
   }
@@ -400,9 +410,10 @@ func miscCloneProgrammer_decode_object(props struct {
 }) *shimast.Node {
   return nativeinternal.FeatureProgrammer.Decode_object(nativeinternal.FeatureProgrammer_DecodeObjectProps{
     Config: nativeinternal.FeatureProgrammer_DecodeObjectConfig{
-      Trace:  false,
-      Path:   false,
-      Prefix: miscCloneProgrammer_PREFIX,
+      Trace:   false,
+      Path:    false,
+      Prefix:  miscCloneProgrammer_PREFIX,
+      Visited: props.Functor.Visited(),
     },
     Functor: props.Functor,
     Input:   props.Input,
@@ -428,7 +439,7 @@ func miscCloneProgrammer_decode_array(props miscCloneProgrammer_decodeArrayProps
       nil,
       nil,
       f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Explore: miscCloneProgrammer_explore_with(props.Explore, "function", "array"),
         Input:   props.Input,
       })),
@@ -480,7 +491,7 @@ func miscCloneProgrammer_decode_tuple(props miscCloneProgrammer_decodeTupleProps
       nil,
       nil,
       f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Explore: miscCloneProgrammer_explore_with(props.Explore, "function", props.Explore.From),
         Input:   props.Input,
       })),
@@ -883,7 +894,7 @@ func miscCloneProgrammer_explore_objects(props miscCloneProgrammer_exploreObject
     nil,
     nil,
     f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
       Input:   props.Input,
       Explore: props.Explore,
     })),
@@ -915,6 +926,10 @@ func miscCloneProgrammer_configure(props struct {
   config.Trace = false
   config.Path = false
   config.Initializer = miscCloneProgrammer_initializer
+  config.Visited = props.Functor.Visited
+  config.VisitGuard = func(next nativeinternal.FeatureProgrammer_VisitGuardProps) *shimast.Node {
+    return nativeinternal.FeatureProgrammer.VisitGuardRebuild(next.Key, false, next.Body, props.Context.Emit)
+  }
   config.Decoder = func(next nativeinternal.FeatureProgrammer_DecoderProps) *shimast.Node {
     return miscCloneProgrammer_decode(struct {
       Context  nativecontext.ITypiaContext
@@ -1065,6 +1080,9 @@ func miscCloneProgrammer_initializer(props nativeinternal.FeatureProgrammer_Init
       Code:   props.Functor.Method,
       Errors: miscCloneProgrammer_errors(result.Errors),
     }))
+  }
+  if nativeinternal.FeatureProgrammer.CollectionRecursive(collection) {
+    props.Functor.SetVisited(true)
   }
   return nativeinternal.FeatureProgrammer_InitializerOutput{
     Collection: collection,

--- a/packages/typia/native/core/programmers/misc/MiscPruneProgrammer.go
+++ b/packages/typia/native/core/programmers/misc/MiscPruneProgrammer.go
@@ -103,29 +103,33 @@ func miscPruneProgrammer_write_array_functions(props struct {
         nil,
         nil,
         f.NewNodeList(nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         })),
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        miscPruneProgrammer_decode_array_inline(miscPruneProgrammer_decodeArrayProps{
-          Context: props.Context,
-          Config:  props.Config,
-          Functor: props.Functor,
-          Input:   f.NewIdentifier("input"),
-          Array: schemametadata.MetadataArray_create(schemametadata.MetadataArray{
-            Type: typ,
-            Tags: [][]schemametadata.IMetadataTypeTag{},
+        nativeinternal.FeatureProgrammer.VisitGuardSkip(
+          nativeinternal.FeatureProgrammer.VisitKey(props.Config.Prefix, "a", i),
+          miscPruneProgrammer_decode_array_inline(miscPruneProgrammer_decodeArrayProps{
+            Context: props.Context,
+            Config:  props.Config,
+            Functor: props.Functor,
+            Input:   f.NewIdentifier("input"),
+            Array: schemametadata.MetadataArray_create(schemametadata.MetadataArray{
+              Type: typ,
+              Tags: [][]schemametadata.IMetadataTypeTag{},
+            }),
+            Explore: nativeinternal.FeatureProgrammer_IExplore{
+              Tracable: props.Config.Trace,
+              Source:   "function",
+              From:     "array",
+              Postfix:  "",
+            },
           }),
-          Explore: nativeinternal.FeatureProgrammer_IExplore{
-            Tracable: props.Config.Trace,
-            Source:   "function",
-            From:     "array",
-            Postfix:  "",
-          },
-        }),
+          props.Context.Emit,
+        ),
       ),
     }, props.Context.Emit))
   }
@@ -150,26 +154,30 @@ func miscPruneProgrammer_write_tuple_functions(props struct {
         nil,
         nil,
         f.NewNodeList(nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         })),
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        miscPruneProgrammer_decode_tuple_inline(miscPruneProgrammer_decodeTupleInlineProps{
-          Context: props.Context,
-          Config:  props.Config,
-          Functor: props.Functor,
-          Input:   f.NewIdentifier("input"),
-          Tuple:   tuple,
-          Explore: nativeinternal.FeatureProgrammer_IExplore{
-            Tracable: props.Config.Trace,
-            Source:   "function",
-            From:     "array",
-            Postfix:  "",
-          },
-        }),
+        nativeinternal.FeatureProgrammer.VisitGuardSkip(
+          nativeinternal.FeatureProgrammer.VisitKey(props.Config.Prefix, "t", i),
+          miscPruneProgrammer_decode_tuple_inline(miscPruneProgrammer_decodeTupleInlineProps{
+            Context: props.Context,
+            Config:  props.Config,
+            Functor: props.Functor,
+            Input:   f.NewIdentifier("input"),
+            Tuple:   tuple,
+            Explore: nativeinternal.FeatureProgrammer_IExplore{
+              Tracable: props.Config.Trace,
+              Source:   "function",
+              From:     "array",
+              Postfix:  "",
+            },
+          }),
+          props.Context.Emit,
+        ),
       ),
     }, props.Context.Emit))
   }
@@ -352,9 +360,10 @@ func miscPruneProgrammer_decode_object(props struct {
 }) *shimast.Node {
   return nativeinternal.FeatureProgrammer.Decode_object(nativeinternal.FeatureProgrammer_DecodeObjectProps{
     Config: nativeinternal.FeatureProgrammer_DecodeObjectConfig{
-      Trace:  false,
-      Path:   false,
-      Prefix: miscPruneProgrammer_PREFIX,
+      Trace:   false,
+      Path:    false,
+      Prefix:  miscPruneProgrammer_PREFIX,
+      Visited: props.Functor.Visited(),
     },
     Functor: props.Functor,
     Object:  props.Object,
@@ -380,7 +389,7 @@ func miscPruneProgrammer_decode_array(props miscPruneProgrammer_decodeArrayProps
       nil,
       nil,
       f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Explore: miscCloneProgrammer_explore_with(props.Explore, "function", "array"),
         Input:   props.Input,
       })),
@@ -432,7 +441,7 @@ func miscPruneProgrammer_decode_tuple(props miscPruneProgrammer_decodeTupleProps
       nil,
       nil,
       f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Explore: miscCloneProgrammer_explore_with(props.Explore, "function", props.Explore.From),
         Input:   props.Input,
       })),
@@ -615,7 +624,7 @@ func miscPruneProgrammer_explore_objects(props miscPruneProgrammer_exploreObject
     nil,
     nil,
     f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
       Input:   props.Input,
       Explore: props.Explore,
     })),
@@ -641,6 +650,10 @@ func miscPruneProgrammer_configure(props struct {
   config.Trace = false
   config.Path = false
   config.Initializer = miscPruneProgrammer_initializer
+  config.Visited = props.Functor.Visited
+  config.VisitGuard = func(next nativeinternal.FeatureProgrammer_VisitGuardProps) *shimast.Node {
+    return nativeinternal.FeatureProgrammer.VisitGuardSkip(next.Key, next.Body, props.Context.Emit)
+  }
   config.Decoder = func(next nativeinternal.FeatureProgrammer_DecoderProps) *shimast.Node {
     return miscPruneProgrammer_decode(struct {
       Context  nativecontext.ITypiaContext
@@ -767,6 +780,9 @@ func miscPruneProgrammer_initializer(props nativeinternal.FeatureProgrammer_Init
       Code:   props.Functor.Method,
       Errors: miscCloneProgrammer_errors(result.Errors),
     }))
+  }
+  if nativeinternal.FeatureProgrammer.CollectionRecursive(collection) {
+    props.Functor.SetVisited(true)
   }
   return nativeinternal.FeatureProgrammer_InitializerOutput{
     Collection: collection,

--- a/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
+++ b/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
@@ -138,29 +138,34 @@ func notationGeneralProgrammer_write_array_functions(props struct {
         nil,
         nil,
         f.NewNodeList(nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         })),
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        notationGeneralProgrammer_decode_array_inline(notationGeneralProgrammer_decodeArrayProps{
-          Context: props.Context,
-          Config:  props.Config,
-          Functor: props.Functor,
-          Input:   f.NewIdentifier("input"),
-          Array: schemametadata.MetadataArray_create(schemametadata.MetadataArray{
-            Type: typ,
-            Tags: [][]schemametadata.IMetadataTypeTag{},
+        nativeinternal.FeatureProgrammer.VisitGuardRebuild(
+          nativeinternal.FeatureProgrammer.VisitKey(props.Config.Prefix, "a", i),
+          true,
+          notationGeneralProgrammer_decode_array_inline(notationGeneralProgrammer_decodeArrayProps{
+            Context: props.Context,
+            Config:  props.Config,
+            Functor: props.Functor,
+            Input:   f.NewIdentifier("input"),
+            Array: schemametadata.MetadataArray_create(schemametadata.MetadataArray{
+              Type: typ,
+              Tags: [][]schemametadata.IMetadataTypeTag{},
+            }),
+            Explore: nativeinternal.FeatureProgrammer_IExplore{
+              Tracable: props.Config.Trace,
+              Source:   "function",
+              From:     "array",
+              Postfix:  "",
+            },
           }),
-          Explore: nativeinternal.FeatureProgrammer_IExplore{
-            Tracable: props.Config.Trace,
-            Source:   "function",
-            From:     "array",
-            Postfix:  "",
-          },
-        }),
+          props.Context.Emit,
+        ),
       ),
     }, props.Context.Emit))
   }
@@ -186,27 +191,32 @@ func notationGeneralProgrammer_write_tuple_functions(props struct {
         nil,
         nil,
         f.NewNodeList(nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         })),
         nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
         nil,
         f.NewToken(shimast.KindEqualsGreaterThanToken),
-        notationGeneralProgrammer_decode_tuple_inline(notationGeneralProgrammer_decodeTupleInlineProps{
-          Context: props.Context,
-          Rename:  props.Rename,
-          Config:  props.Config,
-          Functor: props.Functor,
-          Input:   f.NewIdentifier("input"),
-          Tuple:   tuple,
-          Explore: nativeinternal.FeatureProgrammer_IExplore{
-            Tracable: props.Config.Trace,
-            Source:   "function",
-            From:     "array",
-            Postfix:  "",
-          },
-        }),
+        nativeinternal.FeatureProgrammer.VisitGuardRebuild(
+          nativeinternal.FeatureProgrammer.VisitKey(props.Config.Prefix, "t", i),
+          true,
+          notationGeneralProgrammer_decode_tuple_inline(notationGeneralProgrammer_decodeTupleInlineProps{
+            Context: props.Context,
+            Rename:  props.Rename,
+            Config:  props.Config,
+            Functor: props.Functor,
+            Input:   f.NewIdentifier("input"),
+            Tuple:   tuple,
+            Explore: nativeinternal.FeatureProgrammer_IExplore{
+              Tracable: props.Config.Trace,
+              Source:   "function",
+              From:     "array",
+              Postfix:  "",
+            },
+          }),
+          props.Context.Emit,
+        ),
       ),
     }, props.Context.Emit))
   }
@@ -435,7 +445,7 @@ func notationGeneralProgrammer_decode_object(props struct {
   Explore nativeinternal.FeatureProgrammer_IExplore
 }) *shimast.Node {
   return nativeinternal.FeatureProgrammer.Decode_object(nativeinternal.FeatureProgrammer_DecodeObjectProps{
-    Config:  nativeinternal.FeatureProgrammer_DecodeObjectConfig{Trace: false, Path: false, Prefix: notationGeneralProgrammer_PREFIX},
+    Config:  nativeinternal.FeatureProgrammer_DecodeObjectConfig{Trace: false, Path: false, Prefix: notationGeneralProgrammer_PREFIX, Visited: props.Functor.Visited()},
     Functor: props.Functor,
     Object:  props.Object,
     Input:   props.Input,
@@ -464,7 +474,7 @@ func notationGeneralProgrammer_decode_array(props notationGeneralProgrammer_deco
       nil,
       nil,
       f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Explore: notationGeneralProgrammer_explore_with(props.Explore, "function", "array"),
         Input:   props.Input,
       })),
@@ -521,7 +531,7 @@ func notationGeneralProgrammer_decode_tuple(props notationGeneralProgrammer_deco
       nil,
       nil,
       f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+        Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
         Explore: notationGeneralProgrammer_explore_with(props.Explore, "function", props.Explore.From),
         Input:   props.Input,
       })),
@@ -812,7 +822,7 @@ func notationGeneralProgrammer_explore_objects(props notationGeneralProgrammer_e
     nil,
     nil,
     f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
       Explore: props.Explore,
       Input:   props.Input,
     })),
@@ -929,7 +939,7 @@ func notationGeneralProgrammer_explore_array_like_union_types[T interface {
         Input      *shimast.Node
       }{
         Parameters: nativeinternal.FeatureProgrammer.ParameterDeclarations(nativeinternal.FeatureProgrammer_ParameterDeclarationsProps{
-          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+          Config: nativeinternal.FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
           Type:   nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
           Input:  f.NewIdentifier("input"),
         }),
@@ -940,7 +950,7 @@ func notationGeneralProgrammer_explore_array_like_union_types[T interface {
     nil,
     nil,
     f.NewNodeList(nativeinternal.FeatureProgrammer.ArgumentsArray(nativeinternal.FeatureProgrammer_ArgumentsArrayProps{
-      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace},
+      Config:  nativeinternal.FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: props.Functor.Visited()},
       Explore: arrayExplore,
       Input:   props.Input,
     })),
@@ -972,6 +982,10 @@ func notationGeneralProgrammer_configure(props struct {
     Trace:       false,
     Path:        false,
     Initializer: notationGeneralProgrammer_initializer,
+    Visited:     props.Functor.Visited,
+    VisitGuard: func(next nativeinternal.FeatureProgrammer_VisitGuardProps) *shimast.Node {
+      return nativeinternal.FeatureProgrammer.VisitGuardRebuild(next.Key, false, next.Body, props.Context.Emit)
+    },
     Decoder: func(next nativeinternal.FeatureProgrammer_DecoderProps) *shimast.Node {
       return notationGeneralProgrammer_decode(struct {
         Config   nativeinternal.FeatureProgrammer_IConfig
@@ -1096,6 +1110,9 @@ func notationGeneralProgrammer_initializer(props nativeinternal.FeatureProgramme
       Code:   props.Functor.Method,
       Errors: notationGeneralProgrammer_errors(result.Errors),
     }))
+  }
+  if nativeinternal.FeatureProgrammer.CollectionRecursive(collection) {
+    props.Functor.SetVisited(true)
   }
   return nativeinternal.FeatureProgrammer_InitializerOutput{
     Collection: collection,

--- a/packages/typia/native/core/programmers/protobuf/ProtobufEncodeProgrammer.go
+++ b/packages/typia/native/core/programmers/protobuf/ProtobufEncodeProgrammer.go
@@ -54,6 +54,9 @@ func (protobufEncodeProgrammerNamespace) Decompose(props ProtobufEncodeProgramme
     Components: collection,
     Type:       props.Type,
   })
+  if nativeinternal.FeatureProgrammer.CollectionRecursive(collection) {
+    props.Functor.SetVisited(true)
+  }
 
   callEncoder := func(writer string, factory *shimast.Node) *shimast.Node {
     return nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
@@ -163,6 +166,20 @@ func protobufEncodeProgrammer_write_encoder(props protobufEncodeProgrammer_write
     }, props.Context.Emit))
   }
   statements := []*shimast.Node{}
+  if props.Functor.Visited() {
+    // The encoder closure is created per invocation (once for the sizer
+    // pass, once for the writer pass), so a body-local visit context covers
+    // both the embedded is-functions — which thread it as their `_vctx`
+    // parameter — and the protobuf object guards, without changing any of
+    // the encoder's own function signatures.
+    statements = append(statements, nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
+      Name: "_vctx",
+      Value: f.NewAsExpression(
+        f.NewObjectLiteralExpression(f.NewNodeList(nil), false),
+        nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
+      ),
+    }, props.Context.Emit))
+  }
   statements = append(statements, props.Functor.DeclareUnions()...)
   statements = append(statements, functors...)
   statements = append(statements, nativeprogrammers.IsProgrammer.Write_function_statements(nativeprogrammers.IsProgrammer_WriteFunctionStatementsProps{
@@ -224,6 +241,26 @@ type protobufEncodeProgrammer_writeObjectFunctionProps struct {
 func protobufEncodeProgrammer_write_object_function(props protobufEncodeProgrammer_writeObjectFunctionProps) *shimast.Node {
   f := nativecontext.EmitFactoryOf(protobufEncodeProgrammer_factory, props.Context.Emit)
   body := []*shimast.Node{}
+  guarded := props.Object.Recursive && props.Functor.Visited()
+  if guarded {
+    // On-stack cycle detection: protobuf cannot represent circular
+    // references, while re-encoding a DAG alias at another position is
+    // legal — hence add on entry, delete on exit, throw on revisit.
+    slot := "_vctx." + nativeinternal.FeatureProgrammer.VisitKey(protobufEncodeProgrammer_PREFIX, "o", props.Object.Index)
+    body = append(body,
+      f.NewIfStatement(
+        f.NewIdentifier("("+slot+" || ("+slot+" = new WeakSet())).has(input)"),
+        protobufEncodeProgrammer_create_throw_error(protobufEncodeProgrammer_throwProps{
+          Context:  props.Context,
+          Functor:  props.Functor,
+          Expected: "non-circular reference",
+          Input:    f.NewIdentifier("input"),
+        }),
+        nil,
+      ),
+      f.NewExpressionStatement(f.NewIdentifier(slot+".add(input)")),
+    )
+  }
   for _, property := range props.Object.Properties {
     if property.Of_protobuf_ == nil {
       nativefactories.ProtobufFactory.EmplaceObject(props.Object)
@@ -245,6 +282,10 @@ func protobufEncodeProgrammer_write_object_function(props protobufEncodeProgramm
       f.NewIdentifier("// property "+fmt.Sprintf("%q", key)+": "+property.Value.GetName()),
     ))
     body = append(body, block.Statements()...)
+  }
+  if guarded {
+    slot := "_vctx." + nativeinternal.FeatureProgrammer.VisitKey(protobufEncodeProgrammer_PREFIX, "o", props.Object.Index)
+    body = append(body, f.NewExpressionStatement(f.NewIdentifier(slot+".delete(input)")))
   }
   return f.NewArrowFunction(
     nil,

--- a/tests/template/src/structures/ObjectRecursiveCircular.ts
+++ b/tests/template/src/structures/ObjectRecursiveCircular.ts
@@ -1,0 +1,70 @@
+import { Spoiler } from "../utils/Spoiler";
+import { TestRandomGenerator } from "../utils/TestRandomGenerator";
+
+export type ObjectRecursiveCircular = ObjectRecursiveCircular.ITreeNode;
+export namespace ObjectRecursiveCircular {
+  export const RECURSIVE = true;
+  // The generated value is genuinely circular (parent <-> children), which
+  // JSON, protobuf, and the property-adding spoil harness cannot represent
+  // or traverse — only the visit-tracked validators (issue #1820) run here.
+  export const JSONABLE = false;
+  export const BINARABLE = false;
+  export const ADDABLE = false;
+
+  /**
+   * A doubly-linked tree: every child points back to its parent, so the
+   * generated value contains runtime cycles. Validators used to overflow
+   * the call stack on it; with visit tracking they accept the valid value
+   * coinductively and report a spoiled property exactly once, because the
+   * cyclic re-entry short-circuits while the check is still in progress.
+   */
+  export interface ITreeNode {
+    id: number;
+    name: string;
+    parent: ITreeNode | null;
+    children: ITreeNode[];
+  }
+
+  export function generate(): ObjectRecursiveCircular {
+    const root: ITreeNode = {
+      id: TestRandomGenerator.integer(),
+      name: TestRandomGenerator.string(),
+      parent: null,
+      children: [],
+    };
+    for (let i: number = 0; i < 2; ++i) {
+      const child: ITreeNode = {
+        id: TestRandomGenerator.integer(),
+        name: TestRandomGenerator.string(),
+        parent: root,
+        children: [],
+      };
+      const grandchild: ITreeNode = {
+        id: TestRandomGenerator.integer(),
+        name: TestRandomGenerator.string(),
+        parent: child,
+        children: [],
+      };
+      child.children.push(grandchild);
+      root.children.push(child);
+    }
+    return root;
+  }
+
+  export const SPOILERS: Spoiler<ObjectRecursiveCircular>[] = [
+    (input) => {
+      // Inside the cycle: the parent back-references re-enter nodes whose
+      // checks are still on the stack, so the violation reports exactly once.
+      input.children[0]!.name = 1 as any;
+      return ["$input.children[0].name"];
+    },
+    (input) => {
+      input.name = null as any;
+      return ["$input.name"];
+    },
+    (input) => {
+      input.children[1]!.children[0]!.id = "deep" as any;
+      return ["$input.children[1].children[0].id"];
+    },
+  ];
+}

--- a/tests/template/src/structures/ObjectRecursiveShared.ts
+++ b/tests/template/src/structures/ObjectRecursiveShared.ts
@@ -1,0 +1,64 @@
+import { Spoiler } from "../utils/Spoiler";
+import { TestRandomGenerator } from "../utils/TestRandomGenerator";
+
+export type ObjectRecursiveShared = ObjectRecursiveShared.IDirectory;
+export namespace ObjectRecursiveShared {
+  export const RECURSIVE = true;
+
+  /**
+   * A recursive directory tree whose generated value is a DAG: the very same
+   * `shared` instance is referenced from two different branches. Walking it
+   * is finite, but every visit-tracked feature (issue #1820) crosses its
+   * deduplication path — and a spoiled shared instance must be reported at
+   * every position it appears under, pinning the delete-on-fail re-walk of
+   * the generated validators.
+   */
+  export interface IDirectory {
+    id: number;
+    name: string;
+    children: IDirectory[];
+  }
+
+  export function generate(): ObjectRecursiveShared {
+    const shared: IDirectory = {
+      id: TestRandomGenerator.integer(),
+      name: TestRandomGenerator.string(),
+      children: [],
+    };
+    return {
+      id: TestRandomGenerator.integer(),
+      name: TestRandomGenerator.string(),
+      children: [
+        {
+          id: TestRandomGenerator.integer(),
+          name: TestRandomGenerator.string(),
+          children: [shared],
+        },
+        {
+          id: TestRandomGenerator.integer(),
+          name: TestRandomGenerator.string(),
+          children: [shared],
+        },
+      ],
+    };
+  }
+
+  export const SPOILERS: Spoiler<ObjectRecursiveShared>[] = [
+    (input) => {
+      // One mutation, two paths: the spoiled object is the shared instance.
+      input.children[0]!.children[0]!.name = 1 as any;
+      return [
+        "$input.children[0].children[0].name",
+        "$input.children[1].children[0].name",
+      ];
+    },
+    (input) => {
+      input.name = false as any;
+      return ["$input.name"];
+    },
+    (input) => {
+      input.children[1]!.id = "one" as any;
+      return ["$input.children[1].id"];
+    },
+  ];
+}

--- a/tests/template/src/structures/index.ts
+++ b/tests/template/src/structures/index.ts
@@ -111,6 +111,8 @@ export * from "./ObjectPartialAndRequired";
 export * from "./ObjectPrimitive";
 export * from "./ObjectPropertyNullable";
 export * from "./ObjectRecursive";
+export * from "./ObjectRecursiveCircular";
+export * from "./ObjectRecursiveShared";
 export * from "./ObjectRequired";
 export * from "./ObjectSequenceProtobuf";
 export * from "./ObjectSimple";


### PR DESCRIPTION
## Summary

Closes #1820 — across **every generated function family**. Runtime cycles no longer overflow the stack anywhere: validators accept them coinductively, rebuilders reproduce them, and serializers reject them with a clear error.

```typescript
interface INode { id: number; parent: INode | null; }
const node = { id: 1, parent: null as INode | null };
node.parent = node;

typia.validate<INode>(node);      // { success: true }      (was: RangeError)
typia.misc.clone<INode>(node);    // cyclic clone, fresh identity
typia.misc.prune<INode>(node);    // terminates, erases superfluous props
typia.notations.snake<INode>(node); // cyclic rebuild under renamed keys
typia.json.stringify<INode>(node);  // TypeGuardError: non-circular reference
typia.protobuf.encode<INode>(node); // TypeGuardError: non-circular reference
```

## Design: type-driven, not opt-in

The generated function call graph can only cycle when the **type graph** is recursive, so visit tracking turns on automatically exactly when metadata analysis finds a recursive component — stronger than the issue's opt-in proposal, with a hard invariant: **non-recursive types keep their emission byte-identical** (pinned by a control fixture).

A per-invocation context parameter `_vctx: any = {}` rides the existing `_path` / `_exceptionable` threading lane (`ParameterDeclarations` / `ArgumentsArray`); internal calls forward it, the default materializes only at the public entry, so every invocation is independent (reentrant/async-safe) and the existing assert/validate composition IIFEs absorb it with zero changes. Each recursive function owns a lazily allocated Weak container in a slot named after itself (`_vctx.io0`, `_vctx.co0`, ...) — prefix-qualified because composed features (clone embeds is-checks for union discrimination) share one context.

Per-family guard semantics, injected through a new optional `IConfig.VisitGuard` hook:

| Family | Container | On revisit | Notes |
|--------|-----------|-----------|-------|
| `is` / `assert` / `validate` / `equals` | WeakSet | `true` (coinductive) | **delete-on-fail** keeps union-branch probing of a shared value sound; doubles as DAG dedup |
| `misc.clone`, `notations.*` | WeakMap source→output | return the first-visit output | output registers **before** the body fills it (structured-clone style), so recursive references resolve to the same instance |
| `misc.prune` | WeakSet | skip | pruning is idempotent per instance |
| `json.stringify`, `protobuf.encode` | WeakSet (on-stack) | throw `TypeGuardError` (`expected: "non-circular reference"`) | add on entry / delete on exit, so re-serializing DAG aliases stays legal |

Protobuf needs no parameter threading at all: its encoder closure is created per invocation (sizer pass + writer pass), so a body-local `const _vctx = {} as any` covers both the embedded is-functions and the object guards. `Decode_object` reads the flag from the calling feature's config rather than the shared functor, so a tracking feature composed with a non-tracking one can never leak the argument into functions that do not declare it.

## Testing

`recursive_visit_tracking_transform_test.go` executes the emitted code under node across 16 scenario groups:

- self recursion (the issue's exact case) on is / assert / validate / equals — cyclic valid accepted, cyclic invalid rejected finitely with the cycle-internal error path, assert throws, `equals` still rejects superfluous properties on cyclic values;
- mutual recursion, recursion through arrays / tuples / `Record<string, T>`, a recursive array as a union branch (hoisted predicate path), union probing of shared cyclic values, DAG aliases, repeated invocations staying independent;
- clone & assertClone reproducing cycles with fresh identity (object and array recursion), prune terminating while erasing superfluous properties, notations rebuilding cycles under renamed keys;
- stringify/assertStringify and protobuf encode throwing on cycles while DAG aliases and acyclic recursive values keep serializing;
- a flat control fixture whose emission must contain no `_vctx` at all.

Full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
