### PR TITLE
test(native): guard CLI diagnostics against panic regressions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,12 @@ importers:
         specifier: catalog:utils
         version: 11.0.0
 
+  tests/test-typia-cli:
+    devDependencies:
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.6.0
+
   tests/test-typia-exact-optional:
     dependencies:
       '@nestia/e2e':

--- a/tests/test-typia-cli/package.json
+++ b/tests/test-typia-cli/package.json
@@ -1,0 +1,26 @@
+{
+  "private": true,
+  "name": "@typia/test-typia-cli",
+  "description": "CLI end-to-end tests for typia.",
+  "scripts": {
+    "start": "ttsx src/index.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/typia"
+  },
+  "keywords": [
+    "typia",
+    "test",
+    "cli"
+  ],
+  "author": "Jeongho Nam",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/samchon/typia/issues"
+  },
+  "homepage": "https://typia.io",
+  "devDependencies": {
+    "@types/node": "catalog:utils"
+  }
+}

--- a/tests/test-typia-cli/src/index.ts
+++ b/tests/test-typia-cli/src/index.ts
@@ -9,7 +9,8 @@ interface ICommandResult {
 }
 
 const root: string = path.resolve(__dirname, "..");
-const cache: string = fs.mkdtempSync(path.join(os.tmpdir(), "typia-cli-"));
+const scratch: string = fs.mkdtempSync(path.join(os.tmpdir(), "typia-cli-"));
+const ttscCache: string = process.env.TTSC_CACHE_DIR ?? scratch;
 const typiaSource: string = path.resolve(
   root,
   "..",
@@ -20,7 +21,7 @@ const typiaSource: string = path.resolve(
 );
 
 process.on("exit", () => {
-  fs.rmSync(cache, { recursive: true, force: true });
+  fs.rmSync(scratch, { recursive: true, force: true });
 });
 
 const run = (args: string[]): ICommandResult => {
@@ -29,10 +30,10 @@ const run = (args: string[]): ICommandResult => {
     encoding: "utf8",
     env: {
       ...process.env,
-      TTSC_CACHE_DIR: cache,
+      TTSC_CACHE_DIR: ttscCache,
     },
     shell: process.platform === "win32",
-    timeout: 180_000,
+    timeout: 600_000,
   });
   const error: string =
     result.error instanceof Error
@@ -192,7 +193,7 @@ const writeTypiaPackageStub = (project: string): void => {
  */
 const testGenericTransformDiagnostic = (): void => {
   const project: string = fs.mkdtempSync(
-    path.join(cache, "generic-diagnostic-"),
+    path.join(scratch, "generic-diagnostic-"),
   );
   writeGenericDiagnosticProject(project);
 

--- a/tests/test-typia-cli/src/index.ts
+++ b/tests/test-typia-cli/src/index.ts
@@ -1,0 +1,242 @@
+import cp from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+interface ICommandResult {
+  status: number | null;
+  output: string;
+}
+
+const root: string = path.resolve(__dirname, "..");
+const cache: string = fs.mkdtempSync(path.join(os.tmpdir(), "typia-cli-"));
+const typiaSource: string = path.resolve(
+  root,
+  "..",
+  "..",
+  "packages",
+  "typia",
+  "src",
+);
+
+process.on("exit", () => {
+  fs.rmSync(cache, { recursive: true, force: true });
+});
+
+const run = (args: string[]): ICommandResult => {
+  const result: cp.SpawnSyncReturns<string> = cp.spawnSync("pnpm", args, {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      TTSC_CACHE_DIR: cache,
+    },
+    shell: process.platform === "win32",
+    timeout: 180_000,
+  });
+  const error: string =
+    result.error instanceof Error
+      ? `\n${result.error.name}: ${result.error.message}`
+      : "";
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}\n${result.stderr ?? ""}${error}`.replace(
+      /\\/g,
+      "/",
+    ),
+  };
+};
+
+const writeJson = (file: string, value: unknown): void => {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const listTypiaSourceJavascript = (
+  directory: string = typiaSource,
+): string[] =>
+  fs.existsSync(directory)
+    ? fs
+        .readdirSync(directory, { withFileTypes: true })
+        .flatMap((entry) => {
+          const file: string = path.join(directory, entry.name);
+          if (entry.isDirectory()) return listTypiaSourceJavascript(file);
+          return entry.isFile() && entry.name.endsWith(".js")
+            ? [path.relative(typiaSource, file).replace(/\\/g, "/")]
+            : [];
+        })
+        .sort()
+    : [];
+
+const assertNoTypiaSourceJavascript = (stage: string): void => {
+  const files: string[] = listTypiaSourceJavascript();
+  if (files.length !== 0)
+    throw new Error(
+      [
+        `Unexpected packages/typia/src JavaScript ${stage}:`,
+        ...files.map((file) => `- ${file}`),
+      ].join("\n"),
+    );
+};
+
+const writeGenericDiagnosticProject = (project: string): void => {
+  fs.mkdirSync(path.join(project, "src"), { recursive: true });
+  writeTypiaPackageStub(project);
+  writeJson(path.join(project, "tsconfig.json"), {
+    compilerOptions: {
+      target: "ES2022",
+      lib: ["ES2022"],
+      outDir: "bin",
+      rootDir: "src",
+      noEmit: false,
+      esModuleInterop: true,
+      module: "esnext",
+      moduleResolution: "bundler",
+      strict: true,
+      skipLibCheck: true,
+      types: [],
+      noUnusedLocals: false,
+      noUnusedParameters: false,
+      plugins: [{ transform: "typia/lib/transform" }],
+    },
+    include: ["src"],
+  });
+  fs.writeFileSync(
+    path.join(project, "src", "generic.ts"),
+    [
+      `import typia from "typia";`,
+      `export function generic<T>(input: T): boolean {`,
+      `  return typia.is<T>(input);`,
+      `}`,
+      ``,
+    ].join("\n"),
+  );
+};
+
+const writeTypiaPackageStub = (project: string): void => {
+  const directory: string = path.join(project, "node_modules", "typia");
+  const lib: string = path.join(directory, "lib");
+  fs.mkdirSync(lib, { recursive: true });
+  writeJson(path.join(directory, "package.json"), {
+    name: "typia",
+    main: "./lib/module.js",
+    types: "./lib/module.d.ts",
+    exports: {
+      ".": {
+        types: "./lib/module.d.ts",
+        default: "./lib/module.js",
+      },
+      "./lib/transform": "./lib/transform.js",
+      "./package.json": "./package.json",
+    },
+    ttsc: {
+      plugin: { transform: "typia/lib/transform" },
+    },
+  });
+  fs.writeFileSync(
+    path.join(lib, "module.d.ts"),
+    [
+      `declare namespace typia {`,
+      `  function is<T>(input: unknown): input is T;`,
+      `}`,
+      `declare const typia: {`,
+      `  is: typeof typia.is;`,
+      `};`,
+      `export default typia;`,
+      `export declare function is<T>(input: unknown): input is T;`,
+      ``,
+    ].join("\n"),
+  );
+  fs.writeFileSync(path.join(lib, "module.js"), `exports.is = () => false;\n`);
+  fs.writeFileSync(
+    path.join(lib, "transform.js"),
+    [
+      `"use strict";`,
+      `Object.defineProperty(exports, "__esModule", { value: true });`,
+      `exports.default = createTtscPlugin;`,
+      `function createTtscPlugin() {`,
+      `  return {`,
+      `    name: "typia",`,
+      `    source: ${JSON.stringify(
+        path
+          .resolve(
+            root,
+            "..",
+            "..",
+            "packages",
+            "typia",
+            "native",
+            "cmd",
+            "ttsc-typia",
+          )
+          .replace(/\\/g, "/"),
+      )},`,
+      `  };`,
+      `}`,
+      ``,
+    ].join("\n"),
+  );
+  fs.writeFileSync(path.join(lib, "transform.d.ts"), `export {};\n`);
+};
+
+/**
+ * Verifies the CLI preserves generic transform diagnostic details.
+ *
+ * Locks the ttsc boundary for #1973. The native command may reject a typia call
+ * before emitting JavaScript, but the caller must still see the typia
+ * diagnostic code, source file, and non-specified generic argument cause
+ * instead of a Go panic or a collapsed empty failure.
+ *
+ * 1. Create a temporary project with a minimal typia package stub.
+ * 2. Compile a generic typia.is<T>() call through pnpm exec ttsc.
+ * 3. Assert the command fails with the structured transform diagnostic.
+ */
+const testGenericTransformDiagnostic = (): void => {
+  const project: string = fs.mkdtempSync(
+    path.join(cache, "generic-diagnostic-"),
+  );
+  writeGenericDiagnosticProject(project);
+
+  assertNoTypiaSourceJavascript("before CLI compilation");
+  const result: ICommandResult = run([
+    "exec",
+    "ttsc",
+    "--emit",
+    "--cwd",
+    project,
+    "-p",
+    "tsconfig.json",
+  ]);
+  assertNoTypiaSourceJavascript("after CLI compilation");
+  if (result.status === 0)
+    throw new Error("Generic transform diagnostic unexpectedly succeeded.");
+  if (result.output.includes("non-specified generic argument") === false)
+    throw new Error(
+      `Generic transform diagnostic lost its cause:\n${result.output}`,
+    );
+  if (result.output.includes("error TS(typia.is):") === false)
+    throw new Error(
+      `Generic transform diagnostic lost its typia code:\n${result.output}`,
+    );
+  if (result.output.includes("src/generic.ts") === false)
+    throw new Error(
+      `Generic transform diagnostic lost its source file:\n${result.output}`,
+    );
+  if (
+    /Cannot find module ["']typia["']|Cannot find type definition file/.test(
+      result.output,
+    )
+  )
+    throw new Error(
+      `Generic transform diagnostic mixed in resolution noise:\n${result.output}`,
+    );
+  if (/panic:|SIGSEGV|runtime error/i.test(result.output))
+    throw new Error(
+      `Generic transform diagnostic regressed to a panic:\n${result.output}`,
+    );
+};
+
+const main = (): void => {
+  testGenericTransformDiagnostic();
+  console.log("Success");
+};
+main();

--- a/tests/test-typia-cli/tsconfig.json
+++ b/tests/test-typia-cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../config/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  }
+}


### PR DESCRIPTION
## Intent
Add a dedicated CLI e2e regression for #1973 so the JS workspace matrix verifies the native diagnostic fix at the consumer `pnpm exec ttsc` boundary.

## Scope
- Added `tests/test-typia-cli` as a private test workspace.
- The test creates an OS-temp consumer project with a minimal `typia` package stub and a transform descriptor pointing to `packages/typia/native/cmd/ttsc-typia`.
- It asserts a generic `typia.is<T>` failure preserves `non-specified generic argument`, `error TS(typia.is):`, and `src/generic.ts`.
- It rejects panic/runtime markers, module-resolution noise, and generated JS under `packages/typia/src` before and after the CLI run.

## Deferred
- No `packages/typia/package.json` version bump: this PR is test-only and does not change native package source.
- Full local `pnpm test` is not green because `tests/test-typia-automated` currently reproduces an unrelated TypeScript-Go printer panic: `unexpected Expression: KindBlock`. This branch does not touch that suite or native logic; any CI reproduction will be handled as the next blocker/follow-up.

## Test Plan
- [x] `pnpm exec prettier --write tests/test-typia-cli/src/index.ts`
- [x] `node scripts/with-ttsc-cache.cjs pnpm --filter=./tests/test-typia-cli start`
- [x] `go -C packages/typia/test test ../native/cmd/ttsc-typia -run TestTransformProjectDiagnosticsPreserveDetails|TestBuildDiagnosticsPreserveDetails -count=1`
- [x] `pnpm test:go`
- [x] `go -C packages/typia/test test -tags typia_native_internal ./...`
- [ ] `pnpm test` locally fails in unrelated `tests/test-typia-automated` TypeScript-Go printer `KindBlock` panic

Refs #1973