### PR TITLE
feat: ILlmApplication.description from class/interface JSDoc

### DIFF
--- a/packages/interface/src/schema/ILlmApplication.ts
+++ b/packages/interface/src/schema/ILlmApplication.ts
@@ -28,6 +28,14 @@ export interface ILlmApplication<Class extends object = any> {
   functions: ILlmFunction[];
 
   /**
+   * Configuration used to generate this application.
+   *
+   * Contains the settings that were applied during schema generation, including
+   * strict mode and any custom validation hooks.
+   */
+  config: ILlmApplication.IConfig<Class>;
+
+  /**
    * Human-readable description of the application.
    *
    * Explains the overall purpose of the application and the collection of
@@ -36,19 +44,12 @@ export interface ILlmApplication<Class extends object = any> {
    *
    * As this describes the whole toolset rather than a single function, agent
    * frameworks can surface it as a system instruction (e.g. an MCP server's
-   * `instructions`), while other consumers may treat it as a plain description.
+   * `instructions`), while other consumers may treat it as a plain
+   * description.
    *
    * `undefined` when the source class or interface has no JSDoc comment.
    */
   description?: string | undefined;
-
-  /**
-   * Configuration used to generate this application.
-   *
-   * Contains the settings that were applied during schema generation, including
-   * strict mode and any custom validation hooks.
-   */
-  config: ILlmApplication.IConfig<Class>;
 
   /**
    * Phantom property for TypeScript generic type preservation.

--- a/packages/interface/src/schema/ILlmApplication.ts
+++ b/packages/interface/src/schema/ILlmApplication.ts
@@ -28,6 +28,21 @@ export interface ILlmApplication<Class extends object = any> {
   functions: ILlmFunction[];
 
   /**
+   * Human-readable description of the application.
+   *
+   * Explains the overall purpose of the application and the collection of
+   * {@link functions} it exposes. Extracted from the JSDoc comment written on
+   * the source class or interface.
+   *
+   * As this describes the whole toolset rather than a single function, agent
+   * frameworks can surface it as a system instruction (e.g. an MCP server's
+   * `instructions`), while other consumers may treat it as a plain description.
+   *
+   * `undefined` when the source class or interface has no JSDoc comment.
+   */
+  description?: string | undefined;
+
+  /**
    * Configuration used to generate this application.
    *
    * Contains the settings that were applied during schema generation, including

--- a/packages/typia/native/core/programmers/llm/LlmApplicationProgrammer.go
+++ b/packages/typia/native/core/programmers/llm/LlmApplicationProgrammer.go
@@ -238,7 +238,15 @@ func (llmApplicationProgrammerNamespace) WriteApplication(props struct {
       functions = append(functions, written)
     }
   }
-  return map[string]any{"functions": functions}
+  result := map[string]any{"functions": functions}
+  if len(metadata.Objects) != 0 {
+    if object := metadata.Objects[0].Type; object != nil {
+      if description := llmApplicationProgrammer_describe(object.Description, object.JsDocTags); description != nil && len(*description) != 0 {
+        result["description"] = *description
+      }
+    }
+  }
+  return result
 }
 
 func llmApplicationProgrammer_writeFunction(props struct {
@@ -472,9 +480,12 @@ func llmApplicationProgrammer_validateName(prefix string, name string) []string 
 }
 
 func llmApplicationProgrammer_propertyDescription(property *schemametadata.MetadataProperty) *string {
-  description := property.Description
+  return llmApplicationProgrammer_describe(property.Description, property.JsDocTags)
+}
+
+func llmApplicationProgrammer_describe(description *string, jsDocTags []schemametadata.IJsDocTagInfo) *string {
   if description == nil {
-    for _, tag := range property.JsDocTags {
+    for _, tag := range jsDocTags {
       if tag.Name == "description" && len(tag.Text) != 0 {
         text := tag.Text[0].Text
         description = &text
@@ -486,7 +497,7 @@ func llmApplicationProgrammer_propertyDescription(property *schemametadata.Metad
     Description *string
     JsDocTags   []schemametadata.IJsDocTagInfo
     Kind        string
-  }{Description: description, JsDocTags: property.JsDocTags, Kind: "summary"})
+  }{Description: description, JsDocTags: jsDocTags, Kind: "summary"})
   var summary *string
   if s, ok := desc["summary"].(string); ok {
     summary = &s

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_application_description.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_application_description.ts
@@ -1,0 +1,52 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmApplication } from "@typia/interface";
+import typia from "typia";
+
+/**
+ * Verifies typia.llm.application reflects the source type's JSDoc as
+ * ILlmApplication.description.
+ *
+ * The application-level description is distinct from each function's
+ * description: it comes from the JSDoc comment on the class or interface passed
+ * as the generic argument, not from any method. Consumers such as the MCP
+ * integration surface it as a whole-toolset instruction, so a regression that
+ * dropped it would leave agents without the collection-level guidance the
+ * author wrote. The summary line and the body paragraph are concatenated the
+ * same way function descriptions are.
+ *
+ * 1. Declare an interface with a JSDoc summary and body, plus one method.
+ * 2. Call typia.llm.application<Interface>().
+ * 3. Assert application.description carries both the summary and the body.
+ */
+export const test_llm_application_description = (): void => {
+  /**
+   * Calculator application.
+   *
+   * Provides arithmetic operations that an LLM agent can invoke.
+   */
+  interface ICalculator {
+    /**
+     * Add two numbers.
+     *
+     * @param input Operands to sum
+     */
+    add(input: { a: number; b: number }): void;
+  }
+
+  const app: ILlmApplication = typia.llm.application<ICalculator>();
+
+  TestValidator.predicate(
+    "application description carries the summary",
+    () =>
+      app.description !== undefined &&
+      app.description.includes("Calculator application"),
+  );
+  TestValidator.predicate(
+    "application description carries the body",
+    () =>
+      app.description !== undefined &&
+      app.description.includes(
+        "Provides arithmetic operations that an LLM agent can invoke.",
+      ),
+  );
+};

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_application_description_absent.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_application_description_absent.ts
@@ -1,0 +1,32 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmApplication } from "@typia/interface";
+import typia from "typia";
+
+/**
+ * Verifies ILlmApplication.description stays undefined when the source type has
+ * no JSDoc.
+ *
+ * The description is optional: it must appear only when the author actually
+ * documented the class or interface. Emitting an empty string (or any
+ * placeholder) would pollute agent prompts with meaningless instructions, so
+ * the generator must omit the property entirely when there is nothing to
+ * describe.
+ *
+ * 1. Declare an interface with a method but no leading JSDoc comment.
+ * 2. Call typia.llm.application<Interface>().
+ * 3. Assert application.description is undefined while functions still exist.
+ */
+export const test_llm_application_description_absent = (): void => {
+  interface ICalculator {
+    add(input: { a: number; b: number }): void;
+  }
+
+  const app: ILlmApplication = typia.llm.application<ICalculator>();
+
+  TestValidator.equals(
+    "description omitted without JSDoc",
+    app.description,
+    undefined,
+  );
+  TestValidator.equals("functions still generated", app.functions.length, 1);
+};

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_application_description_summary.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_application_description_summary.ts
@@ -1,0 +1,38 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmApplication } from "@typia/interface";
+import typia from "typia";
+
+/**
+ * Verifies ILlmApplication.description merges a distinct @summary tag with the
+ * body paragraph.
+ *
+ * When the author writes an explicit `@summary` that is not just the first line
+ * of the body, the generator must join them the same way function descriptions
+ * do — the summary (its trailing period trimmed) followed by a blank line and
+ * the body. This pins the merge branch that a plain single-paragraph comment
+ * never reaches, since there the summary is derived from the body and is
+ * already its prefix.
+ *
+ * 1. Declare an interface whose JSDoc has a body paragraph and a separate
+ *    `@summary` tag.
+ * 2. Call typia.llm.application<Interface>().
+ * 3. Assert application.description is "<summary>.\n\n<body>".
+ */
+export const test_llm_application_description_summary = (): void => {
+  /**
+   * Stores the selected animal variant into the database.
+   *
+   * @summary Animal record service
+   */
+  interface IAnimalService {
+    create(input: { name: string }): void;
+  }
+
+  const app: ILlmApplication = typia.llm.application<IAnimalService>();
+
+  TestValidator.equals(
+    "summary and body are merged",
+    app.description,
+    "Animal record service.\n\nStores the selected animal variant into the database.",
+  );
+};

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_controller_description.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_controller_description.ts
@@ -1,0 +1,51 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import typia from "typia";
+
+/**
+ * Verifies typia.llm.controller propagates the class JSDoc as
+ * controller.application.description.
+ *
+ * A controller wraps an ILlmApplication, so the application-level description
+ * must survive the extra layer and be readable from a class source (not only an
+ * interface). This is the shape MCP-style integrations consume, where the
+ * whole-toolset description doubles as the server instruction; a regression
+ * that only wired interfaces would silently drop the description for
+ * class-based controllers.
+ *
+ * 1. Declare a class with a JSDoc summary/body and one method.
+ * 2. Call typia.llm.controller<Class>(name, instance).
+ * 3. Assert controller.application.description carries the summary and body.
+ */
+export const test_llm_controller_description = (): void => {
+  /**
+   * Calculator controller.
+   *
+   * Exposes arithmetic tools that an LLM agent can invoke.
+   */
+  class Calculator {
+    public add(input: { a: number; b: number }): void {
+      input.a + input.b;
+    }
+  }
+
+  const controller: ILlmController = typia.llm.controller<Calculator>(
+    "calculator",
+    new Calculator(),
+  );
+
+  TestValidator.predicate(
+    "controller application description carries the summary",
+    () =>
+      controller.application.description !== undefined &&
+      controller.application.description.includes("Calculator controller"),
+  );
+  TestValidator.predicate(
+    "controller application description carries the body",
+    () =>
+      controller.application.description !== undefined &&
+      controller.application.description.includes(
+        "Exposes arithmetic tools that an LLM agent can invoke.",
+      ),
+  );
+};

--- a/website/src/content/docs/llm/application.mdx
+++ b/website/src/content/docs/llm/application.mdx
@@ -158,6 +158,29 @@ examples/src/llm/application.violation.ts:15:30 - error TS(typia.llm.application
 
 For the deeper type-level rules see [`llm.parameters`](/docs/llm/parameters) and [`llm.schema`](/docs/llm/schema).
 
+## Application description
+
+Just as every method's JSDoc becomes its `ILlmFunction.description`, the JSDoc written on the class or interface itself becomes `ILlmApplication.description` — a description of the whole toolset rather than any single function.
+
+```typescript filename="application-description.ts" showLineNumbers
+import typia, { ILlmApplication } from "typia";
+
+/**
+ * Bulletin board article service.
+ *
+ * Groups the tools an agent uses to create and browse articles.
+ */
+interface BbsArticleService {
+  /** Create a new article. */
+  create(props: { input: { title: string; body: string } }): Promise<{ id: string }>;
+}
+
+const app: ILlmApplication = typia.llm.application<BbsArticleService>();
+//  app.description = "Bulletin board article service.\n\nGroups the tools an agent uses to create and browse articles."
+```
+
+Because it describes the entire collection, agent frameworks can surface it as a system instruction — for example an [MCP](#framework-adapters) server's `instructions` — while other consumers may treat it as a plain description. The property is omitted when the source type carries no JSDoc.
+
 ## Framework adapters
 
 `typia.llm.controller<Class>(name, instance)` wraps the schema together with an executable instance. You pass the controller to an adapter and the adapter does the wiring:


### PR DESCRIPTION
## Intent

`ILlmApplication` describes a whole collection of LLM function-calling tools, yet it had no description of its own — only each `ILlmFunction` carried one. This adds an application-level `description`, extracted from the JSDoc comment written on the class or interface passed to `typia.llm.application<App>()` (and `typia.llm.controller<App>()`).

The toolset-wide description is exactly what agent frameworks want as a system instruction — for example an MCP server's `instructions` — while other consumers can treat it as a plain description.

## Scope

- **`@typia/interface`**: optional `description?: string` on `ILlmApplication`. It flows through `ILlmApplication.__IPrimitive` (an `Omit` of the same interface) and `_llmApplicationFinalize` without further changes.
- **native transform**: `LlmApplicationProgrammer.WriteApplication` now emits the description from the application root object's metadata, reusing the same summary/body merge (`llmApplicationProgrammer_describe`) that function descriptions use. Omitted entirely when the source type has no JSDoc.
- **docs**: new "Application description" section in the LLM application guide.

## Test plan

- New unit tests under `tests/test-typia-schema/src/features/llm.application/`:
  - `test_llm_application_description` — interface JSDoc (summary + body) → `app.description`.
  - `test_llm_application_description_absent` — no JSDoc → `description` omitted.
  - `test_llm_controller_description` — class source via `typia.llm.controller` → `controller.application.description`.
- Ran `tests/test-typia-schema` (full), `test-mcp`, `test-langchain`, `test-vercel`, `test-utils` (llm), plus `go test ./...` and `go test -tags typia_native_internal ./...` — all green.

## Deferred

- `IHttpLlmApplication` (the OpenAPI/Swagger-derived variant) has no matching `description`; it is built at runtime by `@samchon/openapi`'s `HttpLlm` converter, outside this repo, so it is out of scope here.
- No `typia` version bump is included — versioning/releases are handled separately by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)