### PR TITLE
Preserve unsigned protobuf uint32 reads

### DIFF
--- a/packages/typia/src/internal/_ProtobufReader.ts
+++ b/packages/typia/src/internal/_ProtobufReader.ts
@@ -27,7 +27,7 @@ export class _ProtobufReader {
   }
 
   public uint32(): number {
-    return this.varint32();
+    return this.varint32() >>> 0;
   }
 
   public int32(): number {


### PR DESCRIPTION
## Summary
- return unsigned values from the protobuf reader's public uint32 method
- keep int32 signed behavior unchanged by leaving the shared varint accumulator as-is

## Tests
- pnpm --filter @typia/test-typia-automated start -- --include test_protobuf_createDecode_CommentTagType
- pnpm --filter @typia/test-typia-automated start -- --include test_protobuf_createEncode_CommentTagType
- pnpm --filter @typia/test-typia-automated start -- --include test_protobuf_createDecode_TypeTagType
- pnpm --filter @typia/test-typia-automated start -- --include test_protobuf_createEncode_TypeTagType
- go test -tags typia_native_internal ./... (packages/typia/native)
- pnpm --filter @typia/test-typia-automated start (progresses past tag-type protobuf failures; still fails later on separate ObjectGenericUnion protobuf failures)