### PR TITLE
test(mcp): lock markdown structuredContent results

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,14 +23,14 @@ catalogs:
       version: 8.1.2
   typescript:
     '@ttsc/playground':
-      specifier: ^0.16.0
-      version: 0.16.0
+      specifier: ^0.16.10
+      version: 0.16.10
     '@ttsc/unplugin':
-      specifier: ^0.16.0
-      version: 0.16.0
+      specifier: ^0.16.10
+      version: 0.16.10
     '@ttsc/wasm':
-      specifier: ^0.16.0
-      version: 0.16.0
+      specifier: ^0.16.10
+      version: 0.16.10
     ttsc:
       specifier: ^0.16.8
       version: 0.16.8
@@ -223,7 +223,7 @@ importers:
         version: 16.0.3(rollup@4.60.2)
       '@ttsc/unplugin':
         specifier: catalog:typescript
-        version: 0.16.0
+        version: 0.16.10
       rollup:
         specifier: catalog:rollup
         version: 4.60.2
@@ -875,10 +875,10 @@ importers:
         version: 4.3.0
       '@ttsc/playground':
         specifier: catalog:typescript
-        version: 0.16.0(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.16.0)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)
+        version: 0.16.10(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.16.10)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)
       '@ttsc/wasm':
         specifier: catalog:typescript
-        version: 0.16.0
+        version: 0.16.10
       '@typia/interface':
         specifier: workspace:^
         version: link:../packages/interface
@@ -2801,21 +2801,21 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@ttsc/playground@0.16.0':
-    resolution: {integrity: sha512-nRQg3pOSUsYNz0cYZctYyR5Jp3f+LbwgypttsZ/du8m0i78NZIR3kaVxiQzNyyPVsPFubU9yW9r3+dluGAldhQ==}
+  '@ttsc/playground@0.16.10':
+    resolution: {integrity: sha512-rz/A2CBOKMTstJx2roKLpc2H3CmnlX6G5ebQIG7v++tizqqIEMSPN6/LC8IfSpiViTBb0rlgERd+EnjilVGjAw==}
     peerDependencies:
       '@monaco-editor/react': ^4.6.0
-      '@ttsc/wasm': ^0.16.0
+      '@ttsc/wasm': ^0.16.10
       monaco-editor: ^0.52.0
       react: ^18.0.0
       react-dom: ^18.0.0
       tgrid: ^1.0.3
 
-  '@ttsc/unplugin@0.16.0':
-    resolution: {integrity: sha512-SDypVuNBAGrmBiuGP8xsZ+VdFGVHH0ANWHpT43xfNfSwqQjzxafymOgQxebYNtCVmW4OZDLXb2vnPPMh8M/dBQ==}
+  '@ttsc/unplugin@0.16.10':
+    resolution: {integrity: sha512-5zdz1vHT/eQPuxBmH7vQTdG9tgfmjWdeLUP1p9RxjX4jbmxd1519lcPFGYDpMYwPIqOGvED/w0FDyx8b13qtSA==}
 
-  '@ttsc/wasm@0.16.0':
-    resolution: {integrity: sha512-UUGYzSnjhdHabSSP3qWXF3G/IOua5An0Em1jNkyuMw36l/mNy8tWWBvFEr2lrmkECA8aDuSLyL2Es34D1KdzFQ==}
+  '@ttsc/wasm@0.16.10':
+    resolution: {integrity: sha512-dHQHSrwDjtUQXa4Wv3qjfsamFl0ANp3va8dcyTHfIIh1b39DXKCG1Elrx0iq3sBg07H/36T2cf8SBhYl9LtHUw==}
 
   '@ttsc/win32-arm64@0.16.8':
     resolution: {integrity: sha512-kwx6ZYz0Z1AHTKgh1oft7LQRr5oVMWpl435WK8Y0nA8BNY3P5QDy9SSavedyO1dbiX9cg26XrpPoYCGQ2oDu0A==}
@@ -9424,21 +9424,21 @@ snapshots:
   '@ttsc/linux-x64@0.16.8':
     optional: true
 
-  '@ttsc/playground@0.16.0(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.16.0)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)':
+  '@ttsc/playground@0.16.10(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.16.10)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)':
     dependencies:
       '@monaco-editor/react': 4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@ttsc/wasm': 0.16.0
+      '@ttsc/wasm': 0.16.10
       lz-string: 1.5.0
       monaco-editor: 0.50.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tgrid: 1.2.1
 
-  '@ttsc/unplugin@0.16.0':
+  '@ttsc/unplugin@0.16.10':
     dependencies:
       unplugin: 2.3.11
 
-  '@ttsc/wasm@0.16.0': {}
+  '@ttsc/wasm@0.16.10': {}
 
   '@ttsc/win32-arm64@0.16.8':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,9 +13,9 @@ overrides:
   zod@4: 4.1.12
 catalogs:
   typescript:
-    '@ttsc/playground': ^0.16.0
-    '@ttsc/unplugin': ^0.16.0
-    '@ttsc/wasm': ^0.16.0
+    '@ttsc/playground': ^0.16.10
+    '@ttsc/unplugin': ^0.16.10
+    '@ttsc/wasm': ^0.16.10
     ts-node: ^10.9.2
     ttsc: ^0.16.8
     typescript: 7.0.1-rc

--- a/tests/test-mcp/src/features/test_mcp_tool_markdown_structured_content.ts
+++ b/tests/test-mcp/src/features/test_mcp_tool_markdown_structured_content.ts
@@ -1,0 +1,54 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { TestValidator } from "@nestia/e2e";
+import { createMcpServer } from "@typia/mcp";
+import typia from "typia";
+
+import { TicketSearch } from "../structures/TicketSearch";
+
+/**
+ * Verifies Markdown-bearing object results are exposed through
+ * structuredContent.
+ *
+ * Locks the MCP structured-output path for controller methods that wrap raw
+ * Markdown in an object to satisfy typia.llm's object-return rule. A regression
+ * would leave clients with only an escaped JSON text fallback.
+ *
+ * 1. Serve a ticket search controller whose result object contains Markdown.
+ * 2. Call `searchTickets` through tools/call.
+ * 3. Assert `structuredContent` carries the original object while text remains the
+ *    backward-compatible serialized JSON fallback.
+ */
+export const test_mcp_tool_markdown_structured_content =
+  async (): Promise<void> => {
+    const server: McpServer = createMcpServer(
+      typia.llm.controller<TicketSearch>("tickets", new TicketSearch()),
+    );
+
+    const rawServer: Server = server.server;
+    const callHandler: Function = (rawServer as any)._requestHandlers.get(
+      "tools/call",
+    )!;
+    const markdown: string =
+      "# Ticket 123\nStatus: Open\n\nDescription: Payment failed";
+
+    const result: CallToolResult = await callHandler(
+      {
+        method: "tools/call",
+        params: { name: "searchTickets", arguments: { query: "payment" } },
+      },
+      { signal: new AbortController().signal },
+    );
+
+    TestValidator.equals(
+      "structuredContent should carry the Markdown wrapper object",
+      result.structuredContent,
+      { content: markdown },
+    );
+    TestValidator.equals(
+      "text content should remain the JSON fallback",
+      JSON.parse((result.content[0] as { text: string }).text),
+      { content: markdown },
+    );
+  };

--- a/tests/test-mcp/src/structures/TicketSearch.ts
+++ b/tests/test-mcp/src/structures/TicketSearch.ts
@@ -1,0 +1,27 @@
+export class TicketSearch {
+  /**
+   * Search support tickets.
+   *
+   * @param props Search query
+   * @returns Matching ticket summary in Markdown
+   */
+  public searchTickets(props: TicketSearch.IProps): TicketSearch.IResult {
+    void props;
+    return {
+      content: "# Ticket 123\nStatus: Open\n\nDescription: Payment failed",
+    };
+  }
+}
+
+export namespace TicketSearch {
+  export interface IProps {
+    /** Search query */
+    query: string;
+  }
+
+  /** Markdown summary returned by the search. */
+  export interface IResult {
+    /** Markdown text for model-facing ticket context */
+    content: string;
+  }
+}


### PR DESCRIPTION
﻿## Intent

Lock the MCP structured output behavior for Markdown-bearing controller results and include the requested workspace catalog lockfile update.

## Scope

- Add a `test-mcp` regression fixture whose controller returns a Markdown wrapper object.
- Assert `structuredContent` carries the original object while `content[0].text` remains the JSON fallback.
- Update the pnpm catalog/lock entries for `@ttsc/playground`, `@ttsc/unplugin`, and `@ttsc/wasm` to `0.16.10`.

## Deferred

None.

## Test Plan

- `pnpm format`
- `pnpm --filter ./tests/test-mcp exec ttsx --cache-dir <fresh-temp> src/index.ts -- --include markdown_structured_content`
- `pnpm --filter ./tests/test-mcp exec ttsx --cache-dir <fresh-temp> src/index.ts`
