### PR TITLE
feat(typia): enforce type tags inside template-literal interpolation

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/template_interpolation_type_tags_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/template_interpolation_type_tags_transform_test.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestTemplateInterpolationTypeTagsTransform verifies type tags placed inside a
+// template-literal interpolation.
+//
+// For years a `tags.*` constraint inside `${...}` was silently ignored: the
+// template lowered each placeholder to a bare type-shaped regex span with
+// nowhere to carry "and the captured value is in range", so
+// “ `${number & Minimum<0> & Maximum<100>}%` “ validated as “ `${number}%` “
+// (#1965), “ `${number & Type<"int32">}` “ accepted `"0.1"` (#1175), and
+// “ `CHECK${string & MinLength<32> & Pattern<…>}` “ validated as `/^CHECK(.*)/`
+// (#1202). The checker now captures each constrained placeholder and runs the
+// placeholder's own tag predicates against the parsed substring.
+//
+//  1. Transform fixtures covering the three historical reproductions plus a
+//     two-placeholder template, a union of differently-tagged templates, and a
+//     whole-string tag (#1635) combined with an interpolation tag.
+//  2. Require the emitted checker to capture and re-extract each placeholder.
+//  3. Execute runtime cases: structurally-matching but tag-violating strings
+//     must fail, in-range/conforming strings must pass, and validate must name
+//     the violated placeholder tag.
+func TestTemplateInterpolationTypeTagsTransform(t *testing.T) {
+  project := templateInterpolationTypeTagsProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("template interpolation tags transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  // The constrained number placeholder must be captured and re-extracted, and
+  // the int32 tag must reach the parsed numeric value.
+  for _, needle := range []string{
+    `RegExp(/^([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)%$/).test(input)`,
+    `Number(RegExp(/^([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)%$/).exec(input)[1])`,
+    `_isTypeInt32(Number(RegExp(`,
+    // constrained string placeholders capture newlines too
+    `RegExp(/^L:([\s\S]*)$/)`,
+    // bigint placeholders capture an integer and parse via BigInt(...)
+    `BigInt(RegExp(/^#([+-]?\d+)$/).exec(input)[1])`,
+  } {
+    if !strings.Contains(out, needle) {
+      t.Fatalf("emitted checker should capture and re-extract constrained placeholders (missing %q):\n%s", needle, out)
+    }
+  }
+  templateInterpolationTypeTagsRunRuntimeCases(t, project, out)
+}
+
+func templateInterpolationTypeTagsProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "template-interp-tags-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(templateLiteralTypeTagsTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(templateInterpolationTypeTagsSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func templateInterpolationTypeTagsRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  // The int32 tag and the random generator pull two more internals than the
+  // common stub set covers; stub them before the shared rewrite asserts that no
+  // `typia/lib/internal/*` import survives.
+  extraStubs := map[string]string{
+    "is-type-int32-stub.cjs": "module.exports._isTypeInt32 = (value) => Number.isInteger(value) && -2147483648 <= value && value <= 2147483647;\n",
+    "random-number-stub.cjs": templateInterpolationTypeTagsRandomNumberStub,
+  }
+  for name, content := range extraStubs {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  runtimeJS := strings.ReplaceAll(js, `require("typia/lib/internal/_isTypeInt32")`, `require("./is-type-int32-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_randomNumber")`, `require("./random-number-stub.cjs")`)
+  runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(templateInterpolationTypeTagsRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("template interpolation tags runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const templateInterpolationTypeTagsRandomNumberStub = `module.exports._randomNumber = (schema) => {
+  const min = schema.minimum ?? 0;
+  const max = schema.maximum ?? 100;
+  return Math.min(max, Math.max(min, min + (max - min) / 2));
+};
+`
+
+const templateInterpolationTypeTagsSource = `import typia, { tags } from "typia";
+
+type Percent = ` + "`${number & tags.Minimum<0> & tags.Maximum<100>}%`" + `;
+type IntStr = ` + "`${number & tags.Type<\"int32\">}`" + `;
+type Check = ` + "`CHECK${string & tags.MinLength<32> & tags.MaxLength<32> & tags.Pattern<\"^[0-9a-fA-F]+$\">}`" + `;
+type Range = ` + "`${number & tags.Minimum<0>}-${number & tags.Maximum<100>}`" + `;
+type Unit =
+  | (` + "`${number & tags.Minimum<100>}px`" + `)
+  | (` + "`${number & tags.Maximum<10>}em`" + `);
+type Combined = ` + "`${number & tags.Minimum<0> & tags.Maximum<99>}px`" + ` & tags.MaxLength<3>;
+type Multiline = ` + "`L:${string & tags.MinLength<4>}`" + `;
+type BigRange = ` + "`#${bigint & tags.Minimum<10n> & tags.Maximum<20n>}`" + `;
+type BigExcl = ` + "`#${bigint & tags.Minimum<0n> & tags.Exclude<[5n]>}`" + `;
+type Adjacent = ` + "`${string}${number & tags.Minimum<10>}`" + `;
+type Infix = ` + "`a${string & tags.MaxLength<2>}b`" + `;
+type NonAdj = ` + "`${string}X${string & tags.MinLength<3>}`" + `;
+type StrNum = ` + "`${string & tags.MaxLength<2>}-${number}`" + `;
+type NumStr = ` + "`${number & tags.Maximum<9>}-${string & tags.MinLength<2>}`" + `;
+type Dec = ` + "`${number & tags.Maximum<1.2>}.${number}`" + `;
+type BigDot = ` + "`${bigint}.${number & tags.Minimum<5>}`" + `;
+interface DynKey {
+  [key: ` + "`slot${number & tags.Minimum<0> & tags.Maximum<9>}`" + `]: string;
+}
+
+export const isPercent = typia.createIs<Percent>();
+export const validatePercent = typia.createValidate<Percent>();
+export const isIntStr = typia.createIs<IntStr>();
+export const isCheck = typia.createIs<Check>();
+export const isRange = typia.createIs<Range>();
+export const isUnit = typia.createIs<Unit>();
+export const isCombined = typia.createIs<Combined>();
+export const isMultiline = typia.createIs<Multiline>();
+export const isBigRange = typia.createIs<BigRange>();
+export const isBigExcl = typia.createIs<BigExcl>();
+export const isAdjacent = typia.createIs<Adjacent>();
+export const isInfix = typia.createIs<Infix>();
+export const isNonAdj = typia.createIs<NonAdj>();
+export const isStrNum = typia.createIs<StrNum>();
+export const isNumStr = typia.createIs<NumStr>();
+export const isDec = typia.createIs<Dec>();
+export const isBigDot = typia.createIs<BigDot>();
+export const equalsDynKey = typia.createEquals<DynKey>();
+export const randomPercent = typia.createRandom<Percent>();
+`
+
+const templateInterpolationTypeTagsRuntimeRunner = `const mod = require("./main.cjs");
+
+const hex32 = "0123456789abcdef0123456789abcdef";
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + expected + " but got " + actual);
+  }
+};
+
+// #1965 — numeric range inside the interpolation.
+expect("percent 50", mod.isPercent("50%"), true);
+expect("percent 0", mod.isPercent("0%"), true);
+expect("percent 100", mod.isPercent("100%"), true);
+expect("percent 33.5", mod.isPercent("33.5%"), true);
+expect("percent -1", mod.isPercent("-1%"), false);
+expect("percent 150", mod.isPercent("150%"), false);
+// The base number pattern matches "1e3", but Maximum<100> rejects 1000.
+expect("percent 1e3", mod.isPercent("1e3%"), false);
+expect("percent missing suffix", mod.isPercent("50"), false);
+expect("percent non-number", mod.isPercent("abc%"), false);
+
+// #1175 — int32 tag inside the interpolation must reject decimals/overflow.
+expect("int 42", mod.isIntStr("42"), true);
+expect("int -5", mod.isIntStr("-5"), true);
+expect("int 0.1", mod.isIntStr("0.1"), false);
+expect("int overflow", mod.isIntStr("2147483648"), false);
+
+// #1202 — string length + pattern inside the interpolation.
+expect("check valid", mod.isCheck("CHECK" + hex32), true);
+expect("check short", mod.isCheck("CHECK" + hex32.slice(1)), false);
+expect("check long", mod.isCheck("CHECK" + hex32 + "0"), false);
+expect("check non-hex", mod.isCheck("CHECK" + "g".repeat(32)), false);
+expect("check nomatch", mod.isCheck("nomatch"), false);
+
+// Two constrained placeholders — capture indices [1] and [2] must stay distinct.
+expect("range ok", mod.isRange("5-50"), true);
+expect("range min violated", mod.isRange("-1-50"), false);
+expect("range max violated", mod.isRange("5-150"), false);
+
+// Union of differently-tagged templates — the inline path per member.
+expect("unit px ok", mod.isUnit("150px"), true);
+expect("unit px violated", mod.isUnit("50px"), false);
+expect("unit em ok", mod.isUnit("5em"), true);
+expect("unit em violated", mod.isUnit("50em"), false);
+
+// Whole-string tag (#1635) composed with an interpolation tag (#1968).
+expect("combined ok", mod.isCombined("9px"), true);
+expect("combined length violated", mod.isCombined("99px"), false);
+expect("combined range violated", mod.isCombined("-1px"), false);
+
+// A string placeholder spanning a newline: the captured value must include the
+// line break, so MinLength<4> sees the whole "ab\ncd" (5 chars), not just "ab".
+expect("multiline spans newline", mod.isMultiline("L:ab\ncd"), true);
+expect("multiline too short", mod.isMultiline("L:x"), false);
+
+// A bigint placeholder is captured as an integer only, so BigInt(...) is safe:
+// an in-range integer passes, out-of-range fails, and a decimal string is
+// rejected structurally (never reaching a throwing BigInt(".5") call).
+expect("bigint in range", mod.isBigRange("#15"), true);
+expect("bigint below", mod.isBigRange("#5"), false);
+expect("bigint above", mod.isBigRange("#25"), false);
+expect("bigint decimal rejected", mod.isBigRange("#15.5"), false);
+expect("bigint non-digit rejected", mod.isBigRange("#abc"), false);
+
+// bigint Exclude exercises check_exclude_literal's BigInt-literal branch.
+expect("bigint excluded value", mod.isBigExcl("#5"), false);
+expect("bigint allowed value", mod.isBigExcl("#3"), true);
+expect("bigint exclude negative", mod.isBigExcl("#-1"), false);
+
+// Adjacent variable-width placeholders fall back (tag unenforced) rather than a
+// greedy-split false negative: "abc123" is a valid string-then-number(>=10)
+// split (string="abc", number=123). If the number tag were wrongly enforced on
+// the greedy split, the number group would be "3" and this would be false.
+expect("adjacent placeholders fall back", mod.isAdjacent("abc123"), true);
+
+// A sole string fenced by literals is enforced: the ^/$ anchors pin "a" and the
+// final "b", so the split string="XbY" (length 3) is unique and exceeds
+// MaxLength<2>, while "aXb" (string="X", length 1) is in range.
+expect("sole string fenced by literals, too long", mod.isInfix("aXbYb"), false);
+expect("sole string fenced by literals, in range", mod.isInfix("aXb"), true);
+
+// A string with a placeholder sibling falls back (greedy ([\s\S]*) could overrun
+// the fence), so its tag is unenforced rather than a false negative: "aXbXcd" is
+// a valid string-X-string(>=3) split (second="bXcd") and stays true.
+expect("string with sibling falls back", mod.isNonAdj("aXbXcd"), true);
+
+// string-first across a separator the number's exponent can absorb: the string
+// falls back (greedy could capture "xy-1e"), so "xy-1e-9" is no longer a false
+// negative (string="xy" length 2 <= 2 is a valid split).
+expect("strnum string-first falls back", mod.isStrNum("xy-1e-9"), true);
+
+// number-first: "-" is not number-extendable, so both placeholders are pinned
+// and enforced — number=50 > 9 fails, string="a" length 1 < 2 fails.
+expect("numstr ok", mod.isNumStr("5-ab"), true);
+expect("numstr number violated", mod.isNumStr("50-ab"), false);
+expect("numstr string violated", mod.isNumStr("5-a"), false);
+
+// number-"."-number: "." is a decimal extension, so the split slides ("1.9.0"
+// splits as 1.9|0 or 1|9.0); the placeholder falls back, so the valid first="1"
+// (<= 1.2) split is no longer a false negative.
+expect("dec decimal-separator falls back", mod.isDec("1.9.0"), true);
+
+// An untagged bigint lowers to the decimal NUMBER span, so it absorbs the ".";
+// the number after it falls back, so "1.9.4" (valid as bigint=1 | number=9.4 >=
+// 5) is not a false negative.
+expect("bigint-dot-number falls back", mod.isBigDot("1.9.4"), true);
+
+// A dynamic index key typed as a tagged-interpolation template (the
+// check_dynamic_key path): a key whose number violates the tag no longer
+// satisfies the index signature, so a strict equals rejects it.
+expect("dynkey in range", mod.equalsDynKey({ slot5: "x" }), true);
+expect("dynkey both ends", mod.equalsDynKey({ slot0: "x", slot9: "y" }), true);
+expect("dynkey out of range", mod.equalsDynKey({ slot50: "x" }), false);
+expect("dynkey non-number", mod.equalsDynKey({ slotABC: "x" }), false);
+
+// validate must name the violated placeholder tag, not just the template.
+const tooBig = mod.validatePercent("150%");
+if (tooBig.success !== false) {
+  throw new Error("validate should reject the out-of-range percent");
+}
+if (!tooBig.errors.some((e) => e.expected.includes("Maximum<100>"))) {
+  throw new Error("validate error should name Maximum<100>: " + JSON.stringify(tooBig.errors));
+}
+if (mod.validatePercent("50%").success !== true) {
+  throw new Error("validate should accept the in-range percent");
+}
+
+// random output must round-trip through the validator.
+const generator = {
+  array: (closure, count) => {
+    const length = count ?? 3;
+    return Array.from({ length }, (_, i) => closure(i));
+  },
+};
+for (let i = 0; i < 100; ++i) {
+  const value = mod.randomPercent(generator);
+  if (mod.isPercent(value) !== true) {
+    throw new Error("random percent did not round-trip: " + JSON.stringify(value));
+  }
+}
+`

--- a/packages/typia/native/core/programmers/iterate/check_template.go
+++ b/packages/typia/native/core/programmers/iterate/check_template.go
@@ -6,6 +6,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimprinter "github.com/microsoft/typescript-go/shim/printer"
   nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+  nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
   nativehelpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
   nativemetadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
@@ -29,15 +30,12 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
     ),
   }
   internal := make([]*shimast.Node, 0, len(props.Templates))
+  var solePattern string
+  var soleCaptures []templateCapture
   for _, tpl := range props.Templates {
+    pattern, captures := template_runtime_pattern(tpl.Row)
     expression := f.NewCallExpression(
-      f.NewIdentifier("RegExp(/"+template_to_pattern(struct {
-        top      bool
-        template []*nativemetadata.MetadataSchema
-      }{
-        top:      true,
-        template: tpl.Row,
-      })+"/).test"),
+      f.NewIdentifier("RegExp(/"+pattern+"/).test"),
       nil,
       nil,
       f.NewNodeList([]*shimast.Node{props.Input}),
@@ -45,9 +43,10 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
     )
     // A template with more than one neighbor cannot route its type tags
     // through the entry conditions (those gate the whole entry), so inline
-    // them into the member expression instead.
+    // them — both the whole-string matrix and the per-placeholder
+    // interpolation matrix — into the member expression instead.
     if len(props.Templates) > 1 {
-      if tags := check_template_inline_tags(props, tpl); tags != nil {
+      if tags := check_template_inline_all_tags(props, tpl, pattern, captures); tags != nil {
         expression = f.NewBinaryExpression(
           nil,
           expression,
@@ -56,6 +55,9 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
           tags,
         )
       }
+    } else {
+      solePattern = pattern
+      soleCaptures = captures
     }
     internal = append(internal, expression)
   }
@@ -72,7 +74,7 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
     Expected:   strings.Join(names, " | "),
   }
   if len(props.Templates) == 1 {
-    entry.Conditions = check_template_type_tags(props, props.Templates[0])
+    entry.Conditions = check_template_all_conditions(props, props.Templates[0], solePattern, soleCaptures)
   }
   return entry
 }
@@ -103,6 +105,177 @@ func check_template_type_tags(props Check_templateProps, tpl *nativemetadata.Met
   return output
 }
 
+// check_template_all_conditions composes a sole template's whole-string tag
+// matrix (#1635) with its per-placeholder interpolation matrices (#1968) into
+// the entry conditions.
+//
+// Without interpolation matrices the whole-string output is returned verbatim,
+// preserving the established OR-of-rows reporting. With them, every constraint
+// must hold simultaneously, so all matrices collapse into a single AND row:
+// single-row matrices keep one ICondition per tag (so validate still names the
+// exact tag), while a multi-row (union) matrix collapses to one OR'd ICondition.
+func check_template_all_conditions(props Check_templateProps, tpl *nativemetadata.MetadataTemplate, pattern string, captures []templateCapture) [][]nativehelpers.ICheckEntry_ICondition {
+  wholeString := check_template_type_tags(props, tpl)
+  groups := check_template_placeholder_groups(props, tpl, pattern, captures)
+  if len(groups) == 0 {
+    return wholeString
+  }
+  // groups is non-empty here, and every group contributes at least one
+  // condition, so the combined AND row is always non-empty.
+  row := []nativehelpers.ICheckEntry_ICondition{}
+  check_template_append_matrix(&row, wholeString, props.Emit)
+  for _, group := range groups {
+    check_template_append_matrix(&row, group, props.Emit)
+  }
+  return [][]nativehelpers.ICheckEntry_ICondition{row}
+}
+
+// check_template_append_matrix folds one constraint matrix (an OR of AND rows)
+// into the shared AND row. A single-row matrix contributes its conditions
+// individually so each keeps its own report; a multi-row matrix collapses to one
+// condition whose expression is the OR of its rows.
+func check_template_append_matrix(row *[]nativehelpers.ICheckEntry_ICondition, matrix [][]nativehelpers.ICheckEntry_ICondition, emit *shimprinter.EmitContext) {
+  if len(matrix) == 0 {
+    return
+  }
+  if len(matrix) == 1 {
+    *row = append(*row, matrix[0]...)
+    return
+  }
+  rows := make([]*shimast.Node, 0, len(matrix))
+  expectedParts := make([]string, 0, len(matrix))
+  for _, set := range matrix {
+    cols := make([]*shimast.Node, 0, len(set))
+    names := make([]string, 0, len(set))
+    for _, condition := range set {
+      cols = append(cols, condition.Expression)
+      names = append(names, condition.Expected)
+    }
+    rows = append(rows, check_template_reduce(cols, shimast.KindAmpersandAmpersandToken, emit))
+    expectedParts = append(expectedParts, "("+strings.Join(names, " & ")+")")
+  }
+  *row = append(*row, nativehelpers.ICheckEntry_ICondition{
+    Expected:   strings.Join(expectedParts, " | "),
+    Expression: check_template_reduce(rows, shimast.KindBarBarToken, emit),
+  })
+}
+
+// check_template_placeholder_groups builds, for each constrained interpolation
+// placeholder, the matrix of conditions that validate its captured substring.
+func check_template_placeholder_groups(props Check_templateProps, tpl *nativemetadata.MetadataTemplate, pattern string, captures []templateCapture) [][][]nativehelpers.ICheckEntry_ICondition {
+  base := tpl.GetBaseName()
+  output := [][][]nativehelpers.ICheckEntry_ICondition{}
+  for _, capture := range captures {
+    matrix := check_template_capture_conditions(props, base, pattern, capture)
+    if len(matrix) != 0 {
+      output = append(output, matrix)
+    }
+  }
+  return output
+}
+
+// check_template_capture_conditions reuses check_number_transpile /
+// check_string_transpile to validate one placeholder's captured substring,
+// parsed to its base type, against the placeholder's own tag matrix.
+//
+// Every row yields at least one condition: template_constrained_capture admitted
+// this placeholder only because template_fully_constrained holds, i.e. each row
+// carries a validate-able tag, so no produced row is empty.
+func check_template_capture_conditions(props Check_templateProps, base string, pattern string, capture templateCapture) [][]nativehelpers.ICheckEntry_ICondition {
+  output := [][]nativehelpers.ICheckEntry_ICondition{}
+  for _, row := range capture.Atomic.Tags {
+    conditions := []nativehelpers.ICheckEntry_ICondition{}
+    if capture.Kind != "string" {
+      // number and bigint share the numeric transpiler; the bigint validate
+      // scripts already compare via `BigInt(...)`, and check_template_capture_input
+      // hands them a `BigInt(...)`-parsed value. The exclude literals use
+      // capture.Kind so a bigint placeholder emits bigint literals.
+      for _, tag := range check_number_filter_validate(row) {
+        conditions = append(conditions, nativehelpers.ICheckEntry_ICondition{
+          Expected:   base + " & " + tag.Name,
+          Expression: check_number_transpile(props.Context, tag.Validate)(check_template_capture_input(pattern, capture, props.Input, props.Emit)),
+        })
+      }
+      for _, tag := range row {
+        if condition := check_exclude_condition(capture.Kind, tag, check_template_capture_input(pattern, capture, props.Input, props.Emit), props.Emit); condition != nil {
+          conditions = append(conditions, *condition)
+        }
+      }
+    } else {
+      for _, tag := range check_string_filter_validate(row) {
+        conditions = append(conditions, nativehelpers.ICheckEntry_ICondition{
+          Expected:   base + " & " + tag.Name,
+          Expression: check_string_transpile(props.Context, tag.Validate)(check_template_capture_input(pattern, capture, props.Input, props.Emit)),
+        })
+      }
+      for _, tag := range row {
+        if condition := check_exclude_condition("string", tag, check_template_capture_input(pattern, capture, props.Input, props.Emit), props.Emit); condition != nil {
+          conditions = append(conditions, *condition)
+        }
+      }
+    }
+    output = append(output, conditions)
+  }
+  return output
+}
+
+// check_template_capture_input builds the expression that re-extracts a
+// placeholder's captured substring: `RegExp(/pattern/).exec(input)[index]`,
+// coerced through `Number(...)` for a numeric placeholder or `BigInt(...)` for a
+// bigint one (a string placeholder uses the raw substring). The surrounding
+// `.test()` (entry expression for a sole template, member expression for a
+// union) guarantees the match is non-null, and the bigint capture pattern admits
+// only integers, so the conversion never throws.
+func check_template_capture_input(pattern string, capture templateCapture, input *shimast.Expression, emit *shimprinter.EmitContext) *shimast.Expression {
+  f := nativecontext.EmitFactoryOf(check_template_factory, emit)
+  element := f.NewElementAccessExpression(
+    f.NewCallExpression(
+      f.NewIdentifier("RegExp(/"+pattern+"/).exec"),
+      nil,
+      nil,
+      f.NewNodeList([]*shimast.Node{input}),
+      shimast.NodeFlagsNone,
+    ),
+    nil,
+    nativefactories.ExpressionFactory.Number(capture.Index, emit),
+    shimast.NodeFlagsNone,
+  )
+  coerce := ""
+  switch capture.Kind {
+  case "number":
+    coerce = "Number"
+  case "bigint":
+    coerce = "BigInt"
+  }
+  if coerce != "" {
+    return f.NewCallExpression(
+      f.NewIdentifier(coerce),
+      nil,
+      nil,
+      f.NewNodeList([]*shimast.Node{element}),
+      shimast.NodeFlagsNone,
+    )
+  }
+  return element
+}
+
+// check_template_inline_all_tags folds a union member template's whole-string
+// matrix and interpolation matrices into one boolean for members that cannot
+// carry conditions.
+func check_template_inline_all_tags(props Check_templateProps, tpl *nativemetadata.MetadataTemplate, pattern string, captures []templateCapture) *shimast.Node {
+  nodes := []*shimast.Node{}
+  if whole := check_template_inline_tags(props, tpl); whole != nil {
+    nodes = append(nodes, whole)
+  }
+  if interpolation := check_template_inline_interpolation_tags(props, tpl, pattern, captures); interpolation != nil {
+    nodes = append(nodes, interpolation)
+  }
+  if len(nodes) == 0 {
+    return nil
+  }
+  return check_template_reduce(nodes, shimast.KindAmpersandAmpersandToken, props.Emit)
+}
+
 // check_template_inline_tags folds a template's tag matrix (OR of AND rows)
 // into a single expression for union members that cannot carry conditions.
 func check_template_inline_tags(props Check_templateProps, tpl *nativemetadata.MetadataTemplate) *shimast.Node {
@@ -127,6 +300,29 @@ func check_template_inline_tags(props Check_templateProps, tpl *nativemetadata.M
     return nil
   }
   return check_template_reduce(rows, shimast.KindBarBarToken, props.Emit)
+}
+
+// check_template_inline_interpolation_tags folds every constrained placeholder's
+// matrix into one AND'd boolean (each matrix kept as an OR of its rows) for
+// union members that cannot carry conditions.
+func check_template_inline_interpolation_tags(props Check_templateProps, tpl *nativemetadata.MetadataTemplate, pattern string, captures []templateCapture) *shimast.Node {
+  groups := check_template_placeholder_groups(props, tpl, pattern, captures)
+  if len(groups) == 0 {
+    return nil
+  }
+  ands := make([]*shimast.Node, 0, len(groups))
+  for _, matrix := range groups {
+    rows := make([]*shimast.Node, 0, len(matrix))
+    for _, set := range matrix {
+      cols := make([]*shimast.Node, 0, len(set))
+      for _, condition := range set {
+        cols = append(cols, condition.Expression)
+      }
+      rows = append(rows, check_template_reduce(cols, shimast.KindAmpersandAmpersandToken, props.Emit))
+    }
+    ands = append(ands, check_template_reduce(rows, shimast.KindBarBarToken, props.Emit))
+  }
+  return check_template_reduce(ands, shimast.KindAmpersandAmpersandToken, props.Emit)
 }
 
 func check_template_reduce(expressions []*shimast.Node, operator shimast.Kind, emit ...*shimprinter.EmitContext) *shimast.Node {

--- a/packages/typia/native/core/programmers/iterate/check_template.go
+++ b/packages/typia/native/core/programmers/iterate/check_template.go
@@ -310,7 +310,7 @@ func check_template_inline_interpolation_tags(props Check_templateProps, tpl *na
   if len(groups) == 0 {
     return nil
   }
-  ands := make([]*shimast.Node, 0, len(groups))
+  conjuncts := make([]*shimast.Node, 0, len(groups))
   for _, matrix := range groups {
     rows := make([]*shimast.Node, 0, len(matrix))
     for _, set := range matrix {
@@ -320,9 +320,9 @@ func check_template_inline_interpolation_tags(props Check_templateProps, tpl *na
       }
       rows = append(rows, check_template_reduce(cols, shimast.KindAmpersandAmpersandToken, props.Emit))
     }
-    ands = append(ands, check_template_reduce(rows, shimast.KindBarBarToken, props.Emit))
+    conjuncts = append(conjuncts, check_template_reduce(rows, shimast.KindBarBarToken, props.Emit))
   }
-  return check_template_reduce(ands, shimast.KindAmpersandAmpersandToken, props.Emit)
+  return check_template_reduce(conjuncts, shimast.KindAmpersandAmpersandToken, props.Emit)
 }
 
 func check_template_reduce(expressions []*shimast.Node, operator shimast.Kind, emit ...*shimprinter.EmitContext) *shimast.Node {

--- a/packages/typia/native/core/programmers/iterate/template_interpolation_tags_test.go
+++ b/packages/typia/native/core/programmers/iterate/template_interpolation_tags_test.go
@@ -1,0 +1,495 @@
+//go:build typia_native_internal
+// +build typia_native_internal
+
+package iterate
+
+import (
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimprinter "github.com/microsoft/typescript-go/shim/printer"
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+  nativehelpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
+  nativemetadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestTemplateCountCapturingGroups counts regex capturing groups.
+//
+// The running capture index that maps a constrained placeholder to its
+// `match[index]` slot is driven entirely by this counter, so it must agree with
+// how a JS engine numbers groups: count an unescaped `(` that does not open an
+// inline `(?...)` group, and skip escaped parens — including a literal paren
+// that follows an escaped backslash.
+//
+//  1. Count bare, alternation, nested, and non-capturing patterns.
+//  2. Count the numeric span (only inline groups) as zero.
+//  3. Count escaped parens as zero and a real group after `\\` as one.
+func TestTemplateCountCapturingGroups(t *testing.T) {
+  cases := []struct {
+    pattern string
+    want    int
+  }{
+    {"", 0},
+    {"(.*)", 1},
+    {"[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?", 0},
+    {"(a|b|c)", 1},
+    {"(a(b)c)", 2},
+    {"\\(literal\\)", 0},
+    {"\\\\(group)", 1},
+    {"(?:no)(yes)", 1},
+    {"(.*)-([+-]?\\d+)", 2},
+    {"([\\s\\S]*)", 1},
+  }
+  for _, tc := range cases {
+    if got := template_count_capturing_groups(tc.pattern); got != tc.want {
+      t.Fatalf("count(%q) = %d, want %d", tc.pattern, got, tc.want)
+    }
+  }
+}
+
+// TestTemplateFullyConstrained gates which tag matrices earn a capture.
+//
+// A placeholder is only captured when every OR row contributes at least one
+// validate-able tag; otherwise some row admits the base type unconditionally and
+// honoring the others would reject values the type accepts.
+//
+//  1. Reject nil and empty matrices.
+//  2. Accept a matrix whose every row has a validate-able tag.
+//  3. Reject a matrix with a row of only non-validating tags.
+func TestTemplateFullyConstrained(t *testing.T) {
+  validating := nativemetadata.IMetadataTypeTag{Name: "Minimum<0>", Validate: "0 <= $input"}
+  schemaOnly := nativemetadata.IMetadataTypeTag{Name: "Format<\"uuid\">"}
+  cases := []struct {
+    name string
+    tags [][]nativemetadata.IMetadataTypeTag
+    want bool
+  }{
+    {"nil", nil, false},
+    {"empty", [][]nativemetadata.IMetadataTypeTag{}, false},
+    {"single", [][]nativemetadata.IMetadataTypeTag{{validating}}, true},
+    {"mixed-row", [][]nativemetadata.IMetadataTypeTag{{schemaOnly, validating}}, true},
+    {"schema-only-row", [][]nativemetadata.IMetadataTypeTag{{schemaOnly}}, false},
+    {"one-unconstrained-row", [][]nativemetadata.IMetadataTypeTag{{validating}, {schemaOnly}}, false},
+  }
+  for _, tc := range cases {
+    if got := template_fully_constrained(tc.tags); got != tc.want {
+      t.Fatalf("template_fully_constrained(%s) = %v, want %v", tc.name, got, tc.want)
+    }
+  }
+}
+
+// TestTemplateConstrainedCapture decides which placeholders earn a capture.
+//
+// Only a sole, required, non-nullable `number`, `bigint`, or `string` primitive
+// carrying a fully runtime-checkable tag matrix is captured; boolean/union/
+// constant placeholders, schema-only tags, and nullable/optional placeholders
+// fall back to structural-only matching.
+//
+//  1. Accept number, bigint, and string placeholders with validating tags.
+//  2. Reject boolean, unconstrained, nullable, optional, multi-bucket.
+func TestTemplateConstrainedCapture(t *testing.T) {
+  minimum := [][]nativemetadata.IMetadataTypeTag{{{Name: "Minimum<0>", Validate: "0 <= $input"}}}
+
+  if atomic, kind, ok := template_constrained_capture(iterateTemplateAtomic("number", minimum)); ok == false || kind != "number" || atomic == nil {
+    t.Fatal("number placeholder with a validating tag should be captured")
+  }
+  if _, kind, ok := template_constrained_capture(iterateTemplateAtomic("string", [][]nativemetadata.IMetadataTypeTag{{{Name: "MinLength<3>", Validate: "$input.length >= 3"}}})); ok == false || kind != "string" {
+    t.Fatal("string placeholder with a validating tag should be captured")
+  }
+  if _, kind, ok := template_constrained_capture(iterateTemplateAtomic("bigint", [][]nativemetadata.IMetadataTypeTag{{{Name: "Minimum<0>", Validate: "BigInt(0) <= $input"}}})); ok == false || kind != "bigint" {
+    t.Fatal("bigint placeholder with a validating tag should be captured")
+  }
+
+  reject := func(label string, meta *nativemetadata.MetadataSchema) {
+    if _, _, ok := template_constrained_capture(meta); ok {
+      t.Fatalf("%s should not be captured", label)
+    }
+  }
+  reject("nil", nil)
+  reject("boolean", iterateTemplateAtomic("boolean", minimum))
+  reject("unconstrained number", iterateTemplateAtomic("number", nil))
+
+  nullable := iterateTemplateAtomic("number", minimum)
+  nullable.Nullable = true
+  reject("nullable", nullable)
+
+  optional := iterateTemplateAtomic("number", minimum)
+  optional.Required = false
+  optional.Optional = true
+  reject("optional", optional)
+
+  twoAtomics := iterateTemplateAtomic("number", minimum)
+  twoAtomics.Atomics = append(twoAtomics.Atomics, nativemetadata.MetadataAtomic_create(nativemetadata.MetadataAtomic{Type: "string"}))
+  reject("two atomics", twoAtomics)
+
+  withConstant := iterateTemplateAtomic("number", minimum)
+  withConstant.Constants = append(withConstant.Constants, nativemetadata.MetadataConstant_create(nativemetadata.MetadataConstant{
+    Type:   "string",
+    Values: []*nativemetadata.MetadataConstantValue{nativemetadata.MetadataConstantValue_create(nativemetadata.MetadataConstantValue{Value: "x"})},
+  }))
+  reject("multi bucket", withConstant)
+}
+
+// TestTemplateRuntimePattern maps placeholders to stable capture indices.
+//
+// The structural regex mirrors metadata_to_pattern verbatim except that a
+// constrained numeric placeholder is wrapped and a constrained string lowers to
+// the newline-inclusive `([\s\S]*)`; every constrained placeholder must be
+// assigned the capture index a JS engine would give it — counting the
+// preexisting `(.*)`/alternation groups of unconstrained neighbors.
+//
+//  1. A leading literal plus a constrained number captures at index 1.
+//  2. `${n}-${n}` keeps both numbers ("-" is not number-extendable) at 1 and 2;
+//     a string with a sibling absorbs the separator and falls back entirely.
+//  3. A sole constrained string lowers to `([\s\S]*)`, anchored.
+//  4. A constrained bigint lowers to the integer-only `([+-]?\d+)`, anchored.
+//  5. A constrained placeholder adjacent to a variable-width neighbor falls back.
+//  6. A template with no constrained placeholder yields no captures and the
+//     historical pattern.
+func TestTemplateRuntimePattern(t *testing.T) {
+  number := iterateTemplateAtomic("number", [][]nativemetadata.IMetadataTypeTag{{{Name: "Minimum<0>", Validate: "0 <= $input"}}})
+  numberB := iterateTemplateAtomic("number", [][]nativemetadata.IMetadataTypeTag{{{Name: "Maximum<9>", Validate: "$input <= 9"}}})
+  str := iterateTemplateAtomic("string", [][]nativemetadata.IMetadataTypeTag{{{Name: "MinLength<3>", Validate: "$input.length >= 3"}}})
+  numberSpan := "[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?"
+
+  pattern, captures := template_runtime_pattern([]*nativemetadata.MetadataSchema{iterateLiteral("v"), number})
+  if want := "^v(" + numberSpan + ")$"; pattern != want {
+    t.Fatalf("leading-literal pattern = %q, want %q", pattern, want)
+  }
+  if len(captures) != 1 || captures[0].Index != 1 || captures[0].Kind != "number" {
+    t.Fatalf("leading-literal captures = %#v", captures)
+  }
+
+  // `${n}-${n}`: "-" is not in a number's right-extension set, so both numbers
+  // are pinned and capture at indices 1 and 2.
+  _, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{number, iterateLiteral("-"), numberB})
+  if len(captures) != 2 || captures[0].Index != 1 || captures[0].Kind != "number" || captures[1].Index != 2 || captures[1].Kind != "number" {
+    t.Fatalf("number-'-'-number captures = %#v", captures)
+  }
+
+  // A string with a sibling absorbs the "-" (greedy `[\s\S]*`), unpinning both
+  // itself and the number, so the whole template falls back to no captures.
+  _, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{str, iterateLiteral("-"), numberB})
+  if len(captures) != 0 {
+    t.Fatalf("string-with-sibling template must fall back, got %#v", captures)
+  }
+
+  // A constrained string captures every character (newlines included) via
+  // `([\s\S]*)`, not the newline-blind `(.*)`.
+  pattern, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{iterateLiteral("L:"), str})
+  if want := "^L:([\\s\\S]*)$"; pattern != want {
+    t.Fatalf("constrained-string pattern = %q, want %q", pattern, want)
+  }
+  if len(captures) != 1 || captures[0].Index != 1 || captures[0].Kind != "string" {
+    t.Fatalf("constrained-string captures = %#v", captures)
+  }
+
+  // A constrained bigint captures an integer only, so BigInt(...) cannot throw.
+  big := iterateTemplateAtomic("bigint", [][]nativemetadata.IMetadataTypeTag{{{Name: "Minimum<0>", Validate: "BigInt(0) <= $input"}}})
+  pattern, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{iterateLiteral("#"), big})
+  if want := "^#([+-]?\\d+)$"; pattern != want {
+    t.Fatalf("constrained-bigint pattern = %q, want %q", pattern, want)
+  }
+  if len(captures) != 1 || captures[0].Index != 1 || captures[0].Kind != "bigint" {
+    t.Fatalf("constrained-bigint captures = %#v", captures)
+  }
+
+  // A constrained placeholder adjacent to a variable-width neighbor (here an
+  // unconstrained string before the number, with no literal between) is
+  // ambiguous under greedy matching, so it falls back to structural-only
+  // matching with no capture — rather than risking a false negative.
+  _, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{iterateAtomic("string"), number})
+  if len(captures) != 0 {
+    t.Fatalf("number adjacent to a variable-width neighbor must not be captured, got %#v", captures)
+  }
+  _, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{str, numberB})
+  if len(captures) != 0 {
+    t.Fatalf("two adjacent constrained placeholders must both fall back, got %#v", captures)
+  }
+
+  pattern, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{iterateLiteral("plain"), iterateAtomic("string")})
+  if len(captures) != 0 {
+    t.Fatalf("unconstrained template should have no captures, got %#v", captures)
+  }
+  if want := "^plain(.*)"; pattern != want {
+    t.Fatalf("unconstrained pattern = %q, want %q", pattern, want)
+  }
+}
+
+// TestTemplateClearBoundary gates capture on boundaries the greedy regex pins.
+//
+// A placeholder is captured only when, on each side, the template edge or a
+// literal whose first character its relevant variable neighbor cannot absorb
+// pins it; otherwise the split can slide and it falls back.
+//
+//  1. A single literal segment is a boundary; an atomic, a multi-value constant,
+//     and nil are not.
+//  2. Sole / literal-fenced placeholders clear; an adjacent variable does not.
+//  3. `${n}-${n}` clears ("-" not number-extendable); `${n}.${n}` does not (".").
+//  4. A string before a sibling absorbs the separator, unpinning both itself and
+//     the number; a number before a string keeps both.
+func TestTemplateClearBoundary(t *testing.T) {
+  num := iterateTemplateAtomic("number", [][]nativemetadata.IMetadataTypeTag{{{Name: "Minimum<0>", Validate: "0 <= $input"}}})
+  str := iterateTemplateAtomic("string", [][]nativemetadata.IMetadataTypeTag{{{Name: "MinLength<1>", Validate: "$input.length >= 1"}}})
+  bint := iterateTemplateAtomic("bigint", nil)
+  multi := nativemetadata.MetadataSchema_initialize()
+  multi.Constants = append(multi.Constants, nativemetadata.MetadataConstant_create(nativemetadata.MetadataConstant{
+    Type: "string",
+    Values: []*nativemetadata.MetadataConstantValue{
+      nativemetadata.MetadataConstantValue_create(nativemetadata.MetadataConstantValue{Value: "a"}),
+      nativemetadata.MetadataConstantValue_create(nativemetadata.MetadataConstantValue{Value: "bb"}),
+    },
+  }))
+
+  if template_is_literal(iterateLiteral("x")) == false {
+    t.Fatal("a single literal segment must count as a boundary")
+  }
+  for label, meta := range map[string]*nativemetadata.MetadataSchema{"atomic": num, "multi-constant": multi, "nil": nil} {
+    if template_is_literal(meta) {
+      t.Fatalf("%s must not count as a boundary", label)
+    }
+  }
+
+  type clearCase struct {
+    name string
+    row  []*nativemetadata.MetadataSchema
+    i    int
+    want bool
+  }
+  for _, c := range []clearCase{
+    {"sole", []*nativemetadata.MetadataSchema{num}, 0, true},
+    {"fenced by literals", []*nativemetadata.MetadataSchema{iterateLiteral("a"), num, iterateLiteral("b")}, 1, true},
+    {"adjacent variable", []*nativemetadata.MetadataSchema{num, num}, 0, false},
+    {"num-'-'-num left", []*nativemetadata.MetadataSchema{num, iterateLiteral("-"), num}, 0, true},
+    {"num-'-'-num right", []*nativemetadata.MetadataSchema{num, iterateLiteral("-"), num}, 2, true},
+    {"num-'.'-num (decimal absorbs)", []*nativemetadata.MetadataSchema{num, iterateLiteral("."), num}, 0, false},
+    {"string absorbs separator", []*nativemetadata.MetadataSchema{str, iterateLiteral("-"), num}, 0, false},
+    {"number unpinned by left string", []*nativemetadata.MetadataSchema{str, iterateLiteral("-"), num}, 2, false},
+    {"number before string, number pinned", []*nativemetadata.MetadataSchema{num, iterateLiteral("-"), str}, 0, true},
+    {"number before string, string pinned", []*nativemetadata.MetadataSchema{num, iterateLiteral("-"), str}, 2, true},
+    // An empty separator literal has no first character to absorb, so the
+    // boundary is treated as pinned.
+    {"empty separator literal", []*nativemetadata.MetadataSchema{num, iterateLiteral(""), num}, 0, true},
+    // A bigint neighbor lowers to the decimal NUMBER span, so it absorbs "."
+    // too (a constrained number after a bigint must fall back).
+    {"bigint absorbs decimal", []*nativemetadata.MetadataSchema{bint, iterateLiteral("."), num}, 2, false},
+  } {
+    if got := template_clear_boundary(c.row, c.i); got != c.want {
+      t.Fatalf("clear_boundary(%s) = %v, want %v", c.name, got, c.want)
+    }
+  }
+}
+
+// TestTemplateBoundaryHelpers covers the right-extension, kind, and literal-first
+// primitives that drive template_clear_boundary.
+//
+//  1. right_extends: number and bigint grow through digit/'.'/e but not their
+//     sign; string/other through anything.
+//  2. variable_kind: number/bigint/string atomics map to themselves; everything
+//     else (boolean, constant-only, nil) is conservatively "string".
+//  3. literal_first: the text's first rune, or not-ok for empty/non-literal/nil.
+func TestTemplateBoundaryHelpers(t *testing.T) {
+  for _, c := range []struct {
+    kind string
+    ch   rune
+    want bool
+  }{
+    {"number", '5', true}, {"number", '.', true}, {"number", 'e', true}, {"number", 'E', true},
+    {"number", '-', false}, {"number", '%', false},
+    {"bigint", '5', true}, {"bigint", '.', true}, {"bigint", '-', false},
+    {"string", '%', true}, {"boolean", 't', true},
+  } {
+    if got := template_right_extends(c.kind, c.ch); got != c.want {
+      t.Fatalf("right_extends(%q, %q) = %v, want %v", c.kind, c.ch, got, c.want)
+    }
+  }
+
+  for _, c := range []struct {
+    name string
+    meta *nativemetadata.MetadataSchema
+    want string
+  }{
+    {"number", iterateTemplateAtomic("number", nil), "number"},
+    {"bigint", iterateTemplateAtomic("bigint", nil), "bigint"},
+    {"string", iterateTemplateAtomic("string", nil), "string"},
+    {"boolean", iterateTemplateAtomic("boolean", nil), "string"},
+    {"constant-only", iterateLiteral("x"), "string"},
+    {"nil", nil, "string"},
+  } {
+    if got := template_variable_kind(c.meta); got != c.want {
+      t.Fatalf("variable_kind(%s) = %q, want %q", c.name, got, c.want)
+    }
+  }
+
+  if r, ok := template_literal_first(iterateLiteral("abc")); ok == false || r != 'a' {
+    t.Fatalf("literal_first(abc) = %q,%v", r, ok)
+  }
+  for label, meta := range map[string]*nativemetadata.MetadataSchema{
+    "empty":       iterateLiteral(""),
+    "non-literal": iterateTemplateAtomic("number", nil),
+    "nil":         nil,
+  } {
+    if _, ok := template_literal_first(meta); ok {
+      t.Fatalf("literal_first(%s) should be not-ok", label)
+    }
+  }
+}
+
+// TestCheckTemplateInterpolationConditions wires placeholder tags into the
+// checker entry and inline union expressions.
+//
+// A sole template threads its placeholder tags through the entry conditions
+// (one condition per tag for single-row matrices, one collapsed condition for a
+// union matrix), composing with whole-string tags as a single AND row; a union
+// of templates inlines them into the member expression instead.
+//
+//  1. Sole template, single-row numeric matrix → one row, two conditions.
+//  2. Sole template, multi-row matrix → one collapsed condition naming both.
+//  3. Sole template, whole-string tag only → unchanged whole-string conditions.
+//  4. Sole template, string placeholder with an exclude tag → string conditions.
+//  5. Union of constrained templates → no entry conditions, non-nil expression.
+func TestCheckTemplateInterpolationConditions(t *testing.T) {
+  emit := shimprinter.NewEmitContext()
+  factory := shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+  input := factory.NewIdentifier("input")
+  context := nativecontext.ITypiaContext{Emit: emit}
+
+  call := func(templates []*nativemetadata.MetadataTemplate) nativehelpers.ICheckEntry {
+    return Check_template(Check_templateProps{
+      Context:   context,
+      Templates: templates,
+      Input:     input,
+      Emit:      emit,
+    })
+  }
+
+  // 1. single-row numeric matrix
+  percent := iterateTemplateLiteral([]*nativemetadata.MetadataSchema{
+    iterateTemplateAtomic("number", [][]nativemetadata.IMetadataTypeTag{{
+      {Name: "Minimum<0>", Validate: "0 <= $input"},
+      {Name: "Maximum<100>", Validate: "$input <= 100"},
+    }}),
+    iterateLiteral("%"),
+  }, nil)
+  entry := call([]*nativemetadata.MetadataTemplate{percent})
+  if entry.Expression == nil || len(entry.Conditions) != 1 || len(entry.Conditions[0]) != 2 {
+    t.Fatalf("percent entry must hold one row of two conditions, got %#v", entry.Conditions)
+  }
+
+  // 2. multi-row (union) matrix collapses to a single OR'd condition
+  multi := iterateTemplateLiteral([]*nativemetadata.MetadataSchema{
+    iterateTemplateAtomic("number", [][]nativemetadata.IMetadataTypeTag{
+      {{Name: "Minimum<0>", Validate: "0 <= $input"}},
+      {{Name: "Maximum<9>", Validate: "$input <= 9"}},
+    }),
+  }, nil)
+  entry = call([]*nativemetadata.MetadataTemplate{multi})
+  if len(entry.Conditions) != 1 || len(entry.Conditions[0]) != 1 {
+    t.Fatalf("multi-row matrix must collapse to one condition, got %#v", entry.Conditions)
+  }
+  if expected := entry.Conditions[0][0].Expected; !strings.Contains(expected, " | ") {
+    t.Fatalf("collapsed expected should disjoin both rows, got %q", expected)
+  }
+
+  // 2b. bigint placeholder routes through the numeric path with a BigInt(...) input
+  bigEntry := call([]*nativemetadata.MetadataTemplate{iterateTemplateLiteral([]*nativemetadata.MetadataSchema{
+    iterateLiteral("#"),
+    iterateTemplateAtomic("bigint", [][]nativemetadata.IMetadataTypeTag{{
+      {Name: "Minimum<0>", Validate: "BigInt(0) <= $input"},
+    }}),
+  }, nil)})
+  if bigEntry.Expression == nil || len(bigEntry.Conditions) != 1 || len(bigEntry.Conditions[0]) != 1 {
+    t.Fatalf("bigint entry must hold one row of one condition, got %#v", bigEntry.Conditions)
+  }
+
+  // 3. whole-string tag only — interpolation path is inert, output unchanged
+  wholeOnly := iterateTemplateLiteral(
+    []*nativemetadata.MetadataSchema{iterateLiteral("prefix"), iterateAtomic("string")},
+    [][]nativemetadata.IMetadataTypeTag{{{Name: "MaxLength<5>", Validate: "$input.length <= 5"}}},
+  )
+  entry = call([]*nativemetadata.MetadataTemplate{wholeOnly})
+  if len(entry.Conditions) != 1 || len(entry.Conditions[0]) != 1 {
+    t.Fatalf("whole-string-only template should keep its single condition, got %#v", entry.Conditions)
+  }
+
+  // 4. string placeholder carrying a validating tag and an exclude tag
+  excluded := iterateTemplateLiteral([]*nativemetadata.MetadataSchema{
+    iterateLiteral("ID"),
+    iterateTemplateAtomic("string", [][]nativemetadata.IMetadataTypeTag{{
+      {Name: "MinLength<2>", Validate: "$input.length >= 2"},
+      {Name: "Exclude", Kind: "exclude", Schema: map[string]any{"not": map[string]any{"enum": []any{"no"}}}},
+    }}),
+  }, nil)
+  entry = call([]*nativemetadata.MetadataTemplate{excluded})
+  if len(entry.Conditions) != 1 || len(entry.Conditions[0]) != 2 {
+    t.Fatalf("string placeholder should emit a length and an exclude condition, got %#v", entry.Conditions)
+  }
+
+  // 4b. number placeholder carrying a validating tag and an exclude tag
+  numberExcluded := iterateTemplateLiteral([]*nativemetadata.MetadataSchema{
+    iterateTemplateAtomic("number", [][]nativemetadata.IMetadataTypeTag{{
+      {Name: "Minimum<0>", Validate: "0 <= $input"},
+      {Name: "Exclude", Kind: "exclude", Schema: map[string]any{"not": map[string]any{"enum": []any{5}}}},
+    }}),
+    iterateLiteral("u"),
+  }, nil)
+  entry = call([]*nativemetadata.MetadataTemplate{numberExcluded})
+  if len(entry.Conditions) != 1 || len(entry.Conditions[0]) != 2 {
+    t.Fatalf("number placeholder should emit a minimum and an exclude condition, got %#v", entry.Conditions)
+  }
+
+  // 5. union exercising every inline branch: interpolation-only (percent),
+  // multi-row interpolation (multi), whole-string + interpolation combined, and
+  // a tagless member whose inline expression collapses to nil.
+  combined := iterateTemplateLiteral([]*nativemetadata.MetadataSchema{
+    iterateLiteral("q"),
+    iterateTemplateAtomic("number", [][]nativemetadata.IMetadataTypeTag{{{Name: "Minimum<0>", Validate: "0 <= $input"}}}),
+  }, [][]nativemetadata.IMetadataTypeTag{{{Name: "MaxLength<5>", Validate: "$input.length <= 5"}}})
+  tagless := iterateTemplateLiteral([]*nativemetadata.MetadataSchema{
+    iterateLiteral("x"),
+    iterateAtomic("string"),
+  }, nil)
+  union := call([]*nativemetadata.MetadataTemplate{percent, multi, combined, tagless})
+  if union.Expression == nil {
+    t.Fatal("union template expression must not be nil")
+  }
+  if union.Conditions != nil {
+    t.Fatalf("union template must not carry entry conditions, got %#v", union.Conditions)
+  }
+
+  // 6. whole-string tags exercising the exclude branch and an empty
+  // (non-validating) row of check_template_type_tags / check_template_inline_tags.
+  wsExclude := iterateTemplateLiteral(
+    []*nativemetadata.MetadataSchema{iterateLiteral("p"), iterateAtomic("string")},
+    [][]nativemetadata.IMetadataTypeTag{
+      {
+        {Name: "MaxLength<5>", Validate: "$input.length <= 5"},
+        {Name: "Exclude", Kind: "exclude", Schema: map[string]any{"not": map[string]any{"enum": []any{"no"}}}},
+      },
+      {{Name: "Format<\"uuid\">"}}, // non-validating only → skipped row
+    },
+  )
+  entry = call([]*nativemetadata.MetadataTemplate{wsExclude})
+  if len(entry.Conditions) != 1 || len(entry.Conditions[0]) != 2 {
+    t.Fatalf("whole-string exclude should emit length + exclude, got %#v", entry.Conditions)
+  }
+  if unionWs := call([]*nativemetadata.MetadataTemplate{wsExclude, wsExclude}); unionWs.Expression == nil {
+    t.Fatal("union whole-string inline expression must not be nil")
+  }
+
+  // 7. reducing an empty slice yields a literal (true/false) keyword.
+  if check_template_reduce(nil, shimast.KindBarBarToken) == nil {
+    t.Fatal("empty reduce should yield a keyword")
+  }
+}
+
+func iterateTemplateAtomic(kind string, tags [][]nativemetadata.IMetadataTypeTag) *nativemetadata.MetadataSchema {
+  meta := nativemetadata.MetadataSchema_initialize()
+  meta.Atomics = append(meta.Atomics, nativemetadata.MetadataAtomic_create(nativemetadata.MetadataAtomic{Type: kind, Tags: tags}))
+  return meta
+}
+
+func iterateTemplateLiteral(row []*nativemetadata.MetadataSchema, tags [][]nativemetadata.IMetadataTypeTag) *nativemetadata.MetadataTemplate {
+  return &nativemetadata.MetadataTemplate{Row: row, Tags: tags}
+}

--- a/packages/typia/native/core/programmers/iterate/template_runtime_pattern.go
+++ b/packages/typia/native/core/programmers/iterate/template_runtime_pattern.go
@@ -68,7 +68,7 @@ func template_runtime_pattern(row []*nativemetadata.MetadataSchema) (string, []t
       default:
         // A string placeholder lowers to "(.*)", but `.` excludes newlines,
         // so a value spanning a line break would hand the tag check only the
-        // first line (under-reporting length, mis-matching Pattern). Capture
+        // first line (under-reporting length, mismatching Pattern). Capture
         // every character instead, anchored by PatternUtil.Fix.
         sub = "([\\s\\S]*)"
       }

--- a/packages/typia/native/core/programmers/iterate/template_runtime_pattern.go
+++ b/packages/typia/native/core/programmers/iterate/template_runtime_pattern.go
@@ -1,0 +1,262 @@
+package iterate
+
+import (
+  "fmt"
+  "strings"
+
+  nativemetadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  nativeutils "github.com/samchon/typia/packages/typia/native/core/utils"
+)
+
+// templateCapture records a template-literal interpolation whose placeholder
+// carries a runtime-checkable type tag. The structural regex keeps a capturing
+// group around that placeholder so the checker can re-extract the matched
+// substring, parse it to the placeholder's base type, and run the placeholder's
+// own tag predicates against it (#1968).
+type templateCapture struct {
+  // Index is the 1-based position of the capturing group inside the structural
+  // regex, i.e. the `match[Index]` slot that holds the placeholder substring.
+  Index int
+  // Kind is the placeholder base type: "number", "bigint", or "string". It
+  // selects the coercion (`Number(...)` / `BigInt(...)` for the numeric kinds,
+  // the raw substring for string) and which transpiler owns the value checks.
+  Kind string
+  // Atomic is the constrained primitive whose tag matrix drives the conditions.
+  Atomic *nativemetadata.MetadataAtomic
+}
+
+// template_runtime_pattern builds the structural regex of a template literal for
+// the runtime checker and, alongside it, the capture map of every constrained
+// interpolation placeholder.
+//
+// It mirrors template_to_pattern's structural output verbatim for every
+// non-constrained element, so templates without a runtime-checkable
+// interpolation tag emit exactly the same pattern as before (preserving the
+// single-`test()` fast path and the #1635 whole-string behavior). The only
+// structural change is around a constrained placeholder: a numeric one is
+// wrapped in a capturing group, a bigint one is captured as an integer
+// (`([+-]?\d+)`, keeping `BigInt(...)` safe), and a string one is captured with
+// a newline-inclusive `([\s\S]*)` (instead of the bare `(.*)`) so the tag check
+// sees the placeholder's whole value even across a line break.
+//
+// json.schema keeps calling metadata_to_pattern directly, so it stays on the
+// historical lossy pattern (no capture, no sub-range enforcement) — see #1968's
+// schema-lossiness decision.
+func template_runtime_pattern(row []*nativemetadata.MetadataSchema) (string, []templateCapture) {
+  parts := make([]string, 0, len(row))
+  captures := []templateCapture{}
+  running := 0
+  for i, meta := range row {
+    sub := metadata_to_pattern(struct {
+      top      bool
+      metadata *nativemetadata.MetadataSchema
+    }{
+      top:      false,
+      metadata: meta,
+    })
+    if atomic, kind, ok := template_constrained_capture(meta); ok && template_clear_boundary(row, i) {
+      switch kind {
+      case "number":
+        // A bare numeric placeholder lowers to a non-capturing pattern, so wrap
+        // it; the wrapping paren is the next capturing group.
+        sub = "(" + sub + ")"
+      case "bigint":
+        // The shared number pattern admits decimals/exponents, but those make
+        // `BigInt(...)` throw and no bigint stringifies that way. Capture an
+        // integer only, so the extraction parses safely.
+        sub = "([+-]?\\d+)"
+      default:
+        // A string placeholder lowers to "(.*)", but `.` excludes newlines,
+        // so a value spanning a line break would hand the tag check only the
+        // first line (under-reporting length, mis-matching Pattern). Capture
+        // every character instead, anchored by PatternUtil.Fix.
+        sub = "([\\s\\S]*)"
+      }
+      captures = append(captures, templateCapture{
+        Index:  running + 1,
+        Kind:   kind,
+        Atomic: atomic,
+      })
+    }
+    running += template_count_capturing_groups(sub)
+    parts = append(parts, sub)
+  }
+  return nativeutils.PatternUtil.Fix(strings.Join(parts, "")), captures
+}
+
+// template_clear_boundary reports whether the placeholder at row[i] is delimited
+// strongly enough that the greedy structural regex assigns it a unique — hence
+// correct — substring. An ambiguous placeholder falls back to structural-only
+// matching (tag unenforced, as before) rather than risking a false negative.
+//
+// Two adjacent variable-width placeholders slide their shared boundary iff the
+// left one can extend over the first character of the literal between them: a
+// smaller (non-greedy) split exists exactly when the left variable's match could
+// grow rightward past it. So the placeholder is captured only when, on each side,
+// the nearest variable neighbor cannot absorb the separating literal's first
+// character — `template_boundary_safe` checks that with `template_right_extends`.
+//
+// Examples (all confirmed by regex semantics):
+//   - `${n}-${n}` (#1965): "-" is not in a number's right-extension set, so both
+//     numbers are pinned and enforced.
+//   - `${number}.${number}` / IP grids: "." extends a number (decimal), so the
+//     split slides ("5.9.1.1.1" splits as 5.9|… or 5|9.1|…) — fall back.
+//   - `${string}-${number}` / `${string}X${string}`: a string absorbs any
+//     character, so a string with any sibling falls back.
+//   - `a${string}b` / `prefix${string}suffix` / `${number}%` / `CODE-${string}`:
+//     sole placeholder, the `^`/`$` anchors pin both ends — enforced.
+func template_clear_boundary(row []*nativemetadata.MetadataSchema, i int) bool {
+  return template_boundary_safe(row, i, -1) && template_boundary_safe(row, i, 1)
+}
+
+// template_boundary_safe reports whether row[i]'s boundary in direction dir
+// (-1 left, +1 right) is pinned. The template edge or an immediate literal whose
+// first character the relevant variable cannot absorb pins it; an immediate
+// variable neighbor (no separating literal) never does.
+func template_boundary_safe(row []*nativemetadata.MetadataSchema, i int, dir int) bool {
+  j := i + dir
+  if j < 0 || j >= len(row) {
+    return true // template start/end
+  }
+  if template_is_literal(row[j]) == false {
+    return false // a variable-width placeholder sits flush against row[i]
+  }
+  k := j + dir
+  if k < 0 || k >= len(row) {
+    return true // literal then the template edge
+  }
+  // row[k] is the nearest variable across the literal row[j]. The boundary slides
+  // iff the variable on the row[i] side can extend over the literal's first
+  // character: rightward that is row[i] itself, leftward it is the left variable.
+  absorber := row[i]
+  if dir < 0 {
+    absorber = row[k]
+  }
+  ch, ok := template_literal_first(row[j])
+  if ok == false {
+    return true
+  }
+  return template_right_extends(template_variable_kind(absorber), ch) == false
+}
+
+// template_variable_kind returns the base type a variable placeholder matches:
+// "number", "bigint", or "string". Anything else (boolean, unions, constants)
+// is treated as "string" — conservatively absorbing, so its neighbor falls back.
+func template_variable_kind(meta *nativemetadata.MetadataSchema) string {
+  if meta != nil && meta.Bucket() == 1 && len(meta.Atomics) == 1 {
+    switch meta.Atomics[0].Type {
+    case "number", "bigint":
+      return meta.Atomics[0].Type
+    }
+  }
+  return "string"
+}
+
+// template_right_extends reports whether a variable of the given kind, having
+// matched up to a boundary, could extend its match over ch. number and bigint
+// placeholders both lower to PatternUtil.NUMBER (metadata_to_pattern), which ends
+// in a digit and can grow through another digit, a decimal point, or an exponent
+// marker — the leading sign cannot follow a digit. (A constrained bigint is
+// captured as integer-only, but an unconstrained or fallen-back bigint neighbor
+// still matches the decimal/exponent NUMBER span, so it absorbs the same set.) A
+// string matches every character.
+func template_right_extends(kind string, ch rune) bool {
+  switch kind {
+  case "number", "bigint":
+    return (ch >= '0' && ch <= '9') || ch == '.' || ch == 'e' || ch == 'E'
+  default:
+    return true
+  }
+}
+
+// template_literal_first returns the first character of a literal segment's text.
+func template_literal_first(meta *nativemetadata.MetadataSchema) (rune, bool) {
+  if meta == nil || len(meta.Constants) == 0 || len(meta.Constants[0].Values) == 0 {
+    return 0, false
+  }
+  runes := []rune(fmt.Sprint(meta.Constants[0].Values[0].Value))
+  if len(runes) == 0 {
+    return 0, false
+  }
+  return runes[0], true
+}
+
+// template_is_literal reports whether a row element is a single fixed literal
+// segment (exactly one constant value), i.e. a fixed-width boundary between
+// placeholders.
+func template_is_literal(meta *nativemetadata.MetadataSchema) bool {
+  return meta != nil && meta.IsConstant() && meta.Size() == 1
+}
+
+// template_constrained_capture reports whether a template placeholder is a
+// simple primitive (`number`, `bigint`, or `string`) carrying a fully
+// runtime-checkable tag matrix, returning its atomic and base-type kind. Only
+// such placeholders earn a capture group plus extraction-based conditions.
+//
+// The matrix must be fully constrained — every OR row contributes at least one
+// validate-able tag. A row with no validate-able tag accepts every value of the
+// base type, which would unconstrain the whole matrix; honoring only the
+// validate-able rows would then reject values the type accepts. Such
+// placeholders (and `boolean`/union/constant placeholders, and tags with no
+// `Validate`) fall back to the historical behavior: structural match only, with
+// the tag left unenforced rather than emitting a broken check.
+func template_constrained_capture(meta *nativemetadata.MetadataSchema) (*nativemetadata.MetadataAtomic, string, bool) {
+  if meta == nil || meta.Bucket() != 1 || len(meta.Atomics) != 1 {
+    return nil, "", false
+  }
+  if meta.IsRequired() == false || meta.Nullable {
+    return nil, "", false
+  }
+  atomic := meta.Atomics[0]
+  if atomic == nil || (atomic.Type != "number" && atomic.Type != "bigint" && atomic.Type != "string") {
+    return nil, "", false
+  }
+  if template_fully_constrained(atomic.Tags) == false {
+    return nil, "", false
+  }
+  return atomic, atomic.Type, true
+}
+
+// template_fully_constrained reports whether every OR row of a tag matrix holds
+// at least one validate-able tag, so no row admits the base type unconditionally.
+func template_fully_constrained(tags [][]nativemetadata.IMetadataTypeTag) bool {
+  if len(tags) == 0 {
+    return false
+  }
+  for _, row := range tags {
+    validating := false
+    for _, tag := range row {
+      if tag.Validate != "" {
+        validating = true
+        break
+      }
+    }
+    if validating == false {
+      return false
+    }
+  }
+  return true
+}
+
+// template_count_capturing_groups counts the capturing groups in a regex
+// fragment: an unescaped `(` that does not open an inline group `(?...)`. It
+// drives the running capture index, so it must agree with how a JS regex engine
+// numbers groups left to right.
+func template_count_capturing_groups(pattern string) int {
+  runes := []rune(pattern)
+  count := 0
+  backslashes := 0
+  for i, ch := range runes {
+    if ch == '\\' {
+      backslashes++
+      continue
+    }
+    if ch == '(' && backslashes%2 == 0 {
+      if i+1 >= len(runes) || runes[i+1] != '?' {
+        count++
+      }
+    }
+    backslashes = 0
+  }
+  return count
+}

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/tests/template/src/structures/TemplateInterpolationTagged.ts
+++ b/tests/template/src/structures/TemplateInterpolationTagged.ts
@@ -1,0 +1,41 @@
+import typia from "typia";
+
+import { Spoiler } from "../utils/Spoiler";
+import { TestRandomGenerator } from "../utils/TestRandomGenerator";
+
+export interface TemplateInterpolationTagged {
+  percent: `${number & typia.tags.Minimum<0> & typia.tags.Maximum<100>}%`;
+  serial: `SN-${number & typia.tags.Type<"uint32">}`;
+  code: `CODE-${string & typia.tags.MinLength<4> & typia.tags.MaxLength<8>}`;
+}
+export namespace TemplateInterpolationTagged {
+  export function generate(): TemplateInterpolationTagged {
+    return {
+      // The interpolated values are plain `number`/`string`; narrow each
+      // template back to its tagged placeholder type (a structural subtype).
+      percent:
+        `${TestRandomGenerator.integer(0, 100)}%` as TemplateInterpolationTagged["percent"],
+      serial:
+        `SN-${TestRandomGenerator.integer(0, 100_000)}` as TemplateInterpolationTagged["serial"],
+      code: `CODE-${TestRandomGenerator.string(6)}` as TemplateInterpolationTagged["code"],
+    };
+  }
+
+  export const SPOILERS: Spoiler<TemplateInterpolationTagged>[] = [
+    (input) => {
+      // matches `${number}%` structurally, but violates Maximum<100>
+      input.percent = "150%" as any;
+      return ["$input.percent"];
+    },
+    (input) => {
+      // matches `SN-${number}` structurally, but a decimal is not uint32
+      input.serial = "SN-1.5" as any;
+      return ["$input.serial"];
+    },
+    (input) => {
+      // matches `CODE-${string}` structurally, but two characters is below MinLength<4>
+      input.code = "CODE-ab" as any;
+      return ["$input.code"];
+    },
+  ];
+}

--- a/tests/template/src/structures/index.ts
+++ b/tests/template/src/structures/index.ts
@@ -133,6 +133,7 @@ export * from "./SetSimple";
 export * from "./SetUnion";
 export * from "./TemplateAtomic";
 export * from "./TemplateConstant";
+export * from "./TemplateInterpolationTagged";
 export * from "./TemplateUnion";
 export * from "./ToJsonArray";
 export * from "./ToJsonAtomicSimple";

--- a/website/src/content/docs/validators/tags.mdx
+++ b/website/src/content/docs/validators/tags.mdx
@@ -89,6 +89,20 @@ Note the parentheses on the third example — `number & (Type<"int32"> | Type<"f
 
 If you intersect a tag with the wrong base type (e.g. `tags.MaxLength<100>` on a `number`), the TypeScript compiler will reject it.
 
+### Inside template literals
+
+A tag intersected into a template-literal interpolation constrains that placeholder's parsed value, not just the surrounding shape:
+
+```typescript copy
+type Percent = `${number & tags.Minimum<0> & tags.Maximum<100>}%`;
+type Serial = `SN-${bigint & tags.Minimum<0n>}`;
+type Hex = `0x${string & tags.Pattern<"^[0-9a-fA-F]+$">}`;
+```
+
+The validator matches the template's structural pattern, then re-parses each constrained placeholder — `Number(...)` for a `number`, `BigInt(...)` for a `bigint`, the raw substring for a `string` — and runs that placeholder's own tag checks against it. So `"150%"` matches `` `${number}%` `` structurally but fails `Maximum<100>`, and `"0x1.5"` fails the hex `Pattern`. A `bigint` placeholder captures an integer only, so `"SN-1.5"` is rejected up front and `BigInt(...)` never throws. `is` / `assert` / `validate` agree, and `random` generates a constrained value that round-trips.
+
+> `json.schema` / `llm.schema` keep the template's structural `pattern` only: a numeric sub-range like `[0, 100]` cannot be expressed inside a JSON Schema string `pattern`, so a placeholder's tags are intentionally dropped from the emitted schema (the runtime validator still enforces them). Whole-string template tags — e.g. `` tags.MaxLength<30> & `prefix${string}postfix` `` — stay on the schema as before.
+
 ### Full catalogue
 
 #### `number` and `bigint`


### PR DESCRIPTION
## Intent

Enforce `tags.*` constraints placed **inside** a template-literal interpolation (`${...}`), which were silently ignored for years (#1965, #1175, #1202). This is the AI-assisted challenge of #1968.

`` `${number & Minimum<0> & Maximum<100>}%` `` validated as `` `${number}%` ``; `` `${number & Type<"int32">}` `` accepted `"0.1"`; `` `CHECK${string & MinLength<32> & Pattern<…>}` `` validated as `/^CHECK(.*)/`. Now each constrained placeholder is captured, re-extracted, parsed to its base type, and checked against its own tag predicates.

## Scope

- **`core/programmers/iterate/template_runtime_pattern.go`** (new) — builds the capturing structural regex + capture map, with a soundness gate (`template_clear_boundary` / `template_right_extends`) that captures a placeholder only when its greedy split is provably unique.
- **`core/programmers/iterate/check_template.go`** — wires per-placeholder tag conditions (number → `Number(...)`, bigint → integer-only `BigInt(...)`, string → raw `([\s\S]*)`) into the entry/inline paths, composing with whole-string template tags (#1635) and unions.
- Matrix fixture `TemplateInterpolationTagged` + transform/runtime test + white-box unit tests.
- Docs + `typia` version bump (native source change, per Change Integrity).

## Soundness

The structural regex is greedy, so a placeholder is captured only when its boundaries are unambiguous: a separator literal whose first character the neighbouring variable could absorb (`.`/`e`/`E` for number/bigint; any char for string) forces a fallback to structural-only matching (tag unenforced — never a regression). So `${n}-${n}`, IP-integer grids, and `prefix${string}suffix` stay **enforced**, while `${n}.${n}` and `${string}-${number}` **fall back** rather than emit a false negative.

## Deferred / documented

- `json.schema` / `llm.schema` stay lossy: a numeric sub-range cannot be expressed in a JSON Schema string `pattern` (validation still enforces it).
- Ambiguous two-placeholder cases (`${number}.${number}` with a decimal-boundary tag, etc.) fall back — sound under-enforcement, not a false negative.

## Test plan

- **Go**: white-box unit tests (100% of the 21 new/changed functions) + a transform+runtime test covering #1965/#1175/#1202, unions, bigint (decimal rejected without throw), newline strings, dynamic keys, and every adjacency/fallback case. `go test ./...` and `go test -tags typia_native_internal ./...` green locally.
- **TS**: `TemplateInterpolationTagged` crosses the generator-driven matrix (is / assert / validate / equals / random / protobuf / stringify / clone / prune); verified via `pnpm build` + `pnpm test` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbwTJN8tp2F7m2sPzppjh1
