### PR TITLE
test(native): contain the backstop fixture emit inside the fixture

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/intersection_nonsensible_backstop_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/intersection_nonsensible_backstop_transform_test.go
@@ -98,6 +98,31 @@ func TestIntersectionNonsensibleBackstop(t *testing.T) {
   }
 }
 
+// Unlike the sibling suites sharing atomicIntersectionSchemaTSConfig, this
+// test runs a full `--emit` build, and the fixture imports the real "typia"
+// package whose exports ship TypeScript source — so packages/typia/src/**
+// joins the program as emittable input. outDir keeps that emit inside the
+// fixture directory (removed by t.Cleanup) instead of writing .js beside
+// typia's own sources, and tsgo then demands rootDir name the program's
+// common source directory explicitly (TS5011): "../../.." resolves to
+// packages/typia from a fixture at native/.tmp-ttsc-typia-tests/<name>/.
+const intersectionBackstopTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "../../.."
+  },
+  "include": ["src"]
+}
+`
+
 func intersectionBackstopProject(t *testing.T, name string, decl string) string {
   t.Helper()
   root := ttscTypiaTestRepoRoot(t)
@@ -114,7 +139,7 @@ func intersectionBackstopProject(t *testing.T, name string, decl string) string 
   if err := os.MkdirAll(src, 0o755); err != nil {
     t.Fatalf("mkdir fixture src: %v", err)
   }
-  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(atomicIntersectionSchemaTSConfig), 0o644); err != nil {
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(intersectionBackstopTSConfig), 0o644); err != nil {
     t.Fatalf("write tsconfig: %v", err)
   }
   source := fmt.Sprintf(`import typia, { tags } from "typia";

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.0-rc.2",
+  "version": "13.0.0-rc.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Intent

`TestIntersectionNonsensibleBackstop` polluted the source tree on every run: its fixture imports the real `typia` package, whose `exports` ship TypeScript source, so the full `--emit` build pulled `packages/typia/src/**` into the program — and with no `outDir`, tsgo wrote ~14 compiled `.js` files (the `src/index.ts` import closure: `module.js`, `json.js`, `llm.js`, …) **beside typia's own sources**. Discovered while validating #2010; pre-existing since #1970.

Consequences fixed:
- A second consecutive `pnpm test` failed `test-typia-cli`'s `assertNoTypiaSourceJavascript` guard (go tests run last, so each run poisoned the next).
- `pnpm pack` executed after a go-test run shipped the strays inside `typia.tgz` (`files` includes `src`) — reproduced and verified locally.

## Scope

- The backstop test gets its own tsconfig constant with `"outDir": "dist"` and `"rootDir": "../../.."`: tsgo raises TS5011 with a bare `outDir` once the program's common source directory climbs to `packages/typia`, so the rootDir names it explicitly. Emit now lands under the fixture's `dist/` and `t.Cleanup` removes it.
- The shared `atomicIntersectionSchemaTSConfig` stays untouched — its three sibling suites go through the in-memory `runTransform` path, which fails (code 3) under an `outDir`.
- `typia` bumps to `13.0.0-rc.3` per the change-integrity rule: the fixture constants live in the shipped `native` tree (same pattern as #1997).

## Test plan

- `go test -count=1 ./cmd/ttsc-typia` (via the test workspace): all pass, `packages/typia/src` stays clean.
- `pnpm test:go` followed immediately by `pnpm --filter ./tests/test-typia-cli start` — the exact sequence that used to trip the guard — passes.
- Manual CLI repro (`pnpm exec ttsc --emit` on an equivalent fixture) confirms all emit, typia src closure included, lands inside the fixture `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)