### PR TITLE
Align OpenAPI schema examples with raw SchemaObject shape

### DIFF
--- a/packages/interface/src/openapi/OpenApiV3.ts
+++ b/packages/interface/src/openapi/OpenApiV3.ts
@@ -549,10 +549,7 @@ export namespace OpenApiV3 {
     export interface __IAttribute extends Omit<
       IJsonSchemaAttribute,
       "examples"
-    > {
-      /** Example values. */
-      examples?: any[];
-    }
+    > {}
   }
 
   /** Security scheme types. */

--- a/packages/interface/src/openapi/OpenApiV3.ts
+++ b/packages/interface/src/openapi/OpenApiV3.ts
@@ -551,7 +551,7 @@ export namespace OpenApiV3 {
       "examples"
     > {
       /** Example values. */
-      examples?: any[] | Record<string, any>;
+      examples?: any[];
     }
   }
 

--- a/packages/interface/src/openapi/OpenApiV3_1.ts
+++ b/packages/interface/src/openapi/OpenApiV3_1.ts
@@ -631,7 +631,7 @@ export namespace OpenApiV3_1 {
       "examples"
     > {
       /** Example values. */
-      examples?: any[] | Record<string, any>;
+      examples?: any[];
     }
   }
 

--- a/packages/interface/src/openapi/OpenApiV3_2.ts
+++ b/packages/interface/src/openapi/OpenApiV3_2.ts
@@ -643,7 +643,7 @@ export namespace OpenApiV3_2 {
       "examples"
     > {
       /** Example values. */
-      examples?: any[] | Record<string, any>;
+      examples?: any[];
     }
   }
 

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -220,7 +220,6 @@ export namespace OpenApiV3Downgrader {
         readOnly: input.readOnly,
         writeOnly: input.writeOnly,
         example: input.example,
-        examples: downgradeSchemaExamples(input.examples),
         ...Object.fromEntries(
           Object.entries(input).filter(
             ([key, value]) => key.startsWith("x-") && value !== undefined,
@@ -237,20 +236,17 @@ export namespace OpenApiV3Downgrader {
           OpenApiTypeChecker.isString(schema) ||
           OpenApiTypeChecker.isReference(schema)
         )
+          union.push(omitSchemaExamples(schema));
+        else if (OpenApiTypeChecker.isArray(schema)) {
+          const next = omitSchemaExamples(schema);
           union.push({
-            ...schema,
-            examples: downgradeSchemaExamples(schema.examples),
-          });
-        else if (OpenApiTypeChecker.isArray(schema))
-          union.push({
-            ...schema,
-            examples: downgradeSchemaExamples(schema.examples),
+            ...next,
             items: downgradeSchema(collection)(schema.items),
           });
-        else if (OpenApiTypeChecker.isTuple(schema))
+        } else if (OpenApiTypeChecker.isTuple(schema)) {
+          const next = omitSchemaExamples(schema);
           union.push({
-            ...schema,
-            examples: downgradeSchemaExamples(schema.examples),
+            ...next,
             items: ((): OpenApiV3.IJsonSchema => {
               if (schema.additionalItems === true) return {};
               const elements = [
@@ -274,10 +270,10 @@ export namespace OpenApiV3Downgrader {
               additionalItems: undefined,
             },
           });
-        else if (OpenApiTypeChecker.isObject(schema))
+        } else if (OpenApiTypeChecker.isObject(schema)) {
+          const next = omitSchemaExamples(schema);
           union.push({
-            ...schema,
-            examples: downgradeSchemaExamples(schema.examples),
+            ...next,
             properties:
               schema.properties === undefined
                 ? undefined
@@ -297,7 +293,7 @@ export namespace OpenApiV3Downgrader {
                   : schema.additionalProperties,
             required: schema.required,
           });
-        else if (OpenApiTypeChecker.isOneOf(schema))
+        } else if (OpenApiTypeChecker.isOneOf(schema))
           schema.oneOf.forEach(visit);
       };
       const visitConstant = (schema: OpenApi.IJsonSchema): void => {
@@ -377,10 +373,12 @@ export namespace OpenApiV3Downgrader {
       schema.$ref += ".Nullable";
     };
 
-  const downgradeSchemaExamples = (
-    examples: OpenApi.IJsonSchema["examples"],
-  ): any[] | undefined =>
-    examples === undefined ? undefined : Object.values(examples);
+  const omitSchemaExamples = <Schema extends OpenApi.IJsonSchema>(
+    schema: Schema,
+  ): Omit<Schema, "examples"> => {
+    const { examples: _examples, ...rest } = schema;
+    return rest;
+  };
 
   const isNullable =
     (visited: Set<string>) =>

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -220,7 +220,7 @@ export namespace OpenApiV3Downgrader {
         readOnly: input.readOnly,
         writeOnly: input.writeOnly,
         example: input.example,
-        examples: input.examples,
+        examples: downgradeSchemaExamples(input.examples),
         ...Object.fromEntries(
           Object.entries(input).filter(
             ([key, value]) => key.startsWith("x-") && value !== undefined,
@@ -237,15 +237,20 @@ export namespace OpenApiV3Downgrader {
           OpenApiTypeChecker.isString(schema) ||
           OpenApiTypeChecker.isReference(schema)
         )
-          union.push({ ...schema });
+          union.push({
+            ...schema,
+            examples: downgradeSchemaExamples(schema.examples),
+          });
         else if (OpenApiTypeChecker.isArray(schema))
           union.push({
             ...schema,
+            examples: downgradeSchemaExamples(schema.examples),
             items: downgradeSchema(collection)(schema.items),
           });
         else if (OpenApiTypeChecker.isTuple(schema))
           union.push({
             ...schema,
+            examples: downgradeSchemaExamples(schema.examples),
             items: ((): OpenApiV3.IJsonSchema => {
               if (schema.additionalItems === true) return {};
               const elements = [
@@ -272,6 +277,7 @@ export namespace OpenApiV3Downgrader {
         else if (OpenApiTypeChecker.isObject(schema))
           union.push({
             ...schema,
+            examples: downgradeSchemaExamples(schema.examples),
             properties:
               schema.properties === undefined
                 ? undefined
@@ -370,6 +376,11 @@ export namespace OpenApiV3Downgrader {
       }
       schema.$ref += ".Nullable";
     };
+
+  const downgradeSchemaExamples = (
+    examples: OpenApi.IJsonSchema["examples"],
+  ): any[] | undefined =>
+    examples === undefined ? undefined : Object.values(examples);
 
   const isNullable =
     (visited: Set<string>) =>

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -319,9 +319,6 @@ export namespace OpenApiV3Upgrader {
         readOnly: input.readOnly,
         writeOnly: input.writeOnly,
         example: input.example,
-        examples: Array.isArray(input.examples)
-          ? Object.fromEntries(input.examples.map((v, i) => [`v${i}`, v]))
-          : input.examples,
         ...Object.fromEntries(
           Object.entries(input).filter(
             ([key, value]) => key.startsWith("x-") && value !== undefined,

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -127,7 +127,7 @@ export namespace OpenApiV3Upgrader {
         | OpenApiV3.IJsonSchema.IReference<`#/components/headers/${string}`>
         | OpenApiV3.IJsonSchema.IReference<`#/components/parameters/${string}`>,
     ): OpenApiV3.IOperation.IParameter | undefined => {
-      if (!OpenApiV3TypeChecker.isReference(input)) return input;
+      if (!("$ref" in input)) return input;
       const key: string = input.$ref.split("/").pop() ?? "";
       if (input.$ref.startsWith("#/components/headers/")) {
         const header: Omit<OpenApiV3.IOperation.IParameter, "in"> | undefined =
@@ -184,7 +184,7 @@ export namespace OpenApiV3Upgrader {
         | OpenApiV3.IOperation.IRequestBody
         | OpenApiV3.IJsonSchema.IReference<`#/components/requestBodies/${string}`>,
     ): OpenApi.IOperation.IRequestBody | undefined => {
-      if (OpenApiV3TypeChecker.isReference(input)) {
+      if ("$ref" in input) {
         const found: OpenApiV3.IOperation.IRequestBody | undefined =
           doc.components?.requestBodies?.[input.$ref.split("/").pop() ?? ""];
         if (found === undefined) return undefined;
@@ -205,7 +205,7 @@ export namespace OpenApiV3Upgrader {
         | OpenApiV3.IOperation.IResponse
         | OpenApiV3.IJsonSchema.IReference<`#/components/responses/${string}`>,
     ): OpenApi.IOperation.IResponse | undefined => {
-      if (OpenApiV3TypeChecker.isReference(input)) {
+      if ("$ref" in input) {
         const found: OpenApiV3.IOperation.IResponse | undefined =
           doc.components?.responses?.[input.$ref.split("/").pop() ?? ""];
         if (found === undefined) return undefined;
@@ -238,7 +238,7 @@ export namespace OpenApiV3Upgrader {
         | Omit<OpenApiV3.IOperation.IParameter, "in">
         | OpenApiV3.IJsonSchema.IReference<`#/components/headers/${string}`>,
     ): OpenApi.IOperation.IParameter | undefined => {
-      if (OpenApiV3TypeChecker.isReference(input)) {
+      if ("$ref" in input) {
         const found: Omit<OpenApiV3.IOperation.IParameter, "in"> | undefined =
           input.$ref.startsWith("#/components/headers/")
             ? components.headers?.[input.$ref.split("/").pop() ?? ""]

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -235,7 +235,7 @@ export namespace OpenApiV3_1Downgrader {
         readOnly: input.readOnly,
         writeOnly: input.writeOnly,
         example: input.example,
-        examples: input.examples,
+        examples: downgradeSchemaExamples(input.examples),
         ...Object.fromEntries(
           Object.entries(input).filter(
             ([key, value]) => key.startsWith("x-") && value !== undefined,
@@ -253,15 +253,20 @@ export namespace OpenApiV3_1Downgrader {
           OpenApiTypeChecker.isString(schema) ||
           OpenApiTypeChecker.isReference(schema)
         )
-          union.push({ ...schema });
+          union.push({
+            ...schema,
+            examples: downgradeSchemaExamples(schema.examples),
+          });
         else if (OpenApiTypeChecker.isArray(schema))
           union.push({
             ...schema,
+            examples: downgradeSchemaExamples(schema.examples),
             items: downgradeSchema(collection)(schema.items),
           });
         else if (OpenApiTypeChecker.isTuple(schema))
           union.push({
             ...schema,
+            examples: downgradeSchemaExamples(schema.examples),
             prefixItems: schema.prefixItems.map(downgradeSchema(collection)),
             additionalItems:
               typeof schema.additionalItems === "object"
@@ -271,6 +276,7 @@ export namespace OpenApiV3_1Downgrader {
         else if (OpenApiTypeChecker.isObject(schema))
           union.push({
             ...schema,
+            examples: downgradeSchemaExamples(schema.examples),
             properties:
               schema.properties === undefined
                 ? undefined
@@ -303,6 +309,11 @@ export namespace OpenApiV3_1Downgrader {
         ...attribute,
       };
     };
+
+  const downgradeSchemaExamples = (
+    examples: OpenApi.IJsonSchema["examples"],
+  ): any[] | undefined =>
+    examples === undefined ? undefined : Object.values(examples);
 
   const downgradeSecuritySchemes = (
     input: Record<string, OpenApi.ISecurityScheme>,

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -156,7 +156,7 @@ export namespace OpenApiV3_1Upgrader {
         | OpenApiV3_1.IJsonSchema.IReference<`#/components/headers/${string}`>
         | OpenApiV3_1.IJsonSchema.IReference<`#/components/parameters/${string}`>,
     ): OpenApiV3_1.IOperation.IParameter | undefined => {
-      if (!OpenApiV3_1TypeChecker.isReference(input)) return input;
+      if (!("$ref" in input)) return input;
       const key: string = input.$ref.split("/").pop() ?? "";
       if (input.$ref.startsWith("#/components/headers/")) {
         const header:
@@ -216,7 +216,7 @@ export namespace OpenApiV3_1Upgrader {
         | OpenApiV3_1.IOperation.IRequestBody
         | OpenApiV3_1.IJsonSchema.IReference<`#/components/requestBodies/${string}`>,
     ): OpenApi.IOperation.IRequestBody | undefined => {
-      if (OpenApiV3_1TypeChecker.isReference(input)) {
+      if ("$ref" in input) {
         const found: OpenApiV3_1.IOperation.IRequestBody | undefined =
           doc.components?.requestBodies?.[input.$ref.split("/").pop() ?? ""];
         if (found === undefined) return undefined;
@@ -237,7 +237,7 @@ export namespace OpenApiV3_1Upgrader {
         | OpenApiV3_1.IOperation.IResponse
         | OpenApiV3_1.IJsonSchema.IReference<`#/components/responses/${string}`>,
     ): OpenApi.IOperation.IResponse | undefined => {
-      if (OpenApiV3_1TypeChecker.isReference(input)) {
+      if ("$ref" in input) {
         const found: OpenApiV3_1.IOperation.IResponse | undefined =
           doc.components?.responses?.[input.$ref.split("/").pop() ?? ""];
         if (found === undefined) return undefined;
@@ -270,7 +270,7 @@ export namespace OpenApiV3_1Upgrader {
         | Omit<OpenApiV3_1.IOperation.IParameter, "in">
         | OpenApiV3_1.IJsonSchema.IReference<`#/components/headers/${string}`>,
     ): OpenApi.IOperation.IParameter | undefined => {
-      if (OpenApiV3_1TypeChecker.isReference(input)) {
+      if ("$ref" in input) {
         const found: Omit<OpenApiV3_1.IOperation.IParameter, "in"> | undefined =
           input.$ref.startsWith("#/components/headers/")
             ? components.headers?.[input.$ref.split("/").pop() ?? ""]

--- a/packages/utils/src/converters/internal/OpenApiV3_2Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_2Upgrader.ts
@@ -168,7 +168,7 @@ export namespace OpenApiV3_2Upgrader {
         | OpenApiV3_2.IJsonSchema.IReference<`#/components/headers/${string}`>
         | OpenApiV3_2.IJsonSchema.IReference<`#/components/parameters/${string}`>,
     ): OpenApiV3_2.IOperation.IParameter | undefined => {
-      if (!OpenApiV3_1TypeChecker.isReference(input)) return input;
+      if (!("$ref" in input)) return input;
       const key: string = input.$ref.split("/").pop() ?? "";
       if (input.$ref.startsWith("#/components/headers/")) {
         const header:
@@ -228,7 +228,7 @@ export namespace OpenApiV3_2Upgrader {
         | OpenApiV3_2.IOperation.IRequestBody
         | OpenApiV3_2.IJsonSchema.IReference<`#/components/requestBodies/${string}`>,
     ): OpenApi.IOperation.IRequestBody | undefined => {
-      if (OpenApiV3_1TypeChecker.isReference(input)) {
+      if ("$ref" in input) {
         const found: OpenApiV3_2.IOperation.IRequestBody | undefined =
           doc.components?.requestBodies?.[input.$ref.split("/").pop() ?? ""];
         if (found === undefined) return undefined;
@@ -249,7 +249,7 @@ export namespace OpenApiV3_2Upgrader {
         | OpenApiV3_2.IOperation.IResponse
         | OpenApiV3_2.IJsonSchema.IReference<`#/components/responses/${string}`>,
     ): OpenApi.IOperation.IResponse | undefined => {
-      if (OpenApiV3_1TypeChecker.isReference(input)) {
+      if ("$ref" in input) {
         const found: OpenApiV3_2.IOperation.IResponse | undefined =
           doc.components?.responses?.[input.$ref.split("/").pop() ?? ""];
         if (found === undefined) return undefined;
@@ -282,7 +282,7 @@ export namespace OpenApiV3_2Upgrader {
         | Omit<OpenApiV3_2.IOperation.IParameter, "in">
         | OpenApiV3_2.IJsonSchema.IReference<`#/components/headers/${string}`>,
     ): OpenApi.IOperation.IParameter | undefined => {
-      if (OpenApiV3_1TypeChecker.isReference(input)) {
+      if ("$ref" in input) {
         const found: Omit<OpenApiV3_2.IOperation.IParameter, "in"> | undefined =
           input.$ref.startsWith("#/components/headers/")
             ? components.headers?.[input.$ref.split("/").pop() ?? ""]

--- a/tests/test-utils/src/features/openapi/test_document_roundtrip_v31_media_type_examples.ts
+++ b/tests/test-utils/src/features/openapi/test_document_roundtrip_v31_media_type_examples.ts
@@ -1,0 +1,147 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3_1 } from "@typia/interface";
+import { OpenApiConverter } from "@typia/utils";
+
+/**
+ * Verifies media type examples remain named maps during document round trip.
+ *
+ * Schema Object `examples` and Media Type Object `examples` have different
+ * shapes in raw OpenAPI 3.1. This test keeps both in the same document so the
+ * converter cannot accidentally apply the Schema Object array rule to media
+ * examples.
+ *
+ * 1. Upgrade an OpenAPI 3.1 document with schema examples arrays and media
+ *    examples maps.
+ * 2. Assert the emended document resolves example references and keeps media
+ *    examples as a map.
+ * 3. Downgrade back to OpenAPI 3.1 and assert schema examples are arrays while
+ *    media examples remain a map.
+ */
+export const test_document_roundtrip_v31_media_type_examples = (): void => {
+  const input: OpenApiV3_1.IDocument = {
+    openapi: "3.1.0",
+    info: {
+      title: "Examples",
+      version: "1.0.0",
+    },
+    components: {
+      examples: {
+        beta: {
+          value: {
+            name: "beta",
+          },
+        },
+      },
+    },
+    paths: {
+      "/users": {
+        post: {
+          requestBody: {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  examples: [{ name: "alpha" }, { name: "beta" }],
+                  properties: {
+                    name: {
+                      type: "string",
+                      examples: ["alpha", "beta"],
+                    },
+                  },
+                  required: ["name"],
+                },
+                examples: {
+                  alpha: {
+                    value: {
+                      name: "alpha",
+                    },
+                  },
+                  beta: {
+                    $ref: "#/components/examples/beta",
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "204": {
+              description: "No Content",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const upgraded: OpenApi.IDocument = OpenApiConverter.upgradeDocument(input);
+  const upgradedMedia =
+    upgraded.paths?.["/users"]?.post?.requestBody?.content?.[
+      "application/json"
+    ];
+  TestValidator.equals("upgraded media", upgradedMedia, {
+    schema: {
+      type: "object",
+      examples: {
+        v0: { name: "alpha" },
+        v1: { name: "beta" },
+      },
+      properties: {
+        name: {
+          type: "string",
+          examples: {
+            v0: "alpha",
+            v1: "beta",
+          },
+        },
+      },
+      required: ["name"],
+    },
+    examples: {
+      alpha: {
+        value: {
+          name: "alpha",
+        },
+      },
+      beta: {
+        value: {
+          name: "beta",
+        },
+      },
+    },
+  });
+
+  const downgraded: OpenApiV3_1.IDocument = OpenApiConverter.downgradeDocument(
+    upgraded,
+    "3.1",
+  );
+  const downgradedMedia =
+    (
+      downgraded.paths?.["/users"]?.post
+        ?.requestBody as OpenApiV3_1.IOperation.IRequestBody | undefined
+    )?.content?.["application/json"];
+  TestValidator.equals("downgraded media", downgradedMedia, {
+    schema: {
+      type: "object",
+      examples: [{ name: "alpha" }, { name: "beta" }],
+      properties: {
+        name: {
+          type: "string",
+          examples: ["alpha", "beta"],
+        },
+      },
+      required: ["name"],
+    },
+    examples: {
+      alpha: {
+        value: {
+          name: "alpha",
+        },
+      },
+      beta: {
+        value: {
+          name: "beta",
+        },
+      },
+    },
+  });
+};

--- a/tests/test-utils/src/features/openapi/test_json_schema_downgrade_v30_examples.ts
+++ b/tests/test-utils/src/features/openapi/test_json_schema_downgrade_v30_examples.ts
@@ -2,6 +2,18 @@ import { TestValidator } from "@nestia/e2e";
 import { OpenApi, OpenApiV3 } from "@typia/interface";
 import { OpenApiConverter } from "@typia/utils";
 
+/**
+ * Verifies OpenAPI 3.0 schema downgrade omits schema-level `examples`.
+ *
+ * OpenAPI 3.0 Schema Object supports singular `example`, but not JSON Schema's
+ * `examples` keyword. The emended typia schema can carry named examples
+ * internally, so this test pins the downgrade boundary that must not emit a
+ * non-standard Schema Object field.
+ *
+ * 1. Build an emended schema with named examples.
+ * 2. Downgrade it to OpenAPI 3.0.
+ * 3. Assert the resulting Schema Object does not contain `examples`.
+ */
 export const test_json_schema_downgrade_v30_examples = (): void => {
   const input: OpenApi.IJsonSchema = {
     type: "string",
@@ -19,6 +31,5 @@ export const test_json_schema_downgrade_v30_examples = (): void => {
 
   TestValidator.equals("examples", output, {
     type: "string",
-    examples: ["abc", "ABC"],
   });
 };

--- a/tests/test-utils/src/features/openapi/test_json_schema_downgrade_v30_examples.ts
+++ b/tests/test-utils/src/features/openapi/test_json_schema_downgrade_v30_examples.ts
@@ -1,0 +1,24 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3 } from "@typia/interface";
+import { OpenApiConverter } from "@typia/utils";
+
+export const test_json_schema_downgrade_v30_examples = (): void => {
+  const input: OpenApi.IJsonSchema = {
+    type: "string",
+    examples: {
+      lower: "abc",
+      upper: "ABC",
+    },
+  };
+  const output: OpenApiV3.IJsonSchema = OpenApiConverter.downgradeSchema({
+    components: {},
+    downgraded: {},
+    schema: input,
+    version: "3.0",
+  });
+
+  TestValidator.equals("examples", output, {
+    type: "string",
+    examples: ["abc", "ABC"],
+  });
+};

--- a/tests/test-utils/src/features/openapi/test_json_schema_downgrade_v31_examples.ts
+++ b/tests/test-utils/src/features/openapi/test_json_schema_downgrade_v31_examples.ts
@@ -1,0 +1,24 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3_1 } from "@typia/interface";
+import { OpenApiConverter } from "@typia/utils";
+
+export const test_json_schema_downgrade_v31_examples = (): void => {
+  const input: OpenApi.IJsonSchema = {
+    type: "string",
+    examples: {
+      lower: "abc",
+      upper: "ABC",
+    },
+  };
+  const output: OpenApiV3_1.IJsonSchema = OpenApiConverter.downgradeSchema({
+    components: {},
+    downgraded: {},
+    schema: input,
+    version: "3.1",
+  });
+
+  TestValidator.equals("examples", output, {
+    type: "string",
+    examples: ["abc", "ABC"],
+  });
+};

--- a/tests/test-utils/src/features/openapi/test_json_schema_downgrade_v31_examples.ts
+++ b/tests/test-utils/src/features/openapi/test_json_schema_downgrade_v31_examples.ts
@@ -2,6 +2,17 @@ import { TestValidator } from "@nestia/e2e";
 import { OpenApi, OpenApiV3_1 } from "@typia/interface";
 import { OpenApiConverter } from "@typia/utils";
 
+/**
+ * Verifies OpenAPI 3.1 schema downgrade emits array-shaped `examples`.
+ *
+ * OpenAPI 3.1 Schema Object inherits JSON Schema 2020-12 keywords, where
+ * `examples` is an array. The emended typia schema stores examples as a named
+ * record, so this test pins the conversion to the raw Schema Object shape.
+ *
+ * 1. Build an emended schema with named examples.
+ * 2. Downgrade it to OpenAPI 3.1.
+ * 3. Assert the resulting Schema Object contains examples as an array.
+ */
 export const test_json_schema_downgrade_v31_examples = (): void => {
   const input: OpenApi.IJsonSchema = {
     type: "string",

--- a/tests/test-utils/src/features/openapi/test_json_schema_roundtrip_v31_examples.ts
+++ b/tests/test-utils/src/features/openapi/test_json_schema_roundtrip_v31_examples.ts
@@ -1,0 +1,75 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3_1 } from "@typia/interface";
+import { OpenApiConverter } from "@typia/utils";
+
+/**
+ * Verifies OpenAPI 3.1 schema examples survive downgrade and upgrade.
+ *
+ * Typia's emended schema stores examples by name, but raw OpenAPI 3.1 Schema
+ * Objects use an examples array. A round trip must drop only the names, keep
+ * values and ordering, and recursively apply the same rule to child schemas.
+ *
+ * 1. Downgrade an emended object schema with named examples to OpenAPI 3.1.
+ * 2. Assert raw Schema Object examples are arrays at both parent and property
+ *    levels.
+ * 3. Upgrade the raw schema back and assert example values reappear under
+ *    deterministic `v0`, `v1` keys.
+ */
+export const test_json_schema_roundtrip_v31_examples = (): void => {
+  const input: OpenApi.IJsonSchema = {
+    type: "object",
+    examples: {
+      first: { name: "alpha" },
+      second: { name: "beta" },
+    },
+    properties: {
+      name: {
+        type: "string",
+        examples: {
+          short: "alpha",
+          long: "beta",
+        },
+      },
+    },
+    required: ["name"],
+  };
+  const downgraded: OpenApiV3_1.IJsonSchema = OpenApiConverter.downgradeSchema({
+    components: {},
+    downgraded: {},
+    schema: input,
+    version: "3.1",
+  });
+  TestValidator.equals("downgraded", downgraded, {
+    type: "object",
+    examples: [{ name: "alpha" }, { name: "beta" }],
+    properties: {
+      name: {
+        type: "string",
+        examples: ["alpha", "beta"],
+      },
+    },
+    required: ["name"],
+  });
+
+  const upgraded: OpenApi.IJsonSchema = OpenApiConverter.upgradeSchema({
+    components: {},
+    schema: downgraded,
+  });
+  TestValidator.equals("upgraded", upgraded, {
+    type: "object",
+    examples: {
+      v0: { name: "alpha" },
+      v1: { name: "beta" },
+    },
+    properties: {
+      name: {
+        type: "string",
+        examples: {
+          v0: "alpha",
+          v1: "beta",
+        },
+      },
+    },
+    required: ["name"],
+  });
+};

--- a/tests/test-utils/src/features/openapi/test_json_schema_upgrade_v31_examples.ts
+++ b/tests/test-utils/src/features/openapi/test_json_schema_upgrade_v31_examples.ts
@@ -1,0 +1,78 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3_1 } from "@typia/interface";
+import { OpenApiConverter } from "@typia/utils";
+
+/**
+ * Verifies OpenAPI 3.1 schema upgrade converts array-shaped `examples`.
+ *
+ * Raw OpenAPI 3.1 Schema Objects use JSON Schema's array-shaped `examples`,
+ * while typia's emended schema keeps examples as a named record. The nested
+ * property and item schemas pin recursive conversion, not only the top-level
+ * attribute copy.
+ *
+ * 1. Build an OpenAPI 3.1 object schema with examples on the object, a property,
+ *    an array, and its item schema.
+ * 2. Upgrade the schema to typia's emended representation.
+ * 3. Assert every raw examples array is converted to a deterministic `v0`, `v1`
+ *    record.
+ */
+export const test_json_schema_upgrade_v31_examples = (): void => {
+  const input: OpenApiV3_1.IJsonSchema = {
+    type: "object",
+    examples: [
+      { id: "alpha", tags: ["red"] },
+      { id: "beta", tags: ["blue"] },
+    ],
+    properties: {
+      id: {
+        type: "string",
+        examples: ["alpha", "beta"],
+      },
+      tags: {
+        type: "array",
+        examples: [["red"], ["blue"]],
+        items: {
+          type: "string",
+          examples: ["red", "blue"],
+        },
+      },
+    },
+    required: ["id", "tags"],
+  };
+  const output: OpenApi.IJsonSchema = OpenApiConverter.upgradeSchema({
+    components: {},
+    schema: input,
+  });
+
+  TestValidator.equals("examples", output, {
+    type: "object",
+    examples: {
+      v0: { id: "alpha", tags: ["red"] },
+      v1: { id: "beta", tags: ["blue"] },
+    },
+    properties: {
+      id: {
+        type: "string",
+        examples: {
+          v0: "alpha",
+          v1: "beta",
+        },
+      },
+      tags: {
+        type: "array",
+        examples: {
+          v0: ["red"],
+          v1: ["blue"],
+        },
+        items: {
+          type: "string",
+          examples: {
+            v0: "red",
+            v1: "blue",
+          },
+        },
+      },
+    },
+    required: ["id", "tags"],
+  });
+};

--- a/tests/test-utils/src/features/openapi/test_json_schema_upgrade_v32_examples.ts
+++ b/tests/test-utils/src/features/openapi/test_json_schema_upgrade_v32_examples.ts
@@ -1,0 +1,35 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3_2 } from "@typia/interface";
+import { OpenApiConverter } from "@typia/utils";
+
+/**
+ * Verifies OpenAPI 3.2 schema upgrade keeps JSON Schema examples semantics.
+ *
+ * OpenAPI 3.2 shares the same JSON Schema 2020-12 Schema Object semantics used
+ * by OpenAPI 3.1, so its raw `examples` keyword is also array-shaped. This test
+ * pins the v3.2 upgrader path, which delegates schema conversion through the
+ * v3.1 converter.
+ *
+ * 1. Build an OpenAPI 3.2 string schema with raw examples.
+ * 2. Upgrade the schema to typia's emended representation.
+ * 3. Assert the array is converted to a deterministic named record.
+ */
+export const test_json_schema_upgrade_v32_examples = (): void => {
+  const input: OpenApiV3_2.IJsonSchema = {
+    type: "string",
+    examples: ["alpha", "beta", "gamma"],
+  };
+  const output: OpenApi.IJsonSchema = OpenApiConverter.upgradeSchema({
+    components: {},
+    schema: input,
+  });
+
+  TestValidator.equals("examples", output, {
+    type: "string",
+    examples: {
+      v0: "alpha",
+      v1: "beta",
+      v2: "gamma",
+    },
+  });
+};

--- a/website/src/content/docs/json/schema.mdx
+++ b/website/src/content/docs/json/schema.mdx
@@ -47,7 +47,24 @@ const schemas = typia.json.schemas<[User]>();
 // → an IJsonSchemaCollection with `User` under components.schemas
 ```
 
-The output is a plain object — drop it into your OpenAPI spec, hand it to `ajv` if you must, or save it to disk for tooling that wants schemas at rest.
+The output is a plain object. Use it directly with typia and `@typia/utils`, hand it to `ajv` when your JSON Schema consumer accepts typia's emended shape, or save it to disk for tooling that wants schemas at rest.
+
+`typia.json.schema`, `typia.json.schemas`, and `typia.json.application` return typia's emended schema representation. It is designed for typia and `@typia/utils` converters first, not for direct assignment to every third-party OpenAPI `SchemaObject` type. When a tool expects raw OpenAPI 3.1 schemas, convert the components with `OpenApiConverter.downgradeComponents`:
+
+```typescript copy filename="openapi-components.ts"
+import typia from "typia";
+import { OpenApiConverter } from "@typia/utils";
+
+const collection = typia.json.schemas<[User]>();
+const components = OpenApiConverter.downgradeComponents(
+  collection.components,
+  "3.1",
+);
+
+// Use components.schemas in an OpenAPI 3.1 document or plugin option.
+```
+
+This matters for schema-level `examples`: typia keeps `tags.Examples<T>` as named examples in the emended schema, while OpenAPI 3.1's Schema Object uses JSON Schema's array-shaped `examples` keyword. The converter drops the names and emits the raw OpenAPI form.
 
 <Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>


### PR DESCRIPTION
## Summary
- narrow raw OpenAPI Schema Object `examples` types to array-shaped values for v3.0/v3.1/v3.2
- convert typia's emended named schema examples to raw arrays in OpenAPI 3.0/3.1 downgrade paths
- document the emended-schema vs raw-OpenAPI boundary and add downgrade regression tests

## Discussion
- Fixes discussion #1697
- OpenAPI Parameter/Media Type examples remain named records; this only changes schema-level examples.

## Validation
- `pnpm format`
- `pnpm build`
- `node` smoke test against built `OpenApiConverter.downgradeSchema` for v3.0/v3.1 schema examples
- `pnpm run build` from `website/`

## Local Gap
- Filtered `tests/test-utils` execution timed out locally in `ttsx` project check before test execution; the new behavior was still checked via package build plus compiled converter smoke test.