### PR TITLE
fix(typia): point ttsc plugin entry back at typia/lib/transform

### DIFF
--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -14,7 +14,7 @@
     "typia": "./src/executable/typia.ts"
   },
   "ttsc": {
-    "plugin": { "transform": "typia" }
+    "plugin": { "transform": "typia/lib/transform" }
   },
   "scripts": {
     "build": "rimraf lib && ttsc && rollup -c && cp ../../README.md README.md",

--- a/packages/typia/src/index.ts
+++ b/packages/typia/src/index.ts
@@ -1,9 +1,4 @@
 import * as typia from "./module";
-/** @internal */
-import createTtscPlugin from "./transform";
 
 export default typia;
 export * from "./module";
-
-/** @internal */
-export { createTtscPlugin };


### PR DESCRIPTION
Reverts #1946.

`ttsc.plugin.transform: "typia"` resolves (via `exports["."]`) to `src/index.ts`, whose `export * from "./module"` drags the entire typia runtime into the plugin-**descriptor** load. ttsc loads that descriptor during plugin bootstrap — before building the sidecar — so the bare `./module` import fails to resolve there (`Cannot find module .../packages/typia/src/module`), taking down every job that compiles via the typia transform.

Point the entry back at the dedicated, runtime-free `typia/lib/transform` (= `src/transform.ts`, which only returns the `{ name, source }` descriptor) and drop the now-unused `createTtscPlugin` index re-export.

This restores the known-good pre-#1946 state and works with the currently published ttsc — no ttsc release required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
