### PR TITLE
Fix recursive guard block printer panic

### DIFF
--- a/packages/typia/native/core/programmers/internal/FeatureProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/FeatureProgrammer.go
@@ -347,6 +347,7 @@ func (featureProgrammerNamespace) VisitGuardSkip(key string, body *shimast.Node,
 func (featureProgrammerNamespace) VisitGuardSerialize(key string, thrower *shimast.Node, body *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {
   f := nativecontext.EmitFactoryOf(featureProgrammer_factory, emit)
   slot := "_vctx." + key
+  bodyExpression := featureProgrammer_block_to_expression(body, emit)
   finisher := f.NewArrowFunction(
     nil,
     nil,
@@ -379,7 +380,7 @@ func (featureProgrammerNamespace) VisitGuardSerialize(key string, thrower *shima
           f.NewParenthesizedExpression(finisher),
           nil,
           nil,
-          f.NewNodeList([]*shimast.Node{body}),
+          f.NewNodeList([]*shimast.Node{bodyExpression}),
           shimast.NodeFlagsNone,
         ),
       ),
@@ -414,6 +415,7 @@ func (featureProgrammerNamespace) VisitGuardRebuild(key string, array bool, body
 func (featureProgrammerNamespace) VisitGuardRebuildWith(key string, allocator *shimast.Node, body *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {
   f := nativecontext.EmitFactoryOf(featureProgrammer_factory, emit)
   slot := "_vctx." + key
+  bodyExpression := featureProgrammer_block_to_expression(body, emit)
   filler := f.NewArrowFunction(
     nil,
     nil,
@@ -435,7 +437,7 @@ func (featureProgrammerNamespace) VisitGuardRebuildWith(key string, allocator *s
           nil,
           f.NewNodeList([]*shimast.Node{
             f.NewIdentifier("_vout"),
-            body,
+            bodyExpression,
           }),
           shimast.NodeFlagsNone,
         ),
@@ -454,6 +456,13 @@ func (featureProgrammerNamespace) VisitGuardRebuildWith(key string, allocator *s
     ),
     emit,
   )
+}
+
+func featureProgrammer_block_to_expression(body *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {
+  if body != nil && body.Kind == shimast.KindBlock {
+    return nativefactories.ExpressionFactory.SelfCall(emit, body)
+  }
+  return body
 }
 
 var featureProgrammer_factory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{})

--- a/packages/typia/native/core/programmers/internal/feature_programmer_visit_guard_test.go
+++ b/packages/typia/native/core/programmers/internal/feature_programmer_visit_guard_test.go
@@ -1,0 +1,70 @@
+//go:build typia_native_internal
+// +build typia_native_internal
+
+package internal
+
+import (
+	"testing"
+
+	shimast "github.com/microsoft/typescript-go/shim/ast"
+	shimprinter "github.com/microsoft/typescript-go/shim/printer"
+)
+
+func TestFeatureProgrammerVisitGuardsWrapBlockBodiesUsedAsExpressions(t *testing.T) {
+	emit := shimprinter.NewEmitContext()
+	factory := shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+	block := factory.NewBlock(
+		factory.NewNodeList([]*shimast.Node{
+			factory.NewReturnStatement(factory.NewObjectLiteralExpression(factory.NewNodeList(nil), false)),
+		}),
+		true,
+	)
+
+	for _, scenario := range []struct {
+		name string
+		node *shimast.Node
+	}{
+		{
+			name: "rebuild",
+			node: FeatureProgrammer.VisitGuardRebuildWith(
+				"o0",
+				factory.NewObjectLiteralExpression(factory.NewNodeList(nil), false),
+				block,
+				emit,
+			),
+		},
+		{
+			name: "serialize",
+			node: FeatureProgrammer.VisitGuardSerialize(
+				"o1",
+				factory.NewIdentifier("throwCircular()"),
+				block,
+				emit,
+			),
+		},
+	} {
+		if scenario.node == nil {
+			t.Fatalf("%s guard returned nil", scenario.name)
+		}
+		if featureProgrammer_has_block_call_argument(scenario.node) {
+			t.Fatalf("%s guard left a block in call-argument position", scenario.name)
+		}
+	}
+}
+
+func featureProgrammer_has_block_call_argument(node *shimast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == shimast.KindCallExpression {
+		args := node.AsCallExpression().Arguments
+		if args != nil {
+			for _, arg := range args.Nodes {
+				if arg != nil && arg.Kind == shimast.KindBlock {
+					return true
+				}
+			}
+		}
+	}
+	return node.ForEachChild(featureProgrammer_has_block_call_argument)
+}

--- a/tests/test-typia-cli/src/index.ts
+++ b/tests/test-typia-cli/src/index.ts
@@ -113,6 +113,45 @@ const writeGenericDiagnosticProject = (project: string): void => {
   );
 };
 
+const writeRecursiveDynamicCloneProject = (project: string): void => {
+  fs.mkdirSync(path.join(project, "src"), { recursive: true });
+  writeTypiaPackageStub(project);
+  writeJson(path.join(project, "tsconfig.json"), {
+    compilerOptions: {
+      target: "ES2022",
+      lib: ["ES2022"],
+      outDir: "bin",
+      rootDir: "src",
+      noEmit: false,
+      esModuleInterop: true,
+      module: "esnext",
+      moduleResolution: "bundler",
+      strict: true,
+      skipLibCheck: true,
+      types: [],
+      noUnusedLocals: false,
+      noUnusedParameters: false,
+      plugins: [{ transform: "typia/lib/transform" }],
+    },
+    include: ["src"],
+  });
+  fs.writeFileSync(
+    path.join(project, "src", "recursive-clone.ts"),
+    [
+      `import typia from "typia";`,
+      ``,
+      `interface RecursiveDynamicClone {`,
+      `  name: string;`,
+      `  next?: RecursiveDynamicClone;`,
+      `  [key: \`child_\${string}\`]: RecursiveDynamicClone | string | undefined;`,
+      `}`,
+      ``,
+      `export const clone = typia.createClone<RecursiveDynamicClone>();`,
+      ``,
+    ].join("\n"),
+  );
+};
+
 const writeTypiaPackageStub = (project: string): void => {
   const directory: string = path.join(project, "node_modules", "typia");
   const lib: string = path.join(directory, "lib");
@@ -137,17 +176,29 @@ const writeTypiaPackageStub = (project: string): void => {
     path.join(lib, "module.d.ts"),
     [
       `declare namespace typia {`,
+      `  type Resolved<T> = T;`,
       `  function is<T>(input: unknown): input is T;`,
+      `  function createClone<T>(): (input: T) => Resolved<T>;`,
       `}`,
       `declare const typia: {`,
       `  is: typeof typia.is;`,
+      `  createClone: typeof typia.createClone;`,
       `};`,
       `export default typia;`,
+      `export declare type Resolved<T> = typia.Resolved<T>;`,
       `export declare function is<T>(input: unknown): input is T;`,
+      `export declare function createClone<T>(): (input: T) => Resolved<T>;`,
       ``,
     ].join("\n"),
   );
-  fs.writeFileSync(path.join(lib, "module.js"), `exports.is = () => false;\n`);
+  fs.writeFileSync(
+    path.join(lib, "module.js"),
+    [
+      `exports.is = () => false;`,
+      `exports.createClone = () => (input) => input;`,
+      ``,
+    ].join("\n"),
+  );
   fs.writeFileSync(
     path.join(lib, "transform.js"),
     [
@@ -236,8 +287,51 @@ const testGenericTransformDiagnostic = (): void => {
     );
 };
 
+/**
+ * Verifies recursive dynamic clone emit does not feed blocks to the Go printer.
+ *
+ * Recursive clone/classify guards evaluate the object joiner body as an
+ * expression while registering the output in a WeakMap. Dynamic object keys
+ * make the clone joiner return a statement block; the native transform must
+ * wrap that block in an IIFE before passing it to Object.assign, otherwise
+ * TypeScript-Go panics with "unexpected Expression: KindBlock" during emit.
+ */
+const testRecursiveDynamicCloneEmit = (): void => {
+  const project: string = fs.mkdtempSync(
+    path.join(scratch, "recursive-dynamic-clone-"),
+  );
+  writeRecursiveDynamicCloneProject(project);
+
+  assertNoTypiaSourceJavascript("before recursive dynamic clone compilation");
+  const result: ICommandResult = run([
+    "exec",
+    "ttsc",
+    "--emit",
+    "--cwd",
+    project,
+    "-p",
+    "tsconfig.json",
+  ]);
+  assertNoTypiaSourceJavascript("after recursive dynamic clone compilation");
+  if (result.status !== 0)
+    throw new Error(
+      `Recursive dynamic clone emit unexpectedly failed:\n${result.output}`,
+    );
+  if (
+    /unexpected Expression: KindBlock|panic:|SIGSEGV|runtime error/i.test(
+      result.output,
+    )
+  )
+    throw new Error(
+      `Recursive dynamic clone emit regressed to a printer panic:\n${result.output}`,
+    );
+  if (fs.existsSync(path.join(project, "bin", "recursive-clone.js")) === false)
+    throw new Error("Recursive dynamic clone emit did not write JavaScript.");
+};
+
 const main = (): void => {
   testGenericTransformDiagnostic();
+  testRecursiveDynamicCloneEmit();
   console.log("Success");
 };
 main();


### PR DESCRIPTION
## Summary
- Wrap recursive serialize/rebuild guard block bodies in an IIFE before they are used as call arguments.
- Add native AST regression coverage for block bodies in recursive guards.
- Add CLI e2e coverage for recursive dynamic `typia.createClone<T>()` emit so TypeScript-Go printer panics are caught.

## Verification
- `go test -tags typia_native_internal ./...` in `packages/typia/native`
- `pnpm --filter @typia/test-typia-cli start`
- `pnpm --filter @typia/test-typia-automated start` no longer hits `unexpected Expression: KindBlock`; it reaches existing assertEquals/protobuf semantic failures, which are follow-up work on a new branch.

## Notes
- No package version changes.
- No generated JS files are included.