### PR TITLE
feat(typia): add compare.less and rename compare.equal to compare.equals, with method delegation

### DIFF
--- a/examples/src/compare/cover.ts
+++ b/examples/src/compare/cover.ts
@@ -1,0 +1,13 @@
+import typia, { compare } from "typia";
+
+const x: IPoint = typia.random<IPoint>();
+const y: compare.Cover<IPoint> = { x: x.x };
+const covered: boolean = typia.compare.cover<IPoint>(x, y);
+
+console.log(covered);
+
+interface IPoint {
+  x: number;
+  y: number;
+  label: string;
+}

--- a/examples/src/compare/equals.ts
+++ b/examples/src/compare/equals.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+const x: IPoint = typia.random<IPoint>();
+const y: IPoint = typia.random<IPoint>();
+const same: boolean = typia.compare.equals<IPoint>(x, y);
+
+console.log(same);
+
+interface IPoint {
+  x: number;
+  y: number;
+  label: string;
+}

--- a/examples/src/compare/less.ts
+++ b/examples/src/compare/less.ts
@@ -1,0 +1,18 @@
+import typia from "typia";
+
+const items: IPoint[] = typia.random<IPoint[]>();
+items.sort((a, b) =>
+  typia.compare.less<IPoint>(a, b)
+    ? -1
+    : typia.compare.less<IPoint>(b, a)
+      ? 1
+      : 0,
+);
+
+console.log(items);
+
+interface IPoint {
+  x: number;
+  y: number;
+  label: string;
+}

--- a/packages/typia/native/cmd/ttsc-typia/compare_equal_cover_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/compare_equal_cover_transform_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestCompareEqualCoverTransform verifies type-directed structural comparison.
 //
-// Issue #1497 adds `typia.compare.equal` and `typia.compare.cover`:
+// Issue #1497 adds `typia.compare.equals` and `typia.compare.cover`:
 //
 //  1. Transform direct and factory calls for equal/cover.
 //  2. Execute object, partial-object, array-length, native, dynamic-key,
@@ -105,12 +105,12 @@ func compareEqualCoverRejectsUnsupported(t *testing.T) {
     Name   string
     Source string
   }{
-    {"any", "export const bad = typia.compare.createEqual<any>();"},
-    {"function", "export const bad = typia.compare.createEqual<() => void>();"},
+    {"any", "export const bad = typia.compare.createEquals<any>();"},
+    {"function", "export const bad = typia.compare.createEquals<() => void>();"},
     {"set", "export const bad = typia.compare.createCover<Set<string>>();"},
-    {"map", "export const bad = typia.compare.createEqual<Map<string, number>>();"},
+    {"map", "export const bad = typia.compare.createEquals<Map<string, number>>();"},
     {"weak-set", "export const bad = typia.compare.createCover<WeakSet<object>>();"},
-    {"weak-map", "export const bad = typia.compare.createEqual<WeakMap<object, object>>();"},
+    {"weak-map", "export const bad = typia.compare.createEquals<WeakMap<object, object>>();"},
   }
   for _, tc := range cases {
     t.Run(tc.Name, func(t *testing.T) {
@@ -164,22 +164,22 @@ interface IUser {
   bytes: Uint8Array;
 }
 
-export const equalUser = typia.compare.createEqual<IUser>();
+export const equalUser = typia.compare.createEquals<IUser>();
 export const coverUser = typia.compare.createCover<IUser>();
-export const equalUserDirect = (x: IUser, y: IUser) => typia.compare.equal<IUser>(x, y);
+export const equalUserDirect = (x: IUser, y: IUser) => typia.compare.equals<IUser>(x, y);
 export const coverUserDirect = (x: IUser, y: compare.Cover<IUser>) => typia.compare.cover<IUser>(x, y);
 
 interface IDictionary {
   fixed: string;
   [key: string]: string;
 }
-export const equalDictionary = typia.compare.createEqual<IDictionary>();
+export const equalDictionary = typia.compare.createEquals<IDictionary>();
 export const coverDictionary = typia.compare.createCover<IDictionary>();
 
 type Shape =
   | { kind: "circle"; radius: number; nested: { label: string } }
   | { kind: "square"; size: number; nested: { label: string } };
-export const equalShape = typia.compare.createEqual<Shape>();
+export const equalShape = typia.compare.createEquals<Shape>();
 export const coverShape = typia.compare.createCover<Shape>();
 
 interface INode {
@@ -187,7 +187,7 @@ interface INode {
   next: INode | null;
   children: INode[];
 }
-export const equalNode = typia.compare.createEqual<INode>();
+export const equalNode = typia.compare.createEquals<INode>();
 export const coverNode = typia.compare.createCover<INode>();
 `
 

--- a/packages/typia/native/cmd/ttsc-typia/compare_less_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/compare_less_transform_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestCompareLessTransform verifies type-directed lexicographic ordering.
+//
+// Issue #1950 adds `typia.compare.less`, a three-way comparator surfaced as a
+// boolean "x precedes y" predicate:
+//
+//  1. Transform direct and factory `less` calls for objects, arrays, tuples,
+//     nested objects, strings, and nullable scalars.
+//  2. Execute runtime cases asserting first-differing-field semantics, shorter
+//     array/tuple ordering, and undefined < null < value ordering.
+//  3. Confirm `less` composes into an Array.prototype.sort comparator.
+func TestCompareLessTransform(t *testing.T) {
+  project := compareLessProject(t)
+  js := compareLessTransform(t, project)
+  compareLessRunRuntimeCases(t, project, js)
+}
+
+func compareLessProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "compare-less-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(compareLessTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(compareLessSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func compareLessTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("compare less transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func compareLessRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(compareLessRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("compare less runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const compareLessTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const compareLessSource = `import typia from "typia";
+
+interface IPoint {
+  x: number;
+  y: number;
+  label: string;
+}
+export const lessPoint = typia.compare.createLess<IPoint>();
+export const lessPointDirect = (a: IPoint, b: IPoint) => typia.compare.less<IPoint>(a, b);
+
+interface INested {
+  head: { rank: number; name: string };
+  tags: string[];
+}
+export const lessNested = typia.compare.createLess<INested>();
+
+export const lessNumbers = typia.compare.createLess<number[]>();
+export const lessTuple = typia.compare.createLess<[number, string]>();
+export const lessString = typia.compare.createLess<string>();
+export const lessNullable = typia.compare.createLess<number | null | undefined>();
+`
+
+const compareLessRuntimeRunner = `const mod = require("./main.cjs");
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + expected + ", got " + actual);
+  }
+};
+
+// object: first differing field in declaration order decides
+expect("point x decides", mod.lessPoint({ x: 1, y: 9, label: "z" }, { x: 2, y: 0, label: "a" }), true);
+expect("point x decides direct", mod.lessPointDirect({ x: 1, y: 9, label: "z" }, { x: 2, y: 0, label: "a" }), true);
+expect("point y decides", mod.lessPoint({ x: 2, y: 0, label: "z" }, { x: 2, y: 1, label: "a" }), true);
+expect("point label decides", mod.lessPoint({ x: 2, y: 2, label: "a" }, { x: 2, y: 2, label: "b" }), true);
+expect("point equal is not less", mod.lessPoint({ x: 2, y: 2, label: "a" }, { x: 2, y: 2, label: "a" }), false);
+expect("point greater is not less", mod.lessPoint({ x: 3, y: 0, label: "a" }, { x: 2, y: 9, label: "z" }), false);
+
+// nested object + array tie-break
+expect("nested head decides", mod.lessNested({ head: { rank: 1, name: "b" }, tags: ["z"] }, { head: { rank: 2, name: "a" }, tags: ["a"] }), true);
+expect("nested tags decide", mod.lessNested({ head: { rank: 1, name: "a" }, tags: ["a"] }, { head: { rank: 1, name: "a" }, tags: ["b"] }), true);
+
+// arrays: lexicographic, shorter prefix precedes
+expect("array element", mod.lessNumbers([1, 2, 3], [1, 9]), true);
+expect("array shorter prefix", mod.lessNumbers([1, 2], [1, 2, 0]), true);
+expect("array equal not less", mod.lessNumbers([1, 2], [1, 2]), false);
+
+// tuple
+expect("tuple second", mod.lessTuple([1, "a"], [1, "b"]), true);
+expect("tuple first", mod.lessTuple([2, "a"], [1, "z"]), false);
+
+// string
+expect("string less", mod.lessString("apple", "banana"), true);
+expect("string equal", mod.lessString("apple", "apple"), false);
+
+// nullable: undefined < null < value
+expect("undefined < null", mod.lessNullable(undefined, null), true);
+expect("null < value", mod.lessNullable(null, 0), true);
+expect("value not < null", mod.lessNullable(0, null), false);
+expect("value compare", mod.lessNullable(1, 2), true);
+
+// composes into a sort comparator
+const cmp = (a, b) => (mod.lessPoint(a, b) ? -1 : mod.lessPoint(b, a) ? 1 : 0);
+const sorted = [
+  { x: 2, y: 0, label: "a" },
+  { x: 1, y: 5, label: "b" },
+  { x: 1, y: 2, label: "c" },
+].sort(cmp);
+expect("sort[0].y", sorted[0].y, 2);
+expect("sort[1].y", sorted[1].y, 5);
+expect("sort[2].x", sorted[2].x, 2);
+`

--- a/packages/typia/native/cmd/ttsc-typia/compare_method_delegation_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/compare_method_delegation_transform_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestCompareMethodDelegationTransform verifies user-defined comparison methods.
+//
+// When a type declares an `equals(y): boolean` or `less(y): boolean` method,
+// the comparator must defer to it instead of walking properties; other methods
+// carry no comparable data and must be ignored so class instances compare by
+// their fields.
+//
+//  1. Transform compare.equals / compare.less over classes with equals / less.
+//  2. Assert the custom (case-insensitive) semantics win over structural ones.
+//  3. Assert a non-comparison method is ignored rather than rejected.
+func TestCompareMethodDelegationTransform(t *testing.T) {
+  project := compareDelegationProject(t)
+  js := compareDelegationTransform(t, project)
+  compareDelegationRunRuntimeCases(t, project, js)
+}
+
+func compareDelegationProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "compare-delegation-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(compareDelegationTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(compareDelegationSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func compareDelegationTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("compare delegation transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func compareDelegationRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(compareDelegationRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("compare delegation runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const compareDelegationTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const compareDelegationSource = `import typia from "typia";
+
+// custom comparison methods — case-insensitive, diverging from structural
+export class Word {
+  constructor(public value: string) {}
+  equals(other: Word): boolean {
+    return this.value.toLowerCase() === other.value.toLowerCase();
+  }
+  less(other: Word): boolean {
+    return this.value.toLowerCase() < other.value.toLowerCase();
+  }
+}
+export const equalsWord = typia.compare.createEquals<Word>();
+export const lessWord = typia.compare.createLess<Word>();
+
+// nested delegation: the inner type carries the methods
+interface IBox {
+  id: number;
+  word: Word;
+}
+export const equalsBox = typia.compare.createEquals<IBox>();
+export const lessBox = typia.compare.createLess<IBox>();
+
+// a non-comparison method must be ignored (not rejected); compare by fields
+export class Money {
+  constructor(
+    public amount: number,
+    public currency: string,
+  ) {}
+  format(): string {
+    return this.amount + " " + this.currency;
+  }
+}
+export const equalsMoney = typia.compare.createEquals<Money>();
+export const lessMoney = typia.compare.createLess<Money>();
+`
+
+const compareDelegationRuntimeRunner = `const { Word, Money, equalsWord, lessWord, equalsBox, lessBox, equalsMoney, lessMoney } = require("./main.cjs");
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + expected + ", got " + actual);
+  }
+};
+
+// equals delegates to Word.equals (case-insensitive) — structural would be false
+expect("equals delegates true", equalsWord(new Word("AB"), new Word("ab")), true);
+expect("equals delegates false", equalsWord(new Word("ab"), new Word("cd")), false);
+
+// less delegates to Word.less (case-insensitive)
+expect("less delegates true", lessWord(new Word("Apple"), new Word("banana")), true);
+expect("less delegates false", lessWord(new Word("Banana"), new Word("apple")), false);
+expect("less delegates equal", lessWord(new Word("Hi"), new Word("hi")), false);
+
+// nested object delegates to the inner Word methods after comparing id
+expect("nested equals via word", equalsBox({ id: 1, word: new Word("X") }, { id: 1, word: new Word("x") }), true);
+expect("nested equals id differs", equalsBox({ id: 1, word: new Word("x") }, { id: 2, word: new Word("x") }), false);
+expect("nested less via word", lessBox({ id: 1, word: new Word("A") }, { id: 1, word: new Word("b") }), true);
+expect("nested less id decides", lessBox({ id: 1, word: new Word("z") }, { id: 2, word: new Word("a") }), true);
+
+// the format() method is ignored; comparison uses amount then currency
+expect("method ignored equals", equalsMoney(new Money(5, "USD"), new Money(5, "USD")), true);
+expect("method ignored amount", lessMoney(new Money(4, "USD"), new Money(5, "USD")), true);
+expect("method ignored currency", lessMoney(new Money(5, "EUR"), new Money(5, "USD")), true);
+`

--- a/packages/typia/native/core/factories/internal/metadata/IMetadataIteratorProps.go
+++ b/packages/typia/native/core/factories/internal/metadata/IMetadataIteratorProps.go
@@ -10,7 +10,12 @@ type MetadataFactory_IOptions struct {
   Absorb     bool
   Constant   bool
   Functional bool
-  Validate   func(props struct {
+  // Methods opts object/class method members (e.g. an `equals` / `less`
+  // method) into the collected properties as function-typed values, without
+  // switching on full Functional analysis. Used by the compare programmers to
+  // detect user-defined comparison methods.
+  Methods  bool
+  Validate func(props struct {
     Metadata *schemametadata.MetadataSchema
     Explore  MetadataFactory_IExplore
     Top      *schemametadata.MetadataSchema

--- a/packages/typia/native/core/factories/internal/metadata/emplace_metadata_object.go
+++ b/packages/typia/native/core/factories/internal/metadata/emplace_metadata_object.go
@@ -14,7 +14,7 @@ func Emplace_metadata_object(props IMetadataIteratorProps) *schemametadata.Metad
   }
 
   isClass := props.Type != nil && props.Type.IsClass()
-  isProperty := emplace_metadata_object_significant(props.Options.Functional)
+  isProperty := emplace_metadata_object_significant(props.Options.Functional, props.Options.Methods)
   pred := func(node *nativeast.Node) bool {
     if node == nil {
       return true
@@ -358,7 +358,7 @@ func emplace_metadata_object_clone_property(property *schemametadata.MetadataPro
   })
 }
 
-func emplace_metadata_object_significant(functional bool) func(node *nativeast.Node) bool {
+func emplace_metadata_object_significant(functional bool, methods bool) func(node *nativeast.Node) bool {
   if functional {
     return func(node *nativeast.Node) bool {
       return node.Kind != nativeast.KindGetAccessor && node.Kind != nativeast.KindSetAccessor
@@ -373,6 +373,9 @@ func emplace_metadata_object_significant(functional bool) func(node *nativeast.N
       nativeast.KindTypeLiteral,
       nativeast.KindShorthandPropertyAssignment:
       return true
+    case nativeast.KindMethodDeclaration,
+      nativeast.KindMethodSignature:
+      return methods
     default:
       return false
     }

--- a/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
+++ b/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
@@ -48,12 +48,13 @@ func (compareEqualProgrammerNamespace) Write(props CompareEqualProgrammer_IProps
       Escape:   false,
       Constant: true,
       Absorb:   true,
+      Methods:  true,
       Validate: func(next struct {
         Metadata *schemametadata.MetadataSchema
         Explore  nativefactories.MetadataFactory_IExplore
         Top      *schemametadata.MetadataSchema
       }) []string {
-        return compareEqualProgrammer_validate(next.Metadata)
+        return compareEqualProgrammer_validate(next.Metadata, next.Metadata == next.Top)
       },
     },
     Components: collection,
@@ -96,7 +97,7 @@ func (compareEqualProgrammerNamespace) Write(props CompareEqualProgrammer_IProps
   return f.NewIdentifier("(() => { " + strings.Join(statements, " ") + " })()")
 }
 
-func compareEqualProgrammer_validate(metadata *schemametadata.MetadataSchema) []string {
+func compareEqualProgrammer_validate(metadata *schemametadata.MetadataSchema, top bool) []string {
   if metadata == nil {
     return nil
   }
@@ -104,7 +105,11 @@ func compareEqualProgrammer_validate(metadata *schemametadata.MetadataSchema) []
   if metadata.Any {
     output = append(output, "unable to compare any")
   }
-  if len(metadata.Functions) != 0 {
+  // A function-typed property is a method: it carries no comparable data, so it
+  // is ignored during comparison (and an `equals` method triggers delegation).
+  // Only a top-level function type — which has nothing else to compare — is
+  // rejected.
+  if top && len(metadata.Functions) != 0 {
     output = append(output, "unable to compare Function")
   }
   if len(metadata.Sets) != 0 {
@@ -309,9 +314,18 @@ func (g *compareEqualProgrammerGenerator) tupleFunction(tuple *schemametadata.Me
 }
 
 func (g *compareEqualProgrammerGenerator) objectInline(object *schemametadata.MetadataObjectType, x string, y string) string {
+  // Defer to a user-defined `equals(y): boolean` method when the type declares
+  // one — the value owns its equality semantics.
+  if compareProgrammer_hasMethod(object, "equals") {
+    return fmt.Sprintf("%s.equals(%s)", g.wrap(x), g.wrap(y))
+  }
+
   regular := []*schemametadata.MetadataProperty{}
   dynamic := []*schemametadata.MetadataProperty{}
   for _, property := range object.Properties {
+    if compareProgrammer_isMethod(property) {
+      continue // methods carry no comparable data
+    }
     if property.Key.GetSoleLiteral() != nil {
       regular = append(regular, property)
     } else {

--- a/packages/typia/native/core/programmers/compare/CompareLessProgrammer.go
+++ b/packages/typia/native/core/programmers/compare/CompareLessProgrammer.go
@@ -1,0 +1,453 @@
+package compare
+
+import (
+  "fmt"
+  "strconv"
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+  nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
+  nativehelpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
+  nativeinternal "github.com/samchon/typia/packages/typia/native/core/programmers/internal"
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+type compareLessProgrammerNamespace struct{}
+
+var CompareLessProgrammer = compareLessProgrammerNamespace{}
+
+type CompareLessProgrammer_IProps struct {
+  Context nativecontext.ITypiaContext
+  Modulo  *shimast.Node
+  Type    *shimchecker.Type
+}
+
+type compareLessProgrammerGenerator struct {
+  Recursive bool
+  Counter   int
+}
+
+var compareLessProgrammer_factory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+
+// Write emits an `(x, y) => boolean` predicate that reports whether `x`
+// lexicographically precedes `y`. It builds a three-way comparator (negative /
+// zero / positive) over the declared structure of the type and returns
+// `cmp(x, y) < 0` so that `equal` and `less` together compose into an
+// Array.prototype.sort comparator.
+func (compareLessProgrammerNamespace) Write(props CompareLessProgrammer_IProps) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(compareLessProgrammer_factory, props.Context.Emit)
+  method := nativehelpers.ModuloMethodText(props.Modulo)
+  collection := schemametadata.NewMetadataCollection()
+  result := nativefactories.MetadataFactory.Analyze(nativefactories.MetadataFactory_IProps{
+    Checker: props.Context.Checker,
+    Options: nativefactories.MetadataFactory_IOptions{
+      Escape:   false,
+      Constant: true,
+      Absorb:   true,
+      Validate: func(next struct {
+        Metadata *schemametadata.MetadataSchema
+        Explore  nativefactories.MetadataFactory_IExplore
+        Top      *schemametadata.MetadataSchema
+      }) []string {
+        return compareLessProgrammer_validate(next.Metadata)
+      },
+    },
+    Components: collection,
+    Type:       props.Type,
+  })
+  if result.Success == false {
+    panic(nativecontext.TransformerError_from(struct {
+      Code   string
+      Errors []nativecontext.TransformerError_MetadataFactory_IError
+    }{
+      Code:   method,
+      Errors: compareEqualProgrammer_errors(result.Errors),
+    }))
+  }
+
+  generator := &compareLessProgrammerGenerator{
+    Recursive: nativeinternal.FeatureProgrammer.CollectionRecursive(collection),
+  }
+  body := generator.schema(result.Data, "x", "y")
+  statements := []string{}
+  for _, object := range collection.Objects() {
+    statements = append(statements, generator.objectFunction(object))
+  }
+  for _, array := range collection.Arrays() {
+    if array.Recursive {
+      statements = append(statements, generator.arrayFunction(array))
+    }
+  }
+  for _, tuple := range collection.Tuples() {
+    if tuple.Recursive {
+      statements = append(statements, generator.tupleFunction(tuple))
+    }
+  }
+  if generator.Recursive {
+    statements = append(statements, "return (x, y) => { const _vctx = {}; return ("+body+") < 0; };")
+  } else {
+    statements = append(statements, "return (x, y) => ("+body+") < 0;")
+  }
+  return f.NewIdentifier("(() => { " + strings.Join(statements, " ") + " })()")
+}
+
+// compareLessProgrammer_validate rejects types that have no sound total order.
+func compareLessProgrammer_validate(metadata *schemametadata.MetadataSchema) []string {
+  if metadata == nil {
+    return nil
+  }
+  output := []string{}
+  if metadata.Any {
+    output = append(output, "unable to order any")
+  }
+  if len(metadata.Functions) != 0 {
+    output = append(output, "unable to order Function")
+  }
+  if len(metadata.Sets) != 0 {
+    output = append(output, "unable to order Set")
+  }
+  if len(metadata.Maps) != 0 {
+    output = append(output, "unable to order Map")
+  }
+  for _, native := range metadata.Natives {
+    if compareLessProgrammer_orderableNative(native.Name) == false {
+      output = append(output, fmt.Sprintf("unable to order %s", native.Name))
+    }
+  }
+  if len(metadata.Objects) > 1 {
+    output = append(output, "unable to order a union of multiple object types")
+  }
+  return output
+}
+
+// schema renders a three-way comparator expression for `metadata` over the two
+// operands `x` and `y`.
+func (g *compareLessProgrammerGenerator) schema(metadata *schemametadata.MetadataSchema, x string, y string) string {
+  if metadata == nil {
+    return "0"
+  }
+  metadata = schemametadata.MetadataSchema_unalias(metadata)
+  core := g.core(metadata, x, y)
+
+  // wrap the core comparator with undefined / null ordering when the type
+  // admits them: undefined precedes null precedes any present value.
+  guards := []string{}
+  optional := metadata.IsRequired() == false
+  if optional {
+    guards = append(guards, fmt.Sprintf("%s === undefined || %s === undefined", g.wrap(x), g.wrap(y)))
+  }
+  if metadata.Nullable {
+    guards = append(guards, fmt.Sprintf("%s === null || %s === null", g.wrap(x), g.wrap(y)))
+  }
+  if len(guards) == 0 {
+    return core
+  }
+  // rank: undefined(0) < null(1) < value(2); equal ranks fall through to core.
+  rank := func(v string) string {
+    if optional && metadata.Nullable {
+      return fmt.Sprintf("(%s === undefined ? 0 : %s === null ? 1 : 2)", g.wrap(v), g.wrap(v))
+    } else if optional {
+      return fmt.Sprintf("(%s === undefined ? 0 : 1)", g.wrap(v))
+    }
+    return fmt.Sprintf("(%s === null ? 0 : 1)", g.wrap(v))
+  }
+  return fmt.Sprintf("(%s !== %s ? %s - %s : %s)", rank(x), rank(y), rank(x), rank(y), core)
+}
+
+// core renders the comparator for the non-null, non-undefined branches.
+func (g *compareLessProgrammerGenerator) core(metadata *schemametadata.MetadataSchema, x string, y string) string {
+  scalars := g.scalarTypeofs(metadata)
+  hasObject := len(metadata.Objects) != 0
+  hasArray := len(metadata.Arrays) != 0
+  hasTuple := len(metadata.Tuples) != 0
+  hasNative := len(metadata.Natives) != 0
+
+  branchCount := len(scalars)
+  if hasObject {
+    branchCount++
+  }
+  if hasArray {
+    branchCount++
+  }
+  if hasTuple {
+    branchCount++
+  }
+  if hasNative {
+    branchCount += len(metadata.Natives)
+  }
+
+  // single homogeneous branch — emit the specific comparator directly.
+  if branchCount == 1 {
+    if len(scalars) == 1 {
+      return g.primitive(x, y)
+    }
+    if hasObject {
+      return g.objectCall(metadata.Objects[0].Type, x, y)
+    }
+    if hasArray {
+      return g.array(metadata.Arrays[0], x, y)
+    }
+    if hasTuple {
+      return g.tuple(metadata.Tuples[0], x, y)
+    }
+    if hasNative {
+      return g.native(metadata.Natives[0].Name, x, y)
+    }
+  }
+
+  // mixed scalars only (e.g. `string | number`): order by runtime typeof, then
+  // by value within the same primitive kind.
+  if branchCount == len(scalars) && len(scalars) > 1 {
+    return fmt.Sprintf("(%s !== %s ? (%s < %s ? -1 : 1) : %s)",
+      g.typeofRank(x), g.typeofRank(y), g.typeofRank(x), g.typeofRank(y), g.primitive(x, y))
+  }
+
+  // empty (e.g. `never`-ish) — treat as equal.
+  if branchCount == 0 {
+    return "0"
+  }
+
+  // heterogeneous mix (scalar + container, or container + container) — rank by
+  // runtime category, then compare within the matching category.
+  return g.mixed(metadata, x, y)
+}
+
+// primitive renders the scalar three-way comparator (works for number, string,
+// boolean and bigint via the relational operators).
+func (g *compareLessProgrammerGenerator) primitive(x string, y string) string {
+  return fmt.Sprintf("(%s < %s ? -1 : %s > %s ? 1 : 0)", g.wrap(x), g.wrap(y), g.wrap(x), g.wrap(y))
+}
+
+func (g *compareLessProgrammerGenerator) native(name string, x string, y string) string {
+  switch name {
+  case "Date":
+    return g.primitive(g.call(x, "getTime"), g.call(y, "getTime"))
+  default:
+    if compareEqualProgrammer_typedArray(name) {
+      return g.bytes(x, y)
+    }
+    return "0"
+  }
+}
+
+// bytes compares two typed arrays / buffers lexicographically by byte.
+func (g *compareLessProgrammerGenerator) bytes(x string, y string) string {
+  bx := g.local("bx")
+  by := g.local("by")
+  index := g.local("i")
+  length := g.local("n")
+  return fmt.Sprintf("(() => { const %s = new Uint8Array(%s), %s = new Uint8Array(%s); const %s = Math.min(%s.length, %s.length); for (let %s = 0; %s < %s; ++%s) if (%s[%s] !== %s[%s]) return %s[%s] < %s[%s] ? -1 : 1; return %s.length - %s.length; })()",
+    bx, g.bufferOf(x), by, g.bufferOf(y), length, bx, by, index, index, length, index, bx, index, by, index, bx, index, by, index, bx, by)
+}
+
+func (g *compareLessProgrammerGenerator) bufferOf(input string) string {
+  return g.wrap(input)
+}
+
+func (g *compareLessProgrammerGenerator) array(array *schemametadata.MetadataArray, x string, y string) string {
+  if array.Type.Recursive {
+    return g.arrayCall(array.Type, x, y)
+  }
+  return g.arrayInline(array.Type.Value, x, y)
+}
+
+func (g *compareLessProgrammerGenerator) arrayInline(value *schemametadata.MetadataSchema, x string, y string) string {
+  index := g.local("i")
+  length := g.local("n")
+  elem := g.schema(value, fmt.Sprintf("%s[%s]", g.wrap(x), index), fmt.Sprintf("%s[%s]", g.wrap(y), index))
+  cmp := g.local("c")
+  return fmt.Sprintf("(() => { const %s = Math.min(%s.length, %s.length); for (let %s = 0; %s < %s; ++%s) { const %s = %s; if (%s) return %s; } return %s.length - %s.length; })()",
+    length, g.wrap(x), g.wrap(y), index, index, length, index, cmp, elem, cmp, cmp, g.wrap(x), g.wrap(y))
+}
+
+func (g *compareLessProgrammerGenerator) tuple(tuple *schemametadata.MetadataTuple, x string, y string) string {
+  if tuple.Type.Recursive {
+    return g.tupleCall(tuple.Type, x, y)
+  }
+  return g.tupleInline(tuple.Type, x, y)
+}
+
+func (g *compareLessProgrammerGenerator) tupleInline(tuple *schemametadata.MetadataTupleType, x string, y string) string {
+  fixed := len(tuple.Elements)
+  var rest *schemametadata.MetadataSchema
+  if fixed != 0 && tuple.Elements[fixed-1].Rest != nil {
+    rest = tuple.Elements[fixed-1].Rest
+    fixed--
+  }
+  steps := []string{}
+  for i := 0; i < fixed; i++ {
+    cmp := g.schema(tuple.Elements[i], g.index(x, strconv.Itoa(i)), g.index(y, strconv.Itoa(i)))
+    steps = append(steps, fmt.Sprintf("{ const _c = %s; if (_c) return _c; }", cmp))
+  }
+  tail := fmt.Sprintf("return %s.length - %s.length;", g.wrap(x), g.wrap(y))
+  if rest != nil {
+    index := g.local("i")
+    length := g.local("n")
+    inner := g.schema(rest, fmt.Sprintf("%s[%s]", g.wrap(x), index), fmt.Sprintf("%s[%s]", g.wrap(y), index))
+    steps = append(steps, fmt.Sprintf("{ const %s = Math.min(%s.length, %s.length); for (let %s = %d; %s < %s; ++%s) { const _c = %s; if (_c) return _c; } }", length, g.wrap(x), g.wrap(y), index, fixed, index, length, index, inner))
+  }
+  return fmt.Sprintf("(() => { %s %s })()", strings.Join(steps, " "), tail)
+}
+
+func (g *compareLessProgrammerGenerator) objectCall(object *schemametadata.MetadataObjectType, x string, y string) string {
+  if g.Recursive {
+    return fmt.Sprintf("_lo%d(%s, %s, _vctx)", object.Index, g.wrap(x), g.wrap(y))
+  }
+  return fmt.Sprintf("_lo%d(%s, %s)", object.Index, g.wrap(x), g.wrap(y))
+}
+
+func (g *compareLessProgrammerGenerator) arrayCall(array *schemametadata.MetadataArrayType, x string, y string) string {
+  index := 0
+  if array.Index != nil {
+    index = *array.Index
+  }
+  if g.Recursive {
+    return fmt.Sprintf("_la%d(%s, %s, _vctx)", index, g.wrap(x), g.wrap(y))
+  }
+  return fmt.Sprintf("_la%d(%s, %s)", index, g.wrap(x), g.wrap(y))
+}
+
+func (g *compareLessProgrammerGenerator) tupleCall(tuple *schemametadata.MetadataTupleType, x string, y string) string {
+  index := 0
+  if tuple.Index != nil {
+    index = *tuple.Index
+  }
+  if g.Recursive {
+    return fmt.Sprintf("_lt%d(%s, %s, _vctx)", index, g.wrap(x), g.wrap(y))
+  }
+  return fmt.Sprintf("_lt%d(%s, %s)", index, g.wrap(x), g.wrap(y))
+}
+
+func (g *compareLessProgrammerGenerator) objectFunction(object *schemametadata.MetadataObjectType) string {
+  body := g.objectInline(object, "x", "y")
+  if g.Recursive {
+    if object.Recursive {
+      return fmt.Sprintf("const _lo%d = (x, y, _vctx) => { if (x === y) return 0; %s return %s; };", object.Index, g.visit("lo", object.Index), body)
+    }
+    return fmt.Sprintf("const _lo%d = (x, y, _vctx) => { if (x === y) return 0; return %s; };", object.Index, body)
+  }
+  return fmt.Sprintf("const _lo%d = (x, y) => { if (x === y) return 0; return %s; };", object.Index, body)
+}
+
+func (g *compareLessProgrammerGenerator) arrayFunction(array *schemametadata.MetadataArrayType) string {
+  index := 0
+  if array.Index != nil {
+    index = *array.Index
+  }
+  body := g.arrayInline(array.Value, "x", "y")
+  if g.Recursive {
+    return fmt.Sprintf("const _la%d = (x, y, _vctx) => { if (x === y) return 0; %s return %s; };", index, g.visit("la", index), body)
+  }
+  return fmt.Sprintf("const _la%d = (x, y) => %s;", index, body)
+}
+
+func (g *compareLessProgrammerGenerator) tupleFunction(tuple *schemametadata.MetadataTupleType) string {
+  index := 0
+  if tuple.Index != nil {
+    index = *tuple.Index
+  }
+  body := g.tupleInline(tuple, "x", "y")
+  if g.Recursive {
+    return fmt.Sprintf("const _lt%d = (x, y, _vctx) => { if (x === y) return 0; %s return %s; };", index, g.visit("lt", index), body)
+  }
+  return fmt.Sprintf("const _lt%d = (x, y) => %s;", index, body)
+}
+
+func (g *compareLessProgrammerGenerator) objectInline(object *schemametadata.MetadataObjectType, x string, y string) string {
+  steps := []string{}
+  for _, property := range object.Properties {
+    if property.Key.GetSoleLiteral() == nil {
+      continue // dynamic-key (index signature) members have no declaration order
+    }
+    key := *property.Key.GetSoleLiteral()
+    left := g.property(x, key)
+    right := g.property(y, key)
+    cmp := g.schema(property.Value, left, right)
+    steps = append(steps, fmt.Sprintf("{ const _c = %s; if (_c) return _c; }", cmp))
+  }
+  return fmt.Sprintf("(() => { %s return 0; })()", strings.Join(steps, " "))
+}
+
+// mixed orders a heterogeneous union by runtime category rank, then compares
+// within the matching category.
+func (g *compareLessProgrammerGenerator) mixed(metadata *schemametadata.MetadataSchema, x string, y string) string {
+  rankExpr := func(v string) string {
+    return fmt.Sprintf("(typeof %s === \"boolean\" ? 2 : typeof %s === \"number\" ? 3 : typeof %s === \"bigint\" ? 4 : typeof %s === \"string\" ? 5 : Array.isArray(%s) ? 6 : 7)",
+      g.wrap(v), g.wrap(v), g.wrap(v), g.wrap(v), g.wrap(v))
+  }
+  within := []string{}
+  if len(metadata.Objects) != 0 {
+    within = append(within, g.objectCall(metadata.Objects[0].Type, x, y))
+  } else if len(metadata.Arrays) != 0 {
+    within = append(within, g.array(metadata.Arrays[0], x, y))
+  } else if len(metadata.Tuples) != 0 {
+    within = append(within, g.tuple(metadata.Tuples[0], x, y))
+  }
+  inner := g.primitive(x, y)
+  if len(within) != 0 {
+    inner = fmt.Sprintf("(typeof %s === \"object\" && %s !== null ? %s : %s)", g.wrap(x), g.wrap(x), within[0], inner)
+  }
+  return fmt.Sprintf("(%s !== %s ? (%s < %s ? -1 : 1) : %s)", rankExpr(x), rankExpr(y), rankExpr(x), rankExpr(y), inner)
+}
+
+func (g *compareLessProgrammerGenerator) visit(kind string, index int) string {
+  slot := fmt.Sprintf("_vctx.%s%d", kind, index)
+  return fmt.Sprintf("const _map = %s || (%s = new WeakMap()); let _set = _map.get(x); if (_set && _set.has(y)) return 0; if (!_set) _map.set(x, (_set = new WeakSet())); _set.add(y);", slot, slot)
+}
+
+func (g *compareLessProgrammerGenerator) scalarTypeofs(metadata *schemametadata.MetadataSchema) map[string]bool {
+  out := map[string]bool{}
+  for _, atomic := range metadata.Atomics {
+    out[atomic.Type] = true
+  }
+  for _, constant := range metadata.Constants {
+    if constant.Type == "boolean" || constant.Type == "number" || constant.Type == "bigint" || constant.Type == "string" {
+      out[constant.Type] = true
+    }
+  }
+  if len(metadata.Templates) != 0 {
+    out["string"] = true
+  }
+  return out
+}
+
+func (g *compareLessProgrammerGenerator) typeofRank(v string) string {
+  return fmt.Sprintf("(typeof %s === \"boolean\" ? 0 : typeof %s === \"number\" ? 1 : typeof %s === \"bigint\" ? 2 : 3)", g.wrap(v), g.wrap(v), g.wrap(v))
+}
+
+func (g *compareLessProgrammerGenerator) call(input string, method string) string {
+  return fmt.Sprintf("%s.%s()", g.wrap(input), method)
+}
+
+func (g *compareLessProgrammerGenerator) property(input string, key string) string {
+  if compareEqualProgrammer_identifier(key) {
+    return fmt.Sprintf("%s.%s", g.wrap(input), key)
+  }
+  return g.index(input, strconv.Quote(key))
+}
+
+func (g *compareLessProgrammerGenerator) index(input string, key string) string {
+  return fmt.Sprintf("%s[%s]", g.wrap(input), key)
+}
+
+func (g *compareLessProgrammerGenerator) wrap(input string) string {
+  if compareEqualProgrammer_simple(input) {
+    return input
+  }
+  return "(" + input + ")"
+}
+
+func (g *compareLessProgrammerGenerator) local(prefix string) string {
+  next := fmt.Sprintf("_%s%d", prefix, g.Counter)
+  g.Counter++
+  return next
+}
+
+func compareLessProgrammer_orderableNative(name string) bool {
+  if name == "Date" {
+    return true
+  }
+  return compareEqualProgrammer_typedArray(name)
+}

--- a/packages/typia/native/core/programmers/compare/CompareLessProgrammer.go
+++ b/packages/typia/native/core/programmers/compare/CompareLessProgrammer.go
@@ -46,12 +46,13 @@ func (compareLessProgrammerNamespace) Write(props CompareLessProgrammer_IProps) 
       Escape:   false,
       Constant: true,
       Absorb:   true,
+      Methods:  true,
       Validate: func(next struct {
         Metadata *schemametadata.MetadataSchema
         Explore  nativefactories.MetadataFactory_IExplore
         Top      *schemametadata.MetadataSchema
       }) []string {
-        return compareLessProgrammer_validate(next.Metadata)
+        return compareLessProgrammer_validate(next.Metadata, next.Metadata == next.Top)
       },
     },
     Components: collection,
@@ -94,7 +95,7 @@ func (compareLessProgrammerNamespace) Write(props CompareLessProgrammer_IProps) 
 }
 
 // compareLessProgrammer_validate rejects types that have no sound total order.
-func compareLessProgrammer_validate(metadata *schemametadata.MetadataSchema) []string {
+func compareLessProgrammer_validate(metadata *schemametadata.MetadataSchema, top bool) []string {
   if metadata == nil {
     return nil
   }
@@ -102,7 +103,10 @@ func compareLessProgrammer_validate(metadata *schemametadata.MetadataSchema) []s
   if metadata.Any {
     output = append(output, "unable to order any")
   }
-  if len(metadata.Functions) != 0 {
+  // A function-typed property is a method: it carries no orderable data, so it
+  // is ignored (and a `less` method triggers delegation). Only a top-level
+  // function type — which has nothing else to order — is rejected.
+  if top && len(metadata.Functions) != 0 {
     output = append(output, "unable to order Function")
   }
   if len(metadata.Sets) != 0 {
@@ -356,8 +360,17 @@ func (g *compareLessProgrammerGenerator) tupleFunction(tuple *schemametadata.Met
 }
 
 func (g *compareLessProgrammerGenerator) objectInline(object *schemametadata.MetadataObjectType, x string, y string) string {
+  // Defer to a user-defined `less(y): boolean` method when the type declares
+  // one, deriving the three-way result from the two directions.
+  if compareProgrammer_hasMethod(object, "less") {
+    return fmt.Sprintf("(%s.less(%s) ? -1 : %s.less(%s) ? 1 : 0)", g.wrap(x), g.wrap(y), g.wrap(y), g.wrap(x))
+  }
+
   steps := []string{}
   for _, property := range object.Properties {
+    if compareProgrammer_isMethod(property) {
+      continue // methods carry no orderable data
+    }
     if property.Key.GetSoleLiteral() == nil {
       continue // dynamic-key (index signature) members have no declaration order
     }
@@ -450,4 +463,27 @@ func compareLessProgrammer_orderableNative(name string) bool {
     return true
   }
   return compareEqualProgrammer_typedArray(name)
+}
+
+// compareProgrammer_hasMethod reports whether the object type declares a method
+// member (a function-typed property) with the given name — e.g. `equals` or
+// `less` — that the comparator can delegate to.
+func compareProgrammer_hasMethod(object *schemametadata.MetadataObjectType, name string) bool {
+  for _, property := range object.Properties {
+    literal := property.Key.GetSoleLiteral()
+    if literal != nil && *literal == name && compareProgrammer_isMethod(property) {
+      return true
+    }
+  }
+  return false
+}
+
+// compareProgrammer_isMethod reports whether a property is a method (its value
+// is a function type), and therefore carries no comparable / orderable data.
+func compareProgrammer_isMethod(property *schemametadata.MetadataProperty) bool {
+  if property == nil || property.Value == nil {
+    return false
+  }
+  value := schemametadata.MetadataSchema_unalias(property.Value)
+  return value != nil && len(value.Functions) != 0
 }

--- a/packages/typia/native/transform/CallExpressionTransformer.go
+++ b/packages/typia/native/transform/CallExpressionTransformer.go
@@ -400,11 +400,17 @@ func callExpressionTransformer_createFunctors() map[string]map[string]callExpres
       "cover": func() callExpressionTransformerTask {
         return nativecomparetransformers.CompareCoverTransformer.Transform
       },
+      "less": func() callExpressionTransformerTask {
+        return nativecomparetransformers.CompareLessTransformer.Transform
+      },
       "createEquals": func() callExpressionTransformerTask {
         return nativecomparetransformers.CompareCreateEqualTransformer.Transform
       },
       "createCover": func() callExpressionTransformerTask {
         return nativecomparetransformers.CompareCreateCoverTransformer.Transform
+      },
+      "createLess": func() callExpressionTransformerTask {
+        return nativecomparetransformers.CompareCreateLessTransformer.Transform
       },
     },
     "plain": {

--- a/packages/typia/native/transform/CallExpressionTransformer.go
+++ b/packages/typia/native/transform/CallExpressionTransformer.go
@@ -394,13 +394,13 @@ func callExpressionTransformer_createFunctors() map[string]map[string]callExpres
       },
     },
     "compare": {
-      "equal": func() callExpressionTransformerTask {
+      "equals": func() callExpressionTransformerTask {
         return nativecomparetransformers.CompareEqualTransformer.Transform
       },
       "cover": func() callExpressionTransformerTask {
         return nativecomparetransformers.CompareCoverTransformer.Transform
       },
-      "createEqual": func() callExpressionTransformerTask {
+      "createEquals": func() callExpressionTransformerTask {
         return nativecomparetransformers.CompareCreateEqualTransformer.Transform
       },
       "createCover": func() callExpressionTransformerTask {

--- a/packages/typia/native/transform/features/compare/CompareCreateEqualTransformer.go
+++ b/packages/typia/native/transform/features/compare/CompareCreateEqualTransformer.go
@@ -10,5 +10,5 @@ type compareCreateEqualTransformerNamespace struct{}
 var CompareCreateEqualTransformer = compareCreateEqualTransformerNamespace{}
 
 func (compareCreateEqualTransformerNamespace) Transform(props nativeinternal.ITransformProps) *shimast.Node {
-  return compareEqualTransformer_factory(props, "compare.createEqual", false)
+  return compareEqualTransformer_factory(props, "compare.createEquals", false)
 }

--- a/packages/typia/native/transform/features/compare/CompareCreateLessTransformer.go
+++ b/packages/typia/native/transform/features/compare/CompareCreateLessTransformer.go
@@ -1,0 +1,14 @@
+package compare
+
+import (
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  nativeinternal "github.com/samchon/typia/packages/typia/native/transform/internal"
+)
+
+type compareCreateLessTransformerNamespace struct{}
+
+var CompareCreateLessTransformer = compareCreateLessTransformerNamespace{}
+
+func (compareCreateLessTransformerNamespace) Transform(props nativeinternal.ITransformProps) *shimast.Node {
+  return compareLessTransformer_factory(props, "compare.createLess")
+}

--- a/packages/typia/native/transform/features/compare/CompareEqualTransformer.go
+++ b/packages/typia/native/transform/features/compare/CompareEqualTransformer.go
@@ -12,7 +12,7 @@ type compareEqualTransformerNamespace struct{}
 var CompareEqualTransformer = compareEqualTransformerNamespace{}
 
 func (compareEqualTransformerNamespace) Transform(props nativeinternal.ITransformProps) *shimast.Node {
-  return compareEqualTransformer_scalar(props, "compare.equal", false)
+  return compareEqualTransformer_scalar(props, "compare.equals", false)
 }
 
 func compareEqualTransformer_scalar(props nativeinternal.ITransformProps, method string, cover bool) *shimast.Node {

--- a/packages/typia/native/transform/features/compare/CompareLessTransformer.go
+++ b/packages/typia/native/transform/features/compare/CompareLessTransformer.go
@@ -1,0 +1,71 @@
+package compare
+
+import (
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+  nativecompareprogrammers "github.com/samchon/typia/packages/typia/native/core/programmers/compare"
+  nativeinternal "github.com/samchon/typia/packages/typia/native/transform/internal"
+)
+
+type compareLessTransformerNamespace struct{}
+
+var CompareLessTransformer = compareLessTransformerNamespace{}
+
+func (compareLessTransformerNamespace) Transform(props nativeinternal.ITransformProps) *shimast.Node {
+  return compareLessTransformer_scalar(props, "compare.less")
+}
+
+func compareLessTransformer_scalar(props nativeinternal.ITransformProps, method string) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(shimast.NewNodeFactory(shimast.NodeFactoryHooks{}), props.Context.Emit)
+  if props.Expression == nil || props.Expression.Arguments == nil || len(props.Expression.Arguments.Nodes) < 2 {
+    panic(nativeinternal.NewTransformerError(nativeinternal.TransformerError_IProps{
+      Code:    "typia." + method,
+      Message: "two input values are required.",
+    }))
+  }
+
+  typ := props.Context.Checker.GetTypeAtLocation(props.Expression.Arguments.Nodes[0])
+  if props.Expression.TypeArguments != nil && len(props.Expression.TypeArguments.Nodes) != 0 {
+    typ = props.Context.Checker.GetTypeFromTypeNode(props.Expression.TypeArguments.Nodes[0])
+  }
+  if typ != nil && typ.IsTypeParameter() {
+    panic(nativeinternal.NewTransformerError(nativeinternal.TransformerError_IProps{
+      Code:    "typia." + method,
+      Message: "non-specified generic argument.",
+    }))
+  }
+
+  return f.NewCallExpression(
+    nativecompareprogrammers.CompareLessProgrammer.Write(nativecompareprogrammers.CompareLessProgrammer_IProps{
+      Context: props.Context,
+      Modulo:  props.Modulo,
+      Type:    typ,
+    }),
+    nil,
+    nil,
+    props.Expression.Arguments,
+    shimast.NodeFlagsNone,
+  )
+}
+
+func compareLessTransformer_factory(props nativeinternal.ITransformProps, method string) *shimast.Node {
+  if props.Expression == nil || props.Expression.TypeArguments == nil || len(props.Expression.TypeArguments.Nodes) == 0 {
+    panic(nativeinternal.NewTransformerError(nativeinternal.TransformerError_IProps{
+      Code:    "typia." + method,
+      Message: "generic argument is not specified.",
+    }))
+  }
+  node := props.Expression.TypeArguments.Nodes[0]
+  typ := props.Context.Checker.GetTypeFromTypeNode(node)
+  if typ != nil && typ.IsTypeParameter() {
+    panic(nativeinternal.NewTransformerError(nativeinternal.TransformerError_IProps{
+      Code:    "typia." + method,
+      Message: "non-specified generic argument.",
+    }))
+  }
+  return nativecompareprogrammers.CompareLessProgrammer.Write(nativecompareprogrammers.CompareLessProgrammer_IProps{
+    Context: props.Context,
+    Modulo:  props.Modulo,
+    Type:    typ,
+  })
+}

--- a/packages/typia/src/compare.ts
+++ b/packages/typia/src/compare.ts
@@ -2,6 +2,7 @@
     COMPARE
       - EQUALS
       - COVER
+      - LESS
       - FACTORY FUNCTIONS
 =========================================================== */
 import { Atomic } from "@typia/interface";
@@ -26,8 +27,9 @@ export type Cover<T> = T extends Atomic.Type | null | undefined
  *
  * Performs a type-directed deep equality comparison. Object properties are
  * compared by the declared structure of `T`; extra runtime properties are not
- * part of the comparison. When `T` declares an `equals(y: T): boolean` method,
- * that method is used instead of the structural comparison.
+ * part of the comparison. When `T` (or a nested object type) declares an
+ * `equals(y: T): boolean` method, that method is used instead of the structural
+ * comparison.
  *
  * @template T Type of values to compare
  * @param x Left value
@@ -57,6 +59,40 @@ export function cover<T>(x: T, y: Cover<T>): boolean;
 /** @internal */
 export function cover(): never {
   NoTransformConfigurationError("compare.cover");
+}
+
+/* -----------------------------------------------------------
+    LESS
+----------------------------------------------------------- */
+/**
+ * Tests whether `x` precedes `y`.
+ *
+ * Performs a type-directed lexicographic comparison: the properties of `T` are
+ * walked in declaration order, depth-first, and the scalar leaves (`number` /
+ * `boolean` / `string` / `bigint`) are compared one by one. The result is
+ * decided by the first leaf where `x` and `y` differ; if every leaf is equal,
+ * the result is `false` (equal is not "less"). When `T` (or a nested object
+ * type) declares a `less(y: T): boolean` method, that method is used instead of
+ * the structural comparison.
+ *
+ * The ordering is total and deterministic, so it composes into an
+ * `Array.prototype.sort` comparator:
+ *
+ * ```ts
+ * const cmp = (a: T, b: T): number =>
+ *   typia.compare.less(a, b) ? -1 : typia.compare.less(b, a) ? 1 : 0;
+ * ```
+ *
+ * @template T Type of values to compare
+ * @param x Left value
+ * @param y Right value
+ * @returns Whether `x` precedes `y`
+ */
+export function less<T>(x: T, y: T): boolean;
+
+/** @internal */
+export function less(): never {
+  NoTransformConfigurationError("compare.less");
 }
 
 /* -----------------------------------------------------------
@@ -100,4 +136,24 @@ export function createCover<T>(): (x: T, y: Cover<T>) => boolean;
 /** @internal */
 export function createCover(): never {
   NoTransformConfigurationError("compare.createCover");
+}
+
+/**
+ * Creates reusable {@link less} function.
+ *
+ * @danger You must configure the generic argument `T`
+ */
+export function createLess(): never;
+
+/**
+ * Creates reusable {@link less} function.
+ *
+ * @template T Type of values to compare
+ * @returns Reusable ordering function
+ */
+export function createLess<T>(): (x: T, y: T) => boolean;
+
+/** @internal */
+export function createLess(): never {
+  NoTransformConfigurationError("compare.createLess");
 }

--- a/packages/typia/src/compare.ts
+++ b/packages/typia/src/compare.ts
@@ -1,6 +1,6 @@
 /* ===========================================================
     COMPARE
-      - EQUAL
+      - EQUALS
       - COVER
       - FACTORY FUNCTIONS
 =========================================================== */
@@ -19,25 +19,26 @@ export type Cover<T> = T extends Atomic.Type | null | undefined
         : T;
 
 /* -----------------------------------------------------------
-    EQUAL
+    EQUALS
 ----------------------------------------------------------- */
 /**
  * Compares two values of type `T`.
  *
  * Performs a type-directed deep equality comparison. Object properties are
  * compared by the declared structure of `T`; extra runtime properties are not
- * part of the comparison.
+ * part of the comparison. When `T` declares an `equals(y: T): boolean` method,
+ * that method is used instead of the structural comparison.
  *
  * @template T Type of values to compare
  * @param x Left value
  * @param y Right value
  * @returns Whether both values are equal by structure
  */
-export function equal<T>(x: T, y: T): boolean;
+export function equals<T>(x: T, y: T): boolean;
 
 /** @internal */
-export function equal(): never {
-  NoTransformConfigurationError("compare.equal");
+export function equals(): never {
+  NoTransformConfigurationError("compare.equals");
 }
 
 /**
@@ -62,23 +63,23 @@ export function cover(): never {
     FACTORY FUNCTIONS
 ----------------------------------------------------------- */
 /**
- * Creates reusable {@link equal} function.
+ * Creates reusable {@link equals} function.
  *
  * @danger You must configure the generic argument `T`
  */
-export function createEqual(): never;
+export function createEquals(): never;
 
 /**
- * Creates reusable {@link equal} function.
+ * Creates reusable {@link equals} function.
  *
  * @template T Type of values to compare
  * @returns Reusable equality function
  */
-export function createEqual<T>(): (x: T, y: T) => boolean;
+export function createEquals<T>(): (x: T, y: T) => boolean;
 
 /** @internal */
-export function createEqual(): never {
-  NoTransformConfigurationError("compare.createEqual");
+export function createEquals(): never {
+  NoTransformConfigurationError("compare.createEquals");
 }
 
 /**

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -9,7 +9,7 @@ import LocalSource from '../../components/LocalSource';
 
 # Miscellaneous
 
-Small modules that share the typia transform but don't fit anywhere else: `plain` (clone / prune), `notations` (case conversion), `http` (form data / query / headers / route parameters), and `reflect` (type metadata introspection and literal unions).
+Small modules that share the typia transform but don't fit anywhere else: `plain` (clone / prune), `compare` (structural equality / ordering), `notations` (case conversion), `http` (form data / query / headers / route parameters), and `reflect` (type metadata introspection and literal unions).
 
 ## `plain`
 
@@ -140,6 +140,97 @@ Useful when you receive a JSON document with extra fields you'd rather not pass 
     <LocalSource
       path="examples/bin/plain/assertPrune.js"
       filename="examples/bin/plain/assertPrune.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## `compare`
+
+Type-directed structural comparison of two values of the same type `T`. All three compare by the declared structure of `T`; when `T` (or a nested object type) declares an `equals(y): boolean` / `less(y): boolean` method, that method is used instead, and other method members are ignored — so class instances compare by their data.
+
+### `compare.equals`
+
+```typescript copy filename="signatures"
+namespace compare {
+  function equals<T>(x: T, y: T): boolean;
+}
+```
+
+Deep equality by the structure of `T`. Extra runtime properties outside `T` are not part of the comparison.
+
+```typescript copy
+typia.compare.equals<IPoint>(x, y); // true when every declared field matches
+```
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/compare/equals.ts"
+      filename="examples/src/compare/equals.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/compare/equals.js"
+      filename="examples/bin/compare/equals.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+### `compare.cover`
+
+```typescript copy filename="signatures"
+namespace compare {
+  function cover<T>(x: T, y: Cover<T>): boolean;
+}
+```
+
+Asymmetric match: whether `x` covers the (partial) `y`. Object properties whose value is `undefined` in `y` are ignored; arrays and tuples still require identical lengths.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/compare/cover.ts"
+      filename="examples/src/compare/cover.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/compare/cover.js"
+      filename="examples/bin/compare/cover.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+### `compare.less`
+
+```typescript copy filename="signatures"
+namespace compare {
+  function less<T>(x: T, y: T): boolean;
+}
+```
+
+Lexicographic ordering: walks the properties of `T` in declaration order and decides on the first differing scalar leaf (`number` / `boolean` / `string` / `bigint`), with `undefined < null < value`. Arrays compare element-by-element, the shorter prefix preceding. `less` and `equals` compose into an `Array.prototype.sort` comparator:
+
+```typescript copy
+const cmp = (a: IPoint, b: IPoint): number =>
+  typia.compare.less<IPoint>(a, b) ? -1 : typia.compare.less<IPoint>(b, a) ? 1 : 0;
+items.sort(cmp);
+```
+
+Types with no sound total order (`any`, `Function`, `Set`, `Map`, `WeakSet`, `WeakMap`, or a union of multiple object types) are rejected at compile time.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/compare/less.ts"
+      filename="examples/src/compare/less.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/compare/less.js"
+      filename="examples/bin/compare/less.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>


### PR DESCRIPTION
Implements #1950 (the Rust-`Ord` half of #708) and finalizes the `compare` namespace's comparison API.

## What's added

- **`compare.less<T>(x, y): boolean`** — type-directed lexicographic ordering. Builds a three-way comparator over the declared structure of `T` (properties walked in declaration order, first differing scalar leaf decides) and returns `cmp(x, y) < 0`, so `equals` + `less` compose into an `Array.prototype.sort` comparator:
  ```ts
  const cmp = (a: T, b: T): number =>
    typia.compare.less(a, b) ? -1 : typia.compare.less(b, a) ? 1 : 0;
  ```
  Supports objects, arrays (shorter prefix precedes), tuples, nested types, mixed-primitive unions (typeof rank), `Date`, typed arrays, and `undefined < null < value` ordering. Rejects unorderable types (`any`, `Function`, `Set`, `Map`, `Weak*`, multi-variant object unions) at transform time.
- **`compare.createLess<T>()`** factory.

## What's changed

- **`compare.equal` → `compare.equals`** (and `createEqual` → `createEquals`). Aligns with the `Objects.equals(a, b)` / `.equals()` convention and with method delegation below. Pre-release, so no alias.
- **Method delegation** — when a type (or nested object type) declares an `equals(y): boolean` / `less(y): boolean` method, the comparator defers to it instead of walking properties. As a side effect, other method members are now **ignored rather than rejected**, so class instances compare by their data fields.
  - New opt-in `MetadataFactory_IOptions.Methods` flag retains method members during object collection (without full Functional analysis); only the compare programmers enable it.
  - `validate` rejects only a top-level function type; nested method members are allowed.

## Commits

1. `compare.equal` → `compare.equals`
2. `compare.less` comparator
3. method delegation + class-instance support

## Validation

Go transform + node-runtime tests (`go test -tags typia_native_internal ./cmd/ttsc-typia/...`) cover ordering semantics, sort composition, `undefined`/`null` ordering, `equals`/`less` delegation (case-insensitive), nested delegation, and method-ignoring. Full `core/factories` + `cmd/ttsc-typia` internal suites green locally; relying on CI for the end-to-end build/test matrix.

Refs #1950, #708.