### PR TITLE
Improve schema-dts metadata reuse

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/atomic_intersection_schema_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/atomic_intersection_schema_transform_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestAtomicIntersectionSchemaTransform verifies primitive intersections do
+// not fall back to an unconstrained JSON schema.
+//
+// `T & { __meta?: object }` should keep the primitive `T` branch and discard
+// the optional-object metadata branch. `Wrapper<boolean>` reaches the factory
+// as `(false & OptionalObject) | (true & OptionalObject)`, so optional-object
+// constraints must also stay neutral during union/never pruning.
+//
+//  1. Transform the AtomicIntersection fixture into JavaScript.
+//  2. Execute the emitted module with typia runtime imports stubbed out.
+//  3. Assert the three tuple element component schemas are boolean, number,
+//     and string, never an empty unconstrained schema.
+func TestAtomicIntersectionSchemaTransform(t *testing.T) {
+  project := atomicIntersectionSchemaProject(t)
+  js := atomicIntersectionSchemaTransform(t, project)
+  atomicIntersectionSchemaRunRuntimeCases(t, project, js)
+}
+
+func atomicIntersectionSchemaProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "atomic-intersection-schema-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(atomicIntersectionSchemaTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(atomicIntersectionSchemaSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func atomicIntersectionSchemaTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("atomic intersection schema transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func atomicIntersectionSchemaRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(atomicIntersectionSchemaRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("atomic intersection schema runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const atomicIntersectionSchemaTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const atomicIntersectionSchemaSource = `import typia from "typia";
+
+export type AtomicIntersection = [
+  AtomicIntersection.Wrapper<boolean>,
+  AtomicIntersection.Wrapper<number>,
+  AtomicIntersection.Wrapper<string>,
+];
+
+export namespace AtomicIntersection {
+  export type Wrapper<T> = T & { __meta?: object };
+}
+
+export const schema = typia.json.schema<AtomicIntersection>();
+`
+
+const atomicIntersectionSchemaRuntimeRunner = `const unit = require("./main.cjs").schema;
+
+const schemas = unit.components?.schemas ?? {};
+const tuple = schemas.AtomicIntersection;
+if (tuple?.type !== "array" || Array.isArray(tuple.prefixItems) === false) {
+  throw new Error("AtomicIntersection tuple schema was not emitted: " + JSON.stringify(unit));
+}
+
+const schemaName = (ref) => ref.split("/").at(-1);
+const actual = tuple.prefixItems.map((item) => {
+  const target = schemas[schemaName(item.$ref)];
+  if (target === undefined) {
+    throw new Error("missing tuple component for " + item.$ref);
+  }
+  return target.type;
+});
+const expected = ["boolean", "number", "string"];
+if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+  throw new Error("AtomicIntersection wrapper schemas were " + JSON.stringify(actual) + ", expected " + JSON.stringify(expected));
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/instance_union_create_is_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/instance_union_create_is_transform_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "regexp"
+  "testing"
+)
+
+// TestInstanceUnionCreateIsTransform verifies mixed array-like and object
+// helpers do not collide in createIs() output.
+//
+// The template InstanceUnion combines native instances, Set/Map, tuples,
+// arrays, a repeated-property object, and a discriminated object union. That
+// graph exercises both object-property helper emission and array-like union
+// helper emission in the same functor. A prior transform emitted duplicate
+// `const _ip0` declarations, so Node could not even load the generated module.
+func TestInstanceUnionCreateIsTransform(t *testing.T) {
+  project := instanceUnionCreateIsProject(t)
+  js := instanceUnionCreateIsTransform(t, project)
+  instanceUnionCreateIsAssertUniqueHelpers(t, js)
+  instanceUnionCreateIsRunRuntimeCases(t, project, js)
+}
+
+func instanceUnionCreateIsProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "instance-union-create-is-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(instanceUnionCreateIsTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(instanceUnionCreateIsSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func instanceUnionCreateIsTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("instance union createIs transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func instanceUnionCreateIsAssertUniqueHelpers(t *testing.T, js string) {
+  t.Helper()
+  pattern := regexp.MustCompile(`const\s+(_[A-Za-z]+p[0-9]+)\s*=`)
+  seen := map[string]bool{}
+  for _, match := range pattern.FindAllStringSubmatch(js, -1) {
+    name := match[1]
+    if seen[name] {
+      t.Fatalf("duplicate helper declaration %q in generated output:\n%s", name, js)
+    }
+    seen[name] = true
+  }
+}
+
+func instanceUnionCreateIsRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(instanceUnionCreateIsRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("instance union createIs runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const instanceUnionCreateIsTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const instanceUnionCreateIsSource = `import typia from "typia";
+
+export type InstanceUnion = InstanceUnion.Union[];
+export namespace InstanceUnion {
+  export type Union =
+    | number
+    | Uint8Array
+    | Set<boolean>
+    | Map<any, any>
+    | [string, string]
+    | [boolean, number, number]
+    | number[]
+    | boolean[]
+    | []
+    | ObjectSimple
+    | ObjectUnionExplicit;
+}
+
+export interface ObjectSimple {
+  scale: IPoint3D;
+  position: IPoint3D;
+  rotate: IPoint3D;
+  pivot: IPoint3D;
+}
+export interface IPoint3D {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export type ObjectUnionExplicit = Array<
+  | ObjectUnionExplicit.Discriminator<"point", ObjectUnionExplicit.IPoint>
+  | ObjectUnionExplicit.Discriminator<"line", ObjectUnionExplicit.ILine>
+  | ObjectUnionExplicit.Discriminator<"triangle", ObjectUnionExplicit.ITriangle>
+  | ObjectUnionExplicit.Discriminator<"rectangle", ObjectUnionExplicit.IRectangle>
+  | ObjectUnionExplicit.Discriminator<"polyline", ObjectUnionExplicit.IPolyline>
+  | ObjectUnionExplicit.Discriminator<"polygon", ObjectUnionExplicit.IPolygon>
+  | ObjectUnionExplicit.Discriminator<"circle", ObjectUnionExplicit.ICircle>
+>;
+export namespace ObjectUnionExplicit {
+  export type Discriminator<Type extends string, T extends object> = T & {
+    type: Type;
+  };
+  export interface IPoint {
+    x: number;
+    y: number;
+  }
+  export interface ILine {
+    p1: IPoint;
+    p2: IPoint;
+  }
+  export interface ITriangle {
+    p1: IPoint;
+    p2: IPoint;
+    p3: IPoint;
+  }
+  export interface IRectangle {
+    p1: IPoint;
+    p2: IPoint;
+    p3: IPoint;
+    p4: IPoint;
+  }
+  export interface IPolyline {
+    points: IPoint[];
+  }
+  export interface IPolygon {
+    outer: IPolyline;
+    inner: IPolyline[];
+  }
+  export interface ICircle {
+    centroid: IPoint;
+    radius: number;
+  }
+}
+
+export const isInstanceUnion = typia.createIs<InstanceUnion>();
+`
+
+const instanceUnionCreateIsRuntimeRunner = `const { isInstanceUnion } = require("./main.cjs");
+
+const point = (value) => ({ x: value, y: value + 1, z: value + 2 });
+const simple = {
+  scale: point(1),
+  position: point(4),
+  rotate: point(7),
+  pivot: point(10),
+};
+const union = [
+  { type: "point", x: 1, y: 2 },
+  { type: "line", p1: { x: 1, y: 2 }, p2: { x: 3, y: 4 } },
+  { type: "triangle", p1: { x: 1, y: 2 }, p2: { x: 3, y: 4 }, p3: { x: 5, y: 6 } },
+  { type: "rectangle", p1: { x: 1, y: 2 }, p2: { x: 3, y: 4 }, p3: { x: 5, y: 6 }, p4: { x: 7, y: 8 } },
+  { type: "polyline", points: [{ x: 1, y: 2 }] },
+  { type: "polygon", outer: { points: [{ x: 1, y: 2 }] }, inner: [{ points: [{ x: 3, y: 4 }] }] },
+  { type: "circle", centroid: { x: 1, y: 2 }, radius: 5 },
+];
+const valid = [
+  3,
+  new Uint8Array([1, 2]),
+  new Set([false, true]),
+  new Map([[{ key: 1 }, { value: 2 }]]),
+  ["one", "two"],
+  [false, 1, 2],
+  [1, 2, 3],
+  [true, false],
+  [],
+  simple,
+  union,
+];
+
+const cases = [
+  ["valid", valid, true],
+  ["bad set element", [new Set([false, "x"])], false],
+  ["bad tuple", [["one", 2]], false],
+  ["bad object property", [{ ...simple, pivot: { ...simple.pivot, z: "x" } }], false],
+  ["bad discriminator", [[{ type: "circle", centroid: { x: 1, y: 2 } }]], false],
+];
+
+for (const [name, input, expected] of cases) {
+  const actual = isInstanceUnion(input);
+  if (actual !== expected) {
+    throw new Error(name + ": expected " + expected + " but got " + actual);
+  }
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/object_union_explicit_pointer_schema_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/object_union_explicit_pointer_schema_transform_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestObjectUnionExplicitPointerSchemaTransform verifies generic intersection
+// branches keep distinct JSON schema components.
+//
+// ObjectUnionExplicitPointer combines a generic discriminator helper with
+// object intersections under nested pointers. Name-based metadata reuse once
+// collapsed all `Discriminator<Kind, Shape>` instantiations into the first
+// component, so OpenAPI validation saw every branch as the same shape.
+//
+//  1. Transform a local fixture mirroring the template structure.
+//  2. Execute the emitted JavaScript with typia runtime imports stubbed out.
+//  3. Assert the `Shape` oneOf points to seven distinct discriminator
+//     components and that each component retains its literal kind and fields.
+func TestObjectUnionExplicitPointerSchemaTransform(t *testing.T) {
+  project := objectUnionExplicitPointerSchemaProject(t)
+  js := objectUnionExplicitPointerSchemaTransform(t, project)
+  objectUnionExplicitPointerSchemaRunRuntimeCases(t, project, js)
+}
+
+func objectUnionExplicitPointerSchemaProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "object-union-explicit-pointer-schema-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(objectUnionExplicitPointerSchemaTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(objectUnionExplicitPointerSchemaSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func objectUnionExplicitPointerSchemaTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("object union explicit pointer schema transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func objectUnionExplicitPointerSchemaRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(objectUnionExplicitPointerSchemaRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("object union explicit pointer schema runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const objectUnionExplicitPointerSchemaTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const objectUnionExplicitPointerSchemaSource = `import typia from "typia";
+
+interface IPointer<T> {
+  value: T;
+}
+
+export type ObjectUnionExplicitPointer = IPointer<
+  Array<IPointer<ObjectUnionExplicitPointer.Shape>>
+>;
+
+export namespace ObjectUnionExplicitPointer {
+  export type Shape =
+    | ObjectUnionExplicitPointer.Discriminator<
+        "point",
+        ObjectUnionExplicitPointer.IPoint
+      >
+    | ObjectUnionExplicitPointer.Discriminator<
+        "line",
+        ObjectUnionExplicitPointer.ILine
+      >
+    | ObjectUnionExplicitPointer.Discriminator<
+        "triangle",
+        ObjectUnionExplicitPointer.ITriangle
+      >
+    | ObjectUnionExplicitPointer.Discriminator<
+        "rectangle",
+        ObjectUnionExplicitPointer.IRectangle
+      >
+    | ObjectUnionExplicitPointer.Discriminator<
+        "polyline",
+        ObjectUnionExplicitPointer.IPolyline
+      >
+    | ObjectUnionExplicitPointer.Discriminator<
+        "polygon",
+        ObjectUnionExplicitPointer.IPolygon
+      >
+    | ObjectUnionExplicitPointer.Discriminator<
+        "circle",
+        ObjectUnionExplicitPointer.ICircle
+      >;
+
+  export type Discriminator<Type extends string, T extends object> = T & {
+    type: Type;
+  };
+
+  export interface IPoint {
+    x: number;
+    y: number;
+  }
+
+  export interface ILine {
+    p1: IPoint;
+    p2: IPoint;
+  }
+
+  export interface ITriangle {
+    p1: IPoint;
+    p2: IPoint;
+    p3: IPoint;
+  }
+
+  export interface IRectangle {
+    p1: IPoint;
+    p2: IPoint;
+    p3: IPoint;
+    p4: IPoint;
+  }
+
+  export interface IPolyline {
+    points: IPoint[];
+  }
+
+  export interface IPolygon {
+    outer: IPolyline;
+    inner: IPolyline[];
+  }
+
+  export interface ICircle {
+    centroid: IPoint;
+    radius: number;
+  }
+}
+
+export const schema = typia.json.schema<ObjectUnionExplicitPointer>();
+`
+
+const objectUnionExplicitPointerSchemaRuntimeRunner = `const unit = require("./main.cjs").schema;
+
+const schemas = unit.components?.schemas ?? {};
+const expectedKinds = ["circle", "line", "point", "polygon", "polyline", "rectangle", "triangle"];
+const expectedFields = {
+  circle: ["centroid", "radius"],
+  line: ["p1", "p2"],
+  point: ["x", "y"],
+  polygon: ["outer", "inner"],
+  polyline: ["points"],
+  rectangle: ["p1", "p2", "p3", "p4"],
+  triangle: ["p1", "p2", "p3"],
+};
+
+const schemaName = (ref) => ref.split("/").at(-1);
+const refsOf = (schema) =>
+  Array.isArray(schema?.oneOf)
+    ? schema.oneOf.map((branch) => branch?.$ref).filter((ref) => typeof ref === "string")
+    : [];
+const literalOf = (schema) => {
+  const property = schema?.properties?.type;
+  if (typeof property?.const === "string") return property.const;
+  if (Array.isArray(property?.enum) && typeof property.enum[0] === "string") return property.enum[0];
+  return undefined;
+};
+const sameStrings = (actual, expected) =>
+  JSON.stringify([...actual].sort()) === JSON.stringify([...expected].sort());
+
+const candidates = Object.entries(schemas).filter(([, schema]) => {
+  const refs = refsOf(schema);
+  const unique = [...new Set(refs)];
+  if (refs.length !== 7 || unique.length !== 7) return false;
+  const kinds = unique
+    .map((ref) => literalOf(schemas[schemaName(ref)]))
+    .filter((kind) => typeof kind === "string");
+  return sameStrings(kinds, expectedKinds);
+});
+
+if (candidates.length !== 1) {
+  throw new Error(
+    "expected exactly one seven-branch Shape oneOf, got " +
+      candidates.length +
+      " among components " +
+      JSON.stringify(Object.keys(schemas)),
+  );
+}
+
+const [shapeName, shape] = candidates[0];
+const refs = refsOf(shape);
+const uniqueRefs = [...new Set(refs)];
+if (refs.length !== 7 || uniqueRefs.length !== 7) {
+  throw new Error(shapeName + " collapsed discriminator refs: " + JSON.stringify(refs));
+}
+
+for (const ref of uniqueRefs) {
+  const target = schemas[schemaName(ref)];
+  if (target === undefined) {
+    throw new Error("missing component for " + ref);
+  }
+  const kind = literalOf(target);
+  if (expectedKinds.includes(kind) === false) {
+    throw new Error("unexpected discriminator kind for " + ref + ": " + JSON.stringify(target));
+  }
+  const properties = target.properties ?? {};
+  for (const field of expectedFields[kind]) {
+    if (properties[field] === undefined) {
+      throw new Error(kind + " branch lost field " + field + ": " + JSON.stringify(target));
+    }
+  }
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/schema_dts_role_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/schema_dts_role_transform_test.go
@@ -1,0 +1,404 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestSchemaDtsRoleTransform verifies the schema-dts Role/SchemaValue shape.
+//
+// Issue #1710 reported that `schema.Recipe` repeatedly expands the same
+// RoleBase intersection through many `SchemaValue<T, K>` fields. This fixture
+// keeps that generic union-of-intersections graph local to the repository and
+// executes the emitted validators against primitive, Role, and array branches.
+func TestSchemaDtsRoleTransform(t *testing.T) {
+  project := schemaDtsRoleProject(t)
+  js := schemaDtsRoleTransform(t, project)
+  for _, needle := range []string{`"@type"`, "validateRecipe", "validateRoleNameSet"} {
+    if strings.Contains(js, needle) == false {
+      t.Fatalf("schema-dts role fixture did not emit %q:\n%s", needle, js)
+    }
+  }
+  schemaDtsRoleRunRuntimeCases(t, project, js)
+}
+
+func schemaDtsRoleProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "schema-dts-role-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(schemaDtsRoleTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(schemaDtsRoleSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func schemaDtsRoleTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("schema-dts role transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func schemaDtsRoleRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(schemaDtsRoleRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("schema-dts role runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const schemaDtsRoleTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const schemaDtsRoleSource = `import typia from "typia";
+
+type Text = string;
+type SchemaURL = string;
+type DateTime = string;
+
+type SchemaValue<T, TProperty extends string> =
+  | T
+  | Role<T, TProperty>
+  | readonly (T | Role<T, TProperty>)[];
+
+interface ThingBase {
+  "@id"?: SchemaValue<SchemaURL, "@id">;
+  name?: SchemaValue<Text, "name">;
+  alternateName?: SchemaValue<Text, "alternateName">;
+}
+
+interface RoleBase extends ThingBase {
+  endDate?: SchemaValue<Date | DateTime, "endDate">;
+  namedPosition?: SchemaValue<Text | SchemaURL, "namedPosition">;
+  roleName?: SchemaValue<Text | SchemaURL, "roleName">;
+  startDate?: SchemaValue<Date | DateTime, "startDate">;
+}
+
+type RoleLeaf<TContent, TProperty extends string> =
+  RoleBase &
+  {
+    "@type": "Role";
+  } &
+  {
+    [key in TProperty]: TContent;
+  };
+
+type LinkRole<TContent, TProperty extends string> =
+  RoleBase &
+  {
+    "@type": "LinkRole";
+    url?: SchemaValue<SchemaURL, "url">;
+  } &
+  {
+    [key in TProperty]: TContent;
+  };
+
+type OrganizationRole<TContent, TProperty extends string> =
+  RoleBase &
+  {
+    "@type": "OrganizationRole";
+    memberOf?: SchemaValue<Organization, "memberOf">;
+  } &
+  {
+    [key in TProperty]: TContent;
+  };
+
+type PerformanceRole<TContent, TProperty extends string> =
+  RoleBase &
+  {
+    "@type": "PerformanceRole";
+    performanceIn?: SchemaValue<Event, "performanceIn">;
+  } &
+  {
+    [key in TProperty]: TContent;
+  };
+
+type Role<TContent = never, TProperty extends string = never> =
+  | RoleLeaf<TContent, TProperty>
+  | LinkRole<TContent, TProperty>
+  | OrganizationRole<TContent, TProperty>
+  | PerformanceRole<TContent, TProperty>;
+
+interface Recipe extends ThingBase {
+  "@type": "Recipe";
+  author?: SchemaValue<Person | Organization, "author">;
+  image?: SchemaValue<SchemaURL, "image">;
+  recipeIngredient?: SchemaValue<Text, "recipeIngredient">;
+  recipeInstructions?: SchemaValue<HowToStep | Text, "recipeInstructions">;
+  mainEntityOfPage?: SchemaValue<Article, "mainEntityOfPage">;
+  publisher?: SchemaValue<Organization, "publisher">;
+  aggregateRating?: SchemaValue<Rating, "aggregateRating">;
+  video?: SchemaValue<VideoObject, "video">;
+  keywords?: SchemaValue<Text, "keywords">;
+}
+
+interface Person extends ThingBase {
+  "@type": "Person";
+  email?: SchemaValue<Text, "email">;
+  affiliation?: SchemaValue<Organization, "affiliation">;
+}
+
+interface Organization extends ThingBase {
+  "@type": "Organization";
+  url?: SchemaValue<SchemaURL, "url">;
+  member?: SchemaValue<Person, "member">;
+}
+
+interface HowToStep extends ThingBase {
+  "@type": "HowToStep";
+  text?: SchemaValue<Text, "text">;
+}
+
+interface Article extends ThingBase {
+  "@type": "Article";
+  headline?: SchemaValue<Text, "headline">;
+  author?: SchemaValue<Person | Organization, "author">;
+}
+
+interface Rating extends ThingBase {
+  "@type": "Rating";
+  ratingValue?: SchemaValue<number | Text, "ratingValue">;
+  bestRating?: SchemaValue<number | Text, "bestRating">;
+}
+
+interface VideoObject extends ThingBase {
+  "@type": "VideoObject";
+  contentUrl?: SchemaValue<SchemaURL, "contentUrl">;
+  thumbnailUrl?: SchemaValue<SchemaURL, "thumbnailUrl">;
+}
+
+interface Event extends ThingBase {
+  "@type": "Event";
+  startDate?: SchemaValue<Date | DateTime, "startDate">;
+  organizer?: SchemaValue<Person | Organization, "organizer">;
+}
+
+type Timestamp = Date;
+type RoleNameSet = Set<Text>;
+type ScoreMap = Map<Text, number>;
+
+export const validateRecipe = typia.createValidate<Recipe>();
+export const validateTimestamp = typia.createValidate<Timestamp>();
+export const validateRoleNameSet = typia.createValidate<RoleNameSet>();
+export const validateScoreMap = typia.createValidate<ScoreMap>();
+`
+
+const schemaDtsRoleRuntimeRunner = `const mod = require("./main.cjs");
+
+const capture = (task) => {
+  try {
+    task();
+    return null;
+  } catch (error) {
+    return error;
+  }
+};
+
+const validRecipe = {
+  "@type": "Recipe",
+  name: "Layer cake",
+  author: {
+    "@type": "Role",
+    roleName: "chef",
+    startDate: new Date("2026-06-11T00:00:00.000Z"),
+    author: {
+      "@type": "Person",
+      name: "Alice",
+      email: "alice@example.com",
+    },
+  },
+  image: [
+    "https://example.com/cake.jpg",
+    {
+      "@type": "LinkRole",
+      roleName: "primary image",
+      url: "https://example.com",
+      image: "https://example.com/cake-2.jpg",
+    },
+  ],
+  recipeIngredient: [
+    "flour",
+    {
+      "@type": "Role",
+      roleName: "main ingredient",
+      recipeIngredient: "sugar",
+    },
+  ],
+  recipeInstructions: [
+    {
+      "@type": "HowToStep",
+      text: "Mix",
+    },
+    {
+      "@type": "PerformanceRole",
+      performanceIn: {
+        "@type": "Event",
+        name: "Bake-off",
+        organizer: {
+          "@type": "Organization",
+          name: "Kitchen",
+        },
+      },
+      recipeInstructions: {
+        "@type": "HowToStep",
+        text: "Bake",
+      },
+    },
+  ],
+  mainEntityOfPage: {
+    "@type": "Article",
+    headline: "Cake",
+    author: {
+      "@type": "Person",
+      name: "Bob",
+    },
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "Recipe Lab",
+    member: [
+      {
+        "@type": "Person",
+        name: "Carol",
+      },
+    ],
+  },
+  aggregateRating: {
+    "@type": "Rating",
+    ratingValue: 5,
+    bestRating: "5",
+  },
+  video: {
+    "@type": "VideoObject",
+    contentUrl: "https://example.com/cake.mp4",
+    thumbnailUrl: "https://example.com/cake.png",
+  },
+  keywords: ["dessert", "cake"],
+};
+
+const valid = mod.validateRecipe(validRecipe);
+if (valid.success !== true) {
+  throw new Error("schema-dts Recipe shape failed validate: " + JSON.stringify(valid));
+}
+
+const invalidCases = [
+  [
+    "role without selected property",
+    {
+      "@type": "Recipe",
+      author: {
+        "@type": "Role",
+        roleName: "chef",
+      },
+    },
+  ],
+  [
+    "array branch with invalid primitive",
+    {
+      "@type": "Recipe",
+      recipeIngredient: ["flour", 1],
+    },
+  ],
+  [
+    "nested object with invalid field",
+    {
+      "@type": "Recipe",
+      author: {
+        "@type": "Role",
+        author: {
+          "@type": "Person",
+          email: 1,
+        },
+      },
+    },
+  ],
+];
+
+for (const [name, input] of invalidCases) {
+  const result = mod.validateRecipe(input);
+  if (result.success !== false) {
+    throw new Error(name + " unexpectedly passed validate: " + JSON.stringify(result));
+  }
+}
+
+if (mod.validateTimestamp(new Date("2026-06-11T00:00:00.000Z")).success !== true) {
+  throw new Error("Date alias failed valid timestamp");
+}
+if (mod.validateTimestamp("2026-06-11T00:00:00.000Z").success !== false) {
+  throw new Error("Date alias accepted a string timestamp");
+}
+
+if (mod.validateRoleNameSet(new Set(["chef", "writer"])).success !== true) {
+  throw new Error("Set alias failed valid string set");
+}
+if (mod.validateRoleNameSet(new Set(["chef", 1])).success !== false) {
+  throw new Error("Set alias accepted an invalid element");
+}
+
+if (mod.validateScoreMap(new Map([["quality", 5]])).success !== true) {
+  throw new Error("Map alias failed valid score map");
+}
+if (mod.validateScoreMap(new Map([[1, "bad"]])).success !== false) {
+  throw new Error("Map alias accepted invalid key/value types");
+}
+`

--- a/packages/typia/native/core/factories/internal/metadata/IMetadataIteratorProps.go
+++ b/packages/typia/native/core/factories/internal/metadata/IMetadataIteratorProps.go
@@ -46,6 +46,8 @@ type IMetadataIteratorProps struct {
   Type        *nativechecker.Type
   Explore     MetadataFactory_IExplore
   Intersected bool
+  Unioned     bool
+  Prunable    bool
 }
 
 var MetadataTypeTagAnalyzer func(props struct {

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -98,6 +98,17 @@ func metadata_type_symbol_name(checker *nativechecker.Checker, typ *nativechecke
   return name + "<" + strings.Join(names, ", ") + ">"
 }
 
+func metadata_type_symbol_base_name(typ *nativechecker.Type) string {
+  if typ == nil {
+    return ""
+  }
+  symbol := typ.Symbol()
+  if symbol == nil {
+    return ""
+  }
+  return metadata_symbol_name(symbol)
+}
+
 func metadata_symbol_name(symbol *nativeast.Symbol) string {
   if symbol == nil || len(symbol.Declarations) == 0 || symbol.Declarations[0].Parent == nil {
     return "__type"

--- a/packages/typia/native/core/factories/internal/metadata/emplace_metadata_object.go
+++ b/packages/typia/native/core/factories/internal/metadata/emplace_metadata_object.go
@@ -25,41 +25,16 @@ func Emplace_metadata_object(props IMetadataIteratorProps) *schemametadata.Metad
     return isProperty(node)
   }
 
-  insert := func(next struct {
-    Key        *schemametadata.MetadataSchema
-    Value      *schemametadata.MetadataSchema
-    Symbol     *nativeast.Symbol
-    Node       *nativeast.Node
-    FilterTags func(schemametadata.IJsDocTagInfo) bool
-  }) *schemametadata.MetadataProperty {
-    description := metadata_node_description(next.Symbol)
-    jsDocTags := metadata_node_js_doc_tags(next.Symbol)
-    if next.FilterTags != nil {
-      filtered := []schemametadata.IJsDocTagInfo{}
-      for _, tag := range jsDocTags {
-        if next.FilterTags(tag) {
-          filtered = append(filtered, tag)
-        }
-      }
-      jsDocTags = filtered
-    }
-    var mutability *string
-    if next.Node != nil && next.Node.ModifierFlags()&nativeast.ModifierFlagsReadonly != 0 {
-      value := "readonly"
-      mutability = &value
-    }
-    property := schemametadata.MetadataProperty_create(schemametadata.MetadataProperty{
-      Key:         next.Key,
-      Value:       next.Value,
-      Description: description,
-      JsDocTags:   jsDocTags,
-      Mutability:  mutability,
-    })
+  insert := func(next emplace_metadata_object_insert) *schemametadata.MetadataProperty {
+    property := emplace_metadata_object_create_property(next)
     obj.Properties = append(obj.Properties, property)
     return property
   }
+  if emplace_metadata_object_intersection(props, obj, insert, pred) {
+    return obj
+  }
 
-  for _, symbol := range nativechecker.Checker_getApparentProperties(props.Checker, props.Type) {
+  for _, symbol := range props.Components.ApparentProperties(props.Checker, props.Type) {
     if metadata_is_internal(symbol) {
       continue
     }
@@ -98,13 +73,7 @@ func Emplace_metadata_object(props IMetadataIteratorProps) *schemametadata.Metad
       Intersected: false,
     })
     value.Optional = symbol.Flags&nativeast.SymbolFlagsOptional != 0
-    insert(struct {
-      Key        *schemametadata.MetadataSchema
-      Value      *schemametadata.MetadataSchema
-      Symbol     *nativeast.Symbol
-      Node       *nativeast.Node
-      FilterTags func(schemametadata.IJsDocTagInfo) bool
-    }{
+    insert(emplace_metadata_object_insert{
       Key:    key,
       Value:  value,
       Symbol: symbol,
@@ -112,7 +81,7 @@ func Emplace_metadata_object(props IMetadataIteratorProps) *schemametadata.Metad
     })
   }
 
-  for _, index := range nativechecker.Checker_getIndexInfosOfType(props.Checker, props.Type) {
+  for _, index := range props.Components.IndexInfos(props.Checker, props.Type) {
     analyzer := func(typ *nativechecker.Type) func(any) *schemametadata.MetadataSchema {
       return func(property any) *schemametadata.MetadataSchema {
         explore := MetadataFactory_IExplore{
@@ -154,13 +123,7 @@ func Emplace_metadata_object(props IMetadataIteratorProps) *schemametadata.Metad
         Messages: []string{},
       })
     }
-    insert(struct {
-      Key        *schemametadata.MetadataSchema
-      Value      *schemametadata.MetadataSchema
-      Symbol     *nativeast.Symbol
-      Node       *nativeast.Node
-      FilterTags func(schemametadata.IJsDocTagInfo) bool
-    }{
+    insert(emplace_metadata_object_insert{
       Key:   key,
       Value: value,
       FilterTags: func(doc schemametadata.IJsDocTagInfo) bool {
@@ -169,6 +132,230 @@ func Emplace_metadata_object(props IMetadataIteratorProps) *schemametadata.Metad
     })
   }
   return obj
+}
+
+type emplace_metadata_object_insert struct {
+  Key        *schemametadata.MetadataSchema
+  Value      *schemametadata.MetadataSchema
+  Symbol     *nativeast.Symbol
+  Node       *nativeast.Node
+  FilterTags func(schemametadata.IJsDocTagInfo) bool
+}
+
+func emplace_metadata_object_create_property(next emplace_metadata_object_insert) *schemametadata.MetadataProperty {
+  description := metadata_node_description(next.Symbol)
+  jsDocTags := metadata_node_js_doc_tags(next.Symbol)
+  if next.FilterTags != nil {
+    filtered := []schemametadata.IJsDocTagInfo{}
+    for _, tag := range jsDocTags {
+      if next.FilterTags(tag) {
+        filtered = append(filtered, tag)
+      }
+    }
+    jsDocTags = filtered
+  }
+  var mutability *string
+  if next.Node != nil && next.Node.ModifierFlags()&nativeast.ModifierFlagsReadonly != 0 {
+    value := "readonly"
+    mutability = &value
+  }
+  return schemametadata.MetadataProperty_create(schemametadata.MetadataProperty{
+    Key:         next.Key,
+    Value:       next.Value,
+    Description: description,
+    JsDocTags:   jsDocTags,
+    Mutability:  mutability,
+  })
+}
+
+func emplace_metadata_object_intersection(
+  props IMetadataIteratorProps,
+  obj *schemametadata.MetadataObjectType,
+  insert func(emplace_metadata_object_insert) *schemametadata.MetadataProperty,
+  pred func(node *nativeast.Node) bool,
+) bool {
+  if props.Checker == nil ||
+    props.Type == nil ||
+    props.Type.IsIntersection() == false ||
+    iterate_metadata_intersection_is_plain_object_only(props.Checker, props.Components, props.Type, map[*nativechecker.Type]bool{}) == false {
+    return false
+  }
+  children := emplace_metadata_object_intersection_children(props.Type, map[*nativechecker.Type]bool{})
+  if len(children) < 2 || emplace_metadata_object_intersection_has_duplicate_key(props.Checker, props.Components, children) {
+    return false
+  }
+  merged := []*schemametadata.MetadataProperty{}
+  checkProperties := []*schemametadata.MetadataProperty{}
+  parentObjects := []*schemametadata.MetadataObject{}
+  props.Explore.Object = obj
+  props.Explore.Top = false
+  for _, child := range children {
+    if emplace_metadata_object_shareable_child(props, child) {
+      explore := props.Explore
+      explore.Object = obj
+      explore.Property = nil
+      explore.Aliased = false
+      metadata := Explore_metadata(Explore_metadata_IProps{
+        Options:    props.Options,
+        Checker:    props.Checker,
+        Components: props.Components,
+        Errors:     props.Errors,
+        Type:       child,
+        Explore:    explore,
+        Prunable:   props.Prunable,
+      })
+      if metadata.Size() != 1 || len(metadata.Objects) != 1 {
+        return false
+      }
+      if len(metadata.Objects[0].Tags) != 0 {
+        return false
+      }
+      parentObjects = append(parentObjects, metadata.Objects[0])
+      for _, property := range metadata.Objects[0].Type.Properties {
+        merged = append(merged, emplace_metadata_object_clone_property(property))
+      }
+    } else if emplace_metadata_object_intersection_append(
+      props,
+      child,
+      func(next emplace_metadata_object_insert) *schemametadata.MetadataProperty {
+        property := emplace_metadata_object_create_property(next)
+        merged = append(merged, property)
+        checkProperties = append(checkProperties, property)
+        return property
+      },
+      pred,
+    ) == false {
+      return false
+    }
+  }
+  obj.Properties = append(obj.Properties, merged...)
+  if len(parentObjects) != 0 {
+    obj.Parent_objects_ = append(obj.Parent_objects_, parentObjects...)
+    obj.Check_properties_ = append(obj.Check_properties_, checkProperties...)
+  }
+  return true
+}
+
+func emplace_metadata_object_shareable_child(props IMetadataIteratorProps, child *nativechecker.Type) bool {
+  fullName := metadata_type_full_name(props.Checker, child, props.Components)
+  sanitized := iterate_metadata_intersection_sanitize_name(fullName)
+  return iterate_metadata_intersection_shareable_name(fullName, sanitized)
+}
+
+func emplace_metadata_object_intersection_append(
+  props IMetadataIteratorProps,
+  child *nativechecker.Type,
+  insert func(emplace_metadata_object_insert) *schemametadata.MetadataProperty,
+  pred func(node *nativeast.Node) bool,
+) bool {
+  if props.Checker == nil || child == nil || len(props.Components.IndexInfos(props.Checker, child)) != 0 {
+    return false
+  }
+  for _, symbol := range props.Components.ApparentProperties(props.Checker, child) {
+    if metadata_is_internal(symbol) {
+      continue
+    }
+    var node *nativeast.Node
+    if len(symbol.Declarations) != 0 {
+      node = symbol.Declarations[0]
+    }
+    var typ *nativechecker.Type
+    if node != nil {
+      typ = props.Checker.GetTypeOfSymbolAtLocation(symbol, node)
+    } else {
+      typ = nativechecker.Checker_getTypeOfPropertyOfType(props.Checker, child, symbol.Name)
+    }
+    if (node != nil && pred(node) == false) || typ == nil {
+      continue
+    }
+
+    explore := props.Explore
+    explore.Property = symbol.Name
+    explore.Parameter = nil
+    explore.Nested = nil
+    explore.Aliased = false
+    explore.Escaped = false
+    explore.Output = false
+    value := Explore_metadata(Explore_metadata_IProps{
+      Options:     props.Options,
+      Checker:     props.Checker,
+      Components:  props.Components,
+      Errors:      props.Errors,
+      Type:        typ,
+      Explore:     explore,
+      Intersected: false,
+      Prunable:    props.Prunable,
+    })
+    value.Optional = symbol.Flags&nativeast.SymbolFlagsOptional != 0
+    insert(emplace_metadata_object_insert{
+      Key:    MetadataHelper.Literal_to_metadata(symbol.Name),
+      Value:  value,
+      Symbol: symbol,
+      Node:   node,
+    })
+  }
+  return true
+}
+
+func emplace_metadata_object_intersection_children(
+  typ *nativechecker.Type,
+  visited map[*nativechecker.Type]bool,
+) []*nativechecker.Type {
+  if typ == nil || visited[typ] {
+    return nil
+  }
+  visited[typ] = true
+  if typ.IsIntersection() == false {
+    return []*nativechecker.Type{typ}
+  }
+  output := []*nativechecker.Type{}
+  for _, child := range typ.Types() {
+    output = append(output, emplace_metadata_object_intersection_children(child, visited)...)
+  }
+  return output
+}
+
+func emplace_metadata_object_intersection_has_duplicate_key(
+  checker *nativechecker.Checker,
+  collection *schemametadata.MetadataCollection,
+  children []*nativechecker.Type,
+) bool {
+  keys := map[string]bool{}
+  for _, child := range children {
+    if child == nil {
+      return true
+    }
+    for _, symbol := range collection.ApparentProperties(checker, child) {
+      if keys[symbol.Name] {
+        return true
+      }
+      keys[symbol.Name] = true
+    }
+  }
+  return false
+}
+
+func emplace_metadata_object_clone_property(property *schemametadata.MetadataProperty) *schemametadata.MetadataProperty {
+  if property == nil {
+    return nil
+  }
+  description := property.Description
+  if description != nil {
+    value := *description
+    description = &value
+  }
+  mutability := property.Mutability
+  if mutability != nil {
+    value := *mutability
+    mutability = &value
+  }
+  return schemametadata.MetadataProperty_create(schemametadata.MetadataProperty{
+    Key:         property.Key,
+    Value:       property.Value.Clone(),
+    Description: description,
+    JsDocTags:   property.JsDocTags,
+    Mutability:  mutability,
+  })
 }
 
 func emplace_metadata_object_significant(functional bool) func(node *nativeast.Node) bool {

--- a/packages/typia/native/core/factories/internal/metadata/explore_metadata.go
+++ b/packages/typia/native/core/factories/internal/metadata/explore_metadata.go
@@ -13,9 +13,41 @@ type Explore_metadata_IProps struct {
   Type        *nativechecker.Type
   Explore     MetadataFactory_IExplore
   Intersected bool
+  NoCache     bool
+  Prunable    bool
 }
 
 func Explore_metadata(props Explore_metadata_IProps) *schemametadata.MetadataSchema {
+  plainObjectIntersection := false
+  if props.Checker != nil && props.Type != nil && props.Type.IsIntersection() {
+    plainObjectIntersection = iterate_metadata_intersection_is_plain_object_only(props.Checker, props.Components, props.Type, map[*nativechecker.Type]bool{})
+  }
+  cacheable := props.NoCache == false &&
+    props.Intersected == false &&
+    props.Components != nil &&
+    props.Type != nil &&
+    (props.Type.IsIntersection() == false || plainObjectIntersection)
+  cacheKey := schemametadata.MetadataCollection_ExploreCacheKey{}
+  if cacheable {
+    cacheKey = schemametadata.MetadataCollection_ExploreCacheKey{
+      Type:       props.Type,
+      Escape:     props.Options.Escape,
+      Absorb:     props.Options.Absorb,
+      Constant:   props.Options.Constant,
+      Functional: props.Options.Functional,
+      Top:        props.Explore.Top,
+      Aliased:    props.Explore.Aliased,
+      Escaped:    props.Explore.Escaped,
+      Output:     props.Explore.Output,
+    }
+    if cached, ok := props.Components.LookupExploreCache(cacheKey); ok {
+      return cached
+    }
+  }
+  errorCount := 0
+  if props.Errors != nil {
+    errorCount = len(*props.Errors)
+  }
   metadata := schemametadata.MetadataSchema_initialize(props.Explore.Escaped)
   if props.Type == nil {
     return metadata
@@ -29,11 +61,15 @@ func Explore_metadata(props Explore_metadata_IProps) *schemametadata.MetadataSch
     Type:        props.Type,
     Explore:     props.Explore,
     Intersected: props.Intersected,
+    Prunable:    props.Prunable,
   })
   Emend_metadata_atomics(metadata)
   if metadata.Escaped != nil {
     Emend_metadata_atomics(metadata.Escaped.Original)
     Emend_metadata_atomics(metadata.Escaped.Returns)
+  }
+  if cacheable && (props.Errors == nil || len(*props.Errors) == errorCount) {
+    props.Components.StoreExploreCache(cacheKey, metadata)
   }
   return metadata
 }

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_collection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_collection.go
@@ -40,7 +40,8 @@ func Iterate_metadata_collection(props struct {
       props.Collection.SetTupleRecursive(tuple, recursive)
     }
   }
-  for _, object := range props.Collection.Objects() {
+  objects := props.Collection.Objects()
+  for _, object := range objects {
     Iterate_metadata_comment_tags(struct {
       Errors *[]MetadataFactory_IError
       Object *schemametadata.MetadataObjectType
@@ -48,26 +49,8 @@ func Iterate_metadata_collection(props struct {
       Errors: props.Errors,
       Object: object,
     })
-    if object.Recursive == false {
-      visited := map[*schemametadata.MetadataSchema]bool{}
-      recursive := false
-      for _, property := range object.Properties {
-        if iterate_metadata_collection_is_object_recursive(struct {
-          Visited  map[*schemametadata.MetadataSchema]bool
-          Object   *schemametadata.MetadataObjectType
-          Metadata *schemametadata.MetadataSchema
-        }{
-          Visited:  visited,
-          Object:   object,
-          Metadata: property.Value,
-        }) {
-          recursive = true
-          break
-        }
-      }
-      props.Collection.SetObjectRecursive(object, recursive)
-    }
   }
+  iterate_metadata_collection_mark_object_recursives(props.Collection, objects)
 }
 
 func iterate_metadata_collection_is_array_recursive(props struct {
@@ -179,6 +162,141 @@ func iterate_metadata_collection_is_tuple_recursive(props struct {
     return true
   }
   return props.Metadata.Rest != nil && next(props.Metadata.Rest)
+}
+
+func iterate_metadata_collection_mark_object_recursives(
+  collection *schemametadata.MetadataCollection,
+  objects []*schemametadata.MetadataObjectType,
+) {
+  edges := map[*schemametadata.MetadataObjectType]map[*schemametadata.MetadataObjectType]bool{}
+  for _, object := range objects {
+    if object == nil {
+      continue
+    }
+    output := map[*schemametadata.MetadataObjectType]bool{}
+    for _, property := range object.Properties {
+      iterate_metadata_collection_collect_object_edges(struct {
+        Visited map[*schemametadata.MetadataSchema]bool
+        Output  map[*schemametadata.MetadataObjectType]bool
+        Metadata *schemametadata.MetadataSchema
+      }{
+        Visited: map[*schemametadata.MetadataSchema]bool{},
+        Output:  output,
+        Metadata: property.Value,
+      })
+    }
+    edges[object] = output
+  }
+
+  index := 0
+  indexes := map[*schemametadata.MetadataObjectType]int{}
+  lowlinks := map[*schemametadata.MetadataObjectType]int{}
+  onStack := map[*schemametadata.MetadataObjectType]bool{}
+  stack := []*schemametadata.MetadataObjectType{}
+  var strongconnect func(*schemametadata.MetadataObjectType)
+  strongconnect = func(object *schemametadata.MetadataObjectType) {
+    indexes[object] = index
+    lowlinks[object] = index
+    index++
+    stack = append(stack, object)
+    onStack[object] = true
+
+    for next := range edges[object] {
+      if _, ok := indexes[next]; ok == false {
+        strongconnect(next)
+        if lowlinks[next] < lowlinks[object] {
+          lowlinks[object] = lowlinks[next]
+        }
+      } else if onStack[next] && indexes[next] < lowlinks[object] {
+        lowlinks[object] = indexes[next]
+      }
+    }
+
+    if lowlinks[object] != indexes[object] {
+      return
+    }
+    component := []*schemametadata.MetadataObjectType{}
+    for {
+      last := stack[len(stack)-1]
+      stack = stack[:len(stack)-1]
+      onStack[last] = false
+      component = append(component, last)
+      if last == object {
+        break
+      }
+    }
+    recursive := len(component) > 1
+    if recursive == false {
+      recursive = edges[object][object]
+    }
+    if recursive {
+      for _, elem := range component {
+        collection.SetObjectRecursive(elem, true)
+      }
+    }
+  }
+  for _, object := range objects {
+    if object == nil {
+      continue
+    }
+    if _, ok := indexes[object]; ok == false {
+      strongconnect(object)
+    }
+  }
+}
+
+func iterate_metadata_collection_collect_object_edges(props struct {
+  Visited map[*schemametadata.MetadataSchema]bool
+  Output  map[*schemametadata.MetadataObjectType]bool
+  Metadata *schemametadata.MetadataSchema
+}) {
+  if props.Metadata == nil || props.Visited[props.Metadata] {
+    return
+  }
+  props.Visited[props.Metadata] = true
+  next := func(metadata *schemametadata.MetadataSchema) {
+    iterate_metadata_collection_collect_object_edges(struct {
+      Visited map[*schemametadata.MetadataSchema]bool
+      Output  map[*schemametadata.MetadataObjectType]bool
+      Metadata *schemametadata.MetadataSchema
+    }{
+      Visited: props.Visited,
+      Output:  props.Output,
+      Metadata: metadata,
+    })
+  }
+  for _, object := range props.Metadata.Objects {
+    if object.Type != nil {
+      props.Output[object.Type] = true
+    }
+  }
+  for _, alias := range props.Metadata.Aliases {
+    if alias.Type != nil {
+      next(alias.Type.Value)
+    }
+  }
+  for _, array := range props.Metadata.Arrays {
+    if array.Type != nil && array.Type.Recursive == false {
+      next(array.Type.Value)
+    }
+  }
+  for _, tuple := range props.Metadata.Tuples {
+    if tuple.Type != nil && tuple.Type.Recursive == false {
+      for _, elem := range tuple.Type.Elements {
+        next(elem)
+      }
+    }
+  }
+  for _, m := range props.Metadata.Maps {
+    next(m.Value)
+  }
+  for _, set := range props.Metadata.Sets {
+    next(set.Value)
+  }
+  if props.Metadata.Escaped != nil {
+    next(props.Metadata.Escaped.Returns)
+  }
+  next(props.Metadata.Rest)
 }
 
 func iterate_metadata_collection_is_object_recursive(props struct {

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_constant.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_constant.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
   "fmt"
+  "strconv"
 
   nativechecker "github.com/microsoft/typescript-go/shim/checker"
   schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
@@ -93,10 +94,46 @@ func iterate_metadata_constant_take(metadata *schemametadata.MetadataSchema, typ
 }
 
 func iterate_metadata_constant_add(constant *schemametadata.MetadataConstant, value *schemametadata.MetadataConstantValue) {
+  key := iterate_metadata_constant_key(value.Value)
   for _, oldbie := range constant.Values {
-    if fmt.Sprint(oldbie.Value) == fmt.Sprint(value.Value) {
+    if iterate_metadata_constant_key(oldbie.Value) == key {
       return
     }
   }
   constant.Values = append(constant.Values, value)
+}
+
+func iterate_metadata_constant_key(value any) string {
+  switch v := value.(type) {
+  case string:
+    return v
+  case bool:
+    return strconv.FormatBool(v)
+  case int:
+    return strconv.Itoa(v)
+  case int8:
+    return strconv.FormatInt(int64(v), 10)
+  case int16:
+    return strconv.FormatInt(int64(v), 10)
+  case int32:
+    return strconv.FormatInt(int64(v), 10)
+  case int64:
+    return strconv.FormatInt(v, 10)
+  case uint:
+    return strconv.FormatUint(uint64(v), 10)
+  case uint8:
+    return strconv.FormatUint(uint64(v), 10)
+  case uint16:
+    return strconv.FormatUint(uint64(v), 10)
+  case uint32:
+    return strconv.FormatUint(uint64(v), 10)
+  case uint64:
+    return strconv.FormatUint(v, 10)
+  case float32:
+    return strconv.FormatFloat(float64(v), 'g', -1, 32)
+  case float64:
+    return strconv.FormatFloat(v, 'g', -1, 64)
+  default:
+    return fmt.Sprint(value)
+  }
 }

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
@@ -1,8 +1,11 @@
 package metadata
 
 import (
+  "fmt"
   "strings"
 
+  nativeast "github.com/microsoft/typescript-go/shim/ast"
+  nativechecker "github.com/microsoft/typescript-go/shim/checker"
   schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
 
@@ -12,6 +15,18 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
   }
   if props.Type == nil || props.Type.IsIntersection() == false {
     return false
+  }
+  if iterate_metadata_intersection_reduce_union(props) {
+    return true
+  }
+  if iterate_metadata_intersection_is_plain_object_only(props.Checker, props.Components, props.Type, map[*nativechecker.Type]bool{}) {
+    if (props.Unioned || props.Prunable) && iterate_metadata_intersection_has_conflicting_required_literal(props.Checker, props.Components, props.Type, map[*nativechecker.Type]bool{}) {
+      return true
+    }
+    return false
+  }
+  if (props.Unioned || props.Prunable) && iterate_metadata_intersection_is_never(props, props.Type, map[*nativechecker.Type]bool{}) {
+    return true
   }
 
   commit := props.Components.Clone()
@@ -31,6 +46,8 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
       Type:        typ,
       Explore:     explore,
       Intersected: false,
+      NoCache:     true,
+      Prunable:    true,
     }))
   }
 
@@ -134,6 +151,7 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
       for i := len(removable) - 1; i >= 0; i-- {
         index := removable[i]
         metadatas = append(metadatas[:index], metadatas[index+1:]...)
+        indexes = append(indexes[:index], indexes[index+1:]...)
       }
     } else {
       return nonsensible()
@@ -287,6 +305,639 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
     }
   }
   return true
+}
+
+func iterate_metadata_intersection_reduce_union(props IMetadataIteratorProps) bool {
+  if props.Checker == nil || props.Type == nil || props.Type.IsIntersection() == false {
+    return false
+  }
+  var union *nativechecker.Type
+  constraints := []*nativechecker.Type{}
+  for _, child := range props.Type.Types() {
+    if child.IsUnion() {
+      if union != nil {
+        return false
+      }
+      union = child
+      continue
+    }
+    constraints = append(constraints, child)
+  }
+  if union == nil || len(constraints) == 0 {
+    return false
+  }
+
+  identities := make([]iterate_metadata_intersection_identity, 0, len(constraints))
+  for _, constraint := range constraints {
+    if iterate_metadata_intersection_is_removable_object_constraint(props, constraint) {
+      continue
+    }
+    identity := iterate_metadata_intersection_identify(props.Checker, props.Components, constraint)
+    if identity.Kind == "" || identity.Kind == "tag" || identity.Kind == "union" {
+      return false
+    }
+    identities = append(identities, identity)
+  }
+  if len(identities) == 0 {
+    return false
+  }
+  objectExact := map[string]bool{}
+  for _, identity := range identities {
+    if identity.Kind != "object" || identity.Shareable == false {
+      continue
+    }
+    for _, member := range union.Types() {
+      next := iterate_metadata_intersection_identify(props.Checker, props.Components, member)
+      if next.Kind == "object" && next.Shareable && next.Name == identity.Name {
+        objectExact[identity.Name] = true
+      }
+    }
+  }
+
+  matched := false
+  for _, member := range union.Types() {
+    memberIdentity := iterate_metadata_intersection_identify(props.Checker, props.Components, member)
+    if memberIdentity.Kind == "" || memberIdentity.Kind == "tag" || memberIdentity.Kind == "union" {
+      return false
+    }
+    keep := true
+    for _, constraint := range identities {
+      ok, known := iterate_metadata_intersection_identity_matches(memberIdentity, constraint, objectExact)
+      if known == false {
+        return false
+      }
+      if ok == false {
+        keep = false
+        break
+      }
+    }
+    if keep == false {
+      continue
+    }
+    matched = true
+    explore := props.Explore
+    explore.Aliased = false
+    Iterate_metadata(IMetadataIteratorProps{
+      Options:     props.Options,
+      Checker:     props.Checker,
+      Components:  props.Components,
+      Errors:      props.Errors,
+      Metadata:    props.Metadata,
+      Type:        member,
+      Explore:     explore,
+      Intersected: props.Intersected,
+      Unioned:     true,
+      Prunable:    true,
+    })
+  }
+  return matched || iterate_metadata_intersection_identities_decisive(identities)
+}
+
+func iterate_metadata_intersection_is_removable_object_constraint(
+  props IMetadataIteratorProps,
+  typ *nativechecker.Type,
+) bool {
+  checker := props.Checker
+  collection := props.Components
+  if checker == nil || collection == nil || typ == nil {
+    return false
+  }
+  if typ.IsUnion() {
+    return false
+  }
+  if typ.IsIntersection() {
+    children := typ.Types()
+    if len(children) == 0 {
+      return false
+    }
+    for _, child := range children {
+      if iterate_metadata_intersection_is_removable_object_constraint(props, child) == false {
+        return false
+      }
+    }
+    return true
+  }
+  if typ.Flags()&nativechecker.TypeFlagsObject == 0 {
+    return false
+  }
+  if nativechecker.IsTupleType(typ) || nativechecker.Checker_isArrayType(checker, typ) {
+    return false
+  }
+  if metadata_get_function_node(typ) != nil || len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 {
+    return false
+  }
+  name := iterate_metadata_native_getNativeName(metadata_type_symbol_base_name(typ))
+  if name == "" {
+    name = iterate_metadata_native_getNativeName(metadata_type_symbol_base_name(checker.GetApparentType(typ)))
+  }
+  if _, ok := iterate_metadata_native_simples[name]; ok {
+    return false
+  }
+  for _, generic := range iterate_metadata_native_generics {
+    if strings.HasPrefix(name, generic.Name) {
+      return false
+    }
+  }
+  if strings.HasPrefix(name, "Map<") || strings.HasPrefix(name, "ReadonlyMap<") ||
+    strings.HasPrefix(name, "Set<") || strings.HasPrefix(name, "ReadonlySet<") {
+    return false
+  }
+  if len(collection.IndexInfos(checker, typ)) != 0 {
+    return false
+  }
+  for _, symbol := range collection.ApparentProperties(checker, typ) {
+    if symbol.Name == "typia.tag" || symbol.Flags&nativeast.SymbolFlagsOptional == 0 {
+      return false
+    }
+  }
+  return true
+}
+
+type iterate_metadata_intersection_identity struct {
+  Kind      string
+  Name      string
+  Shareable bool
+}
+
+func iterate_metadata_intersection_identify(
+  checker *nativechecker.Checker,
+  collection *schemametadata.MetadataCollection,
+  typ *nativechecker.Type,
+) iterate_metadata_intersection_identity {
+  if checker == nil || typ == nil {
+    return iterate_metadata_intersection_identity{}
+  }
+  if typ.IsUnion() {
+    return iterate_metadata_intersection_identity{Kind: "union"}
+  }
+  if typ.IsIntersection() {
+    return iterate_metadata_intersection_identity{Kind: "intersection"}
+  }
+  for _, info := range iterate_metadata_atomic_atomcs {
+    if typ.Flags()&info.atomic != 0 || typ.Flags()&info.literal != 0 {
+      return iterate_metadata_intersection_identity{Kind: "primitive", Name: info.name}
+    }
+  }
+  name := iterate_metadata_native_getNativeName(metadata_type_symbol_base_name(typ))
+  if name == "" {
+    name = iterate_metadata_native_getNativeName(metadata_type_symbol_base_name(checker.GetApparentType(typ)))
+  }
+  if atomic, ok := schemametadata.MetadataSchema_atomicLikeNative(name); ok {
+    return iterate_metadata_intersection_identity{Kind: "primitive", Name: atomic}
+  }
+  if nativechecker.IsTupleType(typ) || nativechecker.Checker_isArrayType(checker, typ) || name == "Array" || name == "ReadonlyArray" {
+    return iterate_metadata_intersection_identity{
+      Kind: "array",
+      Name: metadata_type_full_name(checker, typ, collection),
+    }
+  }
+  for _, symbol := range collection.ApparentProperties(checker, typ) {
+    if symbol.Name == "typia.tag" {
+      return iterate_metadata_intersection_identity{Kind: "tag"}
+    }
+  }
+  if _, ok := iterate_metadata_native_simples[name]; ok {
+    return iterate_metadata_intersection_identity{Kind: "native", Name: name}
+  }
+  for _, generic := range iterate_metadata_native_generics {
+    if strings.HasPrefix(name, generic.Name) {
+      return iterate_metadata_intersection_identity{Kind: "native", Name: generic.Name}
+    }
+  }
+  if name == "Map" || name == "ReadonlyMap" || name == "Set" || name == "ReadonlySet" {
+    return iterate_metadata_intersection_identity{
+      Kind: "native",
+      Name: name,
+    }
+  }
+  if typ.Flags()&nativechecker.TypeFlagsObject == 0 {
+    return iterate_metadata_intersection_identity{}
+  }
+  fullName := metadata_type_full_name(checker, typ, collection)
+  sanitized := iterate_metadata_intersection_sanitize_name(fullName)
+  return iterate_metadata_intersection_identity{
+    Kind:      "object",
+    Name:      sanitized,
+    Shareable: iterate_metadata_intersection_shareable_name(fullName, sanitized),
+  }
+}
+
+func iterate_metadata_intersection_identity_matches(
+  member iterate_metadata_intersection_identity,
+  constraint iterate_metadata_intersection_identity,
+  objectExact map[string]bool,
+) (bool, bool) {
+  if constraint.Kind == "primitive" || constraint.Kind == "native" || constraint.Kind == "array" {
+    return member.Kind == constraint.Kind && member.Name == constraint.Name, true
+  }
+  if constraint.Kind != "object" {
+    return false, false
+  }
+  if member.Kind == "primitive" || member.Kind == "native" || member.Kind == "array" {
+    return false, true
+  }
+  if member.Kind != "object" || constraint.Shareable == false || objectExact[constraint.Name] == false {
+    return false, false
+  }
+  return member.Shareable && member.Name == constraint.Name, true
+}
+
+func iterate_metadata_intersection_identities_decisive(identities []iterate_metadata_intersection_identity) bool {
+  for _, identity := range identities {
+    if identity.Kind == "object" && identity.Shareable == false {
+      return false
+    }
+  }
+  return true
+}
+
+func iterate_metadata_intersection_sanitize_name(name string) string {
+  name = strings.ToValidUTF8(name, "__")
+  return strings.ReplaceAll(name, "\uFFFD", "__")
+}
+
+func iterate_metadata_intersection_shareable_name(fullName string, sanitized string) bool {
+  fullName = strings.TrimSpace(fullName)
+  if fullName == "" || strings.Contains(fullName, "{") {
+    return false
+  }
+  return strings.Contains(sanitized, "__type") == false
+}
+
+func iterate_metadata_intersection_is_plain_object_only(
+  checker *nativechecker.Checker,
+  collection *schemametadata.MetadataCollection,
+  typ *nativechecker.Type,
+  visited map[*nativechecker.Type]bool,
+) bool {
+  if checker == nil || typ == nil {
+    return false
+  }
+  if visited[typ] {
+    return true
+  }
+  if cached, ok := collection.LookupPlainObjectIntersection(typ); ok {
+    return cached
+  }
+  visited[typ] = true
+
+  result := false
+  defer func() {
+    collection.StorePlainObjectIntersection(typ, result)
+  }()
+  if typ.IsUnion() {
+    return false
+  }
+  if typ.IsIntersection() {
+    for _, child := range typ.Types() {
+      if iterate_metadata_intersection_is_plain_object_only(checker, collection, child, visited) == false {
+        return false
+      }
+    }
+    result = true
+    return true
+  }
+  if typ.Flags()&nativechecker.TypeFlagsObject == 0 {
+    return false
+  }
+  if nativechecker.IsTupleType(typ) || nativechecker.Checker_isArrayType(checker, typ) {
+    return false
+  }
+  if metadata_get_function_node(typ) != nil || len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 {
+    return false
+  }
+
+  name := iterate_metadata_native_getNativeName(metadata_type_symbol_base_name(typ))
+  if name == "" {
+    name = iterate_metadata_native_getNativeName(metadata_type_symbol_base_name(checker.GetApparentType(typ)))
+  }
+  if _, ok := iterate_metadata_native_simples[name]; ok {
+    return false
+  }
+  for _, generic := range iterate_metadata_native_generics {
+    if strings.HasPrefix(name, generic.Name) {
+      return false
+    }
+  }
+  if strings.HasPrefix(name, "Map<") || strings.HasPrefix(name, "ReadonlyMap<") ||
+    strings.HasPrefix(name, "Set<") || strings.HasPrefix(name, "ReadonlySet<") {
+    return false
+  }
+
+  for _, symbol := range collection.ApparentProperties(checker, typ) {
+    if symbol.Name == "typia.tag" {
+      return false
+    }
+  }
+  result = true
+  return true
+}
+
+func iterate_metadata_intersection_is_never(
+  props IMetadataIteratorProps,
+  typ *nativechecker.Type,
+  visited map[*nativechecker.Type]bool,
+) bool {
+  checker := props.Checker
+  collection := props.Components
+  if checker == nil || collection == nil || typ == nil {
+    return false
+  }
+  state := struct {
+    Primitive string
+    Array     bool
+    Object    bool
+    Native    string
+    Unknown   bool
+    Tagged    bool
+    Never     bool
+  }{}
+  var next func(*nativechecker.Type)
+  next = func(child *nativechecker.Type) {
+    if child == nil || state.Never || state.Unknown || state.Tagged {
+      return
+    }
+    if visited[child] {
+      return
+    }
+    visited[child] = true
+    if child.IsUnion() {
+      state.Unknown = true
+      return
+    }
+    if child.IsIntersection() {
+      for _, elem := range child.Types() {
+        next(elem)
+      }
+      return
+    }
+    if iterate_metadata_intersection_is_removable_object_constraint(props, child) {
+      return
+    }
+    category := iterate_metadata_intersection_category(checker, collection, child)
+    if category == "" {
+      state.Unknown = true
+      return
+    }
+    if category == "tag" {
+      state.Tagged = true
+      return
+    }
+    if strings.HasPrefix(category, "primitive:") {
+      if state.Primitive != "" && state.Primitive != category {
+        state.Never = true
+        return
+      }
+      state.Primitive = category
+      if state.Array || state.Object || state.Native != "" {
+        state.Never = true
+      }
+      return
+    }
+    if category == "array" {
+      state.Array = true
+      if state.Primitive != "" || state.Native != "" || state.Object {
+        state.Never = true
+      }
+      return
+    }
+    if strings.HasPrefix(category, "native:") {
+      if state.Native != "" && state.Native != category {
+        state.Never = true
+        return
+      }
+      state.Native = category
+      if state.Primitive != "" || state.Array || state.Object {
+        state.Never = true
+      }
+      return
+    } else {
+      state.Object = true
+    }
+    if state.Primitive != "" || state.Native != "" || state.Array {
+      state.Never = true
+    }
+  }
+  next(typ)
+  return state.Never && state.Unknown == false && state.Tagged == false
+}
+
+type iterate_metadata_intersection_literalSet struct {
+  Kind   string
+  Values map[string]bool
+}
+
+func iterate_metadata_intersection_has_conflicting_required_literal(
+  checker *nativechecker.Checker,
+  collection *schemametadata.MetadataCollection,
+  typ *nativechecker.Type,
+  visited map[*nativechecker.Type]bool,
+) bool {
+  if checker == nil || typ == nil {
+    return false
+  }
+  if typ.IsIntersection() == false {
+    return false
+  }
+  if cached, ok := collection.LookupLiteralConflict(typ); ok {
+    return cached
+  }
+  result := false
+  defer func() {
+    collection.StoreLiteralConflict(typ, result)
+  }()
+  constraints := map[string][]iterate_metadata_intersection_literalSet{}
+  var collect func(*nativechecker.Type) bool
+  collect = func(child *nativechecker.Type) bool {
+    if child == nil {
+      return false
+    }
+    if visited[child] {
+      return false
+    }
+    visited[child] = true
+    if child.IsIntersection() {
+      for _, grand := range child.Types() {
+        if collect(grand) {
+          return true
+        }
+      }
+      return false
+    }
+    if child.IsUnion() || child.Flags()&nativechecker.TypeFlagsObject == 0 {
+      return false
+    }
+    for _, symbol := range collection.ApparentProperties(checker, child) {
+      if symbol.Flags&nativeast.SymbolFlagsOptional != 0 {
+        continue
+      }
+      propertyType := iterate_metadata_intersection_property_type(checker, child, symbol)
+      literal, ok := iterate_metadata_intersection_literal_set(checker, propertyType, map[*nativechecker.Type]bool{})
+      if ok == false {
+        continue
+      }
+      list := constraints[symbol.Name]
+      for _, prev := range list {
+        if iterate_metadata_intersection_literal_disjoint(prev, literal) {
+          result = true
+          return true
+        }
+      }
+      constraints[symbol.Name] = append(list, literal)
+    }
+    return false
+  }
+  result = collect(typ)
+  return result
+}
+
+func iterate_metadata_intersection_property_type(
+  checker *nativechecker.Checker,
+  owner *nativechecker.Type,
+  symbol *nativeast.Symbol,
+) *nativechecker.Type {
+  if checker == nil || owner == nil || symbol == nil {
+    return nil
+  }
+  if len(symbol.Declarations) != 0 {
+    if typ := checker.GetTypeOfSymbolAtLocation(symbol, symbol.Declarations[0]); typ != nil {
+      return typ
+    }
+  }
+  return nativechecker.Checker_getTypeOfPropertyOfType(checker, owner, symbol.Name)
+}
+
+func iterate_metadata_intersection_literal_set(
+  checker *nativechecker.Checker,
+  typ *nativechecker.Type,
+  visited map[*nativechecker.Type]bool,
+) (iterate_metadata_intersection_literalSet, bool) {
+  if checker == nil || typ == nil {
+    return iterate_metadata_intersection_literalSet{}, false
+  }
+  if visited[typ] {
+    return iterate_metadata_intersection_literalSet{}, false
+  }
+  visited[typ] = true
+  if typ.IsUnion() {
+    output := iterate_metadata_intersection_literalSet{}
+    for _, child := range typ.Types() {
+      next, ok := iterate_metadata_intersection_literal_set(checker, child, visited)
+      if ok == false {
+        return iterate_metadata_intersection_literalSet{}, false
+      }
+      if output.Kind == "" {
+        output.Kind = next.Kind
+        output.Values = map[string]bool{}
+      } else if output.Kind != next.Kind {
+        return iterate_metadata_intersection_literalSet{}, false
+      }
+      for value := range next.Values {
+        output.Values[value] = true
+      }
+    }
+    return output, output.Kind != "" && len(output.Values) != 0
+  }
+  filter := func(flag nativechecker.TypeFlags) bool {
+    return typ.Flags()&flag != 0
+  }
+  if filter(nativechecker.TypeFlagsStringLiteral) {
+    return iterate_metadata_intersection_literalSet{
+      Kind:   "string",
+      Values: map[string]bool{fmt.Sprint(typ.AsLiteralType().Value()): true},
+    }, true
+  }
+  if filter(nativechecker.TypeFlagsNumberLiteral) {
+    return iterate_metadata_intersection_literalSet{
+      Kind:   "number",
+      Values: map[string]bool{fmt.Sprint(typ.AsLiteralType().Value()): true},
+    }, true
+  }
+  if filter(nativechecker.TypeFlagsBigIntLiteral) {
+    return iterate_metadata_intersection_literalSet{
+      Kind:   "bigint",
+      Values: map[string]bool{fmt.Sprint(typ.AsLiteralType().Value()): true},
+    }, true
+  }
+  if filter(nativechecker.TypeFlagsBooleanLiteral) {
+    return iterate_metadata_intersection_literalSet{
+      Kind:   "boolean",
+      Values: map[string]bool{checker.TypeToString(typ): true},
+    }, true
+  }
+  return iterate_metadata_intersection_literalSet{}, false
+}
+
+func iterate_metadata_intersection_literal_disjoint(
+  x iterate_metadata_intersection_literalSet,
+  y iterate_metadata_intersection_literalSet,
+) bool {
+  if x.Kind == "" || y.Kind == "" || len(x.Values) == 0 || len(y.Values) == 0 {
+    return false
+  }
+  if x.Kind != y.Kind {
+    return true
+  }
+  if len(x.Values) > len(y.Values) {
+    x, y = y, x
+  }
+  for value := range x.Values {
+    if y.Values[value] {
+      return false
+    }
+  }
+  return true
+}
+
+func iterate_metadata_intersection_category(
+  checker *nativechecker.Checker,
+  collection *schemametadata.MetadataCollection,
+  typ *nativechecker.Type,
+) string {
+  if checker == nil || typ == nil {
+    return ""
+  }
+  for _, info := range iterate_metadata_atomic_atomcs {
+    if typ.Flags()&info.atomic != 0 || typ.Flags()&info.literal != 0 {
+      return "primitive:" + info.name
+    }
+  }
+  if nativechecker.IsTupleType(typ) || nativechecker.Checker_isArrayType(checker, typ) {
+    return "array"
+  }
+  for _, symbol := range collection.ApparentProperties(checker, typ) {
+    if symbol.Name == "typia.tag" {
+      return "tag"
+    }
+  }
+  name := iterate_metadata_native_getNativeName(metadata_type_symbol_base_name(typ))
+  if name == "" {
+    name = iterate_metadata_native_getNativeName(metadata_type_symbol_base_name(checker.GetApparentType(typ)))
+  }
+  if atomic, ok := schemametadata.MetadataSchema_atomicLikeNative(name); ok {
+    return "primitive:" + atomic
+  }
+  if name == "Array" || name == "ReadonlyArray" {
+    return "array"
+  }
+  if _, ok := iterate_metadata_native_simples[name]; ok {
+    return "native:" + name
+  }
+  for _, generic := range iterate_metadata_native_generics {
+    if strings.HasPrefix(name, generic.Name) {
+      return "object"
+    }
+  }
+  if name == "Map" || name == "ReadonlyMap" || name == "Set" || name == "ReadonlySet" {
+    return "object"
+  }
+  if metadata_get_function_node(typ) != nil || len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 {
+    return "object"
+  }
+  if typ.Flags()&nativechecker.TypeFlagsObject != 0 {
+    return "object"
+  }
+  return ""
 }
 
 func iterate_metadata_intersection_is_type_tag(obj *schemametadata.MetadataObjectType) bool {

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection_shareable_name_test.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection_shareable_name_test.go
@@ -1,0 +1,22 @@
+package metadata
+
+import "testing"
+
+func TestIterateMetadataIntersectionShareableNameRejectsStructuralIntersections(t *testing.T) {
+  cases := []struct {
+    name      string
+    sanitized string
+    expected  bool
+  }{
+    {name: "RoleBase", sanitized: "RoleBase", expected: true},
+    {name: "{ x: number; }", sanitized: "__type", expected: false},
+    {name: "IPoint & { type: \"point\"; }", sanitized: "IPoint & { type: \"point\"; }", expected: false},
+    {name: "TypeLiteral", sanitized: "__type", expected: false},
+  }
+  for _, next := range cases {
+    actual := iterate_metadata_intersection_shareable_name(next.name, next.sanitized)
+    if actual != next.expected {
+      t.Fatalf("shareable(%q, %q) = %v", next.name, next.sanitized, actual)
+    }
+  }
+}

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_map.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_map.go
@@ -1,18 +1,13 @@
 package metadata
 
-import (
-  "strings"
-
-  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
-)
+import schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 
 func Iterate_metadata_map(props IMetadataIteratorProps) bool {
   if props.Checker == nil || props.Type == nil {
     return false
   }
   typ := props.Checker.GetApparentType(props.Type)
-  name := metadata_type_symbol_name(props.Checker, typ)
-  if strings.HasPrefix(name, "Map<") == false {
+  if metadata_type_symbol_base_name(typ) != "Map" {
     return false
   }
   generic := metadata_get_type_arguments(props.Checker, typ)

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
@@ -7,10 +7,14 @@ import (
 )
 
 func Iterate_metadata_native(props IMetadataIteratorProps) bool {
-  name := iterate_metadata_native_getNativeName("")
-  if props.Checker != nil && props.Type != nil {
-    name = iterate_metadata_native_getNativeName(props.Checker.TypeToString(props.Type))
+  name := ""
+  if props.Type != nil {
+    name = metadata_type_symbol_base_name(props.Type)
   }
+  if name == "" && props.Checker != nil && props.Type != nil {
+    name = metadata_type_symbol_base_name(props.Checker.GetApparentType(props.Type))
+  }
+  name = iterate_metadata_native_getNativeName(name)
   if _, ok := iterate_metadata_native_simples[name]; ok {
     iterate_metadata_native_take(props.Metadata, name)
     return true

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_set.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_set.go
@@ -1,18 +1,13 @@
 package metadata
 
-import (
-  "strings"
-
-  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
-)
+import schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 
 func Iterate_metadata_set(props IMetadataIteratorProps) bool {
   if props.Checker == nil || props.Type == nil {
     return false
   }
   typ := props.Checker.GetApparentType(props.Type)
-  name := metadata_type_symbol_name(props.Checker, typ)
-  if strings.HasPrefix(name, "Set<") == false {
+  if metadata_type_symbol_base_name(typ) != "Set" {
     return false
   }
   generic := metadata_get_type_arguments(props.Checker, typ)

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_sort.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_sort.go
@@ -2,7 +2,9 @@ package metadata
 
 import (
   "fmt"
+  "slices"
   "sort"
+  "strings"
 
   schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
@@ -12,6 +14,7 @@ func Iterate_metadata_sort(props struct {
   Metadata   *schemametadata.MetadataSchema
 }) {
   visited := map[*schemametadata.MetadataSchema]bool{}
+  objectKeys := map[*schemametadata.MetadataObjectType]iterate_metadata_sort_object_key{}
   next := func(metadata *schemametadata.MetadataSchema) {}
   next = func(metadata *schemametadata.MetadataSchema) {
     iterate_metadata_sort_iterate(struct {
@@ -19,11 +22,13 @@ func Iterate_metadata_sort(props struct {
       collection *schemametadata.MetadataCollection
       metadata   *schemametadata.MetadataSchema
       next       func(*schemametadata.MetadataSchema)
+      objectKeys map[*schemametadata.MetadataObjectType]iterate_metadata_sort_object_key
     }{
       visited:    visited,
       collection: props.Collection,
       metadata:   metadata,
       next:       next,
+      objectKeys: objectKeys,
     })
   }
   for _, array := range props.Collection.Arrays() {
@@ -47,6 +52,7 @@ func iterate_metadata_sort_iterate(props struct {
   collection *schemametadata.MetadataCollection
   metadata   *schemametadata.MetadataSchema
   next       func(*schemametadata.MetadataSchema)
+  objectKeys map[*schemametadata.MetadataObjectType]iterate_metadata_sort_object_key
 }) {
   if props.visited[props.metadata] {
     return
@@ -70,10 +76,10 @@ func iterate_metadata_sort_iterate(props struct {
     sort.SliceStable(props.metadata.Objects, func(i, j int) bool {
       x := props.metadata.Objects[i]
       y := props.metadata.Objects[j]
-      if schemametadata.MetadataObjectType_covers(x.Type, y.Type) {
+      if iterate_metadata_sort_object_covers(props.objectKeys, x.Type, y.Type) {
         return true
       }
-      if schemametadata.MetadataObjectType_covers(y.Type, x.Type) {
+      if iterate_metadata_sort_object_covers(props.objectKeys, y.Type, x.Type) {
         return false
       }
       return false
@@ -131,6 +137,45 @@ func iterate_metadata_sort_iterate(props struct {
       })
     }
   }
+}
+
+func iterate_metadata_sort_object_covers(
+  cache map[*schemametadata.MetadataObjectType]iterate_metadata_sort_object_key,
+  x *schemametadata.MetadataObjectType,
+  y *schemametadata.MetadataObjectType,
+) bool {
+  if x == nil || y == nil || len(x.Properties) < len(y.Properties) {
+    return false
+  }
+  return iterate_metadata_sort_object_keys(cache, x).Signature ==
+    iterate_metadata_sort_object_keys(cache, y).Signature
+}
+
+type iterate_metadata_sort_object_key struct {
+  Signature string
+}
+
+func iterate_metadata_sort_object_keys(
+  cache map[*schemametadata.MetadataObjectType]iterate_metadata_sort_object_key,
+  object *schemametadata.MetadataObjectType,
+) iterate_metadata_sort_object_key {
+  if value, ok := cache[object]; ok {
+    return value
+  }
+  keys := []string{}
+  if object != nil {
+    for _, property := range object.Properties {
+      if property != nil && property.Key != nil {
+        keys = append(keys, property.Key.GetName())
+      }
+    }
+  }
+  slices.Sort(keys)
+  value := iterate_metadata_sort_object_key{
+    Signature: strings.Join(keys, "\x00"),
+  }
+  cache[object] = value
+  return value
 }
 
 func iterate_metadata_sort_float(value any) float64 {

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_union.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_union.go
@@ -16,6 +16,8 @@ func Iterate_metadata_union(props IMetadataIteratorProps) bool {
       Type:        typ,
       Explore:     explore,
       Intersected: props.Intersected,
+      Unioned:     true,
+      Prunable:    true,
     })
   }
   return true

--- a/packages/typia/native/core/programmers/AssertProgrammer.go
+++ b/packages/typia/native/core/programmers/AssertProgrammer.go
@@ -70,6 +70,7 @@ func (assertProgrammerNamespace) Decompose(props AssertProgrammer_DecomposeProps
       Trace:   true,
       Numeric: nativehelpers.OptionPredicator.Numeric(props.Context.Options),
       Equals:  props.Config.Equals,
+      ObjectParents: props.Config.Equals == false,
       Atomist: assertProgrammer_atomist(props),
       Combiner: assertProgrammer_combiner(struct {
         Config  AssertProgrammer_IConfig
@@ -389,13 +390,23 @@ func assertProgrammer_create_guard_call(props assertProgrammer_createGuardCallPr
       f.NewObjectLiteralExpression(f.NewNodeList([]*shimast.Node{
         f.NewPropertyAssignment(nil, nativefactories.IdentifierFactory.Identifier("method", props.Context.Emit), nil, nil, f.NewStringLiteral(props.Functor.Method, shimast.TokenFlagsNone)),
         f.NewPropertyAssignment(nil, nativefactories.IdentifierFactory.Identifier("path", props.Context.Emit), nil, nil, props.Path),
-        f.NewPropertyAssignment(nil, nativefactories.IdentifierFactory.Identifier("expected", props.Context.Emit), nil, nil, f.NewStringLiteral(props.Expected, shimast.TokenFlagsNone)),
+        f.NewPropertyAssignment(nil, nativefactories.IdentifierFactory.Identifier("expected", props.Context.Emit), nil, nil, assertProgrammer_expected_expression(props)),
         f.NewPropertyAssignment(nil, nativefactories.IdentifierFactory.Identifier("value", props.Context.Emit), nil, nil, props.Input),
       }), true),
       f.NewIdentifier("_errorFactory"),
     }),
     shimast.NodeFlagsNone,
   )
+}
+
+func assertProgrammer_expected_expression(props assertProgrammer_createGuardCallProps) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(assertProgrammer_factory, props.Context.Emit)
+  if props.Functor == nil || len(props.Expected) < 128 {
+    return f.NewStringLiteral(props.Expected, shimast.TokenFlagsNone)
+  }
+  return props.Functor.EmplaceVariableByKey("_ae", props.Expected, func(string) *shimast.Expression {
+    return f.NewStringLiteral(props.Expected, shimast.TokenFlagsNone)
+  })
 }
 
 func (assertProgrammerGuardianNamespace) Identifier(emit ...*shimprinter.EmitContext) *shimast.Node {

--- a/packages/typia/native/core/programmers/IsProgrammer.go
+++ b/packages/typia/native/core/programmers/IsProgrammer.go
@@ -81,11 +81,12 @@ func (isProgrammerNamespace) Configure(props struct {
   f := nativecontext.EmitFactoryOf(isProgrammer_factory, props.Context.Emit)
   options := props.Options
   return nativeinternal.CheckerProgrammer_IConfig{
-    Prefix:  "_i",
-    Equals:  options != nil && options.Object != nil,
-    Trace:   false,
-    Path:    false,
-    Numeric: isProgrammer_option_numeric(options),
+    Prefix:        "_i",
+    Equals:        options != nil && options.Object != nil,
+    Trace:         false,
+    Path:          false,
+    Numeric:       isProgrammer_option_numeric(options),
+    ObjectParents: options == nil || options.Object == nil,
     Atomist: func(next nativeinternal.CheckerProgrammer_AtomistProps) *shimast.Node {
       expressions := []*shimast.Node{}
       if next.Entry.Expression != nil {
@@ -191,6 +192,7 @@ func (isProgrammerNamespace) Decompose(props IsProgrammer_DecomposeProps) native
     Functor *nativehelpers.FunctionProgrammer
   }{Options: options, Context: props.Context, Functor: props.Functor})
   config.Trace = props.Config.Equals
+  config.ObjectParents = props.Config.Equals == false
 
   composed := nativeinternal.CheckerProgrammer.Compose(nativeinternal.CheckerProgrammer_ComposeProps{
     Context: props.Context,

--- a/packages/typia/native/core/programmers/ValidateProgrammer.go
+++ b/packages/typia/native/core/programmers/ValidateProgrammer.go
@@ -60,6 +60,7 @@ func (validateProgrammerNamespace) Decompose(props ValidateProgrammer_DecomposeP
       Trace:   true,
       Numeric: nativehelpers.OptionPredicator.Numeric(props.Context.Options),
       Equals:  props.Config.Equals,
+      ObjectParents: props.Config.Equals == false,
       Atomist: validateProgrammer_atomist(props),
       Combiner: validateProgrammer_combine(struct {
         Config  ValidateProgrammer_IConfig
@@ -208,7 +209,7 @@ func validateProgrammer_atomist(props ValidateProgrammer_DecomposeProps) func(ne
         for _, cond := range next.Entry.Conditions[0] {
           expressions = append(expressions, validateProgrammer_or(
             cond.Expression,
-            validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: exceptionable, Path: path, Expected: cond.Expected, Value: next.Input, Emit: props.Context.Emit}),
+            validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: exceptionable, Path: path, Expected: cond.Expected, Value: next.Input, Functor: props.Functor, Emit: props.Context.Emit}),
             props.Context.Emit,
           ))
         }
@@ -223,7 +224,7 @@ func validateProgrammer_atomist(props ValidateProgrammer_DecomposeProps) func(ne
         }
         expressions = append(expressions, validateProgrammer_or(
           validateProgrammer_reduce(rows, shimast.KindBarBarToken, f.NewKeywordExpression(shimast.KindFalseKeyword), props.Context.Emit),
-          validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: exceptionable, Path: path, Expected: next.Entry.Expected, Value: next.Input, Emit: props.Context.Emit}),
+          validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: exceptionable, Path: path, Expected: next.Entry.Expected, Value: next.Input, Functor: props.Functor, Emit: props.Context.Emit}),
           props.Context.Emit,
         ))
       }
@@ -260,7 +261,7 @@ func validateProgrammer_combine(props struct {
         if binary.Combined {
           expressions = append(expressions, binary.Expression)
         } else {
-          expressions = append(expressions, validateProgrammer_or(binary.Expression, validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: exceptionable, Path: path, Expected: next.Expected, Value: next.Input, Emit: props.Context.Emit}), props.Context.Emit))
+          expressions = append(expressions, validateProgrammer_or(binary.Expression, validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: exceptionable, Path: path, Expected: next.Expected, Value: next.Input, Functor: props.Functor, Emit: props.Context.Emit}), props.Context.Emit))
         }
       }
       return validateProgrammer_reduce(expressions, shimast.KindAmpersandAmpersandToken, f.NewKeywordExpression(shimast.KindTrueKeyword), props.Context.Emit)
@@ -271,7 +272,7 @@ func validateProgrammer_combine(props struct {
     }
     return validateProgrammer_or(
       validateProgrammer_reduce(expressions, shimast.KindBarBarToken, f.NewKeywordExpression(shimast.KindFalseKeyword), props.Context.Emit),
-      validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: exceptionable, Path: path, Expected: next.Expected, Value: next.Input, Emit: props.Context.Emit}),
+      validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: exceptionable, Path: path, Expected: next.Expected, Value: next.Input, Functor: props.Functor, Emit: props.Context.Emit}),
       props.Context.Emit,
     )
   }
@@ -307,6 +308,7 @@ func validateProgrammer_validate_object(props validateProgrammer_validateObjectP
           Expected:    "undefined",
           Value:       input,
           Description: description,
+          Functor:     props.Functor,
           Emit:        props.Context.Emit,
         })
       },
@@ -334,7 +336,7 @@ func validateProgrammer_joiner(props ValidateProgrammer_DecomposeProps) nativein
       if next.Explore != nil {
         explore = *next.Explore
       }
-      return validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: validateProgrammer_exceptionable(explore, props.Context.Emit), Path: validateProgrammer_path(explore, props.Context.Emit), Expected: next.Expected, Value: next.Input, Emit: props.Context.Emit})
+      return validateProgrammer_create_report_call(validateProgrammer_createReportCallProps{Exceptionable: validateProgrammer_exceptionable(explore, props.Context.Emit), Path: validateProgrammer_path(explore, props.Context.Emit), Expected: next.Expected, Value: next.Input, Functor: props.Functor, Emit: props.Context.Emit})
     },
     Tuple: func(binaries []*shimast.Node) *shimast.Node {
       return nativeiterate.Check_everything(f.NewArrayLiteralExpression(f.NewNodeList(binaries), true))
@@ -365,6 +367,7 @@ type validateProgrammer_createReportCallProps struct {
   Expected      string
   Value         *shimast.Expression
   Description   *shimast.Expression
+  Functor       *nativehelpers.FunctionProgrammer
   Emit          *shimprinter.EmitContext
 }
 
@@ -376,7 +379,7 @@ func validateProgrammer_create_report_call(props validateProgrammer_createReport
   }
   properties := []*shimast.Node{
     validateProgrammer_property("path", props.Path, props.Emit),
-    validateProgrammer_property("expected", f.NewStringLiteral(props.Expected, shimast.TokenFlagsNone), props.Emit),
+    validateProgrammer_property("expected", validateProgrammer_expected_expression(props), props.Emit),
     validateProgrammer_property("value", props.Value, props.Emit),
   }
   if props.Description != nil {
@@ -392,6 +395,16 @@ func validateProgrammer_create_report_call(props validateProgrammer_createReport
     }),
     shimast.NodeFlagsNone,
   )
+}
+
+func validateProgrammer_expected_expression(props validateProgrammer_createReportCallProps) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(validateProgrammer_factory, props.Emit)
+  if props.Functor == nil || len(props.Expected) < 128 {
+    return f.NewStringLiteral(props.Expected, shimast.TokenFlagsNone)
+  }
+  return props.Functor.EmplaceVariableByKey("_ve", props.Expected, func(string) *shimast.Expression {
+    return f.NewStringLiteral(props.Expected, shimast.TokenFlagsNone)
+  })
 }
 
 func validateProgrammer_reduce(expressions []*shimast.Node, operator shimast.Kind, initial *shimast.Expression, emit *shimprinter.EmitContext) *shimast.Node {

--- a/packages/typia/native/core/programmers/helpers/FunctionProgrammer.go
+++ b/packages/typia/native/core/programmers/helpers/FunctionProgrammer.go
@@ -17,6 +17,8 @@ type FunctionProgrammer struct {
   variables_     map[string]*shimast.Node
   variableKeys_   map[string]string
   variableOrder_ []string
+  nameIndexes_    map[string]int
+  reservedNames_  map[string]bool
   sequence_      int
   disableDeclare bool
   // visited_ turns on per-invocation visit tracking: set after metadata
@@ -47,6 +49,8 @@ func NewFunctionProgrammer(method string, emit ...*shimprinter.EmitContext) *Fun
     variables_:     map[string]*shimast.Node{},
     variableKeys_:   map[string]string{},
     variableOrder_: []string{},
+    nameIndexes_:    map[string]int{},
+    reservedNames_:  map[string]bool{},
   }
   if len(emit) != 0 {
     p.emit_ = emit[0]
@@ -124,8 +128,7 @@ func (p *FunctionProgrammer) EmplaceUnion(prefix string, name string, factory fu
   if oldbie, ok := p.unions_[key]; ok {
     return oldbie.name
   }
-  index := len(p.unions_)
-  accessor := fmt.Sprintf("%sp%d", prefix, index)
+  accessor := p.reserveGeneratedName(prefix + "p")
   tuple := &functionProgrammer_union{name: accessor}
   p.unions_[key] = tuple
   p.unionOrder_ = append(p.unionOrder_, key)
@@ -135,6 +138,11 @@ func (p *FunctionProgrammer) EmplaceUnion(prefix string, name string, factory fu
 
 func (p *FunctionProgrammer) EmplaceVariable(name string, value *shimast.Expression) *shimast.Node {
   if _, ok := p.variables_[name]; !ok {
+    if p.isNameReserved(name) {
+      name = p.reserveGeneratedName(name)
+    } else {
+      p.reserveFixedName(name)
+    }
     p.variableOrder_ = append(p.variableOrder_, name)
   }
   p.variables_[name] = value
@@ -146,7 +154,48 @@ func (p *FunctionProgrammer) EmplaceVariableByKey(prefix string, key string, fac
   if name, ok := p.variableKeys_[compound]; ok {
     return nativecontext.EmitFactoryOf(functionProgrammer_factory, p.emit_).NewIdentifier(name)
   }
-  name := fmt.Sprintf("%s%d", prefix, len(p.variableKeys_))
+  name := p.reserveGeneratedName(prefix)
   p.variableKeys_[compound] = name
-  return p.EmplaceVariable(name, factory(name))
+  if _, ok := p.variables_[name]; !ok {
+    p.variableOrder_ = append(p.variableOrder_, name)
+  }
+  p.variables_[name] = factory(name)
+  return nativecontext.EmitFactoryOf(functionProgrammer_factory, p.emit_).NewIdentifier(name)
+}
+
+func (p *FunctionProgrammer) reserveGeneratedName(prefix string) string {
+  if p.nameIndexes_ == nil {
+    p.nameIndexes_ = map[string]int{}
+  }
+  for {
+    index := p.nameIndexes_[prefix]
+    p.nameIndexes_[prefix] = index + 1
+    name := fmt.Sprintf("%s%d", prefix, index)
+    if p.isNameReserved(name) == false {
+      p.reserveFixedName(name)
+      return name
+    }
+  }
+}
+
+func (p *FunctionProgrammer) reserveFixedName(name string) {
+  if p.reservedNames_ == nil {
+    p.reservedNames_ = map[string]bool{}
+  }
+  p.reservedNames_[name] = true
+}
+
+func (p *FunctionProgrammer) isNameReserved(name string) bool {
+  if p.reservedNames_ != nil && p.reservedNames_[name] {
+    return true
+  }
+  if _, ok := p.variables_[name]; ok {
+    return true
+  }
+  for _, union := range p.unions_ {
+    if union.name == name {
+      return true
+    }
+  }
+  return false
 }

--- a/packages/typia/native/core/programmers/helpers/FunctionProgrammer.go
+++ b/packages/typia/native/core/programmers/helpers/FunctionProgrammer.go
@@ -15,6 +15,7 @@ type FunctionProgrammer struct {
   unions_        map[string]*functionProgrammer_union
   unionOrder_    []string
   variables_     map[string]*shimast.Node
+  variableKeys_   map[string]string
   variableOrder_ []string
   sequence_      int
   disableDeclare bool
@@ -44,6 +45,7 @@ func NewFunctionProgrammer(method string, emit ...*shimprinter.EmitContext) *Fun
     unions_:        map[string]*functionProgrammer_union{},
     unionOrder_:    []string{},
     variables_:     map[string]*shimast.Node{},
+    variableKeys_:   map[string]string{},
     variableOrder_: []string{},
   }
   if len(emit) != 0 {
@@ -137,4 +139,14 @@ func (p *FunctionProgrammer) EmplaceVariable(name string, value *shimast.Express
   }
   p.variables_[name] = value
   return nativecontext.EmitFactoryOf(functionProgrammer_factory, p.emit_).NewIdentifier(name)
+}
+
+func (p *FunctionProgrammer) EmplaceVariableByKey(prefix string, key string, factory func(name string) *shimast.Expression) *shimast.Node {
+  compound := prefix + "::" + key
+  if name, ok := p.variableKeys_[compound]; ok {
+    return nativecontext.EmitFactoryOf(functionProgrammer_factory, p.emit_).NewIdentifier(name)
+  }
+  name := fmt.Sprintf("%s%d", prefix, len(p.variableKeys_))
+  p.variableKeys_[compound] = name
+  return p.EmplaceVariable(name, factory(name))
 }

--- a/packages/typia/native/core/programmers/helpers/UnionPredicator.go
+++ b/packages/typia/native/core/programmers/helpers/UnionPredicator.go
@@ -18,50 +18,47 @@ type unionPredicator_ISpecializedProperty struct {
   Neighbor bool
 }
 
+type unionPredicator_propertyEntry struct {
+  Property *nativemetadata.MetadataProperty
+  Key      string
+}
+
 func (unionPredicatorNamespace) Object(objects []*nativemetadata.MetadataObjectType) []UnionPredicator_ISpecialized {
   matrix := map[string][]*nativemetadata.MetadataProperty{}
-  for _, obj := range objects {
+  entries := make([][]unionPredicator_propertyEntry, len(objects))
+  for i, obj := range objects {
+    entries[i] = make([]unionPredicator_propertyEntry, 0, len(obj.Properties))
     for _, prop := range obj.Properties {
       key := prop.Key.GetSoleLiteral()
       if key == nil {
         continue
       }
-      if _, ok := matrix[*key]; ok == false {
-        matrix[*key] = make([]*nativemetadata.MetadataProperty, len(objects))
+      text := *key
+      if _, ok := matrix[text]; ok == false {
+        matrix[text] = make([]*nativemetadata.MetadataProperty, len(objects))
       }
-    }
-  }
-  for i, obj := range objects {
-    for _, prop := range obj.Properties {
-      key := prop.Key.GetSoleLiteral()
-      if key != nil {
-        matrix[*key][i] = prop
-      }
+      matrix[text][i] = prop
+      entries[i] = append(entries[i], unionPredicator_propertyEntry{
+        Property: prop,
+        Key:      text,
+      })
     }
   }
 
   output := []UnionPredicator_ISpecialized{}
-  for i, obj := range objects {
+  for i, entry := range entries {
     children := []unionPredicator_ISpecializedProperty{}
-    for _, prop := range obj.Properties {
+    for _, item := range entry {
+      prop := item.Property
       if prop.Value.IsRequired() == false {
         continue
       }
-      key := prop.Key.GetSoleLiteral()
-      if key == nil {
-        continue
-      }
-      neighbors := []*nativemetadata.MetadataProperty{}
-      for k, oppo := range matrix[*key] {
+      neighbor := false
+      unique := true
+      for k, oppo := range matrix[item.Key] {
         if i != k && oppo != nil {
-          neighbors = append(neighbors, oppo)
-        }
-      }
-      unique := len(neighbors) == 0
-      if unique == false {
-        unique = true
-        for _, neighbor := range neighbors {
-          if nativemetadata.MetadataSchema_intersects(prop.Value, neighbor.Value) {
+          neighbor = true
+          if nativemetadata.MetadataSchema_intersects(prop.Value, oppo.Value) {
             unique = false
             break
           }
@@ -70,7 +67,7 @@ func (unionPredicatorNamespace) Object(objects []*nativemetadata.MetadataObjectT
       if unique {
         children = append(children, unionPredicator_ISpecializedProperty{
           Property: prop,
-          Neighbor: len(neighbors) != 0,
+          Neighbor: neighbor,
         })
       }
     }
@@ -86,7 +83,7 @@ func (unionPredicatorNamespace) Object(objects []*nativemetadata.MetadataObjectT
     }
     output = append(output, UnionPredicator_ISpecialized{
       Index:    i,
-      Object:   obj,
+      Object:   objects[i],
       Property: top.Property,
       Neighbor: top.Neighbor,
     })

--- a/packages/typia/native/core/programmers/helpers/function_programmer_unique_names_test.go
+++ b/packages/typia/native/core/programmers/helpers/function_programmer_unique_names_test.go
@@ -1,0 +1,54 @@
+package helpers
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestFunctionProgrammerKeepsHelperDeclarationNamesUnique verifies helper
+// declarations share one name space.
+//
+// Object-property helpers and array-like union helpers can use related prefixes
+// inside the same generated validator. They must never reserve the same `const`
+// name, even when their deduplication keys are different.
+func TestFunctionProgrammerKeepsHelperDeclarationNamesUnique(t *testing.T) {
+  factory := shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+  functor := NewFunctionProgrammer("typia.createIs")
+
+  functor.EmplaceVariableByKey("_ip", "property:x", func(string) *shimast.Expression {
+    return factory.NewIdentifier("input => true")
+  })
+  union := functor.EmplaceUnion("_i", "[string, string] | number[]", func() *shimast.Node {
+    return factory.NewIdentifier("input => true")
+  })
+  functor.EmplaceVariable(union, factory.NewIdentifier("input => false"))
+  functor.EmplaceVariableByKey("_ip", "property:y", func(string) *shimast.Expression {
+    return factory.NewIdentifier("input => true")
+  })
+
+  names := map[string]string{}
+  for _, name := range functor.variableOrder_ {
+    if previous, ok := names[name]; ok {
+      t.Fatalf("variable helper %q duplicates %s", name, previous)
+    }
+    names[name] = "variable"
+  }
+  for _, key := range functor.unionOrder_ {
+    name := functor.unions_[key].name
+    if previous, ok := names[name]; ok {
+      t.Fatalf("union helper %q duplicates %s", name, previous)
+    }
+    names[name] = "union"
+  }
+  if union == "_ip0" {
+    t.Fatal("union helper reused the first object-property helper name")
+  }
+
+  again := functor.EmplaceUnion("_i", "[string, string] | number[]", func() *shimast.Node {
+    return factory.NewIdentifier("input => false")
+  })
+  if again != union {
+    t.Fatalf("same union key was not deduplicated: got %q want %q", again, union)
+  }
+}

--- a/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
@@ -19,17 +19,18 @@ type checkerProgrammerNamespace struct{}
 var CheckerProgrammer = checkerProgrammerNamespace{}
 
 type CheckerProgrammer_IConfig struct {
-  Prefix   string
-  Path     bool
-  Trace    bool
-  Equals   bool
-  Numeric  bool
-  Addition func() []*shimast.Node
-  Decoder  func(props CheckerProgrammer_DecoderProps) *shimast.Node
-  Combiner CheckerProgrammer_IConfig_Combiner
-  Atomist  func(props CheckerProgrammer_AtomistProps) *shimast.Node
-  Joiner   CheckerProgrammer_IConfig_IJoiner
-  Success  *shimast.Expression
+  Prefix        string
+  Path          bool
+  Trace         bool
+  Equals        bool
+  Numeric       bool
+  ObjectParents bool
+  Addition      func() []*shimast.Node
+  Decoder       func(props CheckerProgrammer_DecoderProps) *shimast.Node
+  Combiner      CheckerProgrammer_IConfig_Combiner
+  Atomist       func(props CheckerProgrammer_AtomistProps) *shimast.Node
+  Joiner        CheckerProgrammer_IConfig_IJoiner
+  Success       *shimast.Expression
 }
 
 type CheckerProgrammer_IConfig_Combiner func(props CheckerProgrammer_CombinerProps) *shimast.Node
@@ -159,6 +160,7 @@ func (checkerProgrammerNamespace) Write_object_functions(props CheckerProgrammer
   return FeatureProgrammer.Write_object_functions(FeatureProgrammer_WriteObjectFunctionsProps{
     Config:     checkerProgrammer_configure(props.Context, props.Config, props.Functor),
     Context:    props.Context,
+    Functor:    props.Functor,
     Collection: props.Collection,
   })
 }
@@ -290,6 +292,7 @@ func checkerProgrammer_configure(context nativecontext.ITypiaContext, config Che
     Trace:   config.Trace,
     Path:    config.Path,
     Prefix:  config.Prefix,
+    ObjectParents: config.ObjectParents,
     Visited: functor.Visited,
     VisitGuard: func(next FeatureProgrammer_VisitGuardProps) *shimast.Node {
       return checkerProgrammer_visit_guard(next.Key, next.Body, context.Emit)
@@ -614,15 +617,18 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
         }
       }
     }
-    setName := props.Functor.EmplaceVariable(
-      fmt.Sprintf("%sv%d", props.Config.Prefix, props.Functor.Increment()),
-      f.NewNewExpression(
-        f.NewIdentifier("Set"),
-        nil,
-        f.NewNodeList([]*shimast.Node{
-          f.NewArrayLiteralExpression(f.NewNodeList(values), false),
-        }),
-      ),
+    setName := props.Functor.EmplaceVariableByKey(
+      props.Config.Prefix+"v",
+      checkerProgrammer_constant_set_key(constants),
+      func(string) *shimast.Expression {
+        return f.NewNewExpression(
+          f.NewIdentifier("Set"),
+          nil,
+          f.NewNodeList([]*shimast.Node{
+            f.NewArrayLiteralExpression(f.NewNodeList(values), false),
+          }),
+        )
+      },
     )
     add(struct {
       Exact bool
@@ -845,14 +851,7 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
   if len(props.Metadata.Objects) > 0 {
     checkArray := false
     for _, obj := range props.Metadata.Objects {
-      all := true
-      for _, prop := range obj.Type.Properties {
-        if prop.Key.IsSoleLiteral() && prop.Value.IsRequired() {
-          all = false
-          break
-        }
-      }
-      if all {
+      if obj.Type.HasRequiredLiteralProperty() == false {
         checkArray = true
         break
       }
@@ -957,6 +956,20 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
     return props.Config.Combiner(CheckerProgrammer_CombinerProps{Explore: props.Explore, Logic: "or", Input: props.Input, Binaries: binaries, Expected: props.Metadata.GetDisplayName()})
   }
   return props.Config.Success
+}
+
+func checkerProgrammer_constant_set_key(constants []*nativemetadata.MetadataConstant) string {
+  builder := strings.Builder{}
+  for _, constant := range constants {
+    builder.WriteString(constant.Type)
+    builder.WriteByte(':')
+    for _, value := range constant.Values {
+      text := fmt.Sprintf("%T:%v", value.Value, value.Value)
+      fmt.Fprintf(&builder, "%d:%s;", len(text), text)
+    }
+    builder.WriteByte('|')
+  }
+  return builder.String()
 }
 
 func (checkerProgrammerNamespace) Decode_object(props CheckerProgrammer_DecodeObjectProps) *shimast.Node {

--- a/packages/typia/native/core/programmers/internal/FeatureProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/FeatureProgrammer.go
@@ -20,15 +20,16 @@ type featureProgrammerNamespace struct{}
 var FeatureProgrammer = featureProgrammerNamespace{}
 
 type FeatureProgrammer_IConfig struct {
-  Types       FeatureProgrammer_IConfig_ITypes
-  Prefix      string
-  Path        bool
-  Trace       bool
-  Addition    func(collection *nativemetadata.MetadataCollection) []*shimast.Node
-  Initializer func(props FeatureProgrammer_InitializerProps) FeatureProgrammer_InitializerOutput
-  Decoder     func(props FeatureProgrammer_DecoderProps) *shimast.Node
-  Objector    FeatureProgrammer_IConfig_IObjector
-  Generator   FeatureProgrammer_IConfig_IGenerator
+  Types         FeatureProgrammer_IConfig_ITypes
+  Prefix        string
+  Path          bool
+  Trace         bool
+  Addition      func(collection *nativemetadata.MetadataCollection) []*shimast.Node
+  Initializer   func(props FeatureProgrammer_InitializerProps) FeatureProgrammer_InitializerOutput
+  Decoder       func(props FeatureProgrammer_DecoderProps) *shimast.Node
+  Objector      FeatureProgrammer_IConfig_IObjector
+  Generator     FeatureProgrammer_IConfig_IGenerator
+  ObjectParents bool
   // Visited reports whether the analyzed type graph carries a recursive
   // component (issue #1820). It is a closure (usually the functor's Visited
   // method) because the answer is unknown until metadata analysis runs,
@@ -177,6 +178,7 @@ type FeatureProgrammer_WriteProps struct {
 type FeatureProgrammer_WriteObjectFunctionsProps struct {
   Config     FeatureProgrammer_IConfig
   Context    nativecontext.ITypiaContext
+  Functor    *nativehelpers.FunctionProgrammer
   Collection *nativemetadata.MetadataCollection
 }
 
@@ -444,6 +446,7 @@ func (featureProgrammerNamespace) Compose(props FeatureProgrammer_ComposeProps) 
     Functor: props.Functor,
     Type:    props.Type,
   })
+  featureProgrammer_compact_object_parents(props.Config, initialized.Collection)
   featureProgrammer_register_schema_unions(initialized.Collection, initialized.Metadata, map[*nativemetadata.MetadataSchema]bool{})
   body := props.Config.Decoder(FeatureProgrammer_DecoderProps{
     Input:    nativefactories.ValueFactory.INPUT(props.Context.Emit),
@@ -528,6 +531,7 @@ func (featureProgrammerNamespace) Write(props FeatureProgrammer_WriteProps) *shi
     Functor: props.Functor,
     Type:    props.Type,
   })
+  featureProgrammer_compact_object_parents(props.Config, initialized.Collection)
   featureProgrammer_register_schema_unions(initialized.Collection, initialized.Metadata, map[*nativemetadata.MetadataSchema]bool{})
   output := props.Config.Decoder(FeatureProgrammer_DecoderProps{
     Metadata: initialized.Metadata,
@@ -557,6 +561,7 @@ func (featureProgrammerNamespace) Write(props FeatureProgrammer_WriteProps) *shi
   }
 
   statements := append([]*shimast.Node{}, added...)
+  statements = append(statements, props.Functor.Declare()...)
   for _, v := range objects {
     statements = append(statements, v)
   }
@@ -592,7 +597,8 @@ func (featureProgrammerNamespace) Write(props FeatureProgrammer_WriteProps) *shi
 }
 
 func (featureProgrammerNamespace) Write_object_functions(props FeatureProgrammer_WriteObjectFunctionsProps) []*shimast.Node {
-  return featureProgrammer_write_object_functions(props.Config, props.Context, props.Collection)
+  featureProgrammer_compact_object_parents(props.Config, props.Collection)
+  return featureProgrammer_write_object_functions(props.Config, props.Context, props.Functor, props.Collection)
 }
 
 func (featureProgrammerNamespace) Write_union_functions(props FeatureProgrammer_WriteUnionFunctionsProps) []*shimast.Node {
@@ -740,7 +746,7 @@ func featureProgrammer_object_functions(props FeatureProgrammer_ComposeProps, co
   if props.Config.Generator.Objects != nil {
     return props.Config.Generator.Objects(collection)
   }
-  return featureProgrammer_write_object_functions(props.Config, props.Context, collection)
+  return featureProgrammer_write_object_functions(props.Config, props.Context, props.Functor, collection)
 }
 
 func featureProgrammer_union_functions(config FeatureProgrammer_IConfig, collection *nativemetadata.MetadataCollection, emit *shimprinter.EmitContext) []*shimast.Node {
@@ -752,58 +758,229 @@ func featureProgrammer_union_functions(config FeatureProgrammer_IConfig, collect
   return featureProgrammer_write_union_functions(config, collection, emit)
 }
 
-func featureProgrammer_register_schema_unions(collection *nativemetadata.MetadataCollection, metadata *nativemetadata.MetadataSchema, visited map[*nativemetadata.MetadataSchema]bool) {
-  if collection == nil || metadata == nil || visited[metadata] {
+type featureProgrammer_schemaUnionVisit struct {
+  Schemas map[*nativemetadata.MetadataSchema]bool
+  Objects map[*nativemetadata.MetadataObjectType]bool
+}
+
+const featureProgrammer_objectParentMinProperties = 8
+
+type featureProgrammer_objectPropertySet struct {
+  Properties map[string]*nativemetadata.MetadataProperty
+  Order      []string
+  Anchor     string
+}
+
+func featureProgrammer_compact_object_parents(config FeatureProgrammer_IConfig, collection *nativemetadata.MetadataCollection) {
+  if config.ObjectParents == false || collection == nil {
     return
   }
-  visited[metadata] = true
+  objects := collection.Objects()
+  signatures := make([]featureProgrammer_objectPropertySet, len(objects))
+  frequencies := map[string]int{}
+  for i, object := range objects {
+    signatures[i] = featureProgrammer_object_property_set(object)
+    for _, key := range signatures[i].Order {
+      frequencies[key]++
+    }
+  }
+  buckets := map[string][]int{}
+  for i := range objects {
+    if len(signatures[i].Order) < featureProgrammer_objectParentMinProperties {
+      continue
+    }
+    anchor := featureProgrammer_object_parent_anchor(signatures[i], frequencies)
+    if anchor == "" {
+      continue
+    }
+    signatures[i].Anchor = anchor
+    buckets[anchor] = append(buckets[anchor], i)
+  }
+  for i, object := range objects {
+    if object.Check_properties_ != nil || len(object.Properties) <= featureProgrammer_objectParentMinProperties {
+      continue
+    }
+    current := signatures[i]
+    if len(current.Order) <= featureProgrammer_objectParentMinProperties {
+      continue
+    }
+    best := -1
+    bestSize := 0
+    visited := map[int]bool{}
+    for _, key := range current.Order {
+      for _, candidate := range buckets[key] {
+        if visited[candidate] || candidate == i {
+          continue
+        }
+        visited[candidate] = true
+        candidateSize := len(signatures[candidate].Order)
+        if candidateSize <= bestSize || candidateSize >= len(current.Order) {
+          continue
+        }
+        if featureProgrammer_object_parent_covers(current, signatures[candidate]) {
+          best = candidate
+          bestSize = candidateSize
+        }
+      }
+    }
+    if best == -1 {
+      continue
+    }
+    parent := objects[best]
+    object.Parent_objects_ = append(object.Parent_objects_, nativemetadata.MetadataObject_create(nativemetadata.MetadataObject{
+      Type: parent,
+      Tags: [][]nativemetadata.IMetadataTypeTag{},
+    }))
+    object.Check_properties_ = featureProgrammer_object_remaining_properties(object.Properties, signatures[best])
+  }
+}
+
+func featureProgrammer_object_property_set(object *nativemetadata.MetadataObjectType) featureProgrammer_objectPropertySet {
+  if object == nil {
+    return featureProgrammer_objectPropertySet{}
+  }
+  output := featureProgrammer_objectPropertySet{
+    Properties: map[string]*nativemetadata.MetadataProperty{},
+    Order:      []string{},
+  }
+  for _, property := range object.Properties {
+    if property == nil || property.Key == nil {
+      return featureProgrammer_objectPropertySet{}
+    }
+    key := property.Key.GetSoleLiteral()
+    if key == nil {
+      return featureProgrammer_objectPropertySet{}
+    }
+    signature := featureProgrammer_object_property_signature(property)
+    if signature == "" {
+      return featureProgrammer_objectPropertySet{}
+    }
+    output.Properties[signature] = property
+    output.Order = append(output.Order, signature)
+  }
+  return output
+}
+
+func featureProgrammer_object_property_signature(property *nativemetadata.MetadataProperty) string {
+  if property == nil || property.Key == nil || property.Value == nil {
+    return ""
+  }
+  key := property.Key.GetSoleLiteral()
+  if key == nil {
+    return ""
+  }
+  return *key + "\x00" +
+    property.Key.GetName() + "\x00" +
+    property.Value.GetName() + "\x00" +
+    fmt.Sprintf("%t\x00%t", property.Value.Optional, property.Value.Nullable)
+}
+
+func featureProgrammer_object_parent_anchor(set featureProgrammer_objectPropertySet, frequencies map[string]int) string {
+  anchor := ""
+  score := 0
+  for _, key := range set.Order {
+    next := frequencies[key]
+    if anchor == "" || next < score {
+      anchor = key
+      score = next
+    }
+  }
+  return anchor
+}
+
+func featureProgrammer_object_parent_covers(
+  current featureProgrammer_objectPropertySet,
+  candidate featureProgrammer_objectPropertySet,
+) bool {
+  if len(candidate.Order) == 0 || len(candidate.Order) >= len(current.Order) {
+    return false
+  }
+  for _, key := range candidate.Order {
+    if current.Properties[key] == nil {
+      return false
+    }
+  }
+  return true
+}
+
+func featureProgrammer_object_remaining_properties(
+  properties []*nativemetadata.MetadataProperty,
+  parent featureProgrammer_objectPropertySet,
+) []*nativemetadata.MetadataProperty {
+  output := make([]*nativemetadata.MetadataProperty, 0, len(properties)-len(parent.Order))
+  for _, property := range properties {
+    if parent.Properties[featureProgrammer_object_property_signature(property)] != nil {
+      continue
+    }
+    output = append(output, property)
+  }
+  return output
+}
+
+func featureProgrammer_register_schema_unions(collection *nativemetadata.MetadataCollection, metadata *nativemetadata.MetadataSchema, visited map[*nativemetadata.MetadataSchema]bool) {
+  if visited == nil {
+    visited = map[*nativemetadata.MetadataSchema]bool{}
+  }
+  featureProgrammer_register_schema_unions_iterate(collection, metadata, &featureProgrammer_schemaUnionVisit{
+    Schemas: visited,
+    Objects: map[*nativemetadata.MetadataObjectType]bool{},
+  })
+}
+
+func featureProgrammer_register_schema_unions_iterate(collection *nativemetadata.MetadataCollection, metadata *nativemetadata.MetadataSchema, visited *featureProgrammer_schemaUnionVisit) {
+  if collection == nil || metadata == nil || visited.Schemas[metadata] {
+    return
+  }
+  visited.Schemas[metadata] = true
 
   if len(metadata.Objects) > 1 {
     index := collection.GetUnionIndex(metadata)
     metadata.Union_index = &index
   }
   if metadata.Escaped != nil {
-    featureProgrammer_register_schema_unions(collection, metadata.Escaped.Returns, visited)
+    featureProgrammer_register_schema_unions_iterate(collection, metadata.Escaped.Returns, visited)
   }
   if metadata.Rest != nil {
-    featureProgrammer_register_schema_unions(collection, metadata.Rest, visited)
+    featureProgrammer_register_schema_unions_iterate(collection, metadata.Rest, visited)
   }
   for _, alias := range metadata.Aliases {
     if alias.Type != nil {
-      featureProgrammer_register_schema_unions(collection, alias.Type.Value, visited)
+      featureProgrammer_register_schema_unions_iterate(collection, alias.Type.Value, visited)
     }
   }
   for _, array := range metadata.Arrays {
     if array.Type != nil {
-      featureProgrammer_register_schema_unions(collection, array.Type.Value, visited)
+      featureProgrammer_register_schema_unions_iterate(collection, array.Type.Value, visited)
     }
   }
   for _, tuple := range metadata.Tuples {
     if tuple.Type != nil {
       for _, element := range tuple.Type.Elements {
-        featureProgrammer_register_schema_unions(collection, element, visited)
+        featureProgrammer_register_schema_unions_iterate(collection, element, visited)
       }
     }
   }
   for _, object := range metadata.Objects {
-    if object.Type != nil {
+    if object.Type != nil && visited.Objects[object.Type] == false {
+      visited.Objects[object.Type] = true
       for _, property := range object.Type.Properties {
-        featureProgrammer_register_schema_unions(collection, property.Value, visited)
+        featureProgrammer_register_schema_unions_iterate(collection, property.Value, visited)
       }
     }
   }
   for _, set := range metadata.Sets {
-    featureProgrammer_register_schema_unions(collection, set.Value, visited)
+    featureProgrammer_register_schema_unions_iterate(collection, set.Value, visited)
   }
   for _, item := range metadata.Maps {
-    featureProgrammer_register_schema_unions(collection, item.Key, visited)
-    featureProgrammer_register_schema_unions(collection, item.Value, visited)
+    featureProgrammer_register_schema_unions_iterate(collection, item.Key, visited)
+    featureProgrammer_register_schema_unions_iterate(collection, item.Value, visited)
   }
 }
 
-func featureProgrammer_write_object_functions(config FeatureProgrammer_IConfig, context nativecontext.ITypiaContext, collection *nativemetadata.MetadataCollection) []*shimast.Node {
+func featureProgrammer_write_object_functions(config FeatureProgrammer_IConfig, context nativecontext.ITypiaContext, functor *nativehelpers.FunctionProgrammer, collection *nativemetadata.MetadataCollection) []*shimast.Node {
   f := nativecontext.EmitFactoryOf(featureProgrammer_factory, context.Emit)
   objects := collection.Objects()
+  propertyFrequencies := featureProgrammer_object_property_frequencies(config, context, functor, objects)
   output := make([]*shimast.Node, 0, len(objects))
   for _, object := range objects {
     input := f.NewIdentifier("input")
@@ -811,6 +988,21 @@ func featureProgrammer_write_object_functions(config FeatureProgrammer_IConfig, 
     if objectType == nil {
       objectType = nativefactories.TypeFactory.Keyword("any", context.Emit)
     }
+    entriesObject := object
+    if config.ObjectParents && len(object.Parent_objects_) != 0 {
+      entriesObject = &nativemetadata.MetadataObjectType{
+        Name:        object.Name,
+        DisplayName: object.DisplayName,
+        Properties:  object.CheckProperties(),
+        Description: object.Description,
+        JsDocTags:   object.JsDocTags,
+        Index:       object.Index,
+        Validated:   object.Validated,
+        Recursive:   object.Recursive,
+        Nullables:   object.Nullables,
+      }
+    }
+    helperAllProperties := config.ObjectParents && functor != nil && len(entriesObject.Properties) >= 16
     body := config.Objector.Joiner(FeatureProgrammer_ObjectorJoinerProps{
       Input: input,
       Entries: nativeiterate.Feature_object_entries(nativeiterate.Feature_object_entriesProps{
@@ -818,6 +1010,17 @@ func featureProgrammer_write_object_functions(config FeatureProgrammer_IConfig, 
           Path:  config.Path,
           Trace: config.Trace,
           Decoder: func(next nativeiterate.Feature_object_entriesDecoderProps) *shimast.Node {
+            if key := featureProgrammer_object_property_helper_key(context, next.Property, next.Metadata); key != "" && (propertyFrequencies[key] > 1 || helperAllProperties) {
+              return featureProgrammer_object_property_helper_call(featureProgrammer_objectPropertyHelperProps{
+                Config:     config,
+                Context:    context,
+                Functor:    functor,
+                Input:      input,
+                ReturnType: objectType,
+                Next:       next,
+                Key:        key,
+              })
+            }
             return config.Decoder(FeatureProgrammer_DecoderProps{
               Input:    next.Input,
               Metadata: next.Metadata,
@@ -827,10 +1030,28 @@ func featureProgrammer_write_object_functions(config FeatureProgrammer_IConfig, 
         },
         Context: context,
         Input:   input,
-        Object:  object,
+        Object:  entriesObject,
       }),
       Object: object,
     })
+    if config.ObjectParents && len(object.Parent_objects_) != 0 {
+      expressions := make([]*shimast.Node, 0, len(object.Parent_objects_)+1)
+      explore := FeatureProgrammer_IExplore{
+        Tracable: config.Path || config.Trace,
+        Source:   "function",
+        From:     "object",
+        Postfix:  "",
+      }
+      for _, parent := range object.Parent_objects_ {
+        expressions = append(expressions, config.Objector.Decoder(FeatureProgrammer_ObjectorDecoderProps{
+          Input:   input,
+          Object:  parent.Type,
+          Explore: explore,
+        }))
+      }
+      expressions = append(expressions, body)
+      body = checkerProgrammer_reduce(expressions, shimast.KindAmpersandAmpersandToken, f.NewKeywordExpression(shimast.KindTrueKeyword), context.Emit)
+    }
     if object.Recursive && config.VisitGuard != nil && featureProgrammer_visited(config) {
       body = config.VisitGuard(FeatureProgrammer_VisitGuardProps{
         Key:   FeatureProgrammer.VisitKey(config.Prefix, "o", object.Index),
@@ -857,6 +1078,120 @@ func featureProgrammer_write_object_functions(config FeatureProgrammer_IConfig, 
     }, context.Emit))
   }
   return output
+}
+
+type featureProgrammer_objectPropertyHelperProps struct {
+  Config     FeatureProgrammer_IConfig
+  Context    nativecontext.ITypiaContext
+  Functor    *nativehelpers.FunctionProgrammer
+  Input      *shimast.Expression
+  ReturnType *shimast.TypeNode
+  Next       nativeiterate.Feature_object_entriesDecoderProps
+  Key        string
+}
+
+func featureProgrammer_object_property_frequencies(
+  config FeatureProgrammer_IConfig,
+  context nativecontext.ITypiaContext,
+  functor *nativehelpers.FunctionProgrammer,
+  objects []*nativemetadata.MetadataObjectType,
+) map[string]int {
+  output := map[string]int{}
+  if config.ObjectParents == false || functor == nil {
+    return output
+  }
+  for _, object := range objects {
+    for _, property := range object.CheckProperties() {
+      if property == nil || property.Key == nil || property.Value == nil {
+        continue
+      }
+      metadata := property.Value
+      if property.Key.GetSoleLiteral() != nil && nativehelpers.OptionPredicator.StrictOptionalUndefined(context, property.Value) {
+        metadata = property.Value.ShallowClone()
+        metadata.Optional = false
+      }
+      key := featureProgrammer_object_property_helper_key(context, property, metadata)
+      if key != "" {
+        output[key]++
+      }
+    }
+  }
+  return output
+}
+
+func featureProgrammer_object_property_helper_key(
+  context nativecontext.ITypiaContext,
+  property *nativemetadata.MetadataProperty,
+  metadata *nativemetadata.MetadataSchema,
+) string {
+  if property == nil || property.Key == nil || metadata == nil {
+    return ""
+  }
+  key := property.Key.GetSoleLiteral()
+  if key == nil {
+    return ""
+  }
+  return *key + "\x00" +
+    property.Key.GetName() + "\x00" +
+    metadata.GetName() + "\x00" +
+    fmt.Sprintf("%t\x00%t\x00%t", metadata.Optional, metadata.Nullable, nativehelpers.OptionPredicator.Numeric(context.Options))
+}
+
+func featureProgrammer_object_property_helper_call(props featureProgrammer_objectPropertyHelperProps) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(featureProgrammer_factory, props.Context.Emit)
+  helper := props.Functor.EmplaceVariableByKey(props.Config.Prefix+"p", props.Key, func(string) *shimast.Expression {
+    input := nativefactories.ValueFactory.INPUT(props.Context.Emit)
+    propertyInput := featureProgrammer_object_property_input(input, props.Next.Key, props.Context.Emit)
+    body := props.Config.Decoder(FeatureProgrammer_DecoderProps{
+      Input:    propertyInput,
+      Metadata: props.Next.Metadata,
+      Explore:  featureProgrammer_from_iterate_explore(props.Next.Explore),
+    })
+    return f.NewArrowFunction(
+      nil,
+      nil,
+      f.NewNodeList(FeatureProgrammer.ParameterDeclarations(FeatureProgrammer_ParameterDeclarationsProps{
+        Config: FeatureProgrammer_ParameterConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: featureProgrammer_visited(props.Config)},
+        Type:   nativefactories.TypeFactory.Keyword("any"),
+        Input:  input,
+        Emit:   props.Context.Emit,
+      })),
+      props.ReturnType,
+      nil,
+      f.NewToken(shimast.KindEqualsGreaterThanToken),
+      body,
+    )
+  })
+  return f.NewCallExpression(
+    helper,
+    nil,
+    nil,
+    f.NewNodeList(FeatureProgrammer.ArgumentsArray(FeatureProgrammer_ArgumentsArrayProps{
+      Config: FeatureProgrammer_ArgumentsArrayConfig{Path: props.Config.Path, Trace: props.Config.Trace, Visited: featureProgrammer_visited(props.Config)},
+      Input:  props.Input,
+      Explore: FeatureProgrammer_IExplore{
+        Tracable: props.Config.Path || props.Config.Trace,
+        Source:   "function",
+        From:     "object",
+        Postfix:  "",
+      },
+      Emit: props.Context.Emit,
+    })),
+    shimast.NodeFlagsNone,
+  )
+}
+
+func featureProgrammer_object_property_input(input *shimast.Expression, key *string, emit ...*shimprinter.EmitContext) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(featureProgrammer_factory, emit...)
+  if key == nil {
+    return f.NewIdentifier("value")
+  }
+  return f.NewElementAccessExpression(
+    input,
+    nil,
+    f.NewStringLiteral(*key, shimast.TokenFlagsNone),
+    shimast.NodeFlagsNone,
+  )
 }
 
 func featureProgrammer_write_union_functions(config FeatureProgrammer_IConfig, collection *nativemetadata.MetadataCollection, emit *shimprinter.EmitContext) []*shimast.Node {

--- a/packages/typia/native/core/programmers/iterate/feature_object_entries.go
+++ b/packages/typia/native/core/programmers/iterate/feature_object_entries.go
@@ -25,6 +25,8 @@ type Feature_object_entriesConfig struct {
 
 type Feature_object_entriesDecoderProps struct {
   Metadata *nativemetadata.MetadataSchema
+  Property *nativemetadata.MetadataProperty
+  Key      *string
   Input    *shimast.Expression
   Explore  Feature_object_entriesExplore
 }
@@ -70,6 +72,8 @@ func Feature_object_entries(props Feature_object_entriesProps) []nativehelpers.I
       Expression: props.Config.Decoder(Feature_object_entriesDecoderProps{
         Input:    propInput,
         Metadata: metadata,
+        Property: next,
+        Key:      sole,
         Explore: Feature_object_entriesExplore{
           Tracable: props.Config.Path || props.Config.Trace,
           Source:   "function",

--- a/packages/typia/native/core/schemas/metadata/MetadataCollection.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataCollection.go
@@ -32,9 +32,26 @@ type MetadataCollection struct {
   type_full_names_       map[*nativechecker.Type]string
   full_names_            map[*nativechecker.Type]string
   display_names_         map[*nativechecker.Type]string
+  apparent_properties_   map[*nativechecker.Type][]*nativeast.Symbol
+  index_infos_           map[*nativechecker.Type][]*nativechecker.IndexInfo
+  plain_objects_         map[*nativechecker.Type]bool
+  literal_conflicts_     map[*nativechecker.Type]bool
   object_index_          int
   recursive_array_index_ int
   recursive_tuple_index_ int
+  explore_cache_         map[MetadataCollection_ExploreCacheKey]*MetadataSchema
+}
+
+type MetadataCollection_ExploreCacheKey struct {
+  Type       *nativechecker.Type
+  Escape     bool
+  Absorb     bool
+  Constant   bool
+  Functional bool
+  Top        bool
+  Aliased    bool
+  Escaped    bool
+  Output     bool
 }
 
 // LookupTypeFullName / StoreTypeFullName memoize the pure type -> full-name
@@ -83,14 +100,17 @@ func NewMetadataCollection(options ...*MetadataCollection_IOptions) *MetadataCol
     object_index_:          0,
     recursive_array_index_: 0,
     recursive_tuple_index_: 0,
+    explore_cache_:         map[MetadataCollection_ExploreCacheKey]*MetadataSchema{},
+    apparent_properties_:   map[*nativechecker.Type][]*nativeast.Symbol{},
+    index_infos_:           map[*nativechecker.Type][]*nativechecker.IndexInfo{},
+    plain_objects_:         map[*nativechecker.Type]bool{},
+    literal_conflicts_:     map[*nativechecker.Type]bool{},
   }
 }
 
 func (collection *MetadataCollection) Clone() *MetadataCollection {
-  // Clone is the snapshot taken before every intersection exploration, so it is
-  // one of the hottest allocation sites. Pre-size each destination map (maps.Clone)
-  // instead of copying into the empty maps NewMetadataCollection allocates, which
-  // forced repeated rehashing as entries were re-inserted.
+  // Clone snapshots the collection before intersection exploration and keeps
+  // every lookup cache aligned with that snapshot.
   output := &MetadataCollection{
     Options: collection.Options,
 
@@ -107,9 +127,17 @@ func (collection *MetadataCollection) Clone() *MetadataCollection {
     tuples_order_:        slices.Clone(collection.tuples_order_),
 
     names_:                 make(map[string]map[*nativechecker.Type]string, len(collection.names_)),
+    type_full_names_:       maps.Clone(collection.type_full_names_),
+    full_names_:            maps.Clone(collection.full_names_),
+    display_names_:         maps.Clone(collection.display_names_),
+    apparent_properties_:   maps.Clone(collection.apparent_properties_),
+    index_infos_:           maps.Clone(collection.index_infos_),
+    plain_objects_:         maps.Clone(collection.plain_objects_),
+    literal_conflicts_:     maps.Clone(collection.literal_conflicts_),
     object_index_:          collection.object_index_,
     recursive_array_index_: collection.recursive_array_index_,
     recursive_tuple_index_: collection.recursive_tuple_index_,
+    explore_cache_:         maps.Clone(collection.explore_cache_),
   }
   for k, v := range collection.object_unions_ {
     output.object_unions_[k] = slices.Clone(v)
@@ -118,6 +146,93 @@ func (collection *MetadataCollection) Clone() *MetadataCollection {
     output.names_[k] = maps.Clone(v)
   }
   return output
+}
+
+func (collection *MetadataCollection) LookupExploreCache(key MetadataCollection_ExploreCacheKey) (*MetadataSchema, bool) {
+  if collection == nil || collection.explore_cache_ == nil {
+    return nil, false
+  }
+  value, ok := collection.explore_cache_[key]
+  if ok == false || value == nil {
+    return nil, false
+  }
+  return value.Clone(), true
+}
+
+func (collection *MetadataCollection) StoreExploreCache(key MetadataCollection_ExploreCacheKey, value *MetadataSchema) {
+  if collection == nil || key.Type == nil || value == nil {
+    return
+  }
+  if collection.explore_cache_ == nil {
+    collection.explore_cache_ = map[MetadataCollection_ExploreCacheKey]*MetadataSchema{}
+  }
+  collection.explore_cache_[key] = value.Clone()
+}
+
+func (collection *MetadataCollection) ApparentProperties(checker *nativechecker.Checker, typ *nativechecker.Type) []*nativeast.Symbol {
+  if collection == nil {
+    return nativechecker.Checker_getApparentProperties(checker, typ)
+  }
+  if collection.apparent_properties_ == nil {
+    collection.apparent_properties_ = map[*nativechecker.Type][]*nativeast.Symbol{}
+  }
+  if value, ok := collection.apparent_properties_[typ]; ok {
+    return value
+  }
+  value := nativechecker.Checker_getApparentProperties(checker, typ)
+  collection.apparent_properties_[typ] = value
+  return value
+}
+
+func (collection *MetadataCollection) IndexInfos(checker *nativechecker.Checker, typ *nativechecker.Type) []*nativechecker.IndexInfo {
+  if collection == nil {
+    return nativechecker.Checker_getIndexInfosOfType(checker, typ)
+  }
+  if collection.index_infos_ == nil {
+    collection.index_infos_ = map[*nativechecker.Type][]*nativechecker.IndexInfo{}
+  }
+  if value, ok := collection.index_infos_[typ]; ok {
+    return value
+  }
+  value := nativechecker.Checker_getIndexInfosOfType(checker, typ)
+  collection.index_infos_[typ] = value
+  return value
+}
+
+func (collection *MetadataCollection) LookupPlainObjectIntersection(typ *nativechecker.Type) (bool, bool) {
+  if collection == nil || collection.plain_objects_ == nil {
+    return false, false
+  }
+  value, ok := collection.plain_objects_[typ]
+  return value, ok
+}
+
+func (collection *MetadataCollection) StorePlainObjectIntersection(typ *nativechecker.Type, value bool) {
+  if collection == nil || typ == nil {
+    return
+  }
+  if collection.plain_objects_ == nil {
+    collection.plain_objects_ = map[*nativechecker.Type]bool{}
+  }
+  collection.plain_objects_[typ] = value
+}
+
+func (collection *MetadataCollection) LookupLiteralConflict(typ *nativechecker.Type) (bool, bool) {
+  if collection == nil || collection.literal_conflicts_ == nil {
+    return false, false
+  }
+  value, ok := collection.literal_conflicts_[typ]
+  return value, ok
+}
+
+func (collection *MetadataCollection) StoreLiteralConflict(typ *nativechecker.Type, value bool) {
+  if collection == nil || typ == nil {
+    return
+  }
+  if collection.literal_conflicts_ == nil {
+    collection.literal_conflicts_ = map[*nativechecker.Type]bool{}
+  }
+  collection.literal_conflicts_[typ] = value
 }
 
 func (collection *MetadataCollection) Aliases() []*MetadataAliasType {
@@ -171,21 +286,7 @@ func (collection *MetadataCollection) Tuples() []*MetadataTupleType {
 }
 
 func (collection *MetadataCollection) getName(checker *nativechecker.Checker, typ *nativechecker.Type) (string, string) {
-  // metadataCollection_getFullName (checker.TypeToString, recursing generics and
-  // unions) is pure for a given type pointer, but the duplicate-numbering logic
-  // below calls getName again for the same type. Cache only the full-name
-  // reconstruction; the numbering bookkeeping still runs every call so ordering
-  // is unaffected.
-  fullName, ok := collection.full_names_[typ]
-  if ok == false {
-    fullName = metadataCollection_getFullName(checker, typ)
-    if typ != nil {
-      if collection.full_names_ == nil {
-        collection.full_names_ = map[*nativechecker.Type]string{}
-      }
-      collection.full_names_[typ] = fullName
-    }
-  }
+  fullName := collection.getFullName(checker, typ)
   name := fullName
   name = strings.ToValidUTF8(name, "__")
   name = strings.ReplaceAll(name, "\uFFFD", "__")
@@ -210,6 +311,20 @@ func (collection *MetadataCollection) getName(checker *nativechecker.Checker, ty
   }
   duplicates[typ] = addicted
   return addicted, display
+}
+
+func (collection *MetadataCollection) getFullName(checker *nativechecker.Checker, typ *nativechecker.Type) string {
+  fullName, ok := collection.full_names_[typ]
+  if ok == false {
+    fullName = metadataCollection_getFullName(checker, typ)
+    if typ != nil {
+      if collection.full_names_ == nil {
+        collection.full_names_ = map[*nativechecker.Type]string{}
+      }
+      collection.full_names_[typ] = fullName
+    }
+  }
+  return fullName
 }
 
 // getDisplayName renders the structural form (checker.TypeToString) of types

--- a/packages/typia/native/core/schemas/metadata/MetadataObjectType.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataObjectType.go
@@ -13,17 +13,20 @@ type IMetadataSchema_IObjectType struct {
 }
 
 type MetadataObjectType struct {
-  Name        string
-  DisplayName string
-  Properties  []*MetadataProperty
-  Description *string
-  JsDocTags   []IJsDocTagInfo
-  Index       int
-  Validated   bool
-  Recursive   bool
-  Nullables   []bool
-  Tagged_     bool
-  literal_    *bool
+  Name              string
+  DisplayName       string
+  Properties        []*MetadataProperty
+  Description       *string
+  JsDocTags         []IJsDocTagInfo
+  Index             int
+  Validated         bool
+  Recursive         bool
+  Nullables         []bool
+  Parent_objects_  []*MetadataObject
+  Check_properties_ []*MetadataProperty
+  Tagged_           bool
+  literal_          *bool
+  required_literal_ *bool
 }
 
 func MetadataObjectType_create(props MetadataObjectType) *MetadataObjectType {
@@ -64,6 +67,34 @@ func (obj *MetadataObjectType) GetDisplayName() string {
     return obj.DisplayName
   }
   return obj.Name
+}
+
+func (obj *MetadataObjectType) CheckProperties() []*MetadataProperty {
+  if obj.Check_properties_ != nil {
+    return obj.Check_properties_
+  }
+  return obj.Properties
+}
+
+func (obj *MetadataObjectType) HasRequiredLiteralProperty() bool {
+  if obj.required_literal_ != nil {
+    return *obj.required_literal_
+  }
+  value := false
+  for _, parent := range obj.Parent_objects_ {
+    if parent.Type.HasRequiredLiteralProperty() {
+      value = true
+      break
+    }
+  }
+  for _, property := range obj.CheckProperties() {
+    if property.Key.IsSoleLiteral() && property.Value.IsRequired() {
+      value = true
+      break
+    }
+  }
+  obj.required_literal_ = &value
+  return value
 }
 
 func (obj *MetadataObjectType) IsPlain(level ...int) bool {

--- a/packages/typia/native/core/schemas/metadata/MetadataSchema.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataSchema.go
@@ -4,6 +4,7 @@ import (
   "fmt"
   "reflect"
   "sort"
+  "strconv"
   "strings"
 )
 
@@ -59,6 +60,8 @@ type MetadataSchema struct {
   Fixed_                       *int
   Boolean_literal_intersected_ *bool
   is_sequence_                 *bool
+  sole_literal_cached_         bool
+  sole_literal_                *string
 }
 
 func MetadataSchema_create(props MetadataSchema) *MetadataSchema {
@@ -120,6 +123,274 @@ func (obj *MetadataSchema) ShallowClone() *MetadataSchema {
   }
   clone := *obj
   return &clone
+}
+
+func (obj *MetadataSchema) Clone() *MetadataSchema {
+  return metadataSchema_clone(obj, map[*MetadataSchema]*MetadataSchema{})
+}
+
+func metadataSchema_clone(obj *MetadataSchema, visited map[*MetadataSchema]*MetadataSchema) *MetadataSchema {
+  if obj == nil {
+    return nil
+  }
+  if prev, ok := visited[obj]; ok {
+    return prev
+  }
+  clone := MetadataSchema{
+    Any:                          obj.Any,
+    Required:                     obj.Required,
+    Optional:                     obj.Optional,
+    Nullable:                     obj.Nullable,
+    parent_resolved_:             obj.parent_resolved_,
+    Union_index:                  metadataSchema_cloneInt(obj.Union_index),
+    Fixed_:                       metadataSchema_cloneInt(obj.Fixed_),
+    Boolean_literal_intersected_: metadataSchema_cloneBool(obj.Boolean_literal_intersected_),
+  }
+  visited[obj] = &clone
+  if obj.Escaped != nil {
+    clone.Escaped = MetadataEscaped_create(MetadataEscaped{
+      Original: metadataSchema_clone(obj.Escaped.Original, visited),
+      Returns:  metadataSchema_clone(obj.Escaped.Returns, visited),
+    })
+  }
+  clone.Rest = metadataSchema_clone(obj.Rest, visited)
+  clone.Atomics = metadataSchema_cloneAtomics(obj.Atomics)
+  clone.Constants = metadataSchema_cloneConstants(obj.Constants)
+  clone.Templates = metadataSchema_cloneTemplates(obj.Templates, visited)
+  clone.Aliases = metadataSchema_cloneAliases(obj.Aliases)
+  clone.Arrays = metadataSchema_cloneArrays(obj.Arrays)
+  clone.Tuples = metadataSchema_cloneTuples(obj.Tuples)
+  clone.Objects = metadataSchema_cloneObjects(obj.Objects)
+  clone.Functions = metadataSchema_cloneFunctions(obj.Functions, visited)
+  clone.Natives = metadataSchema_cloneNatives(obj.Natives)
+  clone.Sets = metadataSchema_cloneSets(obj.Sets, visited)
+  clone.Maps = metadataSchema_cloneMaps(obj.Maps, visited)
+  return &clone
+}
+
+func metadataSchema_cloneAtomics(input []*MetadataAtomic) []*MetadataAtomic {
+  output := make([]*MetadataAtomic, 0, len(input))
+  for _, elem := range input {
+    if elem == nil {
+      output = append(output, nil)
+      continue
+    }
+    output = append(output, MetadataAtomic_create(MetadataAtomic{
+      Type: elem.Type,
+      Tags: cloneTagMatrix(elem.Tags),
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneConstants(input []*MetadataConstant) []*MetadataConstant {
+  output := make([]*MetadataConstant, 0, len(input))
+  for _, constant := range input {
+    if constant == nil {
+      output = append(output, nil)
+      continue
+    }
+    values := make([]*MetadataConstantValue, 0, len(constant.Values))
+    for _, value := range constant.Values {
+      if value == nil {
+        values = append(values, nil)
+        continue
+      }
+      values = append(values, MetadataConstantValue_create(MetadataConstantValue{
+        Value:       value.Value,
+        Tags:        cloneTagMatrix(value.Tags),
+        Description: value.Description,
+        JsDocTags:   metadataSchema_cloneJsDocTags(value.JsDocTags),
+      }))
+    }
+    output = append(output, MetadataConstant_create(MetadataConstant{
+      Type:   constant.Type,
+      Values: values,
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneTemplates(input []*MetadataTemplate, visited map[*MetadataSchema]*MetadataSchema) []*MetadataTemplate {
+  output := make([]*MetadataTemplate, 0, len(input))
+  for _, template := range input {
+    if template == nil {
+      output = append(output, nil)
+      continue
+    }
+    row := make([]*MetadataSchema, 0, len(template.Row))
+    for _, child := range template.Row {
+      row = append(row, metadataSchema_clone(child, visited))
+    }
+    output = append(output, &MetadataTemplate{
+      Row:  row,
+      Tags: cloneTagMatrix(template.Tags),
+    })
+  }
+  return output
+}
+
+func metadataSchema_cloneArrays(input []*MetadataArray) []*MetadataArray {
+  output := make([]*MetadataArray, 0, len(input))
+  for _, elem := range input {
+    if elem == nil {
+      output = append(output, nil)
+      continue
+    }
+    output = append(output, MetadataArray_create(MetadataArray{
+      Type: elem.Type,
+      Tags: cloneTagMatrix(elem.Tags),
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneTuples(input []*MetadataTuple) []*MetadataTuple {
+  output := make([]*MetadataTuple, 0, len(input))
+  for _, elem := range input {
+    if elem == nil {
+      output = append(output, nil)
+      continue
+    }
+    output = append(output, MetadataTuple_create(MetadataTuple{
+      Type: elem.Type,
+      Tags: cloneTagMatrix(elem.Tags),
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneObjects(input []*MetadataObject) []*MetadataObject {
+  output := make([]*MetadataObject, 0, len(input))
+  for _, elem := range input {
+    if elem == nil {
+      output = append(output, nil)
+      continue
+    }
+    output = append(output, MetadataObject_create(MetadataObject{
+      Type: elem.Type,
+      Tags: cloneTagMatrix(elem.Tags),
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneAliases(input []*MetadataAlias) []*MetadataAlias {
+  output := make([]*MetadataAlias, 0, len(input))
+  for _, elem := range input {
+    if elem == nil {
+      output = append(output, nil)
+      continue
+    }
+    output = append(output, MetadataAlias_create(MetadataAlias{
+      Type: elem.Type,
+      Tags: cloneTagMatrix(elem.Tags),
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneFunctions(input []*MetadataFunction, visited map[*MetadataSchema]*MetadataSchema) []*MetadataFunction {
+  output := make([]*MetadataFunction, 0, len(input))
+  for _, fn := range input {
+    if fn == nil {
+      output = append(output, nil)
+      continue
+    }
+    parameters := make([]*MetadataParameter, 0, len(fn.Parameters))
+    for _, parameter := range fn.Parameters {
+      if parameter == nil {
+        parameters = append(parameters, nil)
+        continue
+      }
+      parameters = append(parameters, MetadataParameter_create(MetadataParameter{
+        Name:        parameter.Name,
+        Type:        metadataSchema_clone(parameter.Type, visited),
+        Description: parameter.Description,
+        JsDocTags:   metadataSchema_cloneJsDocTags(parameter.JsDocTags),
+        TsType:      parameter.TsType,
+      }))
+    }
+    output = append(output, MetadataFunction_create(MetadataFunction{
+      Parameters: parameters,
+      Output:     metadataSchema_clone(fn.Output, visited),
+      Async:      fn.Async,
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneNatives(input []*MetadataNative) []*MetadataNative {
+  output := make([]*MetadataNative, 0, len(input))
+  for _, elem := range input {
+    if elem == nil {
+      output = append(output, nil)
+      continue
+    }
+    output = append(output, MetadataNative_create(MetadataNative{
+      Name: elem.Name,
+      Tags: cloneTagMatrix(elem.Tags),
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneSets(input []*MetadataSet, visited map[*MetadataSchema]*MetadataSchema) []*MetadataSet {
+  output := make([]*MetadataSet, 0, len(input))
+  for _, elem := range input {
+    if elem == nil {
+      output = append(output, nil)
+      continue
+    }
+    output = append(output, MetadataSet_create(MetadataSet{
+      Value: metadataSchema_clone(elem.Value, visited),
+      Tags:  cloneTagMatrix(elem.Tags),
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneMaps(input []*MetadataMap, visited map[*MetadataSchema]*MetadataSchema) []*MetadataMap {
+  output := make([]*MetadataMap, 0, len(input))
+  for _, elem := range input {
+    if elem == nil {
+      output = append(output, nil)
+      continue
+    }
+    output = append(output, MetadataMap_create(MetadataMap{
+      Key:   metadataSchema_clone(elem.Key, visited),
+      Value: metadataSchema_clone(elem.Value, visited),
+      Tags:  cloneTagMatrix(elem.Tags),
+    }))
+  }
+  return output
+}
+
+func metadataSchema_cloneInt(input *int) *int {
+  if input == nil {
+    return nil
+  }
+  output := *input
+  return &output
+}
+
+func metadataSchema_cloneBool(input *bool) *bool {
+  if input == nil {
+    return nil
+  }
+  output := *input
+  return &output
+}
+
+func metadataSchema_cloneJsDocTags(input []IJsDocTagInfo) []IJsDocTagInfo {
+  output := make([]IJsDocTagInfo, 0, len(input))
+  for _, tag := range input {
+    output = append(output, IJsDocTagInfo{
+      Name: tag.Name,
+      Text: append([]IJsDocTagInfo_IText{}, tag.Text...),
+    })
+  }
+  return output
 }
 
 func (obj *MetadataSchema) ToJSON() *IMetadataSchema {
@@ -411,12 +682,29 @@ func (obj *MetadataSchema) IsUnionBucket() bool {
 }
 
 func (obj *MetadataSchema) GetSoleLiteral() *string {
-  if obj.Size() == 1 &&
+  if obj.sole_literal_cached_ {
+    return obj.sole_literal_
+  }
+  obj.sole_literal_cached_ = true
+  if obj.Any == false &&
+    obj.Escaped == nil &&
+    obj.Rest == nil &&
+    len(obj.Templates) == 0 &&
+    len(obj.Atomics) == 0 &&
+    len(obj.Arrays) == 0 &&
+    len(obj.Tuples) == 0 &&
+    len(obj.Objects) == 0 &&
+    len(obj.Aliases) == 0 &&
+    len(obj.Natives) == 0 &&
+    len(obj.Sets) == 0 &&
+    len(obj.Maps) == 0 &&
+    len(obj.Functions) == 0 &&
     len(obj.Constants) == 1 &&
     obj.Constants[0].Type == "string" &&
     len(obj.Constants[0].Values) == 1 {
     if value, ok := obj.Constants[0].Values[0].Value.(string); ok {
-      return &value
+      obj.sole_literal_ = &value
+      return obj.sole_literal_
     }
   }
   return nil
@@ -473,7 +761,7 @@ func MetadataSchema_intersects(x *MetadataSchema, y *MetadataSchema) bool {
     return true
   }
   // Escaped buckets may coexist with primitive buckets, so an escaped match is
-  // sufficient but not necessary — fall through to the remaining comparisons
+  // sufficient but not necessary. Fall through to the remaining comparisons
   // instead of returning their result.
   if x.Escaped != nil && y.Escaped != nil &&
     (MetadataSchema_intersects(x.Escaped.Original, y.Escaped.Original) ||
@@ -504,13 +792,12 @@ func MetadataSchema_intersects(x *MetadataSchema, y *MetadataSchema) bool {
     }
     values := map[string]struct{}{}
     for _, v := range constant.Values {
-      values[fmt.Sprint(v.Value)] = struct{}{}
+      values[metadataSchema_constantValueKey(v.Value)] = struct{}{}
     }
     for _, v := range opposite.Values {
-      values[fmt.Sprint(v.Value)] = struct{}{}
-    }
-    if len(values) != len(constant.Values)+len(opposite.Values) {
-      return true
+      if _, ok := values[metadataSchema_constantValueKey(v.Value)]; ok {
+        return true
+      }
     }
   }
   if len(x.Templates) != 0 && anyOf(y.Atomics, func(ya *MetadataAtomic) bool { return ya.Type == "string" }) {
@@ -529,6 +816,41 @@ func MetadataSchema_intersects(x *MetadataSchema, y *MetadataSchema) bool {
     return true
   }
   return false
+}
+
+func metadataSchema_constantValueKey(value any) string {
+  switch v := value.(type) {
+  case string:
+    return v
+  case bool:
+    return strconv.FormatBool(v)
+  case int:
+    return strconv.Itoa(v)
+  case int8:
+    return strconv.FormatInt(int64(v), 10)
+  case int16:
+    return strconv.FormatInt(int64(v), 10)
+  case int32:
+    return strconv.FormatInt(int64(v), 10)
+  case int64:
+    return strconv.FormatInt(v, 10)
+  case uint:
+    return strconv.FormatUint(uint64(v), 10)
+  case uint8:
+    return strconv.FormatUint(uint64(v), 10)
+  case uint16:
+    return strconv.FormatUint(uint64(v), 10)
+  case uint32:
+    return strconv.FormatUint(uint64(v), 10)
+  case uint64:
+    return strconv.FormatUint(v, 10)
+  case float32:
+    return strconv.FormatFloat(float64(v), 'g', -1, 32)
+  case float64:
+    return strconv.FormatFloat(v, 'g', -1, 64)
+  default:
+    return fmt.Sprint(value)
+  }
 }
 
 func MetadataSchema_covers(x *MetadataSchema, y *MetadataSchema, levelAndEscaped ...any) bool {

--- a/packages/typia/native/core/schemas/metadata/metadata_object_type_required_literal_property_test.go
+++ b/packages/typia/native/core/schemas/metadata/metadata_object_type_required_literal_property_test.go
@@ -1,0 +1,51 @@
+package metadata
+
+import "testing"
+
+// TestMetadataObjectTypeRequiredLiteralPropertyCaches verifies object-level
+// required literal detection is computed once.
+//
+// Object validators ask this question repeatedly when array element decoders
+// revisit the same metadata. The answer depends only on the completed property
+// list, so the object type caches it after the first scan.
+func TestMetadataObjectTypeRequiredLiteralPropertyCaches(t *testing.T) {
+  key := MetadataSchema_initialize()
+  key.Constants = append(key.Constants, MetadataConstant_create(MetadataConstant{
+    Type: "string",
+    Values: []*MetadataConstantValue{
+      MetadataConstantValue_create(MetadataConstantValue{Value: "name"}),
+    },
+  }))
+  value := MetadataSchema_initialize()
+  value.Atomics = append(value.Atomics, MetadataAtomic_create(MetadataAtomic{Type: "string"}))
+
+  object := MetadataObjectType_create(MetadataObjectType{
+    Name: "__type",
+    Properties: []*MetadataProperty{
+      MetadataProperty_create(MetadataProperty{Key: key, Value: value}),
+    },
+  })
+
+  if object.HasRequiredLiteralProperty() == false {
+    t.Fatalf("required literal property was not detected")
+  }
+  if object.required_literal_ == nil || *object.required_literal_ == false {
+    t.Fatalf("required literal property result was not cached")
+  }
+
+  child := MetadataObjectType_create(MetadataObjectType{
+    Name:       "Child",
+    Properties: []*MetadataProperty{},
+  })
+  child.Parent_objects_ = append(child.Parent_objects_, MetadataObject_create(MetadataObject{
+    Type: object,
+    Tags: [][]IMetadataTypeTag{},
+  }))
+  child.Check_properties_ = []*MetadataProperty{}
+  if child.HasRequiredLiteralProperty() == false {
+    t.Fatalf("required literal property was not inherited from parent object")
+  }
+  if len(child.CheckProperties()) != 0 {
+    t.Fatalf("parent properties leaked into child check-only properties")
+  }
+}

--- a/packages/typia/native/core/schemas/metadata/metadata_schema_sole_literal_caches_pointer_test.go
+++ b/packages/typia/native/core/schemas/metadata/metadata_schema_sole_literal_caches_pointer_test.go
@@ -1,0 +1,38 @@
+package metadata
+
+import "testing"
+
+// TestMetadataSchemaSoleLiteralCachesPointer verifies literal property keys are
+// cached after the first lookup.
+//
+// schema-dts-style validators ask for the same property key literal while
+// generating many object helpers, so the schema stores the positive literal
+// result and reuses it.
+func TestMetadataSchemaSoleLiteralCachesPointer(t *testing.T) {
+  schema := MetadataSchema_initialize()
+  schema.Constants = append(schema.Constants, MetadataConstant_create(MetadataConstant{
+    Type: "string",
+    Values: []*MetadataConstantValue{
+      MetadataConstantValue_create(MetadataConstantValue{Value: "roleName"}),
+    },
+  }))
+
+  first := schema.GetSoleLiteral()
+  second := schema.GetSoleLiteral()
+
+  if first == nil || *first != "roleName" {
+    t.Fatalf("first literal = %v, expected roleName", first)
+  }
+  if first != second {
+    t.Fatalf("literal pointer was not cached")
+  }
+
+  nonLiteral := MetadataSchema_initialize()
+  nonLiteral.Atomics = append(nonLiteral.Atomics, MetadataAtomic_create(MetadataAtomic{Type: "string"}))
+  if actual := nonLiteral.GetSoleLiteral(); actual != nil {
+    t.Fatalf("non-literal atomic returned %q", *actual)
+  }
+  if nonLiteral.sole_literal_cached_ == false {
+    t.Fatalf("non-literal lookup was not cached")
+  }
+}


### PR DESCRIPTION
## Summary

- Reuse metadata exploration results for shareable schema/type shapes and clone cached schemas before reuse.
- Decompose plain-object intersections into parent object checks plus local properties where the property sets are non-conflicting.
- Keep primitive intersections constrained when optional object metadata branches are neutral.
- Reserve generated helper declaration names across variable and union helper families, covering the `InstanceUnion` createIs output that previously emitted duplicate `_ip0` declarations.
- Add repo-local schema-dts-style, object-union, atomic-intersection, helper-name, and cmd/node transform fixtures.

Fixes #1710

## Tests

- `go test ./cmd/ttsc-typia -run Test(AtomicIntersectionSchemaTransform|ObjectUnionExplicitPointerSchemaTransform|InstanceUnionCreateIsTransform|SchemaDtsRoleTransform|RecursiveVisitTrackingTransform|IntersectionUnionValidationTransform|InlineTypeDisplayNameTransform|ObjectCustomTagValidationTransform)$ -count=1 -timeout 300s -v`
- `go test ./core/programmers/helpers -run TestFunctionProgrammerKeepsHelperDeclarationNamesUnique -count=1 -v`
- `go test ./core/programmers/helpers ./core/factories/internal/metadata ./core/schemas/metadata ./core/factories ./core/programmers ./core/programmers/internal ./core/programmers/iterate -count=1`
- `go test ./... -count=1` from `packages/typia/native`
- External #1710 repro: `schema-dts@1.1.5` + `typia.createValidate<schema.Recipe>()` through native CLI `transform --output js` completed in 406.69s, emitted 44,462,507 bytes, stderr empty, `node --check` passed.
- External #1710 generated validator runtime check: valid Recipe accepted, invalid Recipe rejected with one error.
- `git diff --cached --check`
- `git diff -- packages/typia/package.json package.json` empty
- `pnpm --dir tests/test-typia-automated start -- --include createIs_InstanceUnion` remains blocked locally on this Windows setup by `Unexpected token '{'` before tests start.
- GitHub PR checks are all green on `d055d0c3225860a53bf8841f27524d0af976f9e3`.