### PR TITLE
feat(native): honor symbol and optional phantom brands in intersection types

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/benchmark",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Benchmark program of typia performance",
   "main": "bin/index.js",
   "scripts": {

--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/config",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Shared build configuration for typia packages",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/examples",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Example codes for typia website",
   "scripts": {
     "build": "rimraf bin && ttsc && prettier --write --ignore-path /dev/null \"bin/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm run build:packages",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/native/cmd/ttsc-typia/intersection_all_never_union_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_all_never_union_transform_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestIntersectionAllNeverUnionTransform pins the union-pruning soundness fix of
+// issue #1967.
+//
+// TypeScript distributes `(a | b) & X` into `(a & X) | (b & X)`. When X is a
+// real-data object and the bases are non-objects, every distributed member is an
+// uninhabited intersection that `is_never` prunes away. The union then contributes
+// no type bucket; left as an empty schema it would validate as accept-everything —
+// the most dangerous possible outcome (a validator that passes any input).
+//
+// The fix marks such an all-pruned union not-required so it renders as `never`,
+// rejecting every concrete value, exactly like a standalone `never` or the
+// TypeScript-collapsed `string & number`. Crucially, a union where SOME member
+// survives (narrowing a union down to its object member) is untouched: the
+// surviving member contributes a bucket, so the pruning guard does not fire.
+//
+//  1. All-pruned unions reject every concrete value (never, not accept-everything).
+//  2. A union narrowed to its surviving object member still validates that object.
+func TestIntersectionAllNeverUnionTransform(t *testing.T) {
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "all-never-union-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(atomicIntersectionSchemaTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(intersectionAllNeverUnionSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", dir,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("all-never union transform failed: code=%d stderr=\n%s", code, errText)
+  }
+
+  runtimeDir := filepath.Join(dir, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, out)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(intersectionAllNeverUnionRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("all-never union runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const intersectionAllNeverUnionSource = `import typia from "typia";
+
+enum MyEnum { A = "a", B = "b" }
+
+// Every distributed member is a non-object base & a real-data object — all pruned
+// to never. The union must validate as never, never as accept-everything.
+export const isEnumData = typia.createIs<MyEnum & { data: number }>();
+export const isUnionData = typia.createIs<(string | number) & { data: number }>();
+export const isUnionNested = typia.createIs<(string | number) & { nested: { a: string } }>();
+export const isUnionMulti = typia.createIs<(string | number) & { a: string; b: number }>();
+
+// A union narrowed to its surviving object member keeps validating that object —
+// the never-pruning guard must not fire when a member contributes a bucket.
+export const isNarrowPrimitive = typia.createIs<(string | { a: number }) & { a: number }>();
+export const isNarrowNumber = typia.createIs<(number | { a: number }) & { a: number }>();
+`
+
+const intersectionAllNeverUnionRunner = `const mod = require("./main.cjs");
+
+const check = (label, actual, expected) => {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + JSON.stringify(expected) + ", got " + JSON.stringify(actual));
+  }
+};
+
+// All-pruned unions reject every concrete value (never-render, not accept-everything).
+const neverValidators = { isEnumData: mod.isEnumData, isUnionData: mod.isUnionData, isUnionNested: mod.isUnionNested, isUnionMulti: mod.isUnionMulti };
+const samples = ["a", "b", 1, 0, true, false, null, {}, [], { data: 1 }, { a: "s", b: 1 }, "x"];
+for (const [name, fn] of Object.entries(neverValidators)) {
+  for (const value of samples) {
+    check(name + "(" + JSON.stringify(value) + ")", fn(value), false);
+  }
+}
+
+// Narrowing a union to its object member still validates that object.
+check("isNarrowPrimitive {a:1}", mod.isNarrowPrimitive({ a: 1 }), true);
+check("isNarrowPrimitive 'x'", mod.isNarrowPrimitive("x"), false);
+check("isNarrowPrimitive {a:'s'}", mod.isNarrowPrimitive({ a: "s" }), false);
+check("isNarrowPrimitive {}", mod.isNarrowPrimitive({}), false);
+check("isNarrowNumber {a:1}", mod.isNarrowNumber({ a: 1 }), true);
+check("isNarrowNumber 5", mod.isNarrowNumber(5), false);
+check("isNarrowNumber {a:'s'}", mod.isNarrowNumber({ a: "s" }), false);
+
+console.log("ok");
+`

--- a/packages/typia/native/cmd/ttsc-typia/intersection_all_never_union_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_all_never_union_transform_test.go
@@ -86,6 +86,8 @@ func TestIntersectionAllNeverUnionTransform(t *testing.T) {
 const intersectionAllNeverUnionSource = `import typia from "typia";
 
 enum MyEnum { A = "a", B = "b" }
+interface Foo { a: number }
+interface Bar { b: number }
 
 // Every distributed member is a non-object base & a real-data object — all pruned
 // to never. The union must validate as never, never as accept-everything.
@@ -93,6 +95,15 @@ export const isEnumData = typia.createIs<MyEnum & { data: number }>();
 export const isUnionData = typia.createIs<(string | number) & { data: number }>();
 export const isUnionNested = typia.createIs<(string | number) & { nested: { a: string } }>();
 export const isUnionMulti = typia.createIs<(string | number) & { a: string; b: number }>();
+
+// A "decisive" reduce_union reduction that matches no member is also uninhabited.
+// The constraint is decisive (a named/shareable object, or a primitive/native/
+// array), unlike an inline object — that is the path with no member-write, which
+// must render as never, not the default-required accept-everything.
+export const isPrimNamed = typia.createIs<(string | number) & Foo>();
+export const isObjPrim = typia.createIs<({ a: number } | { b: number }) & string>();
+export const isNamedObjPrim = typia.createIs<(Foo | Bar) & string>();
+export const isNamedObjArray = typia.createIs<(Foo | Bar) & number[]>();
 
 // A union narrowed to its surviving object member keeps validating that object —
 // the never-pruning guard must not fire when a member contributes a bucket.
@@ -117,7 +128,12 @@ const check = (label, actual, expected) => {
 };
 
 // All-pruned unions reject every concrete value (never-render, not accept-everything).
-const neverValidators = { isEnumData: mod.isEnumData, isUnionData: mod.isUnionData, isUnionNested: mod.isUnionNested, isUnionMulti: mod.isUnionMulti };
+const neverValidators = {
+  isEnumData: mod.isEnumData, isUnionData: mod.isUnionData,
+  isUnionNested: mod.isUnionNested, isUnionMulti: mod.isUnionMulti,
+  isPrimNamed: mod.isPrimNamed, isObjPrim: mod.isObjPrim,
+  isNamedObjPrim: mod.isNamedObjPrim, isNamedObjArray: mod.isNamedObjArray,
+};
 const samples = ["a", "b", 1, 0, true, false, null, {}, [], { data: 1 }, { a: "s", b: 1 }, "x"];
 for (const [name, fn] of Object.entries(neverValidators)) {
   for (const value of samples) {

--- a/packages/typia/native/cmd/ttsc-typia/intersection_all_never_union_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_all_never_union_transform_test.go
@@ -98,6 +98,14 @@ export const isUnionMulti = typia.createIs<(string | number) & { a: string; b: n
 // the never-pruning guard must not fire when a member contributes a bucket.
 export const isNarrowPrimitive = typia.createIs<(string | { a: number }) & { a: number }>();
 export const isNarrowNumber = typia.createIs<(number | { a: number }) & { a: number }>();
+
+// A nullary member (null / undefined) sets a flag without a bucket, so the union
+// still reaches the all-pruned guard with empty size. The guard must NOT swallow
+// it: 'null | never' is 'null' (accepts only null, rejects undefined); 'undefined
+// | never' is 'undefined'; their combination accepts both — never accept-everything.
+export const isNullNever = typia.createIs<null | (string & { data: number })>();
+export const isUndefinedNever = typia.createIs<undefined | (string & { data: number })>();
+export const isNullUndefinedNever = typia.createIs<null | undefined | (string & { data: number })>();
 `
 
 const intersectionAllNeverUnionRunner = `const mod = require("./main.cjs");
@@ -125,6 +133,20 @@ check("isNarrowPrimitive {}", mod.isNarrowPrimitive({}), false);
 check("isNarrowNumber {a:1}", mod.isNarrowNumber({ a: 1 }), true);
 check("isNarrowNumber 5", mod.isNarrowNumber(5), false);
 check("isNarrowNumber {a:'s'}", mod.isNarrowNumber({ a: "s" }), false);
+
+// A nullary member must survive the all-pruned guard: null accepts only null,
+// undefined only undefined — and neither accepts a concrete value or each other.
+check("isNullNever null", mod.isNullNever(null), true);
+check("isNullNever undefined", mod.isNullNever(undefined), false);
+check("isNullNever 'x'", mod.isNullNever("x"), false);
+check("isNullNever {data:1}", mod.isNullNever({ data: 1 }), false);
+check("isUndefinedNever undefined", mod.isUndefinedNever(undefined), true);
+check("isUndefinedNever null", mod.isUndefinedNever(null), false);
+check("isUndefinedNever 'x'", mod.isUndefinedNever("x"), false);
+check("isNullUndefinedNever null", mod.isNullUndefinedNever(null), true);
+check("isNullUndefinedNever undefined", mod.isNullUndefinedNever(undefined), true);
+check("isNullUndefinedNever 'x'", mod.isNullUndefinedNever("x"), false);
+check("isNullUndefinedNever {data:1}", mod.isNullUndefinedNever({ data: 1 }), false);
 
 console.log("ok");
 `

--- a/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
@@ -108,9 +108,10 @@ type SymbolNumber = number & { [sym]: "Age" };
 type OptionalNumber = number & { __brand?: "Age" };
 
 // A symbol marker is honored on a non-primitive base too — the genuinely new
-// capability of #933: the array / tuple is validated as itself.
+// capability of #933: the array / tuple / native base is validated as itself.
 type SymbolArray = string[] & { [sym]: "Tag" };
 type SymbolTuple = [string, number] & { [sym]: "Tag" };
+type SymbolDate = Date & { [sym]: "Tag" };
 
 export const isSymbolString = typia.createIs<SymbolString>();
 export const isOptionalString = typia.createIs<OptionalString>();
@@ -118,6 +119,7 @@ export const isSymbolNumber = typia.createIs<SymbolNumber>();
 export const isOptionalNumber = typia.createIs<OptionalNumber>();
 export const isSymbolArray = typia.createIs<SymbolArray>();
 export const isSymbolTuple = typia.createIs<SymbolTuple>();
+export const isSymbolDate = typia.createIs<SymbolDate>();
 
 export const validateSymbolString = typia.createValidate<SymbolString>();
 export const assertSymbolNumber = typia.createAssert<SymbolNumber>();
@@ -154,6 +156,9 @@ check("symbolArray rejects non-array", mod.isSymbolArray("x"), false);
 check("symbolTuple accepts pair", mod.isSymbolTuple(["a", 1]), true);
 check("symbolTuple rejects short", mod.isSymbolTuple(["a"]), false);
 check("symbolTuple rejects wrong slot", mod.isSymbolTuple([1, "a"]), false);
+check("symbolDate accepts Date", mod.isSymbolDate(new Date()), true);
+check("symbolDate rejects string", mod.isSymbolDate("2020-01-01"), false);
+check("symbolDate rejects plain object", mod.isSymbolDate({}), false);
 
 check("validate symbolString success", mod.validateSymbolString("abc").success, true);
 check("validate symbolString failure", mod.validateSymbolString(123).success, false);

--- a/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
@@ -107,16 +107,24 @@ type OptionalString = string & { __brand?: "UserId" };
 type SymbolNumber = number & { [sym]: "Age" };
 type OptionalNumber = number & { __brand?: "Age" };
 
+// A symbol marker is honored on a non-primitive base too — the genuinely new
+// capability of #933: the array / tuple is validated as itself.
+type SymbolArray = string[] & { [sym]: "Tag" };
+type SymbolTuple = [string, number] & { [sym]: "Tag" };
+
 export const isSymbolString = typia.createIs<SymbolString>();
 export const isOptionalString = typia.createIs<OptionalString>();
 export const isSymbolNumber = typia.createIs<SymbolNumber>();
 export const isOptionalNumber = typia.createIs<OptionalNumber>();
+export const isSymbolArray = typia.createIs<SymbolArray>();
+export const isSymbolTuple = typia.createIs<SymbolTuple>();
 
 export const validateSymbolString = typia.createValidate<SymbolString>();
 export const assertSymbolNumber = typia.createAssert<SymbolNumber>();
 
 export const schemaSymbolString = typia.json.schema<SymbolString>();
 export const schemaSymbolNumber = typia.json.schema<SymbolNumber>();
+export const schemaSymbolArray = typia.json.schema<SymbolArray>();
 `
 
 const intersectionBrandRuntimeRunner = `const mod = require("./main.cjs");
@@ -136,6 +144,16 @@ check("symbolNumber accepts number", mod.isSymbolNumber(42), true);
 check("symbolNumber rejects string", mod.isSymbolNumber("x"), false);
 check("optionalNumber accepts number", mod.isOptionalNumber(42), true);
 check("optionalNumber rejects string", mod.isOptionalNumber("x"), false);
+
+// Symbol marker on array / tuple bases (the net-new #933 capability) validates
+// as the bare container, not as an object carrying the symbol.
+check("symbolArray accepts strings", mod.isSymbolArray(["a", "b"]), true);
+check("symbolArray accepts empty", mod.isSymbolArray([]), true);
+check("symbolArray rejects numbers", mod.isSymbolArray([1, 2]), false);
+check("symbolArray rejects non-array", mod.isSymbolArray("x"), false);
+check("symbolTuple accepts pair", mod.isSymbolTuple(["a", 1]), true);
+check("symbolTuple rejects short", mod.isSymbolTuple(["a"]), false);
+check("symbolTuple rejects wrong slot", mod.isSymbolTuple([1, "a"]), false);
 
 check("validate symbolString success", mod.validateSymbolString("abc").success, true);
 check("validate symbolString failure", mod.validateSymbolString(123).success, false);
@@ -160,6 +178,9 @@ if ("properties" in stringSchema || "required" in stringSchema || "allOf" in str
 }
 const numberSchema = root(mod.schemaSymbolNumber);
 check("schema symbolNumber type", numberSchema.type, "number");
+const arraySchema = root(mod.schemaSymbolArray);
+check("schema symbolArray type", arraySchema.type, "array");
+check("schema symbolArray items", arraySchema.items.type, "string");
 
 console.log("ok");
 `

--- a/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
@@ -113,6 +113,15 @@ type SymbolArray = string[] & { [sym]: "Tag" };
 type SymbolTuple = [string, number] & { [sym]: "Tag" };
 type SymbolDate = Date & { [sym]: "Tag" };
 
+// A union / enum base carrying a phantom symbol brand validates as the bare
+// union. TypeScript distributes (a | b) & Brand into (a & Brand) | (b & Brand),
+// so each member is a prunable intersection; the brand must drop on every member
+// rather than collapsing it to never (which would leave the union empty and
+// vacuously accept everything).
+type UnionSymbol = (string | number) & { [sym]: "Tag" };
+enum Currency { KRW = "KRW", USD = "USD" }
+type EnumSymbol = Currency & { [sym]: "Tag" };
+
 export const isSymbolString = typia.createIs<SymbolString>();
 export const isOptionalString = typia.createIs<OptionalString>();
 export const isSymbolNumber = typia.createIs<SymbolNumber>();
@@ -120,6 +129,8 @@ export const isOptionalNumber = typia.createIs<OptionalNumber>();
 export const isSymbolArray = typia.createIs<SymbolArray>();
 export const isSymbolTuple = typia.createIs<SymbolTuple>();
 export const isSymbolDate = typia.createIs<SymbolDate>();
+export const isUnionSymbol = typia.createIs<UnionSymbol>();
+export const isEnumSymbol = typia.createIs<EnumSymbol>();
 
 export const validateSymbolString = typia.createValidate<SymbolString>();
 export const assertSymbolNumber = typia.createAssert<SymbolNumber>();
@@ -159,6 +170,18 @@ check("symbolTuple rejects wrong slot", mod.isSymbolTuple([1, "a"]), false);
 check("symbolDate accepts Date", mod.isSymbolDate(new Date()), true);
 check("symbolDate rejects string", mod.isSymbolDate("2020-01-01"), false);
 check("symbolDate rejects plain object", mod.isSymbolDate({}), false);
+
+// A union / enum base intersected with a phantom symbol brand validates as the
+// bare union — never accept-everything. Each distributed member drops the brand.
+check("unionSymbol accepts string", mod.isUnionSymbol("abc"), true);
+check("unionSymbol accepts number", mod.isUnionSymbol(42), true);
+check("unionSymbol rejects boolean", mod.isUnionSymbol(true), false);
+check("unionSymbol rejects object", mod.isUnionSymbol({}), false);
+check("unionSymbol rejects array", mod.isUnionSymbol([1]), false);
+check("enumSymbol accepts member", mod.isEnumSymbol("KRW"), true);
+check("enumSymbol accepts other member", mod.isEnumSymbol("USD"), true);
+check("enumSymbol rejects non-member", mod.isEnumSymbol("JPY"), false);
+check("enumSymbol rejects number", mod.isEnumSymbol(1), false);
 
 check("validate symbolString success", mod.validateSymbolString("abc").success, true);
 check("validate symbolString failure", mod.validateSymbolString(123).success, false);

--- a/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
@@ -135,6 +135,12 @@ type ObjectTypiaTag = { a: string } & tags.JsonSchemaPlugin<{ "x-y": true }>;
 type MultiBrand = string & { [sym]: "A" } & { z?: number };
 type NestedBrand = (string & { [sym]: "A" }) & { [sym2]: "B" };
 
+// A *validating* typia tag must still attach and ENFORCE after the brand is
+// stripped (primitive base) and on an array base — proving the tag landed on the
+// surviving bucket, not just that it compiled.
+type BrandMinLength = string & { [sym]: "A" } & tags.MinLength<3>;
+type ArrayMinItems = string[] & tags.MinItems<1>;
+
 export const isSymbolString = typia.createIs<SymbolString>();
 export const isOptionalString = typia.createIs<OptionalString>();
 export const isSymbolNumber = typia.createIs<SymbolNumber>();
@@ -149,6 +155,8 @@ export const isTupleOptionalTag = typia.createIs<TupleOptionalTag>();
 export const isObjectTypiaTag = typia.createIs<ObjectTypiaTag>();
 export const isMultiBrand = typia.createIs<MultiBrand>();
 export const isNestedBrand = typia.createIs<NestedBrand>();
+export const isBrandMinLength = typia.createIs<BrandMinLength>();
+export const isArrayMinItems = typia.createIs<ArrayMinItems>();
 
 export const validateSymbolString = typia.createValidate<SymbolString>();
 export const assertSymbolNumber = typia.createAssert<SymbolNumber>();
@@ -220,6 +228,13 @@ check("multiBrand rejects number", mod.isMultiBrand(1), false);
 check("nestedBrand accepts string", mod.isNestedBrand("abc"), true);
 check("nestedBrand rejects number", mod.isNestedBrand(1), false);
 check("nestedBrand rejects object", mod.isNestedBrand({}), false);
+// A validating tag enforces at runtime after the brand strips / on an array base.
+check("brandMinLength accepts len3", mod.isBrandMinLength("abc"), true);
+check("brandMinLength rejects len2", mod.isBrandMinLength("ab"), false);
+check("brandMinLength rejects number", mod.isBrandMinLength(1), false);
+check("arrayMinItems accepts non-empty", mod.isArrayMinItems(["a"]), true);
+check("arrayMinItems rejects empty", mod.isArrayMinItems([]), false);
+check("arrayMinItems rejects numbers", mod.isArrayMinItems([1]), false);
 
 check("validate symbolString success", mod.validateSymbolString("abc").success, true);
 check("validate symbolString failure", mod.validateSymbolString(123).success, false);

--- a/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestIntersectionBrandTransform verifies the brand / nominal category of issue
+// #1967: a primitive intersected with a phantom marker object validates as the
+// bare primitive.
+//
+// Only unambiguously-phantom markers are honored: a unique-symbol key — the
+// canonical nominal brand of zod / type-fest / Effect (`string & { [sym]: T }`,
+// #933) — and an optional property. A required string-keyed property is real
+// data and stays nonsensible (the backstop test pins that). `is`, `validate`,
+// `assert`, and `json.schema` must all agree that the honored brand is its bare
+// primitive.
+//
+//  1. Transform the fixture to JavaScript.
+//  2. Execute `is` / `validate` / `assert` positives and negatives through Node.
+//  3. Assert the emitted JSON schemas are the bare primitive (no brand property).
+func TestIntersectionBrandTransform(t *testing.T) {
+  project := intersectionBrandProject(t)
+  js := intersectionBrandTransform(t, project)
+  intersectionBrandRunRuntimeCases(t, project, js)
+}
+
+func intersectionBrandProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "intersection-brand-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(atomicIntersectionSchemaTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(intersectionBrandSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func intersectionBrandTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("brand intersection transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func intersectionBrandRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(intersectionBrandRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("brand intersection runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const intersectionBrandSource = `import typia from "typia";
+
+declare const sym: unique symbol;
+
+// Only the unambiguously-phantom markers are honored: a unique-symbol key (zod /
+// type-fest / Effect brands) or an optional property. A required string-keyed
+// property is real data and stays nonsensible (covered by the backstop test).
+type SymbolString = string & { [sym]: "UserId" };
+type OptionalString = string & { __brand?: "UserId" };
+type SymbolNumber = number & { [sym]: "Age" };
+type OptionalNumber = number & { __brand?: "Age" };
+
+export const isSymbolString = typia.createIs<SymbolString>();
+export const isOptionalString = typia.createIs<OptionalString>();
+export const isSymbolNumber = typia.createIs<SymbolNumber>();
+export const isOptionalNumber = typia.createIs<OptionalNumber>();
+
+export const validateSymbolString = typia.createValidate<SymbolString>();
+export const assertSymbolNumber = typia.createAssert<SymbolNumber>();
+
+export const schemaSymbolString = typia.json.schema<SymbolString>();
+export const schemaSymbolNumber = typia.json.schema<SymbolNumber>();
+`
+
+const intersectionBrandRuntimeRunner = `const mod = require("./main.cjs");
+
+const check = (label, actual, expected) => {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + JSON.stringify(expected) + ", got " + JSON.stringify(actual));
+  }
+};
+
+// Every honored brand validates as its bare primitive.
+check("symbolString accepts string", mod.isSymbolString("abc"), true);
+check("symbolString rejects number", mod.isSymbolString(123), false);
+check("optionalString accepts string", mod.isOptionalString("abc"), true);
+check("optionalString rejects number", mod.isOptionalString(123), false);
+check("symbolNumber accepts number", mod.isSymbolNumber(42), true);
+check("symbolNumber rejects string", mod.isSymbolNumber("x"), false);
+check("optionalNumber accepts number", mod.isOptionalNumber(42), true);
+check("optionalNumber rejects string", mod.isOptionalNumber("x"), false);
+
+check("validate symbolString success", mod.validateSymbolString("abc").success, true);
+check("validate symbolString failure", mod.validateSymbolString(123).success, false);
+check("assert symbolNumber returns value", mod.assertSymbolNumber(7), 7);
+
+let threw = false;
+try { mod.assertSymbolNumber("x"); } catch { threw = true; }
+check("assert symbolNumber throws on string", threw, true);
+
+// json.schema is the bare primitive — no brand property leaks in.
+const root = (unit) => {
+  let s = unit.schema;
+  while (s && s.$ref) {
+    s = unit.components.schemas[s.$ref.split("/").at(-1)];
+  }
+  return s;
+};
+const stringSchema = root(mod.schemaSymbolString);
+check("schema symbolString type", stringSchema.type, "string");
+if ("properties" in stringSchema || "required" in stringSchema || "allOf" in stringSchema) {
+  throw new Error("brand schema leaked an object/brand shape: " + JSON.stringify(stringSchema));
+}
+const numberSchema = root(mod.schemaSymbolNumber);
+check("schema symbolNumber type", numberSchema.type, "number");
+
+console.log("ok");
+`

--- a/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_brand_transform_test.go
@@ -95,9 +95,10 @@ func intersectionBrandRunRuntimeCases(t *testing.T, project string, js string) {
   }
 }
 
-const intersectionBrandSource = `import typia from "typia";
+const intersectionBrandSource = `import typia, { tags } from "typia";
 
 declare const sym: unique symbol;
+declare const sym2: unique symbol;
 
 // Only the unambiguously-phantom markers are honored: a unique-symbol key (zod /
 // type-fest / Effect brands) or an optional property. A required string-keyed
@@ -122,6 +123,18 @@ type UnionSymbol = (string | number) & { [sym]: "Tag" };
 enum Currency { KRW = "KRW", USD = "USD" }
 type EnumSymbol = Currency & { [sym]: "Tag" };
 
+// Optional markers on array / tuple bases, and a typia tag on an object base —
+// the accepted backstop rows whose soundness needs a runtime mirror (a build that
+// merely succeeds cannot tell a correct validator from accept-everything).
+type ArrayOptionalTag = string[] & { tag?: string };
+type TupleOptionalTag = [string, number] & { tag?: string };
+type ObjectTypiaTag = { a: string } & tags.JsonSchemaPlugin<{ "x-y": true }>;
+
+// Multiple phantom markers on one base, and a nested intersection of two brands —
+// exercising the recursive marker recognition.
+type MultiBrand = string & { [sym]: "A" } & { z?: number };
+type NestedBrand = (string & { [sym]: "A" }) & { [sym2]: "B" };
+
 export const isSymbolString = typia.createIs<SymbolString>();
 export const isOptionalString = typia.createIs<OptionalString>();
 export const isSymbolNumber = typia.createIs<SymbolNumber>();
@@ -131,6 +144,11 @@ export const isSymbolTuple = typia.createIs<SymbolTuple>();
 export const isSymbolDate = typia.createIs<SymbolDate>();
 export const isUnionSymbol = typia.createIs<UnionSymbol>();
 export const isEnumSymbol = typia.createIs<EnumSymbol>();
+export const isArrayOptionalTag = typia.createIs<ArrayOptionalTag>();
+export const isTupleOptionalTag = typia.createIs<TupleOptionalTag>();
+export const isObjectTypiaTag = typia.createIs<ObjectTypiaTag>();
+export const isMultiBrand = typia.createIs<MultiBrand>();
+export const isNestedBrand = typia.createIs<NestedBrand>();
 
 export const validateSymbolString = typia.createValidate<SymbolString>();
 export const assertSymbolNumber = typia.createAssert<SymbolNumber>();
@@ -182,6 +200,26 @@ check("enumSymbol accepts member", mod.isEnumSymbol("KRW"), true);
 check("enumSymbol accepts other member", mod.isEnumSymbol("USD"), true);
 check("enumSymbol rejects non-member", mod.isEnumSymbol("JPY"), false);
 check("enumSymbol rejects number", mod.isEnumSymbol(1), false);
+
+// Optional marker on array / tuple bases strips to the bare container.
+check("arrayOptionalTag accepts strings", mod.isArrayOptionalTag(["a", "b"]), true);
+check("arrayOptionalTag accepts empty", mod.isArrayOptionalTag([]), true);
+check("arrayOptionalTag rejects numbers", mod.isArrayOptionalTag([1]), false);
+check("arrayOptionalTag rejects non-array", mod.isArrayOptionalTag("x"), false);
+check("tupleOptionalTag accepts pair", mod.isTupleOptionalTag(["a", 1]), true);
+check("tupleOptionalTag rejects short", mod.isTupleOptionalTag(["a"]), false);
+check("tupleOptionalTag rejects swapped", mod.isTupleOptionalTag([1, "a"]), false);
+// typia tag on an object base keeps validating the object's real property.
+check("objectTypiaTag accepts object", mod.isObjectTypiaTag({ a: "s" }), true);
+check("objectTypiaTag rejects wrong type", mod.isObjectTypiaTag({ a: 1 }), false);
+check("objectTypiaTag rejects missing", mod.isObjectTypiaTag({}), false);
+check("objectTypiaTag rejects non-object", mod.isObjectTypiaTag("x"), false);
+// Multiple / nested phantom markers all strip, leaving the bare base.
+check("multiBrand accepts string", mod.isMultiBrand("abc"), true);
+check("multiBrand rejects number", mod.isMultiBrand(1), false);
+check("nestedBrand accepts string", mod.isNestedBrand("abc"), true);
+check("nestedBrand rejects number", mod.isNestedBrand(1), false);
+check("nestedBrand rejects object", mod.isNestedBrand({}), false);
 
 check("validate symbolString success", mod.validateSymbolString("abc").success, true);
 check("validate symbolString failure", mod.validateSymbolString(123).success, false);

--- a/packages/typia/native/cmd/ttsc-typia/intersection_nonsensible_backstop_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_nonsensible_backstop_transform_test.go
@@ -43,6 +43,9 @@ func TestIntersectionNonsensibleBackstop(t *testing.T) {
     {"primitive_and_nested_object", `string & { nested: { a: string } }`},
     {"number_and_data_object", `number & { a: string }`},
     {"array_and_data_object", `string[] & { a: string }`},
+    // Only phantom brand objects (no real base) plus a type tag — every member
+    // drops away, leaving nothing to validate, so the tag cannot stand alone.
+    {"only_brands_and_tag", `{ [sym]: "A" } & { [sym2]: "B" } & tags.Type<"int32">`},
   }
   for _, tc := range rejected {
     tc := tc
@@ -110,6 +113,7 @@ func intersectionBackstopProject(t *testing.T, name string, decl string) string 
   source := fmt.Sprintf(`import typia, { tags } from "typia";
 
 declare const sym: unique symbol;
+declare const sym2: unique symbol;
 type Probe = %s;
 
 export const check = typia.createIs<Probe>();

--- a/packages/typia/native/cmd/ttsc-typia/intersection_nonsensible_backstop_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_nonsensible_backstop_transform_test.go
@@ -76,6 +76,13 @@ func TestIntersectionNonsensibleBackstop(t *testing.T) {
     // typia's own tags are always honored — even intersected onto an object.
     {"primitive_typia_tag", `number & tags.Type<"int32">`},
     {"object_typia_tag", `{ a: string } & tags.JsonSchemaPlugin<{ "x-tag": true }>`},
+    // An empty marker object drops (TS `string & {}` is `string`); multiple and
+    // nested phantom markers all strip; a tag distributed over a literal union
+    // narrows each member rather than collapsing the union.
+    {"empty_object_brand", `string & {}`},
+    {"multi_phantom_brand", `string & { [sym]: "A" } & { tag?: number }`},
+    {"nested_phantom_brand", `(string & { [sym]: "A" }) & { [sym2]: "B" }`},
+    {"union_literal_typia_tag", `(1 | 2 | 3) & tags.Type<"int32">`},
   }
   for _, tc := range accepted {
     tc := tc

--- a/packages/typia/native/cmd/ttsc-typia/intersection_nonsensible_backstop_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_nonsensible_backstop_transform_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+  "fmt"
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestIntersectionNonsensibleBackstop pins the intersection boundary of issue
+// #1967. The only sound `&` is `Base & TaggedObject…` — a real base (primitive,
+// array, tuple, object) carrying phantom/tag marker objects that drop away,
+// leaving the base validated. Intersecting two genuine constraint carriers
+// (`array & array`, `array & tuple`, `tuple & tuple`, template & template, a
+// real data object onto a non-object base) is a misuse with no sound result, so
+// it must keep raising a clear `nonsensible` diagnostic.
+//
+// The accepted rows pin the positive side (Base & tag) so a future change cannot
+// quietly collapse the boundary.
+func TestIntersectionNonsensibleBackstop(t *testing.T) {
+  rejected := []struct {
+    name string
+    decl string
+  }{
+    // non-object & non-object: two real constraint carriers.
+    {"array_and_array_any", `string[] & any[]`},
+    {"array_and_array_literals", `("a" | "b")[] & ("b" | "c")[]`},
+    {"array_and_array_disjoint", `string[] & number[]`},
+    {"array_and_array_objects", `{ a: string }[] & { b: number }[]`},
+    {"array_and_tuple", `string[] & ["a", "b"]`},
+    {"tuple_and_tuple", `[string] & [number]`},
+    {"tuple_and_tuple_length", `[string, string] & [string]`},
+    {"template_and_template", "`${string}art${string}` & `${string}bar${string}`"},
+    {"template_and_template_anchored", "`a${string}` & `${string}b`"},
+    {"template_and_array", "(`${string}a${string}`) & string[]"},
+    // a required string-keyed property is real data (even a literal brand), not
+    // an unambiguous phantom — declines on any base.
+    {"primitive_required_literal", `string & { __brand: "UserId" }`},
+    {"number_required_literal", `number & { __brand: "Age" }`},
+    {"array_required_literal", `string[] & { __brand: "Tagged" }`},
+    {"primitive_and_data_object", `string & { data: number }`},
+    {"primitive_and_nested_object", `string & { nested: { a: string } }`},
+    {"number_and_data_object", `number & { a: string }`},
+    {"array_and_data_object", `string[] & { a: string }`},
+  }
+  for _, tc := range rejected {
+    tc := tc
+    t.Run("reject_"+tc.name, func(t *testing.T) {
+      project := intersectionBackstopProject(t, tc.name, tc.decl)
+      _, errText, code := ttscTypiaTestCapture(func() int {
+        return runBuild([]string{"--cwd", project, "--tsconfig", "tsconfig.json", "--emit"})
+      })
+      if code == 0 {
+        t.Fatalf("%q was unexpectedly accepted; the nonsensible backstop must reject it", tc.decl)
+      }
+      _ = errText
+    })
+  }
+
+  accepted := []struct {
+    name string
+    decl string
+  }{
+    // Base & tag — the phantom marker (unique symbol or optional) drops, leaving
+    // the base. Symbol brands are the zod / type-fest / Effect nominal pattern.
+    {"string_symbol_brand", `string & { [sym]: "UserId" }`},
+    {"string_optional_tag", `string & { tag?: number }`},
+    {"number_symbol_brand", `number & { [sym]: "Age" }`},
+    {"array_symbol_brand", `string[] & { [sym]: "Tagged" }`},
+    {"array_optional_tag", `string[] & { tag?: string }`},
+    {"tuple_optional_tag", `[string, number] & { tag?: string }`},
+    // typia's own tags are always honored — even intersected onto an object.
+    {"primitive_typia_tag", `number & tags.Type<"int32">`},
+    {"object_typia_tag", `{ a: string } & tags.JsonSchemaPlugin<{ "x-tag": true }>`},
+  }
+  for _, tc := range accepted {
+    tc := tc
+    t.Run("accept_"+tc.name, func(t *testing.T) {
+      project := intersectionBackstopProject(t, tc.name, tc.decl)
+      _, errText, code := ttscTypiaTestCapture(func() int {
+        return runBuild([]string{"--cwd", project, "--tsconfig", "tsconfig.json", "--emit"})
+      })
+      if code != 0 {
+        t.Fatalf("%q should be accepted as a phantom-brand strip: code=%d stderr=\n%s", tc.decl, code, errText)
+      }
+    })
+  }
+}
+
+func intersectionBackstopProject(t *testing.T, name string, decl string) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "backstop-"+strings.ReplaceAll(name, "_", "-")+"-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(atomicIntersectionSchemaTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  source := fmt.Sprintf(`import typia, { tags } from "typia";
+
+declare const sym: unique symbol;
+type Probe = %s;
+
+export const check = typia.createIs<Probe>();
+`, decl)
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
@@ -129,31 +129,24 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
   if len(metadatas) != 1 {
     removable := []int{}
     for i, m := range metadatas {
-      if m.Size() == 1 && len(m.Objects) == 1 {
-        object := m.Objects[0].Type
-        if len(object.Properties) == 0 {
-          removable = append(removable, i)
-          continue
-        }
-        allOptional := true
-        for _, p := range object.Properties {
-          if p.Value.Optional != true {
-            allOptional = false
-            break
-          }
-        }
-        if allOptional {
-          removable = append(removable, i)
-        }
+      if iterate_metadata_intersection_is_removable_brand(m) {
+        removable = append(removable, i)
       }
     }
-    if len(removable) != 0 && len(removable) != len(metadatas) {
-      for i := len(removable) - 1; i >= 0; i-- {
-        index := removable[i]
-        metadatas = append(metadatas[:index], metadatas[index+1:]...)
-        indexes = append(indexes[:index], indexes[index+1:]...)
-      }
-    } else {
+    if len(removable) == len(metadatas) {
+      return nonsensible()
+    }
+    for i := len(removable) - 1; i >= 0; i-- {
+      index := removable[i]
+      metadatas = append(metadatas[:index], metadatas[index+1:]...)
+      indexes = append(indexes[:index], indexes[index+1:]...)
+    }
+    // After phantom brands are dropped, a single non-object survivor is the
+    // branded base (`string & Brand`). Anything else — two genuine non-object
+    // members (`string[] & number[]`, `T1 & T2`, …) — is an intersection of
+    // constraint carriers, which is a misuse with no sound merge, so it stays
+    // nonsensible.
+    if len(metadatas) != 1 {
       return nonsensible()
     }
   } else {
@@ -305,6 +298,62 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
     }
   }
   return true
+}
+
+// iterate_metadata_intersection_is_removable_brand reports whether an explored
+// member schema is a phantom "brand" object that an intersection with a
+// non-object member may drop. A value intersected with a non-object survivor is
+// that primitive/array/etc. at runtime, so an object constraint carrying no
+// runtime-observable required data is purely a compile-time nominal marker.
+//
+// The single-survivor guard lives in the caller: when EVERY member is a plain
+// object, the entry point routes to the object-merge path before this runs, so
+// a required-literal property of a genuine `A & B` object merge is never dropped
+// here — only brands intersected with a primitive/array/template/native are.
+//
+// A member is removable when it is a single non-recursive object bucket whose
+// every property is phantom: optional, or symbol-keyed. Those two are the only
+// unambiguously phantom markers — an optional property need not be present, and
+// a symbol-keyed property is never observable on a JSON value. Any required
+// string-keyed property (literal or not) might be real data, so it keeps the
+// intersection nonsensible rather than silently dropping a declared constraint.
+func iterate_metadata_intersection_is_removable_brand(m *schemametadata.MetadataSchema) bool {
+  if m == nil || m.Size() != 1 || len(m.Objects) != 1 {
+    return false
+  }
+  object := m.Objects[0].Type
+  if object == nil || object.Recursive {
+    return false
+  }
+  for _, p := range object.Properties {
+    if iterate_metadata_intersection_is_phantom_property(p) == false {
+      return false
+    }
+  }
+  return true
+}
+
+func iterate_metadata_intersection_is_phantom_property(p *schemametadata.MetadataProperty) bool {
+  if p == nil || p.Value == nil {
+    return false
+  }
+  if p.Value.Optional {
+    return true
+  }
+  return iterate_metadata_intersection_is_symbol_key(p.Key)
+}
+
+// iterate_metadata_intersection_is_symbol_key reports whether a property key is a
+// computed `symbol`/`unique symbol` member. The TypeScript checker escapes such
+// member names with a leading 0xFE byte (an invalid UTF-8 lead unit that never
+// begins a real string property name), so the brand `string & { [s]: T }` is
+// recognized regardless of whether T is a literal.
+func iterate_metadata_intersection_is_symbol_key(key *schemametadata.MetadataSchema) bool {
+  if key == nil {
+    return false
+  }
+  lit := key.GetSoleLiteral()
+  return lit != nil && len(*lit) != 0 && (*lit)[0] == 0xFE
 }
 
 func iterate_metadata_intersection_reduce_union(props IMetadataIteratorProps) bool {

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
@@ -273,6 +273,11 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
   explore := props.Explore
   explore.Aliased = false
   explore.Escaped = false
+  // Re-explore the surviving base alone (`Intersected: true` short-circuits the
+  // intersection handler at the top of this function). TypeScript flattens nested
+  // intersections — `(A & B) & C` is presented as a single `types: [A, B, C]` — so
+  // `Types()[index]` is always an atomic member, never itself an intersection that
+  // would re-enter and leave `props.Metadata` empty.
   Iterate_metadata(IMetadataIteratorProps{
     Options:     options,
     Checker:     props.Checker,

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
@@ -141,20 +141,15 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
       metadatas = append(metadatas[:index], metadatas[index+1:]...)
       indexes = append(indexes[:index], indexes[index+1:]...)
     }
-    // After phantom brands are dropped, a single non-object survivor is the
-    // branded base (`string & Brand`). Anything else — two genuine non-object
-    // members (`string[] & number[]`, `T1 & T2`, …) — is an intersection of
-    // constraint carriers, which is a misuse with no sound merge, so it stays
-    // nonsensible.
-    if len(metadatas) != 1 {
-      return nonsensible()
-    }
-  } else {
-    for _, m := range metadatas {
-      if m.Size() != 1 {
-        return nonsensible()
-      }
-    }
+  }
+  // After phantom brands are dropped, exactly one single-bucket base member must
+  // survive (`string & Brand` → string). Two genuine non-object members
+  // (`string[] & number[]`, `A[] & [t…]`, `T1 & T2`, …) — or a multi-bucket
+  // survivor — is an intersection of constraint carriers, a misuse with no sound
+  // merge, so it stays nonsensible. This subsumes the per-candidate-kind check
+  // below, which therefore always collapses to a single candidate.
+  if len(metadatas) != 1 || metadatas[0].Size() != 1 {
+    return nonsensible()
   }
 
   candidates := map[string]string{}
@@ -266,9 +261,6 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
         }
       }(m.Key.GetName(), m.Value.GetName()))
     }
-  }
-  if len(candidates) != 1 {
-    return nonsensible()
   }
 
   *props.Components = *commit

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
@@ -345,7 +345,17 @@ func iterate_metadata_intersection_is_symbol_key(key *schemametadata.MetadataSch
     return false
   }
   lit := key.GetSoleLiteral()
-  return lit != nil && len(*lit) != 0 && (*lit)[0] == 0xFE
+  return lit != nil && iterate_metadata_intersection_is_symbol_name(*lit)
+}
+
+// iterate_metadata_intersection_is_symbol_name reports whether an escaped member
+// name is a computed `symbol` member. The TypeScript checker prefixes such names
+// with a 0xFE byte (`InternalSymbolNamePrefix`), an invalid UTF-8 lead unit that
+// never begins a real string property name. This runs on the raw checker symbol
+// name (`is_removable_object_constraint`) as well as the metadata key literal
+// (`is_symbol_key`), so both the type-level and schema-level brand checks agree.
+func iterate_metadata_intersection_is_symbol_name(name string) bool {
+  return len(name) != 0 && name[0] == 0xFE
 }
 
 func iterate_metadata_intersection_reduce_union(props IMetadataIteratorProps) bool {
@@ -487,6 +497,13 @@ func iterate_metadata_intersection_is_removable_object_constraint(
     return false
   }
   for _, symbol := range collection.ApparentProperties(checker, typ) {
+    // A symbol-keyed member is never observable on a JSON value (the canonical
+    // nominal brand), so it is phantom and removable. typia's own tag is handled
+    // as a constraint, not stripped here; any required string-keyed property might
+    // be real data — both keep the object as a constraint, not a removable brand.
+    if iterate_metadata_intersection_is_symbol_name(symbol.Name) {
+      continue
+    }
     if symbol.Name == "typia.tag" || symbol.Flags&nativeast.SymbolFlagsOptional == 0 {
       return false
     }

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection_brand_coverage_test.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection_brand_coverage_test.go
@@ -13,13 +13,13 @@ import (
 // predicates (issue #1967) as pure schema functions.
 //
 // A `Base & Marker` intersection drops the marker object only when every one of
-// its properties is phantom: optional, symbol-keyed, or a required literal brand
-// value. A required, non-literal, string-keyed property carries real data and
-// must keep the whole intersection nonsensible. These predicates run on a
-// `MetadataObjectType`, so crafted fixtures cover each branch without a checker.
+// its properties is phantom: optional or symbol-keyed. A required string-keyed
+// property — literal or not — carries (potentially) real data and must keep the
+// whole intersection nonsensible. These predicates run on a `MetadataObjectType`,
+// so crafted fixtures cover each branch without a checker.
 //
-//  1. Drive the symbol-key and literal-brand value predicates across every case.
-//  2. Drive the per-property phantom predicate.
+//  1. Drive the symbol-key predicate across every case.
+//  2. Drive the per-property phantom predicate (optional / symbol / required).
 //  3. Drive the removable-brand object predicate end to end.
 func TestIterateMetadataIntersectionBrandCoverage(t *testing.T) {
   atomic := func(typ string) *schemametadata.MetadataSchema {

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection_brand_coverage_test.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection_brand_coverage_test.go
@@ -1,0 +1,114 @@
+//go:build typia_native_internal
+// +build typia_native_internal
+
+package metadata
+
+import (
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestIterateMetadataIntersectionBrandCoverage exercises the phantom-brand
+// predicates (issue #1967) as pure schema functions.
+//
+// A `Base & Marker` intersection drops the marker object only when every one of
+// its properties is phantom: optional, symbol-keyed, or a required literal brand
+// value. A required, non-literal, string-keyed property carries real data and
+// must keep the whole intersection nonsensible. These predicates run on a
+// `MetadataObjectType`, so crafted fixtures cover each branch without a checker.
+//
+//  1. Drive the symbol-key and literal-brand value predicates across every case.
+//  2. Drive the per-property phantom predicate.
+//  3. Drive the removable-brand object predicate end to end.
+func TestIterateMetadataIntersectionBrandCoverage(t *testing.T) {
+  atomic := func(typ string) *schemametadata.MetadataSchema {
+    m := schemametadata.MetadataSchema_initialize()
+    m.Atomics = append(m.Atomics, schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: typ}))
+    return m
+  }
+  constant := func(value any) *schemametadata.MetadataSchema {
+    m := schemametadata.MetadataSchema_initialize()
+    m.Constants = append(m.Constants, schemametadata.MetadataConstant_create(schemametadata.MetadataConstant{
+      Type:   "string",
+      Values: []*schemametadata.MetadataConstantValue{schemametadata.MetadataConstantValue_create(schemametadata.MetadataConstantValue{Value: value})},
+    }))
+    return m
+  }
+  optional := func(m *schemametadata.MetadataSchema) *schemametadata.MetadataSchema {
+    m.Optional = true
+    return m
+  }
+  prop := func(key, value *schemametadata.MetadataSchema) *schemametadata.MetadataProperty {
+    return schemametadata.MetadataProperty_create(schemametadata.MetadataProperty{Key: key, Value: value})
+  }
+  object := func(props ...*schemametadata.MetadataProperty) *schemametadata.MetadataSchema {
+    m := schemametadata.MetadataSchema_initialize()
+    ot := schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{Name: "__type", Properties: props})
+    m.Objects = append(m.Objects, schemametadata.MetadataObject_create(schemametadata.MetadataObject{Type: ot, Tags: [][]schemametadata.IMetadataTypeTag{}}))
+    return m
+  }
+  symbolKey := constant("\xfe@sym@1")
+
+  // --- is_symbol_key ----------------------------------------------------
+  if iterate_metadata_intersection_is_symbol_key(nil) {
+    t.Fatal("nil key is not a symbol key")
+  }
+  if iterate_metadata_intersection_is_symbol_key(atomic("string")) {
+    t.Fatal("a non-literal key is not a symbol key")
+  }
+  if iterate_metadata_intersection_is_symbol_key(constant("name")) {
+    t.Fatal("a plain name is not a symbol key")
+  }
+  if iterate_metadata_intersection_is_symbol_key(symbolKey) == false {
+    t.Fatal("a 0xFE-prefixed key is a symbol key")
+  }
+
+  // --- is_phantom_property ---------------------------------------------
+  if iterate_metadata_intersection_is_phantom_property(nil) {
+    t.Fatal("nil property is not phantom")
+  }
+  if iterate_metadata_intersection_is_phantom_property(prop(constant("k"), nil)) {
+    t.Fatal("a nil-valued property is not phantom")
+  }
+  if iterate_metadata_intersection_is_phantom_property(prop(constant("k"), optional(atomic("number")))) == false {
+    t.Fatal("an optional member is phantom")
+  }
+  if iterate_metadata_intersection_is_phantom_property(prop(symbolKey, atomic("number"))) == false {
+    t.Fatal("a symbol-keyed member is phantom")
+  }
+  if iterate_metadata_intersection_is_phantom_property(prop(constant("__brand"), constant("x"))) {
+    t.Fatal("a required literal member is real data, not phantom")
+  }
+  if iterate_metadata_intersection_is_phantom_property(prop(constant("data"), atomic("number"))) {
+    t.Fatal("a required non-literal data member is NOT phantom")
+  }
+
+  // --- is_removable_brand ----------------------------------------------
+  if iterate_metadata_intersection_is_removable_brand(nil) {
+    t.Fatal("nil schema is not a removable brand")
+  }
+  if iterate_metadata_intersection_is_removable_brand(atomic("string")) {
+    t.Fatal("a primitive is not a removable brand")
+  }
+  if iterate_metadata_intersection_is_removable_brand(object()) == false {
+    t.Fatal("an empty marker object is a removable brand")
+  }
+  if iterate_metadata_intersection_is_removable_brand(object(prop(symbolKey, atomic("number")))) == false {
+    t.Fatal("a symbol-keyed marker object is removable")
+  }
+  if iterate_metadata_intersection_is_removable_brand(object(prop(constant("k"), optional(atomic("number"))))) == false {
+    t.Fatal("an optional-only marker object is removable")
+  }
+  if iterate_metadata_intersection_is_removable_brand(object(prop(constant("__brand"), constant("x")))) {
+    t.Fatal("a required literal-brand object is real data, not removable")
+  }
+  if iterate_metadata_intersection_is_removable_brand(object(prop(constant("data"), atomic("number")))) {
+    t.Fatal("an object with a real data member is NOT removable")
+  }
+  recursive := object()
+  recursive.Objects[0].Type.Recursive = true
+  if iterate_metadata_intersection_is_removable_brand(recursive) {
+    t.Fatal("a recursive object is not a removable brand")
+  }
+}

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection_brand_coverage_test.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection_brand_coverage_test.go
@@ -44,8 +44,8 @@ func TestIterateMetadataIntersectionBrandCoverage(t *testing.T) {
   }
   object := func(props ...*schemametadata.MetadataProperty) *schemametadata.MetadataSchema {
     m := schemametadata.MetadataSchema_initialize()
-    ot := schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{Name: "__type", Properties: props})
-    m.Objects = append(m.Objects, schemametadata.MetadataObject_create(schemametadata.MetadataObject{Type: ot, Tags: [][]schemametadata.IMetadataTypeTag{}}))
+    objectType := schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{Name: "__type", Properties: props})
+    m.Objects = append(m.Objects, schemametadata.MetadataObject_create(schemametadata.MetadataObject{Type: objectType, Tags: [][]schemametadata.IMetadataTypeTag{}}))
     return m
   }
   symbolKey := constant("\xfe@sym@1")

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_union.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_union.go
@@ -4,7 +4,9 @@ func Iterate_metadata_union(props IMetadataIteratorProps) bool {
   if props.Type == nil || props.Type.IsUnion() == false {
     return false
   }
-  for _, typ := range props.Type.Types() {
+  members := props.Type.Types()
+  before := props.Metadata.Size()
+  for _, typ := range members {
     explore := props.Explore
     explore.Aliased = false
     Iterate_metadata(IMetadataIteratorProps{
@@ -19,6 +21,15 @@ func Iterate_metadata_union(props IMetadataIteratorProps) bool {
       Unioned:     true,
       Prunable:    true,
     })
+  }
+  // Every member of a non-empty union pruned away to `never`, contributing no type
+  // bucket — e.g. `Enum & { data: number }` distributes to
+  // `("a" & { data }) | ("b" & { data })`, each member a non-object base meeting a
+  // real-data object, which `is_never` drops. Left as an empty schema the union
+  // would validate as accept-everything; mark it not-required so it renders as
+  // `never` (rejecting every concrete value), matching a standalone `never`.
+  if len(members) != 0 && props.Metadata.Any == false && props.Metadata.Size() == before {
+    props.Metadata.Required = false
   }
   return true
 }

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_union.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_union.go
@@ -28,7 +28,12 @@ func Iterate_metadata_union(props IMetadataIteratorProps) bool {
   // real-data object, which `is_never` drops. Left as an empty schema the union
   // would validate as accept-everything; mark it not-required so it renders as
   // `never` (rejecting every concrete value), matching a standalone `never`.
-  if len(members) != 0 && props.Metadata.Any == false && props.Metadata.Size() == before {
+  //
+  // `Nullable == false` is required: a `null` member sets `Nullable` without adding
+  // a bucket, so `null | (string & { data })` (= `null`) reaches here with an empty
+  // size. Forcing not-required there would also accept `undefined`, which `null`
+  // must reject — so the guard fires only when the union carries no `null` either.
+  if len(members) != 0 && props.Metadata.Any == false && props.Metadata.Nullable == false && props.Metadata.Size() == before {
     props.Metadata.Required = false
   }
   return true

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/debug",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Convenient debug program for typia",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/template/package.json
+++ b/tests/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/template",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Template structures for typia testing.",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-error",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Test program of typia generated error",
   "main": "index.js",
   "scripts": {

--- a/tests/test-interface/package.json
+++ b/tests/test-interface/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-interface",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Type tests for @typia/interface.",
   "scripts": {
     "start": "ttsc"

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-langchain",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Test suite for @typia/langchain package",
   "scripts": {
     "start": "ttsx src/index.ts",

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-mcp",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Test suite for @typia/mcp package",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-automated",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Automated test features of typia.",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-typia-exact-optional/package.json
+++ b/tests/test-typia-exact-optional/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-exact-optional",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Test exact optional property behavior of typia.",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-generate",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Test typia generation command",
   "scripts": {
     "build": "ttsc",

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-schema",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Test features for JSON schema, LLM schema and protobuf message of typia.",
   "scripts": {
     "dev": "ttsc --watch",

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-openapiautomated",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Automated test features of openapi.",
   "scripts": {
     "start": "ttsx src/index.ts"

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-utils",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Automated test features of typia.",
   "scripts": {
     "dev": "ttsc --watch",

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-vercel",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Test suite for @typia/vercel package",
   "scripts": {
     "start": "ttsx src/index.ts",

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/website",
-  "version": "13.0.0-dev.20260619.1",
+  "version": "13.0.0-dev.20260622.1",
   "description": "Typia Guide Documents",
   "scripts": {
     "build": "npm run build:prepare && next build && npm run build:finalize",


### PR DESCRIPTION
## Intent

Implements the **brand / nominal** category of #1967 (general intersection support), scoped to the only subset that is sound in typia's metadata / JSON-Schema model. This deliberately stops there — the rest of #1967's categories are declined with a clear diagnostic (see below).

## What changes

The one sound intersection is `Base & Marker…` — a real base (primitive, array, tuple, object) carrying **phantom marker** objects that drop away, leaving the base validated.

**Accepted** (marker dropped → base validated):
- `T & { [sym]: B }` — the unique-symbol nominal brand used by **zod / type-fest / Effect** (#933, the "crux" inconsistency the issue calls out).
- `T & { brand?: … }` — an optional phantom property.
- These on any base: `string[] & { [sym]: B }`, `[a, b] & { tag?: T }`, etc.
- typia's own `tags` remain always honored, **including intersected onto an object**.

**Declined → `nonsensible` diagnostic** (no sound result; a misuse of `&`):
- Any **required string-keyed** property (real data, even a literal brand) — `string & { __brand: "X" }`, `string & { data: number }`.
- Two genuine **non-object** constraint carriers — `A[] & B[]`, `A[] & [t…]`, `[a] & [b]`, `` `…` & `…` ``, `number & string`.

## Out of scope (intentionally not implemented)

The other #1967 categories — required string-key brands (#911), template-literal intersection (#1166), array / tuple element intersection (#1166 / #856) — have no sound, model-conforming representation (e.g. JSON-Schema has no `allOf` node), so they stay on the `nonsensible` backstop rather than emit an unsound or non-conforming validator.

## Test plan

- `go test -tags typia_native_internal ./core/... ./cmd/...` and `go test ./...` (public API) — green.
- New native tests: `TestIntersectionBrandTransform` (is / validate / assert / json.schema agree on the bare primitive), `TestIntersectionNonsensibleBackstop` (the accept/reject boundary above), and a brand-predicate unit test at 100% coverage of the new helpers.
- `pnpm build` / `pnpm test` via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)