### PR TITLE
docs(website): use rc install tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ export function random<T>(g?: Partial<IRandomGenerator>): T;
 <!--
 ## Setup
 
-Install `typia@next` with the [`ttsc`](https://github.com/samchon/ttsc) toolchain.
+Install `typia@rc` with the [`ttsc`](https://github.com/samchon/ttsc) toolchain.
 
 ```bash
 # install
-npm i typia@next
+npm i typia@rc
 npm i -D ttsc typescript@rc
 
 # build

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -159,7 +159,7 @@ typia.random<T>();                     // generate a value that satisfies T
 
 The transformation above happens at compile time, so typia needs to be wired into the TypeScript build. There are two supported paths:
 
-- **TypeScript-Go (`@next`)** — use [`ttsc`](/docs/setup/tsgo) as a drop-in replacement for `tsc`. The Go-native compiler ships the typia transform on the side.
+- **TypeScript-Go (`@rc`)** — use [`ttsc`](/docs/setup/tsgo) as a drop-in replacement for `tsc`. The Go-native compiler ships the typia transform on the side.
 - **Stable TypeScript v5 / v6** — use [`ts-patch`](/docs/setup/legacy) to patch the stock JavaScript compiler so it can apply the same transform. This is the production path most teams ship today.
 
 Bundlers (Vite, Next.js, Webpack, esbuild, Rollup, …) plug in through `@ttsc/unplugin` (modern) or `@typia/unplugin` (legacy). Babel and SWC can't run a TypeScript transformer, so for those toolchains typia falls back to its [generation mode](/docs/setup/legacy#generation), which writes the transformed `.ts` files ahead of time.

--- a/website/src/content/docs/setup/index.mdx
+++ b/website/src/content/docs/setup/index.mdx
@@ -10,7 +10,7 @@ typia is a compile-time transformer, so it has to plug into your TypeScript buil
 
 | Path | When to use | Package | Default? |
 |------|-------------|---------|---------|
-| [**TypeScript-Go (`ttsc`)**](/docs/setup/tsgo) | TypeScript-Go (`typescript@7`, release candidate) | `typia@next` | release candidate |
+| [**TypeScript-Go (`ttsc`)**](/docs/setup/tsgo) | TypeScript-Go (`typescript@7`, release candidate) | `typia@rc` | release candidate |
 | [**Legacy (`ts-patch`)**](/docs/setup/legacy) | Stable TypeScript v5 or v6 (the standard `typescript` npm package) | `typia` | ✅ recommended |
 
 **TypeScript-Go** is the in-progress Go-rewrite of the TypeScript compiler shipped by the TypeScript team. The transformer plug-in API is settled, but packaging and binary naming are not — pin versions carefully and expect breakage.
@@ -21,13 +21,13 @@ If you don't know which to pick, choose **Legacy**.
 
 ## TypeScript-Go
 
-Use [`typia@next`](/docs/setup/tsgo). TypeScript is migrating its compiler from JavaScript to Go (the "TypeScript-Go" project). `ttsc` is the Go-native plugin toolchain for that compiler, and `typia@next` ships a Go-rewritten transform that plugs into it.
+Use [`typia@rc`](/docs/setup/tsgo). TypeScript is migrating its compiler from JavaScript to Go (the "TypeScript-Go" project). `ttsc` is the Go-native plugin toolchain for that compiler, and `typia@rc` ships a Go-rewritten transform that plugs into it.
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
 # install
-npm i typia@next
+npm i typia@rc
 npm i -D ttsc typescript@rc
 
 # build
@@ -40,7 +40,7 @@ npx ttsx src/index.ts
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
 # install
-pnpm i typia@next
+pnpm i typia@rc
 pnpm i -D ttsc typescript@rc
 
 # build
@@ -53,7 +53,7 @@ pnpm ttsx src/index.ts
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
 # install
-yarn add typia@next
+yarn add typia@rc
 yarn add -D ttsc typescript@rc
 
 # build
@@ -66,7 +66,7 @@ yarn ttsx src/index.ts
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
 # install
-bun add typia@next
+bun add typia@rc
 bun add -d ttsc typescript@rc
 
 # build

--- a/website/src/content/docs/setup/tsgo.mdx
+++ b/website/src/content/docs/setup/tsgo.mdx
@@ -6,7 +6,7 @@ import { Tabs } from "nextra/components";
 
 ## TypeScript-Go (`ttsc`)
 
-This setup targets **TypeScript-Go** — the Go rewrite of the TypeScript compiler, now shipping as the `typescript@7` release candidate (formerly `@typescript/native-preview`). `typia@next` ships a Go-rewritten transform that plugs into it through the [`ttsc`](https://github.com/samchon/ttsc) toolchain.
+This setup targets **TypeScript-Go** — the Go rewrite of the TypeScript compiler, now shipping as the `typescript@7` release candidate (formerly `@typescript/native-preview`). `typia@rc` ships a Go-rewritten transform that plugs into it through the [`ttsc`](https://github.com/samchon/ttsc) toolchain.
 
 You need three commands:
 
@@ -16,7 +16,7 @@ You need three commands:
 
 > [!NOTE]
 >
-> `typescript@7` is a **release candidate**, and `typia@next` is the matching prerelease of typia. For a fully stable toolchain, use the [Legacy (TS v6) setup](/docs/setup/legacy).
+> `typescript@7` is a **release candidate**, and `typia@rc` is the matching release candidate of typia. For a fully stable toolchain, use the [Legacy (TS v6) setup](/docs/setup/legacy).
 >
 > The stock `tsc`, `ts-node`, and `tsx` cannot apply the typia transform — you must use `ttsc` and `ttsx`.
 
@@ -25,25 +25,25 @@ You need three commands:
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
-npm i typia@next
+npm i typia@rc
 npm i -D ttsc typescript@rc
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
-pnpm i typia@next
+pnpm i typia@rc
 pnpm i -D ttsc typescript@rc
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
-yarn add typia@next
+yarn add typia@rc
 yarn add -D ttsc typescript@rc
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal" showLineNumbers copy
-bun add typia@next
+bun add typia@rc
 bun add -d ttsc typescript@rc
 ```
   </Tabs.Tab>


### PR DESCRIPTION
## Intent
Update the public setup docs now that the TypeScript-Go release candidate is published under the npm `rc` dist-tag.

## Scope
- Replace `typia@next` with `typia@rc` in the root README setup snippet.
- Update the website setup overview and TypeScript-Go guide to use `npm i typia@rc` and matching pnpm/yarn/bun commands.
- Rename the setup-path label from `@next` to `@rc` on the docs index page.

## Deferred
- Full repository build/test is left to CI because this PR only changes Markdown/MDX docs.

## Test plan
- `pnpm format`
- `pnpm --dir website run build`

Before submitting a Pull Request, please test your code.

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
pnpm run build

# DO TEST
pnpm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)