### PR TITLE
fix(native): prevent json.isStringify helper mismatch

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/json_is_stringify_scoped_checker_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_is_stringify_scoped_checker_transform_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"testing"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
 )
 
 // TestJsonIsStringifyScopedCheckerTransform verifies validated stringify owns
@@ -23,98 +23,98 @@ import (
 //  3. Require the serializer to return JSON text instead of throwing a missing
 //     helper `ReferenceError`.
 func TestJsonIsStringifyScopedCheckerTransform(t *testing.T) {
-	project := jsonIsStringifyScopedCheckerProject(t)
-	js := jsonIsStringifyScopedCheckerTransform(t, project)
-	if !strings.Contains(js, "toJSON") {
-		t.Fatalf("stringify fixture did not exercise toJSON emission:\n%s", js)
-	}
-	if !strings.Contains(js, "const _si") {
-		t.Fatalf("validated stringify did not emit scoped is-check helpers:\n%s", js)
-	}
-	jsonIsStringifyScopedCheckerRunRuntime(t, project, js)
+  project := jsonIsStringifyScopedCheckerProject(t)
+  js := jsonIsStringifyScopedCheckerTransform(t, project)
+  if !strings.Contains(js, "toJSON") {
+    t.Fatalf("stringify fixture did not exercise toJSON emission:\n%s", js)
+  }
+  if !strings.Contains(js, "const _si") {
+    t.Fatalf("validated stringify did not emit scoped is-check helpers:\n%s", js)
+  }
+  jsonIsStringifyScopedCheckerRunRuntime(t, project, js)
 }
 
 func jsonIsStringifyScopedCheckerProject(t *testing.T) string {
-	t.Helper()
-	root := ttscTypiaTestRepoRoot(t)
-	base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
-	if err := os.MkdirAll(base, 0o755); err != nil {
-		t.Fatalf("mkdir temp base: %v", err)
-	}
-	dir, err := os.MkdirTemp(base, "json-is-stringify-scoped-checker-")
-	if err != nil {
-		t.Fatalf("create temp fixture: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
-	src := filepath.Join(dir, "src")
-	if err := os.MkdirAll(src, 0o755); err != nil {
-		t.Fatalf("mkdir fixture src: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(jsonIsStringifyScopedCheckerTSConfig), 0o644); err != nil {
-		t.Fatalf("write tsconfig: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonIsStringifyScopedCheckerSource), 0o644); err != nil {
-		t.Fatalf("write source: %v", err)
-	}
-	return dir
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "json-is-stringify-scoped-checker-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(jsonIsStringifyScopedCheckerTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonIsStringifyScopedCheckerSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
 }
 
 func jsonIsStringifyScopedCheckerTransform(t *testing.T, project string) string {
-	t.Helper()
-	out, errText, code := ttscTypiaTestCapture(func() int {
-		return runTransform([]string{
-			"--cwd", project,
-			"--tsconfig", "tsconfig.json",
-			"--file", "src/main.ts",
-			"--output", "js",
-		})
-	})
-	if code != 0 {
-		t.Fatalf("json isStringify transform failed: code=%d stderr=\n%s", code, errText)
-	}
-	return out
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("json isStringify transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
 }
 
 func jsonIsStringifyScopedCheckerRunRuntime(t *testing.T, project string, js string) {
-	t.Helper()
-	node, err := exec.LookPath("node")
-	if err != nil {
-		t.Skip("node executable not found")
-	}
-	runtimeDir := filepath.Join(project, "runtime")
-	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
-		t.Fatalf("mkdir runtime dir: %v", err)
-	}
-	ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
-	stubs := map[string]string{
-		"json-stringify-number-stub.cjs":  jsonIsStringifyScopedCheckerNumberStub,
-		"json-stringify-string-stub.cjs":  jsonIsStringifyScopedCheckerStringStub,
-		"throw-type-guard-error-stub.cjs": jsonIsStringifyScopedCheckerThrowStub,
-	}
-	for name, content := range stubs {
-		if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
-			t.Fatalf("write %s: %v", name, err)
-		}
-	}
-	runtimeJS := strings.ReplaceAll(js, `require("typia/lib/internal/_jsonStringifyNumber")`, `require("./json-stringify-number-stub.cjs")`)
-	runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyString")`, `require("./json-stringify-string-stub.cjs")`)
-	runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
-	runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
-	if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
-		t.Fatalf("write runtime module: %v", err)
-	}
-	runner := filepath.Join(runtimeDir, "run.cjs")
-	if err := os.WriteFile(runner, []byte(jsonIsStringifyScopedCheckerRunner), 0o644); err != nil {
-		t.Fatalf("write runtime runner: %v", err)
-	}
-	cmd := exec.Command(node, runner)
-	cmd.Dir = runtimeDir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("json isStringify runtime failed: %v\n%s", err, output)
-	}
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  stubs := map[string]string{
+    "json-stringify-number-stub.cjs":  jsonIsStringifyScopedCheckerNumberStub,
+    "json-stringify-string-stub.cjs":  jsonIsStringifyScopedCheckerStringStub,
+    "throw-type-guard-error-stub.cjs": jsonIsStringifyScopedCheckerThrowStub,
+  }
+  for name, content := range stubs {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  runtimeJS := strings.ReplaceAll(js, `require("typia/lib/internal/_jsonStringifyNumber")`, `require("./json-stringify-number-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyString")`, `require("./json-stringify-string-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
+  runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(jsonIsStringifyScopedCheckerRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("json isStringify runtime failed: %v\n%s", err, output)
+  }
 }
 
 const jsonIsStringifyScopedCheckerTSConfig = `{

--- a/packages/typia/native/cmd/ttsc-typia/json_is_stringify_scoped_checker_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_is_stringify_scoped_checker_transform_test.go
@@ -1,116 +1,120 @@
 package main
 
 import (
-  "os"
-  "os/exec"
-  "path/filepath"
-  "strings"
-  "testing"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
 // TestJsonIsStringifyScopedCheckerTransform verifies validated stringify owns
 // its branch-selection helpers.
 //
 // `json.isStringify` first validates with the regular checker collection, then
-// serializes with the JSON stringify collection. A type with `toJSON()` can add
-// JSON-only object-union branches, so the serializer must not reference `_io*`
-// helpers from the validator collection.
+// serializes with the JSON stringify collection. A recursive type with
+// `toJSON()` can add JSON-only object-union branches inside serializer helper
+// functions, so the serializer must not reference `_io*` helpers from the
+// validator collection.
 //
-//  1. Transform a `json.isStringify` fixture whose `toJSON()` returns an object
-//     union absent from the regular checker graph.
+//  1. Transform a recursive `json.isStringify` fixture whose `toJSON()` returns
+//     an object union absent from the regular checker graph.
 //  2. Execute the emitted JavaScript through Node.
 //  3. Require the serializer to return JSON text instead of throwing a missing
 //     helper `ReferenceError`.
 func TestJsonIsStringifyScopedCheckerTransform(t *testing.T) {
-  project := jsonIsStringifyScopedCheckerProject(t)
-  js := jsonIsStringifyScopedCheckerTransform(t, project)
-  if !strings.Contains(js, "toJSON") {
-    t.Fatalf("stringify fixture did not exercise toJSON emission:\n%s", js)
-  }
-  jsonIsStringifyScopedCheckerRunRuntime(t, project, js)
+	project := jsonIsStringifyScopedCheckerProject(t)
+	js := jsonIsStringifyScopedCheckerTransform(t, project)
+	if !strings.Contains(js, "toJSON") {
+		t.Fatalf("stringify fixture did not exercise toJSON emission:\n%s", js)
+	}
+	if !strings.Contains(js, "const _si") {
+		t.Fatalf("validated stringify did not emit scoped is-check helpers:\n%s", js)
+	}
+	jsonIsStringifyScopedCheckerRunRuntime(t, project, js)
 }
 
 func jsonIsStringifyScopedCheckerProject(t *testing.T) string {
-  t.Helper()
-  root := ttscTypiaTestRepoRoot(t)
-  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
-  if err := os.MkdirAll(base, 0o755); err != nil {
-    t.Fatalf("mkdir temp base: %v", err)
-  }
-  dir, err := os.MkdirTemp(base, "json-is-stringify-scoped-checker-")
-  if err != nil {
-    t.Fatalf("create temp fixture: %v", err)
-  }
-  t.Cleanup(func() {
-    _ = os.RemoveAll(dir)
-  })
-  src := filepath.Join(dir, "src")
-  if err := os.MkdirAll(src, 0o755); err != nil {
-    t.Fatalf("mkdir fixture src: %v", err)
-  }
-  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(jsonIsStringifyScopedCheckerTSConfig), 0o644); err != nil {
-    t.Fatalf("write tsconfig: %v", err)
-  }
-  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonIsStringifyScopedCheckerSource), 0o644); err != nil {
-    t.Fatalf("write source: %v", err)
-  }
-  return dir
+	t.Helper()
+	root := ttscTypiaTestRepoRoot(t)
+	base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatalf("mkdir temp base: %v", err)
+	}
+	dir, err := os.MkdirTemp(base, "json-is-stringify-scoped-checker-")
+	if err != nil {
+		t.Fatalf("create temp fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir fixture src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(jsonIsStringifyScopedCheckerTSConfig), 0o644); err != nil {
+		t.Fatalf("write tsconfig: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonIsStringifyScopedCheckerSource), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	return dir
 }
 
 func jsonIsStringifyScopedCheckerTransform(t *testing.T, project string) string {
-  t.Helper()
-  out, errText, code := ttscTypiaTestCapture(func() int {
-    return runTransform([]string{
-      "--cwd", project,
-      "--tsconfig", "tsconfig.json",
-      "--file", "src/main.ts",
-      "--output", "js",
-    })
-  })
-  if code != 0 {
-    t.Fatalf("json isStringify transform failed: code=%d stderr=\n%s", code, errText)
-  }
-  return out
+	t.Helper()
+	out, errText, code := ttscTypiaTestCapture(func() int {
+		return runTransform([]string{
+			"--cwd", project,
+			"--tsconfig", "tsconfig.json",
+			"--file", "src/main.ts",
+			"--output", "js",
+		})
+	})
+	if code != 0 {
+		t.Fatalf("json isStringify transform failed: code=%d stderr=\n%s", code, errText)
+	}
+	return out
 }
 
 func jsonIsStringifyScopedCheckerRunRuntime(t *testing.T, project string, js string) {
-  t.Helper()
-  node, err := exec.LookPath("node")
-  if err != nil {
-    t.Skip("node executable not found")
-  }
-  runtimeDir := filepath.Join(project, "runtime")
-  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
-    t.Fatalf("mkdir runtime dir: %v", err)
-  }
-  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
-  stubs := map[string]string{
-    "json-stringify-number-stub.cjs":  jsonIsStringifyScopedCheckerNumberStub,
-    "json-stringify-string-stub.cjs":  jsonIsStringifyScopedCheckerStringStub,
-    "throw-type-guard-error-stub.cjs": jsonIsStringifyScopedCheckerThrowStub,
-  }
-  for name, content := range stubs {
-    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
-      t.Fatalf("write %s: %v", name, err)
-    }
-  }
-  runtimeJS := strings.ReplaceAll(js, `require("typia/lib/internal/_jsonStringifyNumber")`, `require("./json-stringify-number-stub.cjs")`)
-  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyString")`, `require("./json-stringify-string-stub.cjs")`)
-  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
-  runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
-  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
-    t.Fatalf("write runtime module: %v", err)
-  }
-  runner := filepath.Join(runtimeDir, "run.cjs")
-  if err := os.WriteFile(runner, []byte(jsonIsStringifyScopedCheckerRunner), 0o644); err != nil {
-    t.Fatalf("write runtime runner: %v", err)
-  }
-  cmd := exec.Command(node, runner)
-  cmd.Dir = runtimeDir
-  output, err := cmd.CombinedOutput()
-  if err != nil {
-    t.Fatalf("json isStringify runtime failed: %v\n%s", err, output)
-  }
+	t.Helper()
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node executable not found")
+	}
+	runtimeDir := filepath.Join(project, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("mkdir runtime dir: %v", err)
+	}
+	ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+	stubs := map[string]string{
+		"json-stringify-number-stub.cjs":  jsonIsStringifyScopedCheckerNumberStub,
+		"json-stringify-string-stub.cjs":  jsonIsStringifyScopedCheckerStringStub,
+		"throw-type-guard-error-stub.cjs": jsonIsStringifyScopedCheckerThrowStub,
+	}
+	for name, content := range stubs {
+		if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	runtimeJS := strings.ReplaceAll(js, `require("typia/lib/internal/_jsonStringifyNumber")`, `require("./json-stringify-number-stub.cjs")`)
+	runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyString")`, `require("./json-stringify-string-stub.cjs")`)
+	runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
+	runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
+	if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+		t.Fatalf("write runtime module: %v", err)
+	}
+	runner := filepath.Join(runtimeDir, "run.cjs")
+	if err := os.WriteFile(runner, []byte(jsonIsStringifyScopedCheckerRunner), 0o644); err != nil {
+		t.Fatalf("write runtime runner: %v", err)
+	}
+	cmd := exec.Command(node, runner)
+	cmd.Dir = runtimeDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("json isStringify runtime failed: %v\n%s", err, output)
+	}
 }
 
 const jsonIsStringifyScopedCheckerTSConfig = `{
@@ -148,7 +152,8 @@ interface JsonBacked {
 }
 
 interface Payload {
-  items: JsonBacked[];
+  item: JsonBacked;
+  children: Payload[];
 }
 
 export const stringifyPayload = (input: unknown): string | null =>
@@ -158,12 +163,21 @@ export const stringifyPayload = (input: unknown): string | null =>
 const jsonIsStringifyScopedCheckerRunner = `const mod = require("./main.cjs");
 
 const text = mod.stringifyPayload({
-  items: [
+  item: {
+    id: "box",
+    toJSON() {
+      return { data: { count: 3 } };
+    },
+  },
+  children: [
     {
-      id: "box",
-      toJSON() {
-        return { data: { count: 3 } };
+      item: {
+        id: "box",
+        toJSON() {
+          return { data: { value: "nested" } };
+        },
       },
+      children: [],
     },
   ],
 });
@@ -173,7 +187,7 @@ if (text === null) {
 }
 
 const parsed = JSON.parse(text);
-if (parsed.items[0].data.count !== 3) {
+if (parsed.item.data.count !== 3 || parsed.children[0].item.data.value !== "nested") {
   throw new Error("json.isStringify serialized the wrong branch: " + text);
 }
 `

--- a/packages/typia/native/cmd/ttsc-typia/json_is_stringify_scoped_checker_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_is_stringify_scoped_checker_transform_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestJsonIsStringifyScopedCheckerTransform verifies validated stringify owns
+// its branch-selection helpers.
+//
+// `json.isStringify` first validates with the regular checker collection, then
+// serializes with the JSON stringify collection. A type with `toJSON()` can add
+// JSON-only object-union branches, so the serializer must not reference `_io*`
+// helpers from the validator collection.
+//
+//  1. Transform a `json.isStringify` fixture whose `toJSON()` returns an object
+//     union absent from the regular checker graph.
+//  2. Execute the emitted JavaScript through Node.
+//  3. Require the serializer to return JSON text instead of throwing a missing
+//     helper `ReferenceError`.
+func TestJsonIsStringifyScopedCheckerTransform(t *testing.T) {
+  project := jsonIsStringifyScopedCheckerProject(t)
+  js := jsonIsStringifyScopedCheckerTransform(t, project)
+  if !strings.Contains(js, "toJSON") {
+    t.Fatalf("stringify fixture did not exercise toJSON emission:\n%s", js)
+  }
+  jsonIsStringifyScopedCheckerRunRuntime(t, project, js)
+}
+
+func jsonIsStringifyScopedCheckerProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "json-is-stringify-scoped-checker-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(jsonIsStringifyScopedCheckerTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonIsStringifyScopedCheckerSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func jsonIsStringifyScopedCheckerTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("json isStringify transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func jsonIsStringifyScopedCheckerRunRuntime(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  stubs := map[string]string{
+    "json-stringify-number-stub.cjs":  jsonIsStringifyScopedCheckerNumberStub,
+    "json-stringify-string-stub.cjs":  jsonIsStringifyScopedCheckerStringStub,
+    "throw-type-guard-error-stub.cjs": jsonIsStringifyScopedCheckerThrowStub,
+  }
+  for name, content := range stubs {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  runtimeJS := strings.ReplaceAll(js, `require("typia/lib/internal/_jsonStringifyNumber")`, `require("./json-stringify-number-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyString")`, `require("./json-stringify-string-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
+  runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(jsonIsStringifyScopedCheckerRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("json isStringify runtime failed: %v\n%s", err, output)
+  }
+}
+
+const jsonIsStringifyScopedCheckerTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const jsonIsStringifyScopedCheckerSource = `import typia from "typia";
+
+interface JsonAlpha {
+  data: {
+    value: string;
+  };
+}
+
+interface JsonBeta {
+  data: {
+    count: number;
+  };
+}
+
+interface JsonBacked {
+  id: string;
+  toJSON(): JsonAlpha | JsonBeta;
+}
+
+interface Payload {
+  items: JsonBacked[];
+}
+
+export const stringifyPayload = (input: unknown): string | null =>
+  typia.json.isStringify<Payload>(input);
+`
+
+const jsonIsStringifyScopedCheckerRunner = `const mod = require("./main.cjs");
+
+const text = mod.stringifyPayload({
+  items: [
+    {
+      id: "box",
+      toJSON() {
+        return { data: { count: 3 } };
+      },
+    },
+  ],
+});
+
+if (text === null) {
+  throw new Error("json.isStringify rejected a valid toJSON payload");
+}
+
+const parsed = JSON.parse(text);
+if (parsed.items[0].data.count !== 3) {
+  throw new Error("json.isStringify serialized the wrong branch: " + text);
+}
+`
+
+const jsonIsStringifyScopedCheckerNumberStub = `module.exports._jsonStringifyNumber = (value) => (isFinite(value) ? String(value) : "null");
+`
+
+const jsonIsStringifyScopedCheckerStringStub = `module.exports._jsonStringifyString = (value) => JSON.stringify(value);
+`
+
+const jsonIsStringifyScopedCheckerThrowStub = `module.exports._throwTypeGuardError = (props) => {
+  const error = new Error(props.expected);
+  Object.assign(error, props);
+  throw error;
+};
+`

--- a/packages/typia/native/core/programmers/IsProgrammer.go
+++ b/packages/typia/native/core/programmers/IsProgrammer.go
@@ -54,11 +54,11 @@ type IsProgrammer_WriteFunctionStatementsProps struct {
   Context    nativecontext.ITypiaContext
   Functor    *nativehelpers.FunctionProgrammer
   Collection *nativemetadata.MetadataCollection
-  // Prefix overrides the is-helper namespace ("" => the default "_i"). Used by
-  // plain.classify's VALIDATED union construction, which emits its OWN is-check
-  // helpers under "_yi" so the construction ladder references them by the
-  // classify collection's index — disjoint from the assert/validate side's "_i"
-  // (whose helpers come from a SEPARATE collection that may reorder/dedup).
+  // Prefix overrides the is-helper namespace ("" => the default "_i"). Use it
+  // when a caller emits branch-selection helpers from its own metadata
+  // collection, disjoint from an outer assert/validate/is collection that may
+  // reorder or deduplicate helper indexes. For example, plain.classify uses
+  // "_yi" and validated json.stringify uses "_si".
   Prefix string
 }
 
@@ -69,9 +69,9 @@ type IsProgrammer_DecodeProps struct {
   Input    *shimast.Expression
   Explore  nativeinternal.CheckerProgrammer_IExplore
   // Prefix overrides the is-helper namespace ("" => the default "_i"). See
-  // IsProgrammer_WriteFunctionStatementsProps.Prefix — the classify validated
-  // union ladder passes "_yi" so its _yio<i>/_yiu<i> references line up with the
-  // helpers its own Addition emits, not the assert side's _io<i>.
+  // IsProgrammer_WriteFunctionStatementsProps.Prefix; callers must pass the
+  // same prefix to Decode and Write_function_statements so helper references
+  // line up with the helpers emitted from the caller's own collection.
   Prefix string
 }
 
@@ -82,9 +82,8 @@ type IsProgrammer_DecodeObjectProps struct {
   Input   *shimast.Expression
   Explore nativeinternal.FeatureProgrammer_IExplore
   // Prefix overrides the is-helper namespace ("" => the default "_i"). See
-  // IsProgrammer_DecodeProps.Prefix — plain.classify's VALIDATED path passes
-  // "_yi" so a NESTED object discrimination references _yio<i> emitted by its own
-  // classify collection, not the assert side's reordered/deduped _io<i>.
+  // IsProgrammer_DecodeProps.Prefix; nested object discriminations must use the
+  // same caller-owned helper namespace as the surrounding union ladder.
   Prefix string
 }
 

--- a/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
@@ -29,10 +29,13 @@ type JsonStringifyProgrammer_DecomposeProps struct {
 }
 
 const jsonStringifyProgrammer_PREFIX = "_s"
+const jsonStringifyProgrammer_CHECKER_PREFIX = "_i"
+const jsonStringifyProgrammer_CHECKER_PREFIX_VALIDATED = "_si"
 
 var jsonStringifyProgrammer_factory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
 
 func (jsonStringifyProgrammerNamespace) Decompose(props JsonStringifyProgrammer_DecomposeProps) nativeinternal.FeatureProgrammer_IDecomposed {
+  checkerPrefix := jsonStringifyProgrammer_checker_prefix(props.Validated)
   config := jsonStringifyProgrammer_configure(struct {
     Context   nativecontext.ITypiaContext
     Functor   *nativehelpers.FunctionProgrammer
@@ -42,14 +45,13 @@ func (jsonStringifyProgrammerNamespace) Decompose(props JsonStringifyProgrammer_
     Functor:   props.Functor,
     Validated: props.Validated,
   })
-  if props.Validated == false {
-    config.Addition = func(collection *schemametadata.MetadataCollection) []*shimast.Node {
-      return nativeprogrammers.IsProgrammer.Write_function_statements(nativeprogrammers.IsProgrammer_WriteFunctionStatementsProps{
-        Context:    props.Context,
-        Functor:    props.Functor,
-        Collection: collection,
-      })
-    }
+  config.Addition = func(collection *schemametadata.MetadataCollection) []*shimast.Node {
+    return nativeprogrammers.IsProgrammer.Write_function_statements(nativeprogrammers.IsProgrammer_WriteFunctionStatementsProps{
+      Context:    props.Context,
+      Functor:    props.Functor,
+      Collection: collection,
+      Prefix:     checkerPrefix,
+    })
   }
   composed := nativeinternal.FeatureProgrammer.Compose(nativeinternal.FeatureProgrammer_ComposeProps{
     Context: props.Context,
@@ -308,6 +310,7 @@ func jsonStringifyProgrammer_decode(props struct {
           Metadata: next.Metadata,
           Input:    next.Input,
           Explore:  jsonStringifyProgrammer_checker_explore(next.Explore),
+          Prefix:   jsonStringifyProgrammer_checker_prefix(next.Validated),
         })
       },
       Value: func() *shimast.Node {
@@ -346,6 +349,7 @@ func jsonStringifyProgrammer_decode(props struct {
             Metadata: partial,
             Input:    props.Input,
             Explore:  jsonStringifyProgrammer_checker_explore(props.Explore),
+            Prefix:   jsonStringifyProgrammer_checker_prefix(props.Validated),
           })
         },
         Value: func() *shimast.Node {
@@ -379,6 +383,7 @@ func jsonStringifyProgrammer_decode(props struct {
             Metadata: partial,
             Input:    props.Input,
             Explore:  jsonStringifyProgrammer_checker_explore(props.Explore),
+            Prefix:   jsonStringifyProgrammer_checker_prefix(props.Validated),
           })
         },
         Value: func() *shimast.Node {
@@ -412,6 +417,7 @@ func jsonStringifyProgrammer_decode(props struct {
             Metadata: partial,
             Input:    props.Input,
             Explore:  jsonStringifyProgrammer_checker_explore(props.Explore),
+            Prefix:   jsonStringifyProgrammer_checker_prefix(props.Validated),
           })
         },
         Value: func() *shimast.Node {
@@ -440,6 +446,7 @@ func jsonStringifyProgrammer_decode(props struct {
           Metadata: partial,
           Input:    props.Input,
           Explore:  jsonStringifyProgrammer_checker_explore(props.Explore),
+          Prefix:   jsonStringifyProgrammer_checker_prefix(props.Validated),
         })
       },
       Value: func() *shimast.Node {
@@ -484,12 +491,13 @@ func jsonStringifyProgrammer_decode(props struct {
       explore := props.Explore
       explore.From = "array"
       return jsonStringifyProgrammer_explore_arrays(jsonStringifyProgrammer_exploreArraysProps{
-        Context: props.Context,
-        Config:  props.Config,
-        Functor: props.Functor,
-        Input:   props.Input,
-        Arrays:  props.Metadata.Arrays,
-        Explore: explore,
+        Context:   props.Context,
+        Config:    props.Config,
+        Functor:   props.Functor,
+        Input:     props.Input,
+        Arrays:    props.Metadata.Arrays,
+        Explore:   explore,
+        Validated: props.Validated,
       })
     }
     unions = append(unions, jsonStringifyProgrammer_IUnion{
@@ -969,12 +977,13 @@ func jsonStringifyProgrammer_explore_objects(props jsonStringifyProgrammer_explo
 }
 
 type jsonStringifyProgrammer_exploreArraysProps struct {
-  Context nativecontext.ITypiaContext
-  Config  nativeinternal.FeatureProgrammer_IConfig
-  Functor *nativehelpers.FunctionProgrammer
-  Input   *shimast.Node
-  Arrays  []*schemametadata.MetadataArray
-  Explore nativeinternal.FeatureProgrammer_IExplore
+  Context   nativecontext.ITypiaContext
+  Config    nativeinternal.FeatureProgrammer_IConfig
+  Functor   *nativehelpers.FunctionProgrammer
+  Input     *shimast.Node
+  Arrays    []*schemametadata.MetadataArray
+  Explore   nativeinternal.FeatureProgrammer_IExplore
+  Validated bool
 }
 
 func jsonStringifyProgrammer_explore_arrays(props jsonStringifyProgrammer_exploreArraysProps) *shimast.Node {
@@ -994,6 +1003,7 @@ func jsonStringifyProgrammer_explore_arrays(props jsonStringifyProgrammer_explor
               Metadata: v.Definition.(*schemametadata.MetadataSchema),
               Input:    v.Input,
               Explore:  jsonStringifyProgrammer_checker_explore(v.Explore),
+              Prefix:   jsonStringifyProgrammer_checker_prefix(props.Validated),
             })
           },
           Decoder: func(v nativehelpers.UnionExplorer_ArrayLikeDecoderProps) *shimast.Node {
@@ -1189,6 +1199,7 @@ func jsonStringifyProgrammer_configure(props struct {
   Validated bool
 }) nativeinternal.FeatureProgrammer_IConfig {
   f := nativecontext.EmitFactoryOf(jsonStringifyProgrammer_factory, props.Context.Emit)
+  checkerPrefix := jsonStringifyProgrammer_checker_prefix(props.Validated)
   var config nativeinternal.FeatureProgrammer_IConfig
   config = nativeinternal.FeatureProgrammer_IConfig{
     Types: nativeinternal.FeatureProgrammer_IConfig_ITypes{
@@ -1245,6 +1256,7 @@ func jsonStringifyProgrammer_configure(props struct {
           Metadata: next.Metadata,
           Input:    next.Input,
           Explore:  jsonStringifyProgrammer_checker_explore(next.Explore),
+          Prefix:   checkerPrefix,
         })
       },
       Decoder: func(next nativeinternal.FeatureProgrammer_ObjectorDecoderProps) *shimast.Node {
@@ -1270,6 +1282,7 @@ func jsonStringifyProgrammer_configure(props struct {
               Input:   v.Input,
               Object:  v.Object,
               Explore: jsonStringifyProgrammer_feature_explore(v.Explore),
+              Prefix:  checkerPrefix,
             })
           },
           Decoder: func(v nativeiterate.Decode_union_object_next) *shimast.Node {
@@ -1416,6 +1429,13 @@ func jsonStringifyProgrammer_internal(context nativecontext.ITypiaContext, name 
 
 func jsonStringifyProgrammer_method_text(modulo *shimast.Node) string {
   return nativehelpers.ModuloMethodText(modulo)
+}
+
+func jsonStringifyProgrammer_checker_prefix(validated bool) string {
+  if validated {
+    return jsonStringifyProgrammer_CHECKER_PREFIX_VALIDATED
+  }
+  return jsonStringifyProgrammer_CHECKER_PREFIX
 }
 
 func jsonStringifyProgrammer_feature_explore(input any) nativeinternal.FeatureProgrammer_IExplore {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-rc.1",
+  "version": "13.0.0-rc.2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- Scope `json.isStringify` serializer branch-check helpers to the JSON stringify metadata collection.
- Add a transform/runtime regression for `toJSON()` object-union branches that previously emitted missing `_io*` helper references.
- Bump `typia` to `13.0.0-rc.2` because native source changed.

## Root Cause
`json.isStringify` validates with the regular checker collection, then serializes through the JSON stringify collection. When a type defines `toJSON()`, the JSON metadata graph can contain object-union branches that the outer validator never generated. The validated serializer was still using the default `_i` checker helper namespace, so generated serializer helpers could reference validator helpers that did not exist.

## Changed Behavior
Validated JSON stringify now emits and references checker helpers under its own stringify-local namespace for serializer branch selection. This keeps helper generation tied to the metadata collection that actually needs those helpers instead of relying on the outer validator collection.

## Validation
- `pnpm format`
- `git diff --cached --check`
- `go test ./cmd/ttsc-typia -run TestJsonIsStringifyScopedCheckerTransform -count=1`
- `go test ./core/programmers/json ./cmd/ttsc-typia -count=1`
- `pnpm test:go:native`

## Local Limitations
- Full `pnpm test` was not run locally; CI should cover the broader package/test matrix.

Fixes #1966