### PR TITLE
feat(adapters): make direct controller tools practical

### DIFF
--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -34,11 +34,9 @@ import { toLangChainTools } from "@typia/langchain";
 import { AgentExecutor, createToolCallingAgent } from "langchain/agents";
 import typia from "typia";
 
-const tools: DynamicStructuredTool[] = toLangChainTools({
-  controllers: [
-    typia.llm.controller<Calculator>("Calculator", new Calculator()),
-  ],
-});
+const tools: DynamicStructuredTool[] = toLangChainTools(
+  typia.llm.controller<Calculator>("Calculator", new Calculator()),
+);
 
 const agent: Runnable = createToolCallingAgent({
   llm: new ChatOpenAI({ model: "gpt-4o" }),
@@ -60,15 +58,13 @@ import { DynamicStructuredTool } from "@langchain/core/tools";
 import { toLangChainTools } from "@typia/langchain";
 import { HttpLlm } from "@typia/utils";
 
-const tools: DynamicStructuredTool[] = toLangChainTools({
-  controllers: [
-    HttpLlm.controller({
-      name: "petStore",
-      document: yourOpenApiDocument,
-      connection: { host: "https://api.example.com" },
-    }),
-  ],
-});
+const tools: DynamicStructuredTool[] = toLangChainTools(
+  HttpLlm.controller({
+    name: "petStore",
+    document: yourOpenApiDocument,
+    connection: { host: "https://api.example.com" },
+  }),
+);
 ```
 
 ### Structured Output
@@ -111,4 +107,5 @@ if (!result.success) {
 
 - No manual schema definition — generates everything from TypeScript types or OpenAPI
 - Automatic argument validation with LLM-friendly error feedback
+- Runtime tool errors are returned as `{ success: false, error }` for model recovery
 - Supports both class-based (`typia.llm.controller`) and HTTP-based (`HttpLlm.controller`) controllers

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -3,6 +3,32 @@ import { IHttpLlmController, ILlmController } from "@typia/interface";
 
 import { LangChainToolsRegistrar } from "./internal/LangChainToolsRegistrar";
 
+type ILangChainController = ILlmController | IHttpLlmController;
+
+interface ILangChainToolsOptions {
+  /**
+   * Whether to add controller name as prefix to tool names.
+   *
+   * If `true`, tool names become `{controllerName}_{methodName}`. If `false`,
+   * tool names are just `{methodName}`.
+   *
+   * @default false
+   */
+  prefix?: boolean | undefined;
+}
+
+interface ILangChainToolsProps extends ILangChainToolsOptions {
+  /**
+   * List of controllers to convert to LangChain tools.
+   *
+   * - {@link ILlmController}: from `typia.llm.controller<Class>()`, converts all
+   *   methods of the class to tools
+   * - {@link IHttpLlmController}: from `HttpLlm.controller()`, converts all
+   *   operations from OpenAPI document to tools
+   */
+  controllers: ILangChainController[];
+}
+
 /**
  * Convert typia controllers to LangChain tools.
  *
@@ -25,40 +51,56 @@ import { LangChainToolsRegistrar } from "./internal/LangChainToolsRegistrar";
  *     }
  *   }
  *
- *   const tools = toLangChainTools({
- *     controllers: [
- *       typia.llm.controller<Calculator>("calculator", new Calculator()),
- *     ],
- *   });
+ *   const controller = typia.llm.controller<Calculator>(
+ *     "calculator",
+ *     new Calculator(),
+ *   );
+ *   const tools = toLangChainTools(controller);
  *
  *   const llm = await initChatModel();
  *   const modelWithTools = llm.bindTools(tools);
  *   const result = await modelWithTools.invoke("What is 10 + 5?");
  *   ```;
  *
- * @param props Conversion properties
+ * @param input Controller, controller list, or conversion properties
+ * @param options Conversion options when `input` is not a properties object
  * @returns Array of LangChain DynamicStructuredTool
  */
-export function toLangChainTools(props: {
-  /**
-   * List of controllers to convert to LangChain tools.
-   *
-   * - {@link ILlmController}: from `typia.llm.controller<Class>()`, converts all
-   *   methods of the class to tools
-   * - {@link IHttpLlmController}: from `HttpLlm.controller()`, converts all
-   *   operations from OpenAPI document to tools
-   */
-  controllers: Array<ILlmController | IHttpLlmController>;
-
-  /**
-   * Whether to add controller name as prefix to tool names.
-   *
-   * If `true`, tool names become `{controllerName}_{methodName}`. If `false`,
-   * tool names are just `{methodName}`.
-   *
-   * @default false
-   */
-  prefix?: boolean | undefined;
-}): DynamicStructuredTool[] {
-  return LangChainToolsRegistrar.convert(props);
+export function toLangChainTools(
+  controller: ILangChainController,
+  options?: ILangChainToolsOptions | undefined,
+): DynamicStructuredTool[];
+export function toLangChainTools(
+  controllers: ILangChainController[],
+  options?: ILangChainToolsOptions | undefined,
+): DynamicStructuredTool[];
+export function toLangChainTools(
+  props: ILangChainToolsProps,
+): DynamicStructuredTool[];
+export function toLangChainTools(
+  input: ILangChainController | ILangChainController[] | ILangChainToolsProps,
+  options?: ILangChainToolsOptions | undefined,
+): DynamicStructuredTool[] {
+  return LangChainToolsRegistrar.convert(
+    normalizeLangChainToolsProps(input, options),
+  );
 }
+
+const normalizeLangChainToolsProps = (
+  input: ILangChainController | ILangChainController[] | ILangChainToolsProps,
+  options?: ILangChainToolsOptions | undefined,
+): ILangChainToolsProps => {
+  if (isLangChainToolsProps(input)) return input;
+  return {
+    controllers: Array.isArray(input) ? input : [input],
+    prefix: options?.prefix,
+  };
+};
+
+const isLangChainToolsProps = (
+  input: ILangChainController | ILangChainController[] | ILangChainToolsProps,
+): input is ILangChainToolsProps =>
+  Array.isArray(input) === false &&
+  typeof input === "object" &&
+  input !== null &&
+  "controllers" in input;

--- a/packages/langchain/src/internal/LangChainToolsRegistrar.ts
+++ b/packages/langchain/src/internal/LangChainToolsRegistrar.ts
@@ -129,21 +129,34 @@ export namespace LangChainToolsRegistrar {
       description: entry.function.description ?? "",
       schema: entry.function.parameters,
       func: async (args: unknown): Promise<unknown> => {
-        const coerced: unknown = LlmJson.coerce(
-          args,
-          entry.function.parameters,
+        const valid: IValidation<unknown> = LlmJson.validateArguments(
+          entry.function,
+          args ?? {},
         );
-        const valid: IValidation<unknown> = entry.function.validate(coerced);
         if (valid.success === false)
           throw new ToolInputParsingException(
             `Type errors in "${entry.name}" arguments:\n\n` +
               `\`\`\`json\n${LlmJson.stringify(valid)}\n\`\`\``,
-            JSON.stringify(coerced),
+            JSON.stringify(args ?? {}),
           );
-        const result: unknown = await entry.execute(valid.data);
-        return result === undefined
-          ? { success: true }
-          : { success: true, data: result };
+        try {
+          const result: unknown = await entry.execute(valid.data);
+          return result === undefined
+            ? ({ success: true } satisfies ITryResult)
+            : ({ success: true, data: result } satisfies ITryResult);
+        } catch (error) {
+          return {
+            success: false,
+            error:
+              error instanceof Error
+                ? `${error.name}: ${error.message}`
+                : String(error),
+          } satisfies ITryResult;
+        }
       },
     });
 }
+
+type ITryResult =
+  | { success: true; data?: unknown | undefined }
+  | { success: false; error: string };

--- a/packages/langchain/src/internal/LangChainToolsRegistrar.ts
+++ b/packages/langchain/src/internal/LangChainToolsRegistrar.ts
@@ -1,6 +1,7 @@
 import {
   DynamicStructuredTool,
   ToolInputParsingException,
+  tool,
 } from "@langchain/core/tools";
 import {
   IHttpLlmController,
@@ -124,11 +125,8 @@ export namespace LangChainToolsRegistrar {
     function: ILlmFunction | IHttpLlmFunction;
     execute: (args: unknown) => Promise<unknown>;
   }): DynamicStructuredTool =>
-    new DynamicStructuredTool<any>({
-      name: entry.name,
-      description: entry.function.description ?? "",
-      schema: entry.function.parameters,
-      func: async (args: unknown): Promise<unknown> => {
+    tool(
+      async (args: unknown): Promise<unknown> => {
         const valid: IValidation<unknown> = LlmJson.validateArguments(
           entry.function,
           args ?? {},
@@ -141,9 +139,15 @@ export namespace LangChainToolsRegistrar {
           );
         try {
           const result: unknown = await entry.execute(valid.data);
-          return result === undefined
-            ? ({ success: true } satisfies ITryResult)
-            : ({ success: true, data: result } satisfies ITryResult);
+          if (result === undefined) {
+            return entry.function.output === undefined
+              ? ({ success: true } satisfies ITryResult)
+              : ({
+                  success: false,
+                  error: `Function "${entry.name}" returned undefined despite declaring an output schema`,
+                } satisfies ITryResult);
+          }
+          return { success: true, data: result } satisfies ITryResult;
         } catch (error) {
           return {
             success: false,
@@ -154,7 +158,12 @@ export namespace LangChainToolsRegistrar {
           } satisfies ITryResult;
         }
       },
-    });
+      {
+        name: entry.name,
+        description: entry.function.description ?? "",
+        schema: entry.function.parameters,
+      },
+    );
 }
 
 type ITryResult =

--- a/packages/vercel/README.md
+++ b/packages/vercel/README.md
@@ -102,6 +102,7 @@ const { object } = await generateObject({
 
 - No manual schema definition — generates everything from TypeScript types or OpenAPI
 - Automatic argument validation with LLM-friendly error feedback
+- Reflected return types advertise the `{ success, data/error }` output wrapper
 - Runtime tool errors are returned as `{ success: false, error }` for model recovery
 - Supports both class-based (`typia.llm.controller`) and HTTP-based (`HttpLlm.controller`) controllers
 - Works with any LLM provider supported by Vercel AI SDK

--- a/packages/vercel/README.md
+++ b/packages/vercel/README.md
@@ -31,11 +31,9 @@ import { toVercelTools } from "@typia/vercel";
 import { generateText, GenerateTextResult, Tool } from "ai";
 import typia from "typia";
 
-const tools: Record<string, Tool> = toVercelTools({
-  controllers: [
-    typia.llm.controller<Calculator>("Calculator", new Calculator()),
-  ],
-});
+const tools: Record<string, Tool> = toVercelTools(
+  typia.llm.controller<Calculator>("Calculator", new Calculator()),
+);
 
 const result: GenerateTextResult = await generateText({
   model: openai("gpt-4o"),
@@ -51,15 +49,13 @@ import { toVercelTools } from "@typia/vercel";
 import { HttpLlm } from "@typia/utils";
 import { Tool } from "ai";
 
-const tools: Record<string, Tool> = toVercelTools({
-  controllers: [
-    HttpLlm.controller({
-      name: "petStore",
-      document: yourOpenApiDocument,
-      connection: { host: "https://api.example.com" },
-    }),
-  ],
-});
+const tools: Record<string, Tool> = toVercelTools(
+  HttpLlm.controller({
+    name: "petStore",
+    document: yourOpenApiDocument,
+    connection: { host: "https://api.example.com" },
+  }),
+);
 ```
 
 ### Structured Output
@@ -106,5 +102,6 @@ const { object } = await generateObject({
 
 - No manual schema definition — generates everything from TypeScript types or OpenAPI
 - Automatic argument validation with LLM-friendly error feedback
+- Runtime tool errors are returned as `{ success: false, error }` for model recovery
 - Supports both class-based (`typia.llm.controller`) and HTTP-based (`HttpLlm.controller`) controllers
 - Works with any LLM provider supported by Vercel AI SDK

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -8,6 +8,32 @@ import type { Schema, Tool } from "ai";
 import { VercelParameterConverter } from "./internal/VercelParameterConverter";
 import { VercelToolsRegistrar } from "./internal/VercelToolsRegistrar";
 
+type IVercelController = ILlmController | IHttpLlmController;
+
+interface IVercelToolsOptions {
+  /**
+   * Whether to prefix tool names with controller name.
+   *
+   * If `true`, tool names are formatted as `{controller}_{function}`. If
+   * `false`, only the function name is used (may cause conflicts).
+   *
+   * @default false
+   */
+  prefix?: boolean | undefined;
+}
+
+interface IVercelToolsProps extends IVercelToolsOptions {
+  /**
+   * List of controllers to convert to Vercel tools.
+   *
+   * - {@link ILlmController}: from `typia.llm.controller<Class>()`, converts all
+   *   methods of the class to tools
+   * - {@link IHttpLlmController}: from `HttpLlm.controller()`, converts all
+   *   operations from OpenAPI document to tools
+   */
+  controllers: IVercelController[];
+}
+
 /**
  * Convert typia controllers to Vercel AI SDK tools.
  *
@@ -35,7 +61,7 @@ import { VercelToolsRegistrar } from "./internal/VercelToolsRegistrar";
  * }
  *
  * const controller = typia.llm.controller<Calculator>("calc", new Calculator());
- * const tools = toVercelTools({ controllers: [controller] });
+ * const tools = toVercelTools(controller);
  *
  * const result = await generateText({
  *   model: openai("gpt-4o"),
@@ -53,7 +79,7 @@ import { VercelToolsRegistrar } from "./internal/VercelToolsRegistrar";
  *
  * const result = await generateText({
  *   model: anthropic("claude-sonnet-4-20250514"),
- *   tools: toVercelTools({ controllers: [controller] }),
+ *   tools: toVercelTools(controller),
  *   prompt: "Calculate 100 * 50",
  * });
  * ```
@@ -82,31 +108,26 @@ import { VercelToolsRegistrar } from "./internal/VercelToolsRegistrar";
  * ```
  *
  * @author Jeongho Nam - https://github.com/samchon
- * @param props Conversion properties
+ * @param input Controller, controller list, or conversion properties
+ * @param options Conversion options when `input` is not a properties object
  * @returns Record of Vercel AI SDK Tools keyed by tool name
  */
-export function toVercelTools(props: {
-  /**
-   * List of controllers to convert to Vercel tools.
-   *
-   * - {@link ILlmController}: from `typia.llm.controller<Class>()`, converts all
-   *   methods of the class to tools
-   * - {@link IHttpLlmController}: from `HttpLlm.controller()`, converts all
-   *   operations from OpenAPI document to tools
-   */
-  controllers: Array<ILlmController | IHttpLlmController>;
-
-  /**
-   * Whether to prefix tool names with controller name.
-   *
-   * If `true`, tool names are formatted as `{controller}_{function}`. If
-   * `false`, only the function name is used (may cause conflicts).
-   *
-   * @default false
-   */
-  prefix?: boolean | undefined;
-}): Record<string, Tool> {
-  return VercelToolsRegistrar.convert(props);
+export function toVercelTools(
+  controller: IVercelController,
+  options?: IVercelToolsOptions | undefined,
+): Record<string, Tool>;
+export function toVercelTools(
+  controllers: IVercelController[],
+  options?: IVercelToolsOptions | undefined,
+): Record<string, Tool>;
+export function toVercelTools(props: IVercelToolsProps): Record<string, Tool>;
+export function toVercelTools(
+  input: IVercelController | IVercelController[] | IVercelToolsProps,
+  options?: IVercelToolsOptions | undefined,
+): Record<string, Tool> {
+  return VercelToolsRegistrar.convert(
+    normalizeVercelToolsProps(input, options),
+  );
 }
 
 /**
@@ -153,3 +174,22 @@ export function toVercelSchema(
 ): Schema<object> {
   return VercelParameterConverter.convert(parameters);
 }
+
+const normalizeVercelToolsProps = (
+  input: IVercelController | IVercelController[] | IVercelToolsProps,
+  options?: IVercelToolsOptions | undefined,
+): IVercelToolsProps => {
+  if (isVercelToolsProps(input)) return input;
+  return {
+    controllers: Array.isArray(input) ? input : [input],
+    prefix: options?.prefix,
+  };
+};
+
+const isVercelToolsProps = (
+  input: IVercelController | IVercelController[] | IVercelToolsProps,
+): input is IVercelToolsProps =>
+  Array.isArray(input) === false &&
+  typeof input === "object" &&
+  input !== null &&
+  "controllers" in input;

--- a/packages/vercel/src/internal/VercelParameterConverter.ts
+++ b/packages/vercel/src/internal/VercelParameterConverter.ts
@@ -5,4 +5,37 @@ import { JSONSchema7 } from "json-schema";
 export namespace VercelParameterConverter {
   export const convert = (parameters: ILlmSchema.IParameters): Schema<object> =>
     jsonSchema<object>(parameters as JSONSchema7);
+
+  export const convertToolOutput = (
+    parameters: ILlmSchema.IParameters,
+  ): Schema<object> =>
+    jsonSchema<object>({
+      type: "object",
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            success: { type: "boolean", enum: [true] },
+            data: {
+              type: "object",
+              properties: parameters.properties,
+              required: parameters.required,
+              additionalProperties: false,
+            },
+          },
+          required: ["success", "data"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: {
+            success: { type: "boolean", enum: [false] },
+            error: { type: "string" },
+          },
+          required: ["success", "error"],
+          additionalProperties: false,
+        },
+      ],
+      $defs: parameters.$defs,
+    } as JSONSchema7);
 }

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -133,8 +133,10 @@ export namespace VercelToolsRegistrar {
       description: func.description ?? "",
       inputSchema: VercelParameterConverter.convert(func.parameters),
       execute: async (args: unknown): Promise<ITryResult> => {
-        const coerced: unknown = LlmJson.coerce(args, func.parameters);
-        const validation: IValidation<unknown> = func.validate(coerced);
+        const validation: IValidation<unknown> = LlmJson.validateArguments(
+          func,
+          args ?? {},
+        );
         if (!validation.success)
           return {
             success: false,

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -132,6 +132,13 @@ export namespace VercelToolsRegistrar {
     return tool({
       description: func.description ?? "",
       inputSchema: VercelParameterConverter.convert(func.parameters),
+      ...(func.output !== undefined
+        ? {
+            outputSchema: VercelParameterConverter.convertToolOutput(
+              func.output,
+            ),
+          }
+        : {}),
       execute: async (args: unknown): Promise<ITryResult> => {
         const validation: IValidation<unknown> = LlmJson.validateArguments(
           func,
@@ -146,9 +153,15 @@ export namespace VercelToolsRegistrar {
           } satisfies ITryResult;
         try {
           const result: unknown = await execute(validation.data);
-          return result === undefined
-            ? ({ success: true } satisfies ITryResult)
-            : ({ success: true, data: result } satisfies ITryResult);
+          if (result === undefined) {
+            return func.output === undefined
+              ? ({ success: true } satisfies ITryResult)
+              : ({
+                  success: false,
+                  error: `Function "${name}" returned undefined despite declaring an output schema`,
+                } satisfies ITryResult);
+          }
+          return { success: true, data: result } satisfies ITryResult;
         } catch (error) {
           return {
             success: false,

--- a/tests/test-langchain/src/features/test_langchain_class_controller_error_handling.ts
+++ b/tests/test-langchain/src/features/test_langchain_class_controller_error_handling.ts
@@ -40,4 +40,35 @@ export const test_langchain_class_controller_error_handling =
         typeof failure.error === "string" &&
         failure.error.includes("Division by zero"),
     );
+
+    const broken: DynamicStructuredTool[] = toLangChainTools(
+      typia.llm.controller<BrokenOutput>("broken", new BrokenOutput()),
+    );
+    const read: DynamicStructuredTool | undefined = broken.find(
+      (tool) => tool.name === "read",
+    );
+    if (read === undefined) throw new Error("Missing read tool");
+
+    TestValidator.equals(
+      "typed undefined result should be returned as a failure object",
+      await read.invoke({}),
+      {
+        success: false,
+        error:
+          'Function "read" returned undefined despite declaring an output schema',
+      },
+    );
   };
+
+class BrokenOutput {
+  /** Read a typed result but violate it at runtime. */
+  read(_: BrokenOutput.IProps): BrokenOutput.IResult {
+    return undefined as any;
+  }
+}
+namespace BrokenOutput {
+  export interface IProps {}
+  export interface IResult {
+    value: number;
+  }
+}

--- a/tests/test-langchain/src/features/test_langchain_class_controller_error_handling.ts
+++ b/tests/test-langchain/src/features/test_langchain_class_controller_error_handling.ts
@@ -1,0 +1,43 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { TestValidator } from "@nestia/e2e";
+import { toLangChainTools } from "@typia/langchain";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+/**
+ * Verifies runtime controller errors become model-readable tool results.
+ *
+ * LangChain should still throw `ToolInputParsingException` for invalid
+ * arguments, but a valid tool call whose implementation throws is feedback for
+ * the model, not an adapter crash. Returning the same failure object shape as
+ * `@typia/vercel` keeps the tool-call loop recoverable.
+ *
+ * 1. Convert a `Calculator` controller and find the `divide` tool.
+ * 2. Invoke it with valid arguments that trigger the controller's divide-by-zero
+ *    branch.
+ * 3. Assert the tool returns `{ success: false, error }` with the original
+ *    message.
+ */
+export const test_langchain_class_controller_error_handling =
+  async (): Promise<void> => {
+    const tools: DynamicStructuredTool[] = toLangChainTools(
+      typia.llm.controller<Calculator>("calculator", new Calculator()),
+    );
+
+    const divide: DynamicStructuredTool | undefined = tools.find(
+      (tool) => tool.name === "divide",
+    );
+    if (divide === undefined) throw new Error("Missing divide tool");
+
+    const result: unknown = await divide.invoke({ x: 10, y: 0 });
+    const failure = result as { success?: boolean; error?: string };
+
+    TestValidator.predicate(
+      "runtime error should be returned as a failure object",
+      () =>
+        failure.success === false &&
+        typeof failure.error === "string" &&
+        failure.error.includes("Division by zero"),
+    );
+  };

--- a/tests/test-langchain/src/features/test_langchain_single_controller_lazy_execute.ts
+++ b/tests/test-langchain/src/features/test_langchain_single_controller_lazy_execute.ts
@@ -1,0 +1,54 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { TestValidator } from "@nestia/e2e";
+import { toLangChainTools } from "@typia/langchain";
+import typia from "typia";
+
+import { Inspector } from "../structures/Inspector";
+
+/**
+ * Verifies a single controller can become LangChain tools without eager work.
+ *
+ * Mirrors the practical `createMcpServer(controller)` path: callers should not
+ * have to wrap one controller in `{ controllers: [...] }`, and tool conversion
+ * must not build state that the controller intentionally defers until
+ * execution.
+ *
+ * 1. Convert one lazily-constructed `Inspector` controller directly.
+ * 2. Assert conversion exposes the tool description without building state.
+ * 3. Invoke the tool and assert the state builds exactly once.
+ */
+export const test_langchain_single_controller_lazy_execute =
+  async (): Promise<void> => {
+    let built: number = 0;
+    const tools: DynamicStructuredTool[] = toLangChainTools(
+      typia.llm.controller<Inspector>(
+        "inspector",
+        new Inspector(() => {
+          ++built;
+          return { value: 42 };
+        }),
+      ),
+    );
+
+    TestValidator.equals(
+      "conversion should not build deferred state",
+      built,
+      0,
+    );
+    TestValidator.equals("single controller exposes one tool", tools.length, 1);
+
+    const inspect: DynamicStructuredTool | undefined = tools.find(
+      (tool) => tool.name === "inspect",
+    );
+    if (inspect === undefined) throw new Error("Missing inspect tool");
+    TestValidator.predicate("tool description should come from JSDoc", () =>
+      inspect.description.includes("Inspect the deferred state"),
+    );
+
+    const result: unknown = await inspect.invoke({ query: "depth" });
+    TestValidator.equals("first call builds the state once", built, 1);
+    TestValidator.equals("tool returns the inspected result", result, {
+      success: true,
+      data: { answer: "depth=42" },
+    });
+  };

--- a/tests/test-langchain/src/structures/Inspector.ts
+++ b/tests/test-langchain/src/structures/Inspector.ts
@@ -1,0 +1,36 @@
+/**
+ * Deferred inspection service.
+ *
+ * Holds expensive state behind a closure so tool conversion can be checked
+ * without building that state.
+ */
+export class Inspector {
+  private readonly state: () => Inspector.IState;
+
+  public constructor(source: Inspector.IState | (() => Inspector.IState)) {
+    this.state = typeof source === "function" ? source : () => source;
+  }
+
+  /**
+   * Inspect the deferred state.
+   *
+   * @param props Query to run against the state
+   * @returns The matching answer
+   */
+  public inspect(props: Inspector.IProps): Inspector.IResult {
+    return { answer: `${props.query}=${this.state().value}` };
+  }
+}
+export namespace Inspector {
+  export interface IState {
+    value: number;
+  }
+  export interface IProps {
+    /** Question to answer from the state */
+    query: string;
+  }
+  export interface IResult {
+    /** Answer text */
+    answer: string;
+  }
+}

--- a/tests/test-vercel/src/features/test_vercel_single_controller_lazy_execute.ts
+++ b/tests/test-vercel/src/features/test_vercel_single_controller_lazy_execute.ts
@@ -1,0 +1,60 @@
+import { TestValidator } from "@nestia/e2e";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+import typia from "typia";
+
+import { Inspector } from "../structures/Inspector";
+
+/**
+ * Verifies a single controller can become Vercel tools without eager work.
+ *
+ * Mirrors the practical `createMcpServer(controller)` path: callers should not
+ * have to wrap one controller in `{ controllers: [...] }`, and tool conversion
+ * must not build state that the controller intentionally defers until
+ * execution.
+ *
+ * 1. Convert one lazily-constructed `Inspector` controller directly.
+ * 2. Assert conversion exposes the tool description without building state.
+ * 3. Execute the tool and assert the state builds exactly once.
+ */
+export const test_vercel_single_controller_lazy_execute =
+  async (): Promise<void> => {
+    let built: number = 0;
+    const tools: Record<string, Tool> = toVercelTools(
+      typia.llm.controller<Inspector>(
+        "inspector",
+        new Inspector(() => {
+          ++built;
+          return { value: 42 };
+        }),
+      ),
+    );
+
+    TestValidator.equals(
+      "conversion should not build deferred state",
+      built,
+      0,
+    );
+    TestValidator.equals(
+      "single controller exposes one tool",
+      Object.keys(tools),
+      ["inspect"],
+    );
+
+    const inspect: Tool = tools["inspect"]!;
+    TestValidator.predicate(
+      "tool description should come from JSDoc",
+      () =>
+        inspect.description?.includes("Inspect the deferred state") === true,
+    );
+
+    const result: unknown = await inspect.execute!(
+      { query: "depth" },
+      { toolCallId: "test-1", messages: [], abortSignal: undefined as any },
+    );
+    TestValidator.equals("first call builds the state once", built, 1);
+    TestValidator.equals("tool returns the inspected result", result, {
+      success: true,
+      data: { answer: "depth=42" },
+    });
+  };

--- a/tests/test-vercel/src/features/test_vercel_tool_omitted_arguments.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_omitted_arguments.ts
@@ -1,0 +1,35 @@
+import { TestValidator } from "@nestia/e2e";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+import typia from "typia";
+
+import { Greeter } from "../structures/Greeter";
+
+/**
+ * Verifies a zero-parameter Vercel tool succeeds when arguments are omitted.
+ *
+ * Some tool-call paths hand `undefined` to the execute function for
+ * parameterless calls. The adapter must normalize the omission to `{}` before
+ * typia validation; otherwise a valid zero-parameter method fails before the
+ * controller can run.
+ *
+ * 1. Convert `Greeter.hello()` as a Vercel AI SDK tool.
+ * 2. Execute it with an omitted arguments object.
+ * 3. Assert the tool returns the greeting as a successful result.
+ */
+export const test_vercel_tool_omitted_arguments = async (): Promise<void> => {
+  const tools: Record<string, Tool> = toVercelTools(
+    typia.llm.controller<Greeter>("greeter", new Greeter()),
+  );
+
+  const result: unknown = await tools["hello"]!.execute!(undefined as any, {
+    toolCallId: "test-1",
+    messages: [],
+    abortSignal: undefined as any,
+  });
+
+  TestValidator.equals("omitted arguments should call hello()", result, {
+    success: true,
+    data: { message: "Hello, world!" },
+  });
+};

--- a/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
@@ -1,0 +1,98 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_tool_output_schema = async (): Promise<void> => {
+  const controller: ILlmController<Calculator> =
+    typia.llm.controller<Calculator>("calculator", new Calculator());
+  const tools: Record<string, Tool> = toVercelTools(controller);
+  const add: Tool = tools["add"]!;
+  const schema: IJsonSchema | undefined = getJsonSchema(add.outputSchema);
+  const branches: IJsonSchema[] = schema?.anyOf ?? [];
+  const success: IJsonSchema | undefined = branches.find((branch) =>
+    hasBooleanEnum(branch.properties?.success, true),
+  );
+  const failure: IJsonSchema | undefined = branches.find((branch) =>
+    hasBooleanEnum(branch.properties?.success, false),
+  );
+  const data: IJsonSchema | undefined = success?.properties?.data as
+    | IJsonSchema
+    | undefined;
+
+  TestValidator.predicate(
+    "outputSchema should describe successful typed data",
+    success !== undefined && data?.properties?.value !== undefined,
+  );
+  TestValidator.predicate(
+    "outputSchema should describe tool error feedback",
+    failure?.properties?.error !== undefined,
+  );
+
+  const result: unknown = await add.execute!(
+    { x: 10, y: 5 },
+    { toolCallId: "test-output", messages: [], abortSignal: undefined as any },
+  );
+  TestValidator.equals(
+    "execute result should match outputSchema wrapper",
+    result,
+    {
+      success: true,
+      data: { value: 15 },
+    },
+  );
+
+  const broken: Record<string, Tool> = toVercelTools(
+    typia.llm.controller<BrokenOutput>("broken", new BrokenOutput()),
+  );
+  const brokenResult: unknown = await broken["read"]!.execute!(
+    {},
+    {
+      toolCallId: "test-broken-output",
+      messages: [],
+      abortSignal: undefined as any,
+    },
+  );
+  TestValidator.equals(
+    "typed undefined result should match outputSchema error branch",
+    brokenResult,
+    {
+      success: false,
+      error:
+        'Function "read" returned undefined despite declaring an output schema',
+    },
+  );
+};
+
+class BrokenOutput {
+  /** Read a typed result but violate it at runtime. */
+  read(_: BrokenOutput.IProps): BrokenOutput.IResult {
+    return undefined as any;
+  }
+}
+namespace BrokenOutput {
+  export interface IProps {}
+  export interface IResult {
+    value: number;
+  }
+}
+
+interface IJsonSchema {
+  anyOf?: IJsonSchema[] | undefined;
+  properties?: Record<string, unknown> | undefined;
+  enum?: unknown[] | undefined;
+}
+
+const getJsonSchema = (schema: unknown): IJsonSchema | undefined =>
+  typeof schema === "object" && schema !== null && "jsonSchema" in schema
+    ? ((schema as { jsonSchema?: IJsonSchema }).jsonSchema ?? undefined)
+    : undefined;
+
+const hasBooleanEnum = (schema: unknown, value: boolean): boolean =>
+  typeof schema === "object" &&
+  schema !== null &&
+  Array.isArray((schema as IJsonSchema).enum) &&
+  (schema as IJsonSchema).enum?.includes(value) === true;

--- a/tests/test-vercel/src/structures/Greeter.ts
+++ b/tests/test-vercel/src/structures/Greeter.ts
@@ -1,0 +1,22 @@
+/**
+ * Greeting service.
+ *
+ * Serves friendly greetings through zero-parameter tools.
+ */
+export class Greeter {
+  /**
+   * Say hello to the world.
+   *
+   * @returns The greeting message
+   */
+  hello(): Greeter.IGreeting {
+    return { message: "Hello, world!" };
+  }
+}
+export namespace Greeter {
+  /** Greeting produced by {@link Greeter.hello}. */
+  export interface IGreeting {
+    /** Greeting sentence */
+    message: string;
+  }
+}

--- a/tests/test-vercel/src/structures/Inspector.ts
+++ b/tests/test-vercel/src/structures/Inspector.ts
@@ -1,0 +1,36 @@
+/**
+ * Deferred inspection service.
+ *
+ * Holds expensive state behind a closure so tool conversion can be checked
+ * without building that state.
+ */
+export class Inspector {
+  private readonly state: () => Inspector.IState;
+
+  public constructor(source: Inspector.IState | (() => Inspector.IState)) {
+    this.state = typeof source === "function" ? source : () => source;
+  }
+
+  /**
+   * Inspect the deferred state.
+   *
+   * @param props Query to run against the state
+   * @returns The matching answer
+   */
+  public inspect(props: Inspector.IProps): Inspector.IResult {
+    return { answer: `${props.query}=${this.state().value}` };
+  }
+}
+export namespace Inspector {
+  export interface IState {
+    value: number;
+  }
+  export interface IProps {
+    /** Question to answer from the state */
+    query: string;
+  }
+  export interface IResult {
+    /** Answer text */
+    answer: string;
+  }
+}

--- a/website/src/content/docs/utilization/langchain.mdx
+++ b/website/src/content/docs/utilization/langchain.mdx
@@ -7,11 +7,19 @@ import LocalSource from "../../../components/LocalSource";
 
 # LangChain.js
 
-[`@typia/langchain`](https://github.com/samchon/typia/tree/master/packages/langchain) plugs typia controllers into [LangChain.js](https://github.com/langchain-ai/langchainjs). Every method on your TypeScript class — or every endpoint in an OpenAPI document — becomes a `DynamicStructuredTool` ready for `AgentExecutor` and friends, with the same parse/coerce/validate/feedback machinery as [`typia.llm.application`](/docs/llm/application#the-function-calling-harness) wired in automatically.
+[`@typia/langchain`](https://github.com/samchon/typia/tree/master/packages/langchain) plugs typia controllers into [LangChain.js](https://github.com/langchain-ai/langchainjs). Every method on your TypeScript class or every endpoint in an OpenAPI document becomes a `DynamicStructuredTool` ready for `AgentExecutor` and friends, with the same parse/coerce/validate/feedback machinery as [`typia.llm.application`](/docs/llm/application#the-function-calling-harness) wired in automatically.
 
 ```typescript copy filename="signature"
 import { toLangChainTools } from "@typia/langchain";
 
+export function toLangChainTools(
+  controller: ILlmController | IHttpLlmController,
+  options?: { prefix?: boolean },
+): DynamicStructuredTool[];
+export function toLangChainTools(
+  controllers: Array<ILlmController | IHttpLlmController>,
+  options?: { prefix?: boolean },
+): DynamicStructuredTool[];
 export function toLangChainTools(props: {
   controllers: Array<ILlmController | IHttpLlmController>;
   prefix?: boolean;   // default false; if true, tool names are "{controller}_{method}"
@@ -26,6 +34,14 @@ export function toLangChainTools(props: {
   ]}>
   <Tabs.Tab>
 ```typescript filename="@typia/langchain" showLineNumbers
+export function toLangChainTools(
+  controller: ILlmController | IHttpLlmController,
+  options?: { prefix?: boolean },
+): DynamicStructuredTool[];
+export function toLangChainTools(
+  controllers: Array<ILlmController | IHttpLlmController>,
+  options?: { prefix?: boolean },
+): DynamicStructuredTool[];
 export function toLangChainTools(props: {
   controllers: Array<ILlmController | IHttpLlmController>;
   prefix?: boolean | undefined;
@@ -73,11 +89,9 @@ import typia from "typia";
 
 import { Calculator } from "./Calculator";
 
-const tools: DynamicStructuredTool[] = toLangChainTools({
-  controllers: [
-    typia.llm.controller<Calculator>("calculator", new Calculator()),
-  ],
-});
+const tools: DynamicStructuredTool[] = toLangChainTools(
+  typia.llm.controller<Calculator>("calculator", new Calculator()),
+);
 
 const agent: Runnable = createToolCallingAgent({
   llm: new ChatOpenAI({ model: "gpt-4o" }),
@@ -94,7 +108,7 @@ const result: ChainValues = await executor.invoke({
 });
 ```
 
-Every method on `Calculator` is now a LangChain tool. JSDoc comments become tool descriptions, TypeScript types become JSON schemas. Tool names default to the bare method name; pass `prefix: true` to get `{controllerName}_{methodName}`.
+Every method on `Calculator` is now a LangChain tool. JSDoc comments become tool descriptions, TypeScript types become JSON schemas. Tool names default to the bare method name; pass `{ prefix: true }` as the second argument to `toLangChainTools` to get `{controllerName}_{methodName}`. The older `toLangChainTools({ controllers: [...] })` form still works when that shape is clearer for multiple controllers.
 
 <Tabs items={[
     <code>Calculator</code>,
@@ -134,25 +148,23 @@ import { DynamicStructuredTool } from "@langchain/core/tools";
 import { toLangChainTools } from "@typia/langchain";
 import { HttpLlm } from "@typia/utils";
 
-const tools: DynamicStructuredTool[] = toLangChainTools({
-  controllers: [
-    HttpLlm.controller({
-      name: "shopping",
-      document: await fetch(
-        "https://shopping-be.wrtn.ai/editor/swagger.json",
-      ).then((r) => r.json()),
-      connection: {
-        host: "https://shopping-be.wrtn.ai",
-        headers: { Authorization: "Bearer ********" },
-      },
-    }),
-  ],
-});
+const tools: DynamicStructuredTool[] = toLangChainTools(
+  HttpLlm.controller({
+    name: "shopping",
+    document: await fetch(
+      "https://shopping-be.wrtn.ai/editor/swagger.json",
+    ).then((r) => r.json()),
+    connection: {
+      host: "https://shopping-be.wrtn.ai",
+      headers: { Authorization: "Bearer ********" },
+    },
+  }),
+);
 ```
 
 ## The function calling harness
 
-Every tool carries the harness — lenient parsing, type coercion, validation feedback. When validation fails, the tool returns the original input annotated with `// ❌` markers:
+Every tool carries the harness: type coercion, validation, and model-readable feedback. When typia validation catches invalid arguments, the tool raises `ToolInputParsingException` with the original input annotated by `// ❌` markers:
 
 ```json
 {
@@ -166,10 +178,19 @@ Every tool carries the harness — lenient parsing, type coercion, validation fe
 For the mechanics see [`LlmJson`](/docs/llm/json).
 
 <Callout type="info">
-**Why typia replaces LangChain's built-in validator**
+**How LangChain validation fits**
 
-LangChain validates tool arguments with `@cfworker/json-schema`, which throws `ToolInputParsingException` *before* anything else can run. `@typia/langchain` works around this by registering a permissive passthrough Zod schema (`z.record(z.unknown())`) — then runs typia's much more detailed validator inside the tool body. You get the harness output instead of a generic JSON-schema error.
+LangChain may reject malformed tool inputs before the adapter body runs. For inputs that reach the tool body, `@typia/langchain` still runs typia's coerce-then-validate path, so TypeScript constraints and typia tags become the feedback the model sees.
 </Callout>
+
+## Runtime errors
+
+There are two distinct failure modes:
+
+- **Validation error**: the LLM passed arguments that don't match the schema. The tool raises `ToolInputParsingException` with validation feedback.
+- **Runtime error**: the tool itself threw, for example a divide-by-zero, network error, or business-rule violation.
+
+`@typia/langchain` catches runtime errors after argument validation and returns `{ success: false, error: "..." }`. That keeps the agent loop alive while preserving the original error message for the model.
 
 ## Structured output
 
@@ -220,8 +241,8 @@ The `IMember` interface is the single source of truth. The schema and the valida
 
 ## Where to go next
 
-- Source TypeScript class for the tools → [`typia.llm.application`](/docs/llm/application)
-- Source OpenAPI document for the tools → [`HttpLlm`](/docs/llm/http)
-- Harness internals → [`LlmJson`](/docs/llm/json)
-- Same idea, different framework → [Vercel AI SDK](/docs/utilization/vercel) · [MCP](/docs/utilization/mcp)
-- Full agent loop on top → [Agentica](/docs/llm/chat)
+- Source TypeScript class for the tools: [`typia.llm.application`](/docs/llm/application)
+- Source OpenAPI document for the tools: [`HttpLlm`](/docs/llm/http)
+- Harness internals: [`LlmJson`](/docs/llm/json)
+- Same idea, different framework: [Vercel AI SDK](/docs/utilization/vercel) and [MCP](/docs/utilization/mcp)
+- Full agent loop on top: [Agentica](/docs/llm/chat)

--- a/website/src/content/docs/utilization/vercel.mdx
+++ b/website/src/content/docs/utilization/vercel.mdx
@@ -110,7 +110,7 @@ const result: GenerateTextResult = await generateText({
 });
 ```
 
-The JSDoc on each method becomes the tool description; the parameter type becomes the JSON schema. Every method on `Calculator` is now a Vercel `Tool`. Tool names default to the bare method name; pass `{ prefix: true }` as the second argument to `toVercelTools` to get `{controllerName}_{methodName}` instead. The older `toVercelTools({ controllers: [...] })` form still works when that shape is clearer for multiple controllers.
+The JSDoc on each method becomes the tool description; the parameter type becomes the JSON schema. Every method on `Calculator` is now a Vercel `Tool`. Tool names default to the bare method name; pass `{ prefix: true }` as the second argument to `toVercelTools` to get `{controllerName}_{methodName}` instead. The older `toVercelTools({ controllers: [...] })` form still works when that shape is clearer for multiple controllers. When a method has a reflected return type, the tool also advertises an `outputSchema` for the `{ success, data/error }` result wrapper returned by `execute`.
 
 <Tabs items={[
     <code>Calculator</code>,

--- a/website/src/content/docs/utilization/vercel.mdx
+++ b/website/src/content/docs/utilization/vercel.mdx
@@ -12,6 +12,14 @@ import LocalSource from "../../../components/LocalSource";
 ```typescript copy filename="signature"
 import { toVercelTools } from "@typia/vercel";
 
+export function toVercelTools(
+  controller: ILlmController | IHttpLlmController,
+  options?: { prefix?: boolean },
+): Record<string, Tool>;
+export function toVercelTools(
+  controllers: Array<ILlmController | IHttpLlmController>,
+  options?: { prefix?: boolean },
+): Record<string, Tool>;
 export function toVercelTools(props: {
   controllers: Array<ILlmController | IHttpLlmController>;
   prefix?: boolean;   // default false; if true, tool names are "{controller}_{method}"
@@ -26,6 +34,14 @@ export function toVercelTools(props: {
   ]}>
   <Tabs.Tab>
 ```typescript filename="@typia/vercel" showLineNumbers
+export function toVercelTools(
+  controller: ILlmController | IHttpLlmController,
+  options?: { prefix?: boolean },
+): Record<string, Tool>;
+export function toVercelTools(
+  controllers: Array<ILlmController | IHttpLlmController>,
+  options?: { prefix?: boolean },
+): Record<string, Tool>;
 export function toVercelTools(props: {
   controllers: Array<ILlmController | IHttpLlmController>;
   prefix?: boolean | undefined;
@@ -83,11 +99,9 @@ import typia from "typia";
 
 import { Calculator } from "./Calculator";
 
-const tools: Record<string, Tool> = toVercelTools({
-  controllers: [
-    typia.llm.controller<Calculator>("calculator", new Calculator()),
-  ],
-});
+const tools: Record<string, Tool> = toVercelTools(
+  typia.llm.controller<Calculator>("calculator", new Calculator()),
+);
 
 const result: GenerateTextResult = await generateText({
   model: openai("gpt-4o"),
@@ -96,7 +110,7 @@ const result: GenerateTextResult = await generateText({
 });
 ```
 
-The JSDoc on each method becomes the tool description; the parameter type becomes the JSON schema. Every method on `Calculator` is now a Vercel `Tool`. JSDoc comments become tool descriptions, TypeScript types become JSON schemas. Tool names default to the bare method name; pass `prefix: true` to `toVercelTools` to get `{controllerName}_{methodName}` instead.
+The JSDoc on each method becomes the tool description; the parameter type becomes the JSON schema. Every method on `Calculator` is now a Vercel `Tool`. Tool names default to the bare method name; pass `{ prefix: true }` as the second argument to `toVercelTools` to get `{controllerName}_{methodName}` instead. The older `toVercelTools({ controllers: [...] })` form still works when that shape is clearer for multiple controllers.
 
 <Tabs items={[
     <code>Calculator</code>,
@@ -136,20 +150,18 @@ import { toVercelTools } from "@typia/vercel";
 import { HttpLlm } from "@typia/utils";
 import { Tool } from "ai";
 
-const tools: Record<string, Tool> = toVercelTools({
-  controllers: [
-    HttpLlm.controller({
-      name: "shopping",
-      document: await fetch(
-        "https://shopping-be.wrtn.ai/editor/swagger.json",
-      ).then((r) => r.json()),
-      connection: {
-        host: "https://shopping-be.wrtn.ai",
-        headers: { Authorization: "Bearer ********" },
-      },
-    }),
-  ],
-});
+const tools: Record<string, Tool> = toVercelTools(
+  HttpLlm.controller({
+    name: "shopping",
+    document: await fetch(
+      "https://shopping-be.wrtn.ai/editor/swagger.json",
+    ).then((r) => r.json()),
+    connection: {
+      host: "https://shopping-be.wrtn.ai",
+      headers: { Authorization: "Bearer ********" },
+    },
+  }),
+);
 ```
 
 Every API operation becomes a tool with parameters, descriptions, and the same harness wrapping each call.
@@ -228,7 +240,7 @@ There are two distinct failure modes:
 - **Validation error** — the LLM passed arguments that don't match the schema. Tool returns the annotated input so the model can fix it.
 - **Runtime error** — the tool itself threw (e.g. divide-by-zero, network error, business-rule violation).
 
-`@typia/vercel` catches the runtime error and surfaces it as `{ error: true, message: "..." }`. That keeps the conversation alive — the model can see the failure and either retry with different inputs or apologize to the user.
+`@typia/vercel` catches the runtime error and surfaces it as `{ success: false, error: "..." }`. That keeps the conversation alive — the model can see the failure and either retry with different inputs or apologize to the user.
 
 <Tabs items={[
     "Error handling test",


### PR DESCRIPTION
## Intent

Bring the practical direct-controller workflow from `@typia/mcp` to the Vercel AI SDK and LangChain adapters without removing the existing `{ controllers: [...] }` API.

## Scope

- Add `toVercelTools(controller | controllers, options?)` overloads while preserving `toVercelTools({ controllers, prefix })`.
- Add `toLangChainTools(controller | controllers, options?)` overloads while preserving `toLangChainTools({ controllers, prefix })`.
- Route Vercel/LangChain argument handling through `LlmJson.validateArguments(..., args ?? {})` so omitted zero-parameter arguments validate like MCP.
- Return post-validation runtime failures as `{ success: false, error }`, keeping tool-call loops recoverable in both adapters.
- Advertise Vercel `outputSchema` for reflected return types using the actual `{ success, data/error }` result wrapper.
- Register LangChain tools through the current `@langchain/core/tools` `tool()` factory while preserving the `DynamicStructuredTool[]` public surface.
- Add focused adapter tests and update package READMEs plus website guides.

## Deferred

- No new adapter names such as `createVercelTools` or `createLangChainTools`; overloads keep the public surface smaller.
- No dependency changes.

## Test plan

- `pnpm format`
- `pnpm --filter @typia/vercel build`
- `pnpm --filter @typia/langchain build`
- `pnpm --filter ./tests/test-vercel start`
- `pnpm --filter ./tests/test-langchain start`
- `pnpm --dir website run build`

Not run locally: root `pnpm build` and root `pnpm test`; the package-specific builds/tests plus website build cover the changed adapters and docs, and CI should run the full matrix.