### PR TITLE
fix(native): preserve transform diagnostic details

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/build.go
+++ b/packages/typia/native/cmd/ttsc-typia/build.go
@@ -79,8 +79,8 @@ func runBuild(args []string) int {
   pluginOptions := readTypiaPluginOptions(cwd, *tsconfigPath)
   transformOptions := pluginOptions.TransformOptions()
   extras := nativecontext.ITypiaContext_Extras{
-    AddDiagnostic: func(diag *shimast.Diagnostic) int {
-      transformDiags = append(transformDiags, typiaTransformDiagnostic{Message: "typia transform error"})
+    AddDiagnostic: func(diag *nativecontext.ITypiaDiagnostic) int {
+      transformDiags = append(transformDiags, typiaTransformDiagnosticFrom(diag))
       return len(transformDiags)
     },
   }
@@ -149,17 +149,6 @@ type typiaTransformDiagnostic struct {
   Column  int
   Code    string
   Message string
-}
-
-func (d typiaTransformDiagnostic) String(cwd string) string {
-  file := d.File
-  if rel, err := filepath.Rel(cwd, file); err == nil {
-    file = rel
-  }
-  if d.Line > 0 {
-    return fmt.Sprintf("%s:%d:%d - error TS(%s): %s", file, d.Line, d.Column, d.Code, d.Message)
-  }
-  return fmt.Sprintf("%s - error TS(%s): %s", file, d.Code, d.Message)
 }
 
 func writeTypiaTransformDiagnostics(out io.Writer, diagnostics []typiaTransformDiagnostic, cwd string) {

--- a/packages/typia/native/cmd/ttsc-typia/diagnostics.go
+++ b/packages/typia/native/cmd/ttsc-typia/diagnostics.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+  "fmt"
+  "path/filepath"
+
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+)
+
+const typiaTransformDiagnosticFallbackMessage = "typia transform error"
+
+func typiaTransformDiagnosticFrom(diag *nativecontext.ITypiaDiagnostic) typiaTransformDiagnostic {
+  out := typiaTransformDiagnostic{Message: typiaTransformDiagnosticFallbackMessage}
+  if diag == nil {
+    return out
+  }
+  if diag.Code != "" {
+    out.Code = diag.Code
+  }
+  if diag.Message != "" {
+    out.Message = diag.Message
+  }
+  if diag.File != nil {
+    out.File = diag.File.FileName()
+    if diag.Start != nil && *diag.Start >= 0 {
+      line, column := shimscanner.GetECMALineAndByteOffsetOfPosition(diag.File, *diag.Start)
+      out.Line = line + 1
+      out.Column = column + 1
+    }
+  }
+  return out
+}
+
+func (d typiaTransformDiagnostic) String(cwd string) string {
+  code := d.Code
+  if code == "" {
+    code = "typia"
+  }
+  if d.File == "" {
+    return fmt.Sprintf("error TS(%s): %s", code, d.Message)
+  }
+  file := d.File
+  if rel, err := filepath.Rel(cwd, file); err == nil {
+    file = rel
+  }
+  if d.Line > 0 {
+    return fmt.Sprintf("%s:%d:%d - error TS(%s): %s", file, d.Line, d.Column, code, d.Message)
+  }
+  return fmt.Sprintf("%s - error TS(%s): %s", file, code, d.Message)
+}

--- a/packages/typia/native/cmd/ttsc-typia/shallow_depth_argument_error_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/shallow_depth_argument_error_transform_test.go
@@ -15,9 +15,8 @@ import (
 // lowered into a concrete budget. Each must abort the transform with a
 // diagnostic instead of silently defaulting; otherwise a typo like
 // `shallow<T, -1>` would emit a surprising guard rather than failing loudly.
-// The transform layer collapses the TransformerError message to a generic
-// "typia transform error" diagnostic, so the assertion pins the rejection (a
-// non-zero exit with that diagnostic) rather than the per-branch wording.
+// This test only pins the rejection path; transform diagnostic detail is covered
+// by the command diagnostics tests.
 //
 //  1. Transform a call site whose N is the `number` type (not a literal).
 //  2. Transform a call site whose N is the negative literal `-1`.

--- a/packages/typia/native/cmd/ttsc-typia/transform.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform.go
@@ -72,8 +72,8 @@ func runTransform(args []string) int {
   pluginOptions := readTypiaPluginOptions(cwd, *tsconfigPath)
   transformOptions := pluginOptions.TransformOptions()
   extras := nativecontext.ITypiaContext_Extras{
-    AddDiagnostic: func(diag *shimast.Diagnostic) int {
-      transformDiags = append(transformDiags, typiaTransformDiagnostic{Message: "typia transform error"})
+    AddDiagnostic: func(diag *nativecontext.ITypiaDiagnostic) int {
+      transformDiags = append(transformDiags, typiaTransformDiagnosticFrom(diag))
       return len(transformDiags)
     },
   }

--- a/packages/typia/native/cmd/ttsc-typia/transform_diagnostics_preserve_details_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_diagnostics_preserve_details_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+)
+
+// TestTypiaTransformDiagnosticFallbacks verifies diagnostic formatting is nil-safe.
+//
+// Issue #1972's suggested fix explicitly called out the risk of dereferencing a
+// nil diagnostic file while trying to preserve details. The command adapter must
+// therefore keep a useful fallback for nil/global diagnostics and still include
+// code/message details when no file location exists.
+//
+// 1. Convert a nil transform diagnostic.
+// 2. Convert a global transform diagnostic without a source file.
+// 3. Format both diagnostics and assert neither path needs a file.
+func TestTypiaTransformDiagnosticFallbacks(t *testing.T) {
+  fallback := typiaTransformDiagnosticFrom(nil)
+  if fallback.Message != typiaTransformDiagnosticFallbackMessage {
+    t.Fatalf("nil diagnostic fallback mismatch: %+v", fallback)
+  }
+
+  global := typiaTransformDiagnosticFrom(&nativecontext.ITypiaDiagnostic{
+    Code:    "typia.global",
+    Message: "global transform failure",
+  })
+  if global.File != "" || global.Line != 0 || global.Column != 0 {
+    t.Fatalf("global diagnostic should not invent a location: %+v", global)
+  }
+  formatted := global.String(t.TempDir())
+  if !strings.Contains(formatted, "error TS(typia.global): global transform failure") {
+    t.Fatalf("global diagnostic did not format code/message: %s", formatted)
+  }
+}
+
+// TestTransformProjectDiagnosticsPreserveDetails verifies project JSON output.
+//
+// The transform command used to collapse every transform-layer diagnostic to the
+// bare string "typia transform error". A generic typia call inside a generic
+// function is a compact real-world trigger: it is valid TypeScript, but typia
+// cannot lower the unspecialized type parameter and raises a TransformerError.
+//
+// 1. Build a temporary project containing `typia.is<T>(input)`.
+// 2. Run `ttsc-typia transform` in project mode.
+// 3. Decode the JSON envelope and assert file, line, column, code, and message.
+func TestTransformProjectDiagnosticsPreserveDetails(t *testing.T) {
+  project := transformDiagnosticProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+    })
+  })
+  if code != 3 {
+    t.Fatalf("generic transform should fail with code 3, got %d\nstdout=%s\nstderr=%s", code, out, errText)
+  }
+
+  var result transformProjectOutput
+  if err := json.Unmarshal([]byte(out), &result); err != nil {
+    t.Fatalf("decode transform output: %v\n%s", err, out)
+  }
+  if len(result.Diagnostics) != 1 {
+    t.Fatalf("expected one transform diagnostic, got %+v", result.Diagnostics)
+  }
+  diag := result.Diagnostics[0]
+  if diag.File == nil || !strings.HasSuffix(filepath.ToSlash(*diag.File), "src/main.ts") {
+    t.Fatalf("diagnostic file was not preserved: %+v", diag)
+  }
+  if diag.Line != 3 || diag.Character != 9 {
+    t.Fatalf("diagnostic location mismatch: %+v", diag)
+  }
+  if diag.Code != "typia.is" {
+    t.Fatalf("diagnostic code mismatch: %+v", diag)
+  }
+  if diag.MessageText == typiaTransformDiagnosticFallbackMessage ||
+    !strings.Contains(diag.MessageText, "non-specified generic argument") {
+    t.Fatalf("diagnostic message did not preserve detail: %+v", diag)
+  }
+}
+
+// TestBuildDiagnosticsPreserveDetails verifies build stderr output.
+//
+// Issue #1972 named both command entrypoints. Project JSON proves the transform
+// path, while build mode has a separate AddDiagnostic callback and pretty
+// formatter. This test forces emit so typia's transformer actually runs.
+//
+// 1. Build the same generic typia fixture.
+// 2. Run `ttsc-typia build --emit` into a temporary outDir.
+// 3. Assert stderr contains the relative source location, typia code, and cause.
+func TestBuildDiagnosticsPreserveDetails(t *testing.T) {
+  project := transformDiagnosticProject(t)
+  _, errText, code := ttscTypiaTestCapture(func() int {
+    return runBuild([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--emit",
+      "--outDir", filepath.Join(project, "dist"),
+    })
+  })
+  if code != 3 {
+    t.Fatalf("generic build should fail with code 3, got %d\nstderr=%s", code, errText)
+  }
+  normalized := filepath.ToSlash(errText)
+  if !strings.Contains(normalized, "src/main.ts:3:9 - error TS(typia.is):") ||
+    !strings.Contains(normalized, "non-specified generic argument") {
+    t.Fatalf("build diagnostic did not preserve location/code/message:\n%s", errText)
+  }
+  if strings.Contains(normalized, "error TS(): typia transform error") {
+    t.Fatalf("build diagnostic still looks like the swallowed fallback:\n%s", errText)
+  }
+}
+
+func transformDiagnosticProject(t *testing.T) string {
+  t.Helper()
+  dir := t.TempDir()
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(transformDiagnosticTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  transformDiagnosticWriteTypiaStub(t, dir)
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(transformDiagnosticSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func transformDiagnosticWriteTypiaStub(t *testing.T, project string) {
+  t.Helper()
+  root := filepath.Join(project, "node_modules", "typia")
+  lib := filepath.Join(root, "lib")
+  if err := os.MkdirAll(lib, 0o755); err != nil {
+    t.Fatalf("mkdir typia stub: %v", err)
+  }
+  files := map[string]string{
+    "package.json": `{
+  "name": "typia",
+  "version": "0.0.0-test",
+  "main": "./lib/module.js",
+  "types": "./lib/module.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/module.d.ts",
+      "default": "./lib/module.js"
+    },
+    "./lib/transform": "./lib/transform.js"
+  },
+  "ttsc": {
+    "plugin": { "transform": "typia/lib/transform" }
+  }
+}
+`,
+    filepath.Join("lib", "module.d.ts"): `declare namespace typia {
+  function is<T>(input: unknown): input is T;
+}
+declare const typia: {
+  is: typeof typia.is;
+};
+export default typia;
+export declare function is<T>(input: unknown): input is T;
+`,
+    filepath.Join("lib", "module.js"):      "exports.is = () => false;\n",
+    filepath.Join("lib", "transform.js"):   "module.exports = {};\n",
+    filepath.Join("lib", "transform.d.ts"): "export {};\n",
+  }
+  for name, body := range files {
+    path := filepath.Join(root, name)
+    if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+      t.Fatalf("write typia stub %s: %v", name, err)
+    }
+  }
+}
+
+const transformDiagnosticTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}
+`
+
+const transformDiagnosticSource = `import typia from "typia";
+export function generic<T>(input: T): boolean {
+  return typia.is<T>(input);
+}
+`

--- a/packages/typia/native/core/context/ITypiaContext.go
+++ b/packages/typia/native/core/context/ITypiaContext.go
@@ -24,5 +24,13 @@ type ITypiaContext struct {
 }
 
 type ITypiaContext_Extras struct {
-  AddDiagnostic func(diag *shimast.Diagnostic) int
+  AddDiagnostic func(diag *ITypiaDiagnostic) int
+}
+
+type ITypiaDiagnostic struct {
+  File    *shimast.SourceFile
+  Start   *int
+  Length  *int
+  Code    string
+  Message string
 }

--- a/packages/typia/native/transform/FileTransformer.go
+++ b/packages/typia/native/transform/FileTransformer.go
@@ -71,6 +71,7 @@ func fileTransformer_iterate_file(context nativecontext.ITypiaContext, file *shi
     }
     next := fileTransformer_try_transform_node(FileTransformer_TryTransformNodeProps{
       Context: context,
+      File:    file,
       Node:    node,
     })
     if next == nil {
@@ -96,6 +97,7 @@ func fileTransformer_iterate_file(context nativecontext.ITypiaContext, file *shi
 
 type FileTransformer_TryTransformNodeProps struct {
   Context nativecontext.ITypiaContext
+  File    *shimast.SourceFile
   Node    *shimast.Node
 }
 
@@ -109,9 +111,13 @@ func fileTransformer_try_transform_node(props FileTransformer_TryTransformNodePr
       // a diagnostic, not a repanic that kills the whole emit (the legacy text
       // adapter swallowed every panic, so the node path must at least handle
       // both error types).
-      switch exp.(type) {
-      case *TransformerError, *nativecontext.TransformerError:
-        fileTransformer_addDiagnostic(props)
+      switch err := exp.(type) {
+      case *TransformerError:
+        fileTransformer_addDiagnostic(props, err.Code, err.Message)
+        output = nil
+        return
+      case *nativecontext.TransformerError:
+        fileTransformer_addDiagnostic(props, err.Code, err.Message)
         output = nil
         return
       }
@@ -124,11 +130,29 @@ func fileTransformer_try_transform_node(props FileTransformer_TryTransformNodePr
   })
 }
 
-func fileTransformer_addDiagnostic(props FileTransformer_TryTransformNodeProps) {
+func fileTransformer_addDiagnostic(props FileTransformer_TryTransformNodeProps, code string, message string) {
   if props.Context.Extras.AddDiagnostic == nil {
     return
   }
-  props.Context.Extras.AddDiagnostic(&shimast.Diagnostic{})
+  text := "typia transform error"
+  if message != "" {
+    text += ": " + message
+  }
+  diag := &nativecontext.ITypiaDiagnostic{
+    File:    props.File,
+    Code:    code,
+    Message: text,
+  }
+  if props.Node != nil {
+    if pos := props.Node.Pos(); pos >= 0 {
+      diag.Start = &pos
+      if end := props.Node.End(); end >= pos {
+        length := end - pos
+        diag.Length = &length
+      }
+    }
+  }
+  props.Context.Extras.AddDiagnostic(diag)
 }
 
 func fileTransformer_inject_imports(file *shimast.SourceFile, imports []*shimast.Node, emit ...*shimprinter.EmitContext) *shimast.SourceFile {

--- a/packages/typia/native/transform/TypiaGenerator.go
+++ b/packages/typia/native/transform/TypiaGenerator.go
@@ -8,7 +8,6 @@ import (
   "regexp"
   "strings"
 
-  shimast "github.com/microsoft/typescript-go/shim/ast"
   "github.com/samchon/ttsc/packages/ttsc/driver"
   nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
 )
@@ -91,8 +90,12 @@ func (typiaGeneratorNamespace) Build(location TypiaGenerator_ILocation) error {
   }
 
   plugin := Transform(program, nil, nativecontext.ITypiaContext_Extras{
-    AddDiagnostic: func(diag *shimast.Diagnostic) int {
-      diagnostics = append(diagnostics, driver.Diagnostic{Message: "typia transform diagnostic"})
+    AddDiagnostic: func(diag *nativecontext.ITypiaDiagnostic) int {
+      message := "typia transform diagnostic"
+      if diag != nil && diag.Message != "" {
+        message = diag.Message
+      }
+      diagnostics = append(diagnostics, driver.Diagnostic{Message: message})
       return len(diagnostics)
     },
   }, nil)

--- a/packages/typia/native/transform/file_transformer_coverage_test.go
+++ b/packages/typia/native/transform/file_transformer_coverage_test.go
@@ -4,14 +4,14 @@
 package transform
 
 import (
-	"path/filepath"
-	"testing"
+  "path/filepath"
+  "testing"
 
-	shimast "github.com/microsoft/typescript-go/shim/ast"
-	shimcore "github.com/microsoft/typescript-go/shim/core"
-	shimparser "github.com/microsoft/typescript-go/shim/parser"
-	shimprinter "github.com/microsoft/typescript-go/shim/printer"
-	nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcore "github.com/microsoft/typescript-go/shim/core"
+  shimparser "github.com/microsoft/typescript-go/shim/parser"
+  shimprinter "github.com/microsoft/typescript-go/shim/printer"
+  nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
 )
 
 // TestFileTransformerCoverage exercises file-level transform scaffolding.
@@ -26,65 +26,69 @@ import (
 // 3. Recover transformer diagnostics from a controlled panic path.
 // 4. Exercise environment cast helpers and strict-option fallback helpers.
 func TestFileTransformerCoverage(t *testing.T) {
-	file := shimparser.ParseSourceFile(
-		shimast.SourceFileParseOptions{FileName: filepath.ToSlash(filepath.Join(t.TempDir(), "file.ts"))},
-		`"use strict";
+  file := shimparser.ParseSourceFile(
+    shimast.SourceFileParseOptions{FileName: filepath.ToSlash(filepath.Join(t.TempDir(), "file.ts"))},
+    `"use strict";
 export const value = 1;
 `,
-		shimcore.ScriptKindTS,
-	)
-	if file == nil {
-		t.Fatal("source file parse failed")
-	}
-	transformer := FileTransformer.Transform(FileTransformer_IEnvironments{})(nil)
-	if transformer(nil) != nil {
-		t.Fatal("nil source file should remain nil")
-	}
-	declFile := *file
-	declFile.IsDeclarationFile = true
-	if transformer(&declFile) != &declFile {
-		t.Fatal("declaration file should remain unchanged")
-	}
-	factory := shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
-	injected := fileTransformer_inject_imports(file, []*shimast.Node{
-		factory.NewImportDeclaration(
-			nil,
-			nil,
-			factory.NewStringLiteral("side-effect", shimast.TokenFlagsNone),
-			nil,
-		),
-	})
-	if injected == nil || len(injected.Statements.Nodes) != len(file.Statements.Nodes)+1 {
-		t.Fatal("import injection did not add a statement")
-	}
-	if index := fileTransformer_find_import_injection_index(file); index != 1 {
-		t.Fatalf("directive prologue injection index mismatch: %d", index)
-	}
+    shimcore.ScriptKindTS,
+  )
+  if file == nil {
+    t.Fatal("source file parse failed")
+  }
+  transformer := FileTransformer.Transform(FileTransformer_IEnvironments{})(nil)
+  if transformer(nil) != nil {
+    t.Fatal("nil source file should remain nil")
+  }
+  declFile := *file
+  declFile.IsDeclarationFile = true
+  if transformer(&declFile) != &declFile {
+    t.Fatal("declaration file should remain unchanged")
+  }
+  factory := shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+  injected := fileTransformer_inject_imports(file, []*shimast.Node{
+    factory.NewImportDeclaration(
+      nil,
+      nil,
+      factory.NewStringLiteral("side-effect", shimast.TokenFlagsNone),
+      nil,
+    ),
+  })
+  if injected == nil || len(injected.Statements.Nodes) != len(file.Statements.Nodes)+1 {
+    t.Fatal("import injection did not add a statement")
+  }
+  if index := fileTransformer_find_import_injection_index(file); index != 1 {
+    t.Fatalf("directive prologue injection index mismatch: %d", index)
+  }
 
-	count := 0
-	context := nativecontext.ITypiaContext{
-		Extras: nativecontext.ITypiaContext_Extras{
-			AddDiagnostic: func(*shimast.Diagnostic) int {
-				count++
-				return count
-			},
-		},
-	}
-	fileTransformer_addDiagnostic(FileTransformer_TryTransformNodeProps{Context: context})
-	if count != 1 {
-		t.Fatalf("diagnostic hook was not called: %d", count)
-	}
-	if fileTransformer_program("bad") != nil ||
-		fileTransformer_compilerOptions("bad") != nil ||
-		fileTransformer_checker("bad") != nil {
-		t.Fatal("environment cast helpers should return nil for wrong types")
-	}
-	if transform_compilerOptions(nil) != nil ||
-		transform_checker(nil) != nil ||
-		!transform_strict(nil) {
-		t.Fatal("transform fallback helpers returned unexpected values")
-	}
-	if Transform(nil, nil, context.Extras, shimprinter.NewEmitContext())(file) == nil {
-		t.Fatal("top-level transform should return a source file")
-	}
+  count := 0
+  message := ""
+  context := nativecontext.ITypiaContext{
+    Extras: nativecontext.ITypiaContext_Extras{
+      AddDiagnostic: func(diag *nativecontext.ITypiaDiagnostic) int {
+        count++
+        if diag != nil {
+          message = diag.Message
+        }
+        return count
+      },
+    },
+  }
+  fileTransformer_addDiagnostic(FileTransformer_TryTransformNodeProps{Context: context}, "typia.test", "details")
+  if count != 1 || message != "typia transform error: details" {
+    t.Fatalf("diagnostic hook was not called: %d", count)
+  }
+  if fileTransformer_program("bad") != nil ||
+    fileTransformer_compilerOptions("bad") != nil ||
+    fileTransformer_checker("bad") != nil {
+    t.Fatal("environment cast helpers should return nil for wrong types")
+  }
+  if transform_compilerOptions(nil) != nil ||
+    transform_checker(nil) != nil ||
+    !transform_strict(nil) {
+    t.Fatal("transform fallback helpers returned unexpected values")
+  }
+  if Transform(nil, nil, context.Extras, shimprinter.NewEmitContext())(file) == nil {
+    t.Fatal("top-level transform should return a source file")
+  }
 }

--- a/packages/typia/native/transform/transform.go
+++ b/packages/typia/native/transform/transform.go
@@ -17,7 +17,9 @@ type TransformFactory func(file *shimast.SourceFile) *shimast.SourceFile
 func Transform(program *driver.Program, options *nativecontext.ITransformOptions, extras nativecontext.ITypiaContext_Extras, ec *shimprinter.EmitContext) TransformFactory {
   compilerOptions := transform_compilerOptions(program)
   if transform_strict(compilerOptions) == false && extras.AddDiagnostic != nil {
-    extras.AddDiagnostic(&shimast.Diagnostic{})
+    extras.AddDiagnostic(&nativecontext.ITypiaDiagnostic{
+      Message: "typia transform error",
+    })
   }
   opt := nativecontext.ITransformOptions{}
   if options != nil {

--- a/website/compiler/cmd/playground/typia_plugin.go
+++ b/website/compiler/cmd/playground/typia_plugin.go
@@ -31,6 +31,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
   shimprinter "github.com/microsoft/typescript-go/shim/printer"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 
   "github.com/samchon/ttsc/packages/ttsc/driver"
   typiaadapter "github.com/samchon/typia/packages/typia/native/adapter"
@@ -322,8 +323,8 @@ func newTypiaTransform(
 ) driver.PluginTransform {
   transformOptions := readTypiaPluginOptions(cwd, tsconfigPath).TransformOptions()
   extras := nativecontext.ITypiaContext_Extras{
-    AddDiagnostic: func(diag *shimast.Diagnostic) int {
-      *sink = append(*sink, typiaPlaygroundDiag{Message: "typia transform error"})
+    AddDiagnostic: func(diag *nativecontext.ITypiaDiagnostic) int {
+      *sink = append(*sink, typiaPlaygroundDiagFrom(diag))
       return len(*sink)
     },
   }
@@ -390,15 +391,44 @@ type typiaPlaygroundDiag struct {
   Message string
 }
 
+func typiaPlaygroundDiagFrom(diag *nativecontext.ITypiaDiagnostic) typiaPlaygroundDiag {
+  out := typiaPlaygroundDiag{Message: "typia transform error"}
+  if diag == nil {
+    return out
+  }
+  if diag.Code != "" {
+    out.Code = diag.Code
+  }
+  if diag.Message != "" {
+    out.Message = diag.Message
+  }
+  if diag.File != nil {
+    out.File = diag.File.FileName()
+    if diag.Start != nil && *diag.Start >= 0 {
+      line, column := shimscanner.GetECMALineAndByteOffsetOfPosition(diag.File, *diag.Start)
+      out.Line = line + 1
+      out.Column = column + 1
+    }
+  }
+  return out
+}
+
 func (d typiaPlaygroundDiag) String(cwd string) string {
+  code := d.Code
+  if code == "" {
+    code = "typia"
+  }
+  if d.File == "" {
+    return fmt.Sprintf("error TS(%s): %s", code, d.Message)
+  }
   file := d.File
   if rel, err := filepath.Rel(cwd, file); err == nil {
     file = rel
   }
   if d.Line > 0 {
-    return fmt.Sprintf("%s:%d:%d - error TS(%s): %s", file, d.Line, d.Column, d.Code, d.Message)
+    return fmt.Sprintf("%s:%d:%d - error TS(%s): %s", file, d.Line, d.Column, code, d.Message)
   }
-  return fmt.Sprintf("%s - error TS(%s): %s", file, d.Code, d.Message)
+  return fmt.Sprintf("%s - error TS(%s): %s", file, code, d.Message)
 }
 
 func writeTypiaPlaygroundDiagnostics(diagnostics []typiaPlaygroundDiag, cwd string) {


### PR DESCRIPTION
## Intent

Fixes #1972.

The native `ttsc-typia` command adapters were replacing transform-layer diagnostics with the hardcoded `typia transform error` fallback. This PR preserves the transform error code, message, source file, and location for both `transform` JSON output and `build` stderr output.

## Scope

- Adds a native `ITypiaDiagnostic` envelope for transform diagnostics.
- Carries file/position/code/message out of recovered `TransformerError` values.
- Formats nil/global diagnostics safely so preserving details does not introduce a secondary nil-file panic.
- Adds command tests for transform JSON output, build stderr output, and nil/global fallback formatting.

## Deferred

- #1973 remains separate. This PR removes the diagnostic-swallowing/nil-file hazard related to #1972, but it does not claim to fully validate the reported TypeORM/SvelteKit project shape.
- No package version bump is included in this branch.

## Validation

- `pnpm run format:go`
- `go -C packages/typia/test test ../native/cmd/ttsc-typia -run TestTypiaTransformDiagnosticFallbacks|TestTransformProjectDiagnosticsPreserveDetails|TestBuildDiagnosticsPreserveDetails -count=1`
- `go -C packages/typia/test test -tags typia_native_internal ../native/transform -run TestFileTransformerCoverage -count=1`
- `go -C packages/typia/test test ../native/core/context ../native/transform -count=1`

## Local limitations

I did not run the full native command package suite in this workspace because existing build tests emit JS into `packages/typia/src`. The focused tests above were kept side-effect-free and the final worktree had no generated JS files.