### PR TITLE
Accept shared-object paths in assert-equals tests

### DIFF
--- a/tests/test-typia-automated/src/internal/_test_assertEquals.ts
+++ b/tests/test-typia-automated/src/internal/_test_assertEquals.ts
@@ -26,17 +26,23 @@ export const _test_assertEquals =
 
     // WRONG TYPES
     const accessors: IAccessor[] = [];
-    trace(accessors, "$input", input);
+    trace(
+      accessors,
+      new WeakMap<object, IAccessor>(),
+      new WeakSet<object>(),
+      "$input",
+      input,
+    );
 
     if (factory.ADDABLE === false || accessors.length === 0) return;
 
     // SPOIL PROPERTIES
-    for (const { path, value } of accessors) {
+    for (const { paths, value } of accessors) {
       const variable: boolean = Math.random() < 0.5;
       const key: string = variable ? "non_regular_type" : "non-regular-type";
-      const fullPath: string = variable
-        ? `${path}.${key}`
-        : `${path}["${key}"]`;
+      const fullPaths: string[] = paths.map((path) =>
+        variable ? `${path}.${key}` : `${path}["${key}"]`,
+      );
 
       value[key] = key;
 
@@ -51,7 +57,8 @@ export const _test_assertEquals =
           typia.is<TypeGuardError.IProps>(exp) &&
           (exp.method === "typia.assertEquals" ||
             exp.method === "typia.createAssertEquals") &&
-          exp.path === fullPath &&
+          typeof exp.path === "string" &&
+          fullPaths.includes(exp.path) &&
           exp.expected === "undefined" &&
           exp.value === key
         ) {
@@ -64,7 +71,7 @@ export const _test_assertEquals =
           console.log({
             method: exp.method,
             path: exp.path,
-            full: fullPath,
+            full: fullPaths,
             actual: exp.expected,
           });
           throw new Error(
@@ -75,36 +82,72 @@ export const _test_assertEquals =
     }
   };
 
-function trace(accessors: IAccessor[], path: string, input: any): void {
-  if (Array.isArray(input)) trace_array(accessors, path, input);
+function trace(
+  accessors: IAccessor[],
+  accessorMap: WeakMap<object, IAccessor>,
+  stack: WeakSet<object>,
+  path: string,
+  input: any,
+): void {
+  if (Array.isArray(input))
+    trace_array(accessors, accessorMap, stack, path, input);
   else if (
     typeof input === "object" &&
     input !== null &&
     typeof input.valueOf() === "object"
   )
-    trace_object(accessors, path, input);
+    trace_object(accessors, accessorMap, stack, path, input);
 }
 
-function trace_object(accessors: IAccessor[], path: string, obj: any): void {
-  accessors.push({
-    path,
-    value: obj,
-  });
+function trace_object(
+  accessors: IAccessor[],
+  accessorMap: WeakMap<object, IAccessor>,
+  stack: WeakSet<object>,
+  path: string,
+  obj: any,
+): void {
+  let accessor: IAccessor | undefined = accessorMap.get(obj);
+  if (accessor === undefined) {
+    accessor = {
+      paths: [],
+      value: obj,
+    };
+    accessorMap.set(obj, accessor);
+    accessors.push(accessor);
+  }
+  accessor.paths.push(path);
+  if (stack.has(obj)) return;
+
+  stack.add(obj);
   for (const [key, value] of Object.entries(obj))
     trace(
       accessors,
+      accessorMap,
+      stack,
       NamingConvention.variable(key)
         ? `${path}.${key}`
         : `${path}[${JSON.stringify(key)}]`,
       value,
     );
+  stack.delete(obj);
 }
 
-function trace_array(accessors: IAccessor[], path: string, array: any[]): void {
-  array.forEach((elem, i) => trace(accessors, `${path}[${i}]`, elem));
+function trace_array(
+  accessors: IAccessor[],
+  accessorMap: WeakMap<object, IAccessor>,
+  stack: WeakSet<object>,
+  path: string,
+  array: any[],
+): void {
+  if (stack.has(array)) return;
+  stack.add(array);
+  array.forEach((elem, i) =>
+    trace(accessors, accessorMap, stack, `${path}[${i}]`, elem),
+  );
+  stack.delete(array);
 }
 
 interface IAccessor {
-  path: string;
+  paths: string[];
   value: any;
 }

--- a/tests/test-typia-automated/src/internal/_test_assertGuardEquals.ts
+++ b/tests/test-typia-automated/src/internal/_test_assertGuardEquals.ts
@@ -24,17 +24,23 @@ export const _test_assertGuardEquals =
 
     // WRONG TYPES
     const accessors: IAccessor[] = [];
-    trace(accessors, "$input", input);
+    trace(
+      accessors,
+      new WeakMap<object, IAccessor>(),
+      new WeakSet<object>(),
+      "$input",
+      input,
+    );
 
     if (factory.ADDABLE === false || accessors.length === 0) return;
 
     // SPOIL PROPERTIES
-    for (const { path, value } of accessors) {
+    for (const { paths, value } of accessors) {
       const variable: boolean = Math.random() < 0.5;
       const key: string = variable ? "non_regular_type" : "non-regular-type";
-      const fullPath: string = variable
-        ? `${path}.${key}`
-        : `${path}["${key}"]`;
+      const fullPaths: string[] = paths.map((path) =>
+        variable ? `${path}.${key}` : `${path}["${key}"]`,
+      );
 
       value[key] = key;
 
@@ -49,7 +55,8 @@ export const _test_assertGuardEquals =
           typia.is<TypeGuardError.IProps>(exp) &&
           (exp.method === "typia.assertGuardEquals" ||
             exp.method === "typia.createAssertGuardEquals") &&
-          exp.path === fullPath &&
+          typeof exp.path === "string" &&
+          fullPaths.includes(exp.path) &&
           exp.expected === "undefined" &&
           exp.value === key
         ) {
@@ -62,47 +69,83 @@ export const _test_assertGuardEquals =
           console.log({
             method: exp.method,
             path: exp.path,
-            full: fullPath,
+            full: fullPaths,
             actual: exp.expected,
           });
           throw new Error(
-            `Bug on typia.assertEquals(): failed to detect surplus property on the ${name} type.`,
+            `Bug on typia.assertGuardEquals(): failed to detect surplus property on the ${name} type.`,
           );
         } else throw exp;
       }
     }
   };
 
-function trace(accessors: IAccessor[], path: string, input: any): void {
-  if (Array.isArray(input)) trace_array(accessors, path, input);
+function trace(
+  accessors: IAccessor[],
+  accessorMap: WeakMap<object, IAccessor>,
+  stack: WeakSet<object>,
+  path: string,
+  input: any,
+): void {
+  if (Array.isArray(input))
+    trace_array(accessors, accessorMap, stack, path, input);
   else if (
     typeof input === "object" &&
     input !== null &&
     typeof input.valueOf() === "object"
   )
-    trace_object(accessors, path, input);
+    trace_object(accessors, accessorMap, stack, path, input);
 }
 
-function trace_object(accessors: IAccessor[], path: string, obj: any): void {
-  accessors.push({
-    path,
-    value: obj,
-  });
+function trace_object(
+  accessors: IAccessor[],
+  accessorMap: WeakMap<object, IAccessor>,
+  stack: WeakSet<object>,
+  path: string,
+  obj: any,
+): void {
+  let accessor: IAccessor | undefined = accessorMap.get(obj);
+  if (accessor === undefined) {
+    accessor = {
+      paths: [],
+      value: obj,
+    };
+    accessorMap.set(obj, accessor);
+    accessors.push(accessor);
+  }
+  accessor.paths.push(path);
+  if (stack.has(obj)) return;
+
+  stack.add(obj);
   for (const [key, value] of Object.entries(obj))
     trace(
       accessors,
+      accessorMap,
+      stack,
       NamingConvention.variable(key)
         ? `${path}.${key}`
         : `${path}[${JSON.stringify(key)}]`,
       value,
     );
+  stack.delete(obj);
 }
 
-function trace_array(accessors: IAccessor[], path: string, array: any[]): void {
-  array.forEach((elem, i) => trace(accessors, `${path}[${i}]`, elem));
+function trace_array(
+  accessors: IAccessor[],
+  accessorMap: WeakMap<object, IAccessor>,
+  stack: WeakSet<object>,
+  path: string,
+  array: any[],
+): void {
+  if (stack.has(array)) return;
+  stack.add(array);
+  array.forEach((elem, i) =>
+    trace(accessors, accessorMap, stack, `${path}[${i}]`, elem),
+  );
+  stack.delete(array);
 }
 
 interface IAccessor {
-  path: string;
+  paths: string[];
   value: any;
 }


### PR DESCRIPTION
## Summary
- make assertEquals/assertGuardEquals surplus-property helpers track every finite path for a shared object identity
- keep circular fixture traversal finite with an active recursion stack
- correct the assertGuardEquals diagnostic message in the same helper

## Tests
- pnpm --filter @typia/test-typia-automated start -- --include test_createAssertEquals_ObjectRecursiveShared
- pnpm --filter @typia/test-typia-automated start -- --include test_createAssertGuardEquals_ObjectRecursiveShared
- pnpm --filter @typia/test-typia-automated start -- --include ObjectRecursiveShared
- go test -tags typia_native_internal ./... (packages/typia/native)
- pnpm --filter @typia/test-typia-automated start (progresses past the assert-equals shared-object failures; still fails later on separate protobuf CommentTagType/ObjectGenericUnion/TypeTagType failures)