### PR TITLE
fix(website): stop the "/" search hotkey from hijacking the playground

### DIFF
--- a/website/src/movies/PlaygroundMovie.tsx
+++ b/website/src/movies/PlaygroundMovie.tsx
@@ -5,10 +5,21 @@ import {
   createSandboxRequire,
   loadTypiaRuntimePack,
 } from "@ttsc/playground";
+import { useEffect } from "react";
 
 import { PLAYGROUND_DEFAULT_SCRIPT } from "../components/playground/PLAYGROUND_DEFAULT_SCRIPT";
 
 const TYPIA_RUNTIME_PACK_URL = "/compiler/typia-runtime-pack.json";
+
+// Nextra's docs Search binds a global "/" hotkey (a window-level, bubbling
+// keydown listener) that focuses the search box whenever the active element is
+// not an editable field. On the playground that steals "/" the moment focus
+// sits on a non-editable pane — the console, the option toggles, the shell
+// chrome — instead of the Monaco textarea, so a "/" meant for the editor jumps
+// the caret up into the navbar search. The tag set below mirrors Nextra's own
+// guard so genuine text inputs (including the Monaco editor's textarea) keep
+// receiving "/".
+const EDITABLE_TAGS = new Set(["INPUT", "SELECT", "BUTTON", "TEXTAREA"]);
 
 /**
  * In-browser typia playground.
@@ -28,6 +39,28 @@ const TYPIA_RUNTIME_PACK_URL = "/compiler/typia-runtime-pack.json";
  *   the `executeBundle` doc below), capturing its `console.*` calls.
  */
 export default function PlaygroundMovie() {
+  // Suppress Nextra's "/" search-focus hotkey while the playground is mounted.
+  // Listening in the capture phase means the event is stopped before it can
+  // bubble up to Nextra's window-level handler; the activeElement guard lets
+  // "/" through untouched whenever an editable element (the Monaco editor, an
+  // input, ...) is focused, so only the stray "/" over non-editable panes is
+  // swallowed. The listener is torn down on unmount, so search's "/" hotkey
+  // keeps working on every other docs page.
+  useEffect(() => {
+    const suppressSearchHotkey = (event: KeyboardEvent) => {
+      if (event.key !== "/") return;
+      const el = document.activeElement;
+      if (
+        el &&
+        (EDITABLE_TAGS.has(el.tagName) || (el as HTMLElement).isContentEditable)
+      )
+        return;
+      event.stopPropagation();
+    };
+    window.addEventListener("keydown", suppressSearchHotkey, true);
+    return () =>
+      window.removeEventListener("keydown", suppressSearchHotkey, true);
+  }, []);
   return (
     <PlaygroundShell
       workerUrl="/compiler/index.js"


### PR DESCRIPTION
## Intent

On the playground page, pressing <kbd>/</kbd> jumps the caret up into the navbar search box instead of typing into the editor.

The cause is Nextra's docs `<Search>`, which registers a **global, window-level** keydown listener that focuses the search box on <kbd>/</kbd> whenever `document.activeElement` is not an editable field. Nextra already exempts real inputs (`INPUT`/`SELECT`/`BUTTON`/`TEXTAREA` + contentEditable), so typing inside the Monaco editor is fine — but the moment focus leaves the editor (clicking the console pane, an option toggle, or the surrounding shell chrome), `activeElement` becomes a non-editable element and <kbd>/</kbd> gets hijacked.

## Scope

`website/src/movies/PlaygroundMovie.tsx` (the playground page body, already a `"use client"` component):

- Add a **capture-phase** `keydown` listener on `window` that swallows <kbd>/</kbd> via `stopPropagation()` **before** it bubbles to Nextra's handler.
- Mirror Nextra's own `activeElement` guard, so genuine text inputs — including the Monaco editor's `<textarea>` — still receive <kbd>/</kbd>.
- Register/unregister inside `useEffect`, so the suppression is scoped to the playground's lifetime; <kbd>/</kbd> search continues to work on every other docs page.

Only <kbd>/</kbd> is suppressed; the <kbd>⌘/Ctrl+K</kbd> search shortcut is left untouched.

## Test plan

- [x] `tsc` type diagnostics clean on the changed file
- [ ] On `/playground`, focus a non-editable pane and press <kbd>/</kbd> → search box is **not** focused
- [ ] Inside the Monaco editor, <kbd>/</kbd> still types normally
- [ ] On any other docs page, <kbd>/</kbd> still focuses search

🤖 Generated with [Claude Code](https://claude.com/claude-code)