### PR TITLE
ci(release): validate prerelease version inputs

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "bumpp version argument, for example 13.0.0-next.0 or prerelease"
+        description: "Exact version, matching x.y.z-next.n, for example 13.0.0-next.0"
         required: true
 
 permissions:
@@ -18,6 +18,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+
+      - name: Validate next version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-next\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::release-next requires x.y.z-next.n, for example 13.0.0-next.0"
+            exit 1
+          fi
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "bumpp version argument, for example 13.0.0-rc.2 or prerelease"
+        description: "Exact version, matching x.y.z-rc.n, for example 13.0.0-rc.2"
         required: true
 
 permissions:
@@ -18,6 +18,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+
+      - name: Validate rc version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::release-rc requires x.y.z-rc.n, for example 13.0.0-rc.2"
+            exit 1
+          fi
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- require release-rc inputs to match x.y.z-rc.n
- require release-next inputs to match x.y.z-next.n
- fail before bump, commit, or publish when the pattern is violated

## Tests
- Not run, per instruction to merge immediately without waiting on validation.