### PR TITLE
fix(native): materialize text helper aliases

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/dynamic_key_path_helper_alias_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/dynamic_key_path_helper_alias_transform_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestDynamicKeyPathHelperAliasTransform verifies dynamic-key path helpers run.
+//
+// Dynamic object keys build path postfixes as expression text, so the
+// emit-context importer must materialize the internal helper alias that those
+// snippets reference. Otherwise transformed assert and validate functions import
+// the helper module but throw ReferenceError before reporting the path.
+//
+//  1. Transform a string-keyed record fixture through ttsc-typia.
+//  2. Assert the generated JavaScript defines the text-snippet helper alias.
+//  3. Execute assert, assertGuard, and validate failures for identifier and
+//     quoted keys, and verify their reported paths.
+func TestDynamicKeyPathHelperAliasTransform(t *testing.T) {
+  project := dynamicKeyPathHelperAliasProject(t)
+  js := dynamicKeyPathHelperAliasTransform(t, project, "js")
+  if !strings.Contains(js, "const __typia_transform__accessExpressionAsString =") {
+    t.Fatalf("dynamic-key path helper alias was not materialized:\n%s", js)
+  }
+  dynamicKeyPathHelperAliasRunRuntimeCases(t, project, js)
+}
+
+func dynamicKeyPathHelperAliasProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "dynamic-key-path-helper-alias-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(dynamicKeyPathHelperAliasTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(dynamicKeyPathHelperAliasSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func dynamicKeyPathHelperAliasTransform(t *testing.T, project string, output string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", output,
+    })
+  })
+  if code != 0 {
+    t.Fatalf("dynamic-key path transform failed: output=%s code=%d stderr=\n%s", output, code, errText)
+  }
+  return out
+}
+
+func dynamicKeyPathHelperAliasRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(dynamicKeyPathHelperAliasRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = project
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("dynamic-key path runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const dynamicKeyPathHelperAliasTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const dynamicKeyPathHelperAliasSource = `import typia from "typia";
+
+type NumericRecord = Record<string, number>;
+
+const assertRecord = typia.createAssert<NumericRecord>();
+const assertGuardRecord = typia.createAssertGuard<NumericRecord>();
+const validateRecord = typia.createValidate<NumericRecord>();
+
+const capture = (task: () => void): null | { path?: string; expected?: string } => {
+  try {
+    task();
+    return null;
+  } catch (error) {
+    return error as { path?: string; expected?: string };
+  }
+};
+
+export const run = () => ({
+  assertIdentifier: capture(() => assertRecord({ validKey: "not-number" as any })),
+  assertQuoted: capture(() => assertRecord({ "bad-key": "not-number" as any })),
+  guardQuoted: capture(() => assertGuardRecord({ "bad-key": "not-number" as any })),
+  validateQuoted: validateRecord({ "bad-key": "not-number" as any }),
+});
+`
+
+const dynamicKeyPathHelperAliasRuntimeRunner = `const mod = require("./main.cjs");
+const result = mod.run();
+
+if (!result.assertIdentifier || result.assertIdentifier.path !== "$input.validKey") {
+  throw new Error("assert identifier key path mismatch: " + JSON.stringify(result.assertIdentifier));
+}
+if (!result.assertQuoted || result.assertQuoted.path !== "$input[\"bad-key\"]") {
+  throw new Error("assert quoted key path mismatch: " + JSON.stringify(result.assertQuoted));
+}
+if (!result.guardQuoted || result.guardQuoted.path !== "$input[\"bad-key\"]") {
+  throw new Error("assertGuard quoted key path mismatch: " + JSON.stringify(result.guardQuoted));
+}
+if (result.validateQuoted.success !== false) {
+  throw new Error("validate accepted a non-number record value");
+}
+if (!result.validateQuoted.errors.some((error) => error.path === "$input[\"bad-key\"]")) {
+  throw new Error("validate quoted key path mismatch: " + JSON.stringify(result.validateQuoted.errors));
+}
+`

--- a/packages/typia/native/core/context/ImportProgrammer.go
+++ b/packages/typia/native/core/context/ImportProgrammer.go
@@ -55,6 +55,7 @@ type importProgrammer_asset struct {
   Default   *ImportProgrammer_IDefault
   namespace *ImportProgrammer_INamespace
   instances map[string]ImportProgrammer_IInstance
+  textRefs  map[string]struct{}
   order     []string
 }
 
@@ -183,11 +184,15 @@ func (p *ImportProgrammer) GetInternalText(name string) string {
     name = "_" + name
   }
   alias := p.alias(name)
-  p.Instance(ImportProgrammer_IInstance{
+  props := ImportProgrammer_IInstance{
     File:  "typia/lib/internal/" + name,
     Name:  name,
     Alias: &alias,
-  })
+  }
+  p.Instance(props)
+  if p.emit_ != nil {
+    p.take(props.File).textRefs[alias] = struct{}{}
+  }
   return alias
 }
 
@@ -223,6 +228,26 @@ func (p *ImportProgrammer) ToStatements() []*shimast.Node {
         modSpec,
         nil,
       ))
+      for _, alias := range asset.order {
+        if _, ok := asset.textRefs[alias]; !ok {
+          continue
+        }
+        instance := asset.instances[alias]
+        statements = append(statements, p.emit_.Factory.NewVariableStatement(
+          nil,
+          p.emit_.Factory.NewVariableDeclarationList(
+            p.emit_.Factory.NewNodeList([]*shimast.Node{
+              p.emit_.Factory.NewVariableDeclaration(
+                p.emit_.Factory.NewIdentifier(alias),
+                nil,
+                nil,
+                p.member(asset, instance.Name),
+              ),
+            }),
+            shimast.NodeFlagsConst,
+          ),
+        ))
+      }
       continue
     }
     if asset.namespace != nil {
@@ -317,6 +342,7 @@ func (p *ImportProgrammer) take(file string) *importProgrammer_asset {
   asset := &importProgrammer_asset{
     file:      file,
     instances: map[string]ImportProgrammer_IInstance{},
+    textRefs:  map[string]struct{}{},
     order:     []string{},
   }
   p.assets_[file] = asset

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260605.19",
+  "version": "13.0.0-dev.20260605.20",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
﻿## Summary
- Materialize local aliases for `ImportProgrammer.GetInternalText()` references in emit-context mode.
- Cover dynamic record-key paths through `createAssert`, `createAssertGuard`, and `createValidate` runtime execution.
- Bump the `typia` package dev version because the native source is shipped in the npm package.

## Root Cause
`GetInternalText()` registered the internal helper import but still returned the legacy bare alias text. In emit-context mode the importer emits namespace imports, so dynamic-key path snippets referenced `__typia_transform__accessExpressionAsString(key)` without any local binding and threw `ReferenceError` before reporting validation paths.

This surfaced while checking samchon/ttsc#222 against typia `next`: the ttsc driver contract for generated namespace imports still passes, but typia dynamic-key assert/validate output imported the helper module without materializing the text-snippet alias.

## Validation
- `pnpm format`
- `go -C packages/typia/native test ./cmd/ttsc-typia -run TestDynamicKeyPathHelperAliasTransform -count=1 -v`
- Non-empty proof: intentionally changed the expected assertGuard quoted-key path to `$input.wrong`; the test failed with actual path `$input["bad-key"]`, then the expectation was restored and the test passed.
- `go -C packages/typia/native test ./cmd/ttsc-typia -count=1`
- `go -C packages/typia/native test ./... -count=1`

Local note: this checkout is nested under `ttsc/experimental/typia`, so Go validation used a temporary `GOWORK` file pointing typia at the local `D:/github/samchon/ttsc` checkout instead of the sibling-layout `experimental/ttsc` path.
