### PR TITLE
docs(website): add debugging setup guide

### DIFF
--- a/website/src/content/docs/setup/_meta.ts
+++ b/website/src/content/docs/setup/_meta.ts
@@ -2,6 +2,7 @@ import { MetaRecord } from "nextra";
 
 export default {
   index: { display: "hidden" },
+  debugging: "Debugging",
   legacy: "Legacy (TS v6)",
   tsgo: "TypeScript-Go",
 } satisfies MetaRecord;

--- a/website/src/content/docs/setup/_meta.ts
+++ b/website/src/content/docs/setup/_meta.ts
@@ -2,7 +2,7 @@ import { MetaRecord } from "nextra";
 
 export default {
   index: { display: "hidden" },
-  debugging: "Debugging",
   legacy: "Legacy (TS v6)",
   tsgo: "TypeScript-Go",
+  debugging: "Debugging",
 } satisfies MetaRecord;

--- a/website/src/content/docs/setup/debugging.mdx
+++ b/website/src/content/docs/setup/debugging.mdx
@@ -10,7 +10,7 @@ typia runs at compile time. The debugger must start code that has already passed
 
 ## Build first
 
-The most reliable VSCode setup is to build with source maps and debug the emitted JavaScript. This works for Node.js, Bun, and any app that eventually runs JavaScript from `dist`.
+The most reliable VSCode setup is to build with source maps and debug the emitted JavaScript. Use this for Node.js and for any workflow where `ttsc` or the patched `tsc` emits the file you run from `dist`. Bun projects that rely on `Bun.build` should use the [Bun](#bun) section, because the debug build has to run the same Bun plugin path.
 
 ```json filename="tsconfig.json" showLineNumbers copy
 {
@@ -45,7 +45,7 @@ Add a build script for your setup path:
   </Tabs.Tab>
 </Tabs>
 
-Then make VSCode run that script before starting the debugger:
+Then make VSCode run that script before starting the debugger. Use the Bun tab here only when Bun is the package manager for a build script that emits the JavaScript this Node.js launch configuration runs.
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
@@ -141,7 +141,7 @@ For a quick TypeScript-Go debug session without a persistent `dist` directory, l
 }
 ```
 
-<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+<Tabs items={["npm", "pnpm", "yarn"]}>
   <Tabs.Tab>
 ```json filename=".vscode/launch.json" showLineNumbers copy
 {
@@ -196,25 +196,9 @@ For a quick TypeScript-Go debug session without a persistent `dist` directory, l
 }
 ```
   </Tabs.Tab>
-  <Tabs.Tab>
-```json filename=".vscode/launch.json" showLineNumbers copy
-{
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Debug with ttsx",
-      "runtimeExecutable": "bun",
-      "runtimeArgs": ["run", "debug:ttsx"],
-      "autoAttachChildProcesses": true,
-      "skipFiles": ["<node_internals>/**"]
-    }
-  ]
-}
-```
-  </Tabs.Tab>
 </Tabs>
+
+If Bun is your package manager, run the same `debug:ttsx` script from the terminal (`bun run debug:ttsx`) or use the [Bun](#bun) section for Bun inspector workflows. Do not switch this VSCode launch block to `runtimeExecutable: "bun"` unless your Bun debugger setup is already working independently of typia.
 
 Put application arguments after the entry file:
 
@@ -274,51 +258,49 @@ If your legacy project is ESM-only, use the same loader command that runs the ap
 
 ## Bun
 
-For TypeScript-Go Bun applications, debug generated JavaScript. [`@ttsc/unplugin/bun`](/docs/setup/tsgo#bundlers) integrates with `Bun.build`, so keep typia in that build path, emit to `dist`, then start Bun's inspector on the emitted entry.
+Bun debugging has two separate requirements: typia must still run in the same build or preload path, and Bun's inspector must attach to the process. The examples below show the Bun commands that preserve typia's transform path. Attach with Bun's [web debugger](https://bun.com/docs/guides/runtime/web-debugger), or use Bun's [VSCode debugger](https://bun.com/docs/guides/runtime/vscode-debugger) after installing and validating the Bun extension.
 
-```json filename=".vscode/launch.json" showLineNumbers copy
+### `Bun.build` output
+
+For TypeScript-Go Bun applications, debug generated JavaScript. [`@ttsc/unplugin/bun`](/docs/setup/tsgo#bundlers) integrates with `Bun.build`, so keep typia in that build path, emit to `dist`, then start Bun's inspector on the emitted entry. The same shape applies to legacy `Bun.build` projects that use [`@typia/unplugin/bun`](/docs/setup/legacy#typiaunplugin).
+
+```json filename="package.json" showLineNumbers copy
 {
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Debug Bun output",
-      "runtimeExecutable": "bun",
-      "runtimeArgs": ["--inspect-brk"],
-      "program": "${workspaceFolder}/dist/index.js",
-      "skipFiles": ["<node_internals>/**"]
-    }
-  ]
+  "scripts": {
+    "build:debug": "bun run build.ts",
+    "debug:bun": "bun --inspect-brk dist/index.js"
+  }
 }
 ```
 
+```bash filename="Terminal" showLineNumbers copy
+bun run build:debug
+bun run debug:bun
+```
+
+### Bun runtime preload
+
 Legacy Bun projects can also debug the raw `.ts` entry when [`@typia/unplugin/bun`](/docs/setup/legacy#typiaunplugin) is registered through `bunfig.toml` preload.
 
-```json filename=".vscode/launch.json" showLineNumbers copy
+```json filename="package.json" showLineNumbers copy
 {
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Debug Bun runtime",
-      "runtimeExecutable": "bun",
-      "runtimeArgs": ["--inspect-brk"],
-      "program": "${workspaceFolder}/src/index.ts",
-      "skipFiles": ["<node_internals>/**"]
-    }
-  ]
+  "scripts": {
+    "debug:bun": "bun --inspect-brk src/index.ts"
+  }
 }
+```
+
+```bash filename="Terminal" showLineNumbers copy
+bun run debug:bun
 ```
 
 Do not point Bun or VSCode at the raw `.ts` entry unless the Bun plugin is already registered in that runtime. Without the plugin, the program can run with untransformed `typia.*` calls.
 
 ## Verify the debugger path
 
-Add a one-line setup check and start the same debug configuration:
+Temporarily add a setup check to the entry file that your debug configuration already runs:
 
-```ts filename="src/check-setup.ts" showLineNumbers copy
+```ts filename="src/index.ts" showLineNumbers copy
 import typia from "typia";
 
 console.log(typia.is<{ id: string }>({ id: "ok" }));

--- a/website/src/content/docs/setup/debugging.mdx
+++ b/website/src/content/docs/setup/debugging.mdx
@@ -131,7 +131,9 @@ The debugger opens the emitted `.js` file, but breakpoints bind back to the orig
 
 ## Generation mode
 
-Projects that use [`typia generate`](/docs/setup/legacy#generation) should debug the generated source or the JavaScript built from it. Point VSCode, Bun, or your bundler at `src/generated/**` instead of the template files that still contain raw `typia.*` calls.
+Projects that use [`typia generate`](/docs/setup/legacy#generation) should debug the generated source or the JavaScript built from it. Point VSCode, Bun, or your bundler at the files under your `--output` directory, such as `src/generated/**`, instead of the template files that still contain raw `typia.*` calls.
+
+When you pass file paths or globs to `typia generate`, each generated file is written as `--output/<basename>`, so point the debugger at those emitted basenames.
 
 If you compile the generated TypeScript into `dist`, use the [build first](#build-first) flow after running `typia generate`. If you run generated TypeScript directly, use the same runtime command that works outside the debugger.
 
@@ -208,8 +210,12 @@ If Bun is your package manager, run the same `debug:ttsx` script from the termin
 
 Put application arguments after the entry file:
 
-```json copy
-"debug:ttsx": "ttsx --project tsconfig.json src/index.ts -- --port 3000"
+```json filename="package.json" showLineNumbers copy
+{
+  "scripts": {
+    "debug:ttsx": "ttsx --project tsconfig.json src/index.ts -- --port 3000"
+  }
+}
 ```
 
 Flags before the entry file are handled by `ttsx` and the TypeScript-Go compiler. Flags after `--` are delivered to your program as `process.argv`.

--- a/website/src/content/docs/setup/debugging.mdx
+++ b/website/src/content/docs/setup/debugging.mdx
@@ -22,16 +22,41 @@ The most reliable VSCode setup is to build with source maps and debug the emitte
 }
 ```
 
+Add a build script for your setup path:
+
 <Tabs items={["TypeScript-Go", "Legacy"]}>
+  <Tabs.Tab>
+```json filename="package.json" showLineNumbers copy
+{
+  "scripts": {
+    "build:debug": "ttsc"
+  }
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json filename="package.json" showLineNumbers copy
+{
+  "scripts": {
+    "build:debug": "tsc"
+  }
+}
+```
+  </Tabs.Tab>
+</Tabs>
+
+Then make VSCode run that script before starting the debugger:
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab>
 ```json filename=".vscode/tasks.json" showLineNumbers copy
 {
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "ttsc: build",
+      "label": "build:debug",
       "type": "shell",
-      "command": "pnpm ttsc",
+      "command": "npm run build:debug",
       "problemMatcher": "$tsc"
     }
   ]
@@ -44,9 +69,39 @@ The most reliable VSCode setup is to build with source maps and debug the emitte
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "tsc: build",
+      "label": "build:debug",
       "type": "shell",
-      "command": "pnpm tsc",
+      "command": "pnpm run build:debug",
+      "problemMatcher": "$tsc"
+    }
+  ]
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json filename=".vscode/tasks.json" showLineNumbers copy
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build:debug",
+      "type": "shell",
+      "command": "yarn build:debug",
+      "problemMatcher": "$tsc"
+    }
+  ]
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json filename=".vscode/tasks.json" showLineNumbers copy
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build:debug",
+      "type": "shell",
+      "command": "bun run build:debug",
       "problemMatcher": "$tsc"
     }
   ]
@@ -64,7 +119,7 @@ The most reliable VSCode setup is to build with source maps and debug the emitte
       "request": "launch",
       "name": "Debug compiled app",
       "program": "${workspaceFolder}/dist/index.js",
-      "preLaunchTask": "ttsc: build",
+      "preLaunchTask": "build:debug",
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "skipFiles": ["<node_internals>/**"]
     }
@@ -72,12 +127,22 @@ The most reliable VSCode setup is to build with source maps and debug the emitte
 }
 ```
 
-Use `preLaunchTask: "tsc: build"` when you are on the legacy setup. The debugger still opens the emitted `.js` file, but breakpoints bind back to the original `.ts` files through the source map.
+The debugger opens the emitted `.js` file, but breakpoints bind back to the original `.ts` files through the source map.
 
 ## Run through `ttsx`
 
-For a quick TypeScript-Go debug session without a persistent `dist` directory, launch the `ttsx` runner itself and let VSCode attach to the child Node process that executes your entrypoint.
+For a quick TypeScript-Go debug session without a persistent `dist` directory, launch `ttsx` through a package script and let VSCode attach to the child Node process that executes your entrypoint.
 
+```json filename="package.json" showLineNumbers copy
+{
+  "scripts": {
+    "debug:ttsx": "ttsx --project tsconfig.json src/index.ts"
+  }
+}
+```
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
 ```json filename=".vscode/launch.json" showLineNumbers copy
 {
   "version": "0.2.0",
@@ -86,27 +151,105 @@ For a quick TypeScript-Go debug session without a persistent `dist` directory, l
       "type": "node",
       "request": "launch",
       "name": "Debug with ttsx",
-      "runtimeExecutable": "node",
-      "program": "${workspaceFolder}/node_modules/ttsc/lib/launcher/ttsx.js",
-      "args": ["--project", "tsconfig.json", "src/index.ts"],
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "debug:ttsx"],
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**"]
     }
   ]
 }
 ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json filename=".vscode/launch.json" showLineNumbers copy
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug with ttsx",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["run", "debug:ttsx"],
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json filename=".vscode/launch.json" showLineNumbers copy
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug with ttsx",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["debug:ttsx"],
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json filename=".vscode/launch.json" showLineNumbers copy
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug with ttsx",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "debug:ttsx"],
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}
+```
+  </Tabs.Tab>
+</Tabs>
 
 Put application arguments after the entry file:
 
 ```json copy
-"args": ["--project", "tsconfig.json", "src/index.ts", "--", "--port", "3000"]
+"debug:ttsx": "ttsx --project tsconfig.json src/index.ts -- --port 3000"
 ```
 
 Flags before the entry file are handled by `ttsx` and the TypeScript-Go compiler. Flags after `--` are delivered to your program as `process.argv`.
 
 ## Legacy `ts-node`
 
-The legacy setup can debug directly through `ts-node/register`, because `typia setup` patched the TypeScript compiler that `ts-node` uses.
+The legacy setup can debug directly through `ts-node/register`, because `typia setup` patched the TypeScript compiler that `ts-node` uses. Install `ts-node` first if your project only installed `typia`, `typescript`, and `ts-patch`.
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+npm install -D ts-node
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+pnpm install -D ts-node
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+yarn add -D ts-node
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash filename="Terminal" showLineNumbers copy
+bun add -d ts-node
+```
+  </Tabs.Tab>
+</Tabs>
 
 ```json filename=".vscode/launch.json" showLineNumbers copy
 {
@@ -131,7 +274,7 @@ If your legacy project is ESM-only, use the same loader command that runs the ap
 
 ## Bun
 
-For Bun applications, keep typia in the build path and debug the generated JavaScript. Use [`@ttsc/unplugin/bun`](/docs/setup/tsgo#bundlers) with TypeScript-Go or [`@typia/unplugin/bun`](/docs/setup/legacy#typiaunplugin) with the legacy setup, emit to `dist`, then start Bun's inspector on the emitted entry.
+For TypeScript-Go Bun applications, debug generated JavaScript. [`@ttsc/unplugin/bun`](/docs/setup/tsgo#bundlers) integrates with `Bun.build`, so keep typia in that build path, emit to `dist`, then start Bun's inspector on the emitted entry.
 
 ```json filename=".vscode/launch.json" showLineNumbers copy
 {
@@ -144,6 +287,25 @@ For Bun applications, keep typia in the build path and debug the generated JavaS
       "runtimeExecutable": "bun",
       "runtimeArgs": ["--inspect-brk"],
       "program": "${workspaceFolder}/dist/index.js",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}
+```
+
+Legacy Bun projects can also debug the raw `.ts` entry when [`@typia/unplugin/bun`](/docs/setup/legacy#typiaunplugin) is registered through `bunfig.toml` preload.
+
+```json filename=".vscode/launch.json" showLineNumbers copy
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Bun runtime",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["--inspect-brk"],
+      "program": "${workspaceFolder}/src/index.ts",
       "skipFiles": ["<node_internals>/**"]
     }
   ]

--- a/website/src/content/docs/setup/debugging.mdx
+++ b/website/src/content/docs/setup/debugging.mdx
@@ -1,0 +1,165 @@
+---
+title: Guide Documents > Setup > Debugging
+---
+
+import { Tabs } from "nextra/components";
+
+## Debugging typia projects
+
+typia runs at compile time. The debugger must start code that has already passed through the typia transformer, so use the same toolchain that you use for normal builds: `ttsc` / `ttsx` for TypeScript-Go, or the patched TypeScript compiler from the legacy setup.
+
+## Build first
+
+The most reliable VSCode setup is to build with source maps and debug the emitted JavaScript. This works for Node.js, Bun, and any app that eventually runs JavaScript from `dist`.
+
+```json filename="tsconfig.json" showLineNumbers copy
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "sourceMap": true,
+    "strict": true
+  }
+}
+```
+
+<Tabs items={["TypeScript-Go", "Legacy"]}>
+  <Tabs.Tab>
+```json filename=".vscode/tasks.json" showLineNumbers copy
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "ttsc: build",
+      "type": "shell",
+      "command": "pnpm ttsc",
+      "problemMatcher": "$tsc"
+    }
+  ]
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json filename=".vscode/tasks.json" showLineNumbers copy
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "tsc: build",
+      "type": "shell",
+      "command": "pnpm tsc",
+      "problemMatcher": "$tsc"
+    }
+  ]
+}
+```
+  </Tabs.Tab>
+</Tabs>
+
+```json filename=".vscode/launch.json" showLineNumbers copy
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug compiled app",
+      "program": "${workspaceFolder}/dist/index.js",
+      "preLaunchTask": "ttsc: build",
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}
+```
+
+Use `preLaunchTask: "tsc: build"` when you are on the legacy setup. The debugger still opens the emitted `.js` file, but breakpoints bind back to the original `.ts` files through the source map.
+
+## Run through `ttsx`
+
+For a quick TypeScript-Go debug session without a persistent `dist` directory, launch the `ttsx` runner itself and let VSCode attach to the child Node process that executes your entrypoint.
+
+```json filename=".vscode/launch.json" showLineNumbers copy
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug with ttsx",
+      "runtimeExecutable": "node",
+      "program": "${workspaceFolder}/node_modules/ttsc/lib/launcher/ttsx.js",
+      "args": ["--project", "tsconfig.json", "src/index.ts"],
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}
+```
+
+Put application arguments after the entry file:
+
+```json copy
+"args": ["--project", "tsconfig.json", "src/index.ts", "--", "--port", "3000"]
+```
+
+Flags before the entry file are handled by `ttsx` and the TypeScript-Go compiler. Flags after `--` are delivered to your program as `process.argv`.
+
+## Legacy `ts-node`
+
+The legacy setup can debug directly through `ts-node/register`, because `typia setup` patched the TypeScript compiler that `ts-node` uses.
+
+```json filename=".vscode/launch.json" showLineNumbers copy
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug legacy ts-node",
+      "runtimeArgs": ["-r", "ts-node/register"],
+      "args": ["${workspaceFolder}/src/index.ts"],
+      "env": {
+        "TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"
+      },
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}
+```
+
+If your legacy project is ESM-only, use the same loader command that runs the app outside VSCode. The important part is unchanged: do not replace the patched compiler path with stock `tsx` or an SWC/Babel loader, because those runners cannot apply typia's transformer.
+
+## Bun
+
+For Bun applications, keep typia in the build path and debug the generated JavaScript. Use [`@ttsc/unplugin/bun`](/docs/setup/tsgo#bundlers) with TypeScript-Go or [`@typia/unplugin/bun`](/docs/setup/legacy#typiaunplugin) with the legacy setup, emit to `dist`, then start Bun's inspector on the emitted entry.
+
+```json filename=".vscode/launch.json" showLineNumbers copy
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Bun output",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["--inspect-brk"],
+      "program": "${workspaceFolder}/dist/index.js",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}
+```
+
+Do not point Bun or VSCode at the raw `.ts` entry unless the Bun plugin is already registered in that runtime. Without the plugin, the program can run with untransformed `typia.*` calls.
+
+## Verify the debugger path
+
+Add a one-line setup check and start the same debug configuration:
+
+```ts filename="src/check-setup.ts" showLineNumbers copy
+import typia from "typia";
+
+console.log(typia.is<{ id: string }>({ id: "ok" }));
+```
+
+If the debug console prints `true`, the debugger is running transformed code. If it throws `typia transformer has not been configured`, the launch configuration is bypassing `ttsc`, the legacy patched compiler, or the bundler plugin.

--- a/website/src/content/docs/setup/debugging.mdx
+++ b/website/src/content/docs/setup/debugging.mdx
@@ -6,7 +6,7 @@ import { Tabs } from "nextra/components";
 
 ## Debugging typia projects
 
-typia runs at compile time. The debugger must start code that has already passed through the typia transformer, so use the same toolchain that you use for normal builds: `ttsc` / `ttsx` for TypeScript-Go, or the patched TypeScript compiler from the legacy setup.
+typia runs at compile time. The debugger must start code that has already passed through the typia transform path, so use the same toolchain that you use for normal builds: `ttsc` / `ttsx` for TypeScript-Go, the patched TypeScript compiler from the legacy setup, a bundler plugin, or generated output from `typia generate`.
 
 ## Build first
 
@@ -128,6 +128,12 @@ Then make VSCode run that script before starting the debugger. Use the Bun tab h
 ```
 
 The debugger opens the emitted `.js` file, but breakpoints bind back to the original `.ts` files through the source map.
+
+## Generation mode
+
+Projects that use [`typia generate`](/docs/setup/legacy#generation) should debug the generated source or the JavaScript built from it. Point VSCode, Bun, or your bundler at `src/generated/**` instead of the template files that still contain raw `typia.*` calls.
+
+If you compile the generated TypeScript into `dist`, use the [build first](#build-first) flow after running `typia generate`. If you run generated TypeScript directly, use the same runtime command that works outside the debugger.
 
 ## Run through `ttsx`
 
@@ -262,7 +268,34 @@ Bun debugging has two separate requirements: typia must still run in the same bu
 
 ### `Bun.build` output
 
-For TypeScript-Go Bun applications, debug generated JavaScript. [`@ttsc/unplugin/bun`](/docs/setup/tsgo#bundlers) integrates with `Bun.build`, so keep typia in that build path, emit to `dist`, then start Bun's inspector on the emitted entry. The same shape applies to legacy `Bun.build` projects that use [`@typia/unplugin/bun`](/docs/setup/legacy#typiaunplugin).
+For TypeScript-Go Bun applications, debug generated JavaScript. [`@ttsc/unplugin/bun`](/docs/setup/tsgo#bundlers) integrates with `Bun.build`, so keep typia in that build path, emit to `dist`, then start Bun's inspector on the emitted entry. The same shape applies to legacy `Bun.build` projects that use [`@typia/unplugin/bun`](/docs/setup/legacy#typiaunplugin). Bun's bundler [`sourcemap`](https://bun.com/docs/bundler#sourcemap) option defaults to no source maps, so set `sourcemap: "linked"` and keep the generated `.js.map` files beside the emitted `.js` files.
+
+<Tabs items={["TypeScript-Go", "Legacy"]}>
+  <Tabs.Tab>
+```ts filename="build.ts" showLineNumbers copy
+import ttsc from "@ttsc/unplugin/bun";
+
+await Bun.build({
+  entrypoints: ["src/index.ts"],
+  outdir: "dist",
+  sourcemap: "linked",
+  plugins: [ttsc()],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="build.ts" showLineNumbers copy
+import UnpluginTypia from "@typia/unplugin/bun";
+
+await Bun.build({
+  entrypoints: ["src/index.ts"],
+  outdir: "dist",
+  sourcemap: "linked",
+  plugins: [UnpluginTypia()],
+});
+```
+  </Tabs.Tab>
+</Tabs>
 
 ```json filename="package.json" showLineNumbers copy
 {
@@ -306,4 +339,4 @@ import typia from "typia";
 console.log(typia.is<{ id: string }>({ id: "ok" }));
 ```
 
-If the debug console prints `true`, the debugger is running transformed code. If it throws `Error on typia.<method>(): no transform has been configured.`, the launch configuration is bypassing `ttsc`, the legacy patched compiler, or the bundler plugin.
+If the debug console prints `true`, the debugger is running transformed code. If it throws `Error on typia.<method>(): no transform has been configured.`, the launch configuration is bypassing `ttsc`, the legacy patched compiler, the bundler plugin, or is still pointed at the template files instead of the generated files from `typia generate`.

--- a/website/src/content/docs/setup/debugging.mdx
+++ b/website/src/content/docs/setup/debugging.mdx
@@ -306,4 +306,4 @@ import typia from "typia";
 console.log(typia.is<{ id: string }>({ id: "ok" }));
 ```
 
-If the debug console prints `true`, the debugger is running transformed code. If it throws `typia transformer has not been configured`, the launch configuration is bypassing `ttsc`, the legacy patched compiler, or the bundler plugin.
+If the debug console prints `true`, the debugger is running transformed code. If it throws `Error on typia.<method>(): no transform has been configured.`, the launch configuration is bypassing `ttsc`, the legacy patched compiler, or the bundler plugin.

--- a/website/src/content/docs/setup/debugging.mdx
+++ b/website/src/content/docs/setup/debugging.mdx
@@ -264,7 +264,7 @@ If your legacy project is ESM-only, use the same loader command that runs the ap
 
 ## Bun
 
-Bun debugging has two separate requirements: typia must still run in the same build or preload path, and Bun's inspector must attach to the process. The examples below show the Bun commands that preserve typia's transform path. Attach with Bun's [web debugger](https://bun.com/docs/guides/runtime/web-debugger), or use Bun's [VSCode debugger](https://bun.com/docs/guides/runtime/vscode-debugger) after installing and validating the Bun extension.
+Bun debugging has two separate requirements: typia must still run in the same build or preload path, and Bun's inspector must attach to the process. The examples below show the Bun commands that preserve typia's transform path. Prefer Bun's [web debugger](https://bun.com/docs/runtime/debugger#debug-bun-sh) for the attach step. Treat Bun's [VSCode debugger](https://bun.com/docs/runtime/debugger#visual-studio-code-debugger) as an experimental fallback after installing and validating the Bun extension.
 
 ### `Bun.build` output
 

--- a/website/src/content/docs/setup/debugging.mdx
+++ b/website/src/content/docs/setup/debugging.mdx
@@ -274,7 +274,7 @@ Bun debugging has two separate requirements: typia must still run in the same bu
 
 ### `Bun.build` output
 
-For TypeScript-Go Bun applications, debug generated JavaScript. [`@ttsc/unplugin/bun`](/docs/setup/tsgo#bundlers) integrates with `Bun.build`, so keep typia in that build path, emit to `dist`, then start Bun's inspector on the emitted entry. The same shape applies to legacy `Bun.build` projects that use [`@typia/unplugin/bun`](/docs/setup/legacy#typiaunplugin). Bun's bundler [`sourcemap`](https://bun.com/docs/bundler#sourcemap) option defaults to no source maps, so set `sourcemap: "linked"` and keep the generated `.js.map` files beside the emitted `.js` files.
+For TypeScript-Go Bun applications, debug generated JavaScript. [`@ttsc/unplugin/bun`](/docs/setup/tsgo#bundlers) integrates with `Bun.build`, so keep typia in that build path, emit a bundle for the same runtime you attach to, then start Bun's inspector on the emitted entry. The same shape applies to legacy `Bun.build` projects that use [`@typia/unplugin/bun`](/docs/setup/legacy#typiaunplugin). Bun's bundler [`target`](https://bun.com/docs/bundler#target) defaults to browser output and its [`sourcemap`](https://bun.com/docs/bundler#sourcemap) option defaults to no source maps, so set `target: "bun"` for `bun --inspect-brk` and keep the generated `.js.map` files beside the emitted `.js` files.
 
 <Tabs items={["TypeScript-Go", "Legacy"]}>
   <Tabs.Tab>
@@ -284,6 +284,7 @@ import ttsc from "@ttsc/unplugin/bun";
 await Bun.build({
   entrypoints: ["src/index.ts"],
   outdir: "dist",
+  target: "bun",
   sourcemap: "linked",
   plugins: [ttsc()],
 });
@@ -296,6 +297,7 @@ import UnpluginTypia from "@typia/unplugin/bun";
 await Bun.build({
   entrypoints: ["src/index.ts"],
   outdir: "dist",
+  target: "bun",
   sourcemap: "linked",
   plugins: [UnpluginTypia()],
 });


### PR DESCRIPTION
## Intent

Add a focused setup guide for debugging typia applications in VSCode after the transformer is in the build path.

Refs discussion #1329.

## Scope

- Adds `website/src/content/docs/setup/debugging.mdx`.
- Registers the page in `website/src/content/docs/setup/_meta.ts`.
- Covers build-first debugging, `ttsx`, legacy `ts-node`, and Bun output debugging.

## Deferred

- Did not change compiler/runtime behavior.
- Did not add a manual VSCode integration test; this is documentation only.

## Validation

- `pnpm run build` from `website/`
- `pnpm format` from repo root

## Not run

- `pnpm test` because this PR only changes website documentation and sidebar metadata.