### PR TITLE
ci(release): add prerelease publish workflows

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,0 +1,52 @@
+name: release-next
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "bumpp version argument, for example 13.0.0-next.0 or prerelease"
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org/
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.26.x
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Bump versions
+        env:
+          VERSION: ${{ inputs.version }}
+        run: pnpm bumpp "$VERSION" --no-commit --no-tag --no-push --recursive --yes
+
+      - name: Commit bumped versions
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json pnpm-lock.yaml ":(glob)**/package.json"
+          git commit -m "chore(release): bump next to ${VERSION}"
+          git push origin HEAD:${GITHUB_REF_NAME}
+
+      - name: Publish next to npm
+        run: pnpm run package:next --no-git-checks --provenance

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,52 @@
+name: release-rc
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "bumpp version argument, for example 13.0.0-rc.2 or prerelease"
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org/
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.26.x
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Bump versions
+        env:
+          VERSION: ${{ inputs.version }}
+        run: pnpm bumpp "$VERSION" --no-commit --no-tag --no-push --recursive --yes
+
+      - name: Commit bumped versions
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json pnpm-lock.yaml ":(glob)**/package.json"
+          git commit -m "chore(release): bump rc to ${VERSION}"
+          git push origin HEAD:${GITHUB_REF_NAME}
+
+      - name: Publish rc to npm
+        run: pnpm run package:rc --no-git-checks --provenance

--- a/next.bash
+++ b/next.bash
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-pnpm bumpp "$1" --no-commit --no-tag --no-push --recursive --yes
-pnpm --filter=./packages/* -r publish --tag rc --access public --no-git-checks

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "test:go:native": "node scripts/with-ttsc-cache.cjs go -C packages/typia/test test ../native/...",
     "test:toolchain": "pnpm run test:go",
     "package:latest": "bash -c 'pnpm --filter=./packages/* -r publish --tag latest --access public \"$@\"' --",
-    "package:next": "bash next.bash",
-    "package:rc": "bash rc.bash",
+    "package:next": "bash -c 'pnpm --filter=./packages/* -r publish --tag next --access public \"$@\"' --",
+    "package:rc": "bash -c 'pnpm --filter=./packages/* -r publish --tag rc --access public \"$@\"' --",
     "package:tgz": "node experiments/tarballs",
     "release": "bumpp -r"
   },

--- a/rc.bash
+++ b/rc.bash
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-pnpm bumpp "$1" --no-commit --no-tag --no-push --recursive --yes
-pnpm --filter=./packages/* -r publish --tag next --access public --no-git-checks


### PR DESCRIPTION
## Summary
- add manual rc and next release workflows
- commit recursive version bumps before publishing prerelease packages
- keep package:rc/package:next scripts inline and remove the old bash wrappers

## Tests
- Not run, per instruction to merge immediately without waiting on validation.