### PR TITLE
ci(release): restrict prerelease dispatch side effects

### DIFF
--- a/.github/workflows/release-guard.cjs
+++ b/.github/workflows/release-guard.cjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+"use strict";
+
+const childProcess = require("child_process");
+const fs = require("fs");
+
+const STABLE_VERSION = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+const PRERELEASE_PATTERNS = {
+  rc: {
+    pattern:
+      /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc\.(0|[1-9][0-9]*)$/,
+    example: "13.0.0-rc.2",
+  },
+  next: {
+    pattern:
+      /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-next\.(0|[1-9][0-9]*)$/,
+    example: "13.0.0-next.0",
+  },
+};
+
+const command = process.argv[2];
+
+const fail = (message) => {
+  console.error(`::error::${message}`);
+  process.exit(1);
+};
+
+const exportEnvironment = (entries) => {
+  const text = Object.entries(entries)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  if (process.env.GITHUB_ENV)
+    fs.appendFileSync(process.env.GITHUB_ENV, `${text}\n`);
+  else console.log(text);
+};
+
+const packageJsonFiles = () =>
+  childProcess
+    .execFileSync("git", ["ls-files"], { encoding: "utf8" })
+    .split(/\r?\n/)
+    .filter(
+      (file) => file === "package.json" || file.endsWith("/package.json"),
+    );
+
+const assertPackageVersions = (version) => {
+  if (!version) fail("RELEASE_VERSION is required");
+  const mismatches = [];
+  for (const file of packageJsonFiles()) {
+    const json = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (json.version && json.version !== "0.0.0" && json.version !== version)
+      mismatches.push(`${file}: ${json.version}`);
+  }
+  if (mismatches.length) {
+    console.error(`Package versions must all be ${version}:`);
+    for (const line of mismatches) console.error(`- ${line}`);
+    process.exit(1);
+  }
+};
+
+const validateContext = () => {
+  const eventName = process.env.GITHUB_EVENT_NAME;
+  const refName = process.env.GITHUB_REF_NAME ?? "";
+
+  if (eventName === "push") {
+    const match = /^v(.+)$/.exec(refName);
+    if (!match || !STABLE_VERSION.test(match[1]))
+      fail("release tag must be stable vX.Y.Z, for example v13.0.0");
+    assertPackageVersions(match[1]);
+    exportEnvironment({ NPM_TAG: "latest", RELEASE_VERSION: match[1] });
+    return;
+  }
+
+  if (eventName === "workflow_dispatch") {
+    const tag = process.env.INPUT_TAG;
+    const version = process.env.INPUT_VERSION;
+    if (refName !== "master")
+      fail("manual prerelease publishing must run from master");
+    const rule = PRERELEASE_PATTERNS[tag];
+    if (!rule) fail("tag must be rc or next");
+    if (!rule.pattern.test(version))
+      fail(`tag '${tag}' requires version like ${rule.example}`);
+    exportEnvironment({ NPM_TAG: tag, RELEASE_VERSION: version });
+    return;
+  }
+
+  fail(`unsupported release event: ${eventName}`);
+};
+
+const bumpIfNeeded = () => {
+  const version = process.env.RELEASE_VERSION;
+  if (!version) fail("RELEASE_VERSION is required");
+  const current = JSON.parse(fs.readFileSync("package.json", "utf8")).version;
+  if (current === version) {
+    console.log(`Version is already ${version}.`);
+    return;
+  }
+  childProcess.execFileSync(
+    "pnpm",
+    [
+      "bumpp",
+      version,
+      "--no-commit",
+      "--no-tag",
+      "--no-push",
+      "--recursive",
+      "--yes",
+    ],
+    { stdio: "inherit" },
+  );
+};
+
+switch (command) {
+  case "validate-context":
+    validateContext();
+    break;
+  case "bump-if-needed":
+    bumpIfNeeded();
+    break;
+  case "validate-package-versions":
+    assertPackageVersions(process.env.RELEASE_VERSION);
+    break;
+  default:
+    fail(
+      "usage: release-guard.cjs <validate-context|bump-if-needed|validate-package-versions>",
+    );
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: release
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
+      - "!v*-*"
+      - '!v*\+*'
   workflow_dispatch:
     inputs:
       tag:
@@ -24,73 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
-        with:
-          ref: ${{ github.ref_name }}
-      - name: Validate release tag
-        if: github.event_name == 'push'
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          if [[ ! "$TAG_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            echo "::error::release tag must be stable vX.Y.Z, for example v13.0.0"
-            exit 1
-          fi
-          export VERSION="${TAG_NAME#v}"
-          node - <<'NODE'
-          const cp = require("child_process");
-          const fs = require("fs");
-          const version = process.env.VERSION;
-          const files = cp
-            .execFileSync("git", ["ls-files"], { encoding: "utf8" })
-            .split(/\r?\n/)
-            .filter((file) => file === "package.json" || file.endsWith("/package.json"));
-          const mismatches = [];
-          for (const file of files) {
-            const json = JSON.parse(fs.readFileSync(file, "utf8"));
-            if (json.version && json.version !== "0.0.0" && json.version !== version)
-              mismatches.push(`${file}: ${json.version}`);
-          }
-          if (mismatches.length) {
-            console.error(`release tag ${process.env.TAG_NAME} does not match package versions:`);
-            for (const line of mismatches) console.error(`- ${line}`);
-            process.exit(1);
-          }
-          NODE
-      - name: Validate dispatch ref
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if [[ "$GITHUB_REF_NAME" != "master" ]]; then
-            echo "::error::manual prerelease publishing must run from master"
-            exit 1
-          fi
-      - name: Validate dispatch inputs
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          NPM_TAG: ${{ inputs.tag }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          case "$NPM_TAG" in
-            rc)
-              PATTERN='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc\.(0|[1-9][0-9]*)$'
-              EXAMPLE='13.0.0-rc.2'
-              ;;
-            next)
-              PATTERN='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-next\.(0|[1-9][0-9]*)$'
-              EXAMPLE='13.0.0-next.0'
-              ;;
-            *)
-              echo "::error::tag must be rc or next"
-              exit 1
-              ;;
-          esac
-          if [[ ! "$VERSION" =~ $PATTERN ]]; then
-            echo "::error::tag '$NPM_TAG' requires version like $EXAMPLE"
-            exit 1
-          fi
       - uses: actions/setup-node@v6
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org/
+      - name: Validate release context
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: node .github/workflows/release-guard.cjs validate-context
       - uses: actions/setup-go@v5
         with:
           go-version: 1.26.x
@@ -99,45 +43,12 @@ jobs:
         run: pnpm install
       - name: Bump versions
         if: github.event_name == 'workflow_dispatch'
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          CURRENT="$(node -p "require('./package.json').version")"
-          if [[ "$CURRENT" == "$VERSION" ]]; then
-            echo "Version is already $VERSION."
-          else
-            pnpm bumpp "$VERSION" --no-commit --no-tag --no-push --recursive --yes
-          fi
+        run: node .github/workflows/release-guard.cjs bump-if-needed
       - name: Validate bumped versions
         if: github.event_name == 'workflow_dispatch'
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          node - <<'NODE'
-          const cp = require("child_process");
-          const fs = require("fs");
-          const version = process.env.VERSION;
-          const files = cp
-            .execFileSync("git", ["ls-files"], { encoding: "utf8" })
-            .split(/\r?\n/)
-            .filter((file) => file === "package.json" || file.endsWith("/package.json"));
-          const mismatches = [];
-          for (const file of files) {
-            const json = JSON.parse(fs.readFileSync(file, "utf8"));
-            if (json.version && json.version !== "0.0.0" && json.version !== version)
-              mismatches.push(`${file}: ${json.version}`);
-          }
-          if (mismatches.length) {
-            console.error(`dispatch version ${version} does not match package versions:`);
-            for (const line of mismatches) console.error(`- ${line}`);
-            process.exit(1);
-          }
-          NODE
+        run: node .github/workflows/release-guard.cjs validate-package-versions
       - name: Commit bumped versions
         if: github.event_name == 'workflow_dispatch'
-        env:
-          NPM_TAG: ${{ inputs.tag }}
-          VERSION: ${{ inputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -145,17 +56,15 @@ jobs:
           if git diff --cached --quiet; then
             echo "No version changes to commit."
           else
-            git commit -m "chore(release): bump ${NPM_TAG} to ${VERSION} [skip ci]"
+            git commit -m "chore(release): bump ${NPM_TAG} to ${RELEASE_VERSION} [skip ci]"
             git push origin HEAD:${GITHUB_REF_NAME}
           fi
       - name: Publish to npm
-        env:
-          NPM_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || 'latest' }}
         run: pnpm run "package:${NPM_TAG}" --no-git-checks --provenance
   release:
     runs-on: ubuntu-latest
     needs: publish
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    if: github.event_name == 'push'
     permissions:
       contents: write
     steps:
@@ -169,7 +78,7 @@ jobs:
   website:
     runs-on: ubuntu-latest
     needs: release
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    if: github.event_name == 'push'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,19 +3,18 @@ name: release
 on:
   push:
     tags:
-      - "*"
+      - "v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "npm dist-tag to publish"
+        description: "prerelease npm dist-tag to publish"
         required: true
         type: choice
         options:
-          - latest
           - rc
           - next
       version:
-        description: "Exact version. latest: x.y.z, rc: x.y.z-rc.n, next: x.y.z-next.n"
+        description: "Exact prerelease version. rc: x.y.z-rc.n, next: x.y.z-next.n"
         required: true
 permissions:
   id-token: write
@@ -27,6 +26,43 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           ref: ${{ github.ref_name }}
+      - name: Validate release tag
+        if: github.event_name == 'push'
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$TAG_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::release tag must be stable vX.Y.Z, for example v13.0.0"
+            exit 1
+          fi
+          export VERSION="${TAG_NAME#v}"
+          node - <<'NODE'
+          const cp = require("child_process");
+          const fs = require("fs");
+          const version = process.env.VERSION;
+          const files = cp
+            .execFileSync("git", ["ls-files"], { encoding: "utf8" })
+            .split(/\r?\n/)
+            .filter((file) => file === "package.json" || file.endsWith("/package.json"));
+          const mismatches = [];
+          for (const file of files) {
+            const json = JSON.parse(fs.readFileSync(file, "utf8"));
+            if (json.version && json.version !== "0.0.0" && json.version !== version)
+              mismatches.push(`${file}: ${json.version}`);
+          }
+          if (mismatches.length) {
+            console.error(`release tag ${process.env.TAG_NAME} does not match package versions:`);
+            for (const line of mismatches) console.error(`- ${line}`);
+            process.exit(1);
+          }
+          NODE
+      - name: Validate dispatch ref
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [[ "$GITHUB_REF_NAME" != "master" ]]; then
+            echo "::error::manual prerelease publishing must run from master"
+            exit 1
+          fi
       - name: Validate dispatch inputs
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -34,10 +70,6 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           case "$NPM_TAG" in
-            latest)
-              PATTERN='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
-              EXAMPLE='13.0.0'
-              ;;
             rc)
               PATTERN='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc\.(0|[1-9][0-9]*)$'
               EXAMPLE='13.0.0-rc.2'
@@ -47,7 +79,7 @@ jobs:
               EXAMPLE='13.0.0-next.0'
               ;;
             *)
-              echo "::error::tag must be one of latest, rc, or next"
+              echo "::error::tag must be rc or next"
               exit 1
               ;;
           esac
@@ -69,7 +101,38 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           VERSION: ${{ inputs.version }}
-        run: pnpm bumpp "$VERSION" --no-commit --no-tag --no-push --recursive --yes
+        run: |
+          CURRENT="$(node -p "require('./package.json').version")"
+          if [[ "$CURRENT" == "$VERSION" ]]; then
+            echo "Version is already $VERSION."
+          else
+            pnpm bumpp "$VERSION" --no-commit --no-tag --no-push --recursive --yes
+          fi
+      - name: Validate bumped versions
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          node - <<'NODE'
+          const cp = require("child_process");
+          const fs = require("fs");
+          const version = process.env.VERSION;
+          const files = cp
+            .execFileSync("git", ["ls-files"], { encoding: "utf8" })
+            .split(/\r?\n/)
+            .filter((file) => file === "package.json" || file.endsWith("/package.json"));
+          const mismatches = [];
+          for (const file of files) {
+            const json = JSON.parse(fs.readFileSync(file, "utf8"));
+            if (json.version && json.version !== "0.0.0" && json.version !== version)
+              mismatches.push(`${file}: ${json.version}`);
+          }
+          if (mismatches.length) {
+            console.error(`dispatch version ${version} does not match package versions:`);
+            for (const line of mismatches) console.error(`- ${line}`);
+            process.exit(1);
+          }
+          NODE
       - name: Commit bumped versions
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -92,7 +155,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: publish
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     permissions:
       contents: write
     steps:
@@ -106,7 +169,7 @@ jobs:
   website:
     runs-on: ubuntu-latest
     needs: release
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No version changes to commit."
           else
-            git commit -m "chore(release): bump ${NPM_TAG} to ${VERSION}"
+            git commit -m "chore(release): bump ${NPM_TAG} to ${VERSION} [skip ci]"
             git push origin HEAD:${GITHUB_REF_NAME}
           fi
       - name: Publish to npm

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,15 +1,5 @@
 name: website
-on: 
-  push: 
-    branches:
-      - master
-    paths:
-      - .github/workflows/website.yml
-      - 'examples/**'
-      - 'packages/**'
-      - 'website/**'
-      - 'website/package.json'
-      - 'package.json'
+on:
   pull_request:
     paths:
       - .github/workflows/website.yml
@@ -19,7 +9,7 @@ on:
       - 'website/package.json'
       - 'package.json'
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
@@ -53,10 +43,3 @@ jobs:
       - name: Build
         working-directory: website
         run: pnpm run build
-
-      - name: Deploy
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          branch: gh-pages
-          folder: ./website/out

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -2,6 +2,7 @@ name: website
 on:
   pull_request:
     paths:
+      - .github/workflows/release.yml
       - .github/workflows/website.yml
       - 'examples/**'
       - 'packages/**'


### PR DESCRIPTION
## Summary
- keep prerelease publishing inside the trusted `release.yml` workflow
- restrict manual dispatch to `rc` and `next` from `master`
- validate prerelease version patterns before bumping or publishing
- require stable `vX.Y.Z` git tags and matching package versions for official release jobs
- remove website deployment from `website.yml`; website deploy now exists only in `release.yml` after stable tag release

## Review Notes
- `release.yml` dispatch cannot run GitHub Release or website jobs because those jobs require `github.event_name == 'push'` and a tag ref.
- `release.yml` tag push rejects prerelease tags such as `v13.0.0-rc.2` before npm publish.
- `website.yml` now has no `push` trigger and no deploy action.

## Tests
- `pnpm dlx yaml-lint .github/workflows/release.yml .github/workflows/website.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/website.yml`
- local bash simulations for rc/next version acceptance and prerelease tag rejection
- local Node package-version validator simulation for `13.0.0-rc.2` and mismatched stable tag rejection