### PR TITLE
fix(typia): prevent downlevel import alias collisions

### DIFF
--- a/packages/typia/native/core/context/ImportProgrammer.go
+++ b/packages/typia/native/core/context/ImportProgrammer.go
@@ -14,7 +14,7 @@ type ImportProgrammer struct {
   options_ ImportProgrammer_IOptions
   // emit_ switches import emission to AST-integration mode. When set, imports
   // become namespace imports created by emit_.Factory, and every reference is a
-  // member access on NewGeneratedNameForNode so tsgo's module transform owns the
+  // member access on a cloned unique name so tsgo's module transform owns the
   // CommonJS aliasing. Nil keeps the legacy text-emission path with named,
   // default, namespace imports and bare identifier references.
   emit_ *shimprinter.EmitContext
@@ -51,6 +51,7 @@ type ImportProgrammer_TypeProps struct {
 type importProgrammer_asset struct {
   file      string
   modSpec   *shimast.Node
+  binding   *shimast.Node
   Default   *ImportProgrammer_IDefault
   namespace *ImportProgrammer_INamespace
   instances map[string]ImportProgrammer_IInstance
@@ -80,8 +81,7 @@ func (p *ImportProgrammer) SetEmitContext(ec *shimprinter.EmitContext) {
 }
 
 // moduleSpecifier returns the asset's module-specifier string literal, allocated
-// once and reused as the stable key for NewGeneratedNameForNode so the namespace
-// alias prints identically in the import declaration and every reference.
+// once and reused by the namespace import declaration.
 func (p *ImportProgrammer) moduleSpecifier(asset *importProgrammer_asset) *shimast.Node {
   if asset.modSpec == nil {
     asset.modSpec = p.emit_.Factory.NewStringLiteral(asset.file, shimast.TokenFlagsNone)
@@ -89,11 +89,20 @@ func (p *ImportProgrammer) moduleSpecifier(asset *importProgrammer_asset) *shima
   return asset.modSpec
 }
 
+// namespaceName returns a clone of the asset's unique generated identifier.
+// Clones preserve the generated-name id while keeping distinct AST parents.
+func (p *ImportProgrammer) namespaceName(asset *importProgrammer_asset) *shimast.Node {
+  if asset.binding == nil {
+    asset.binding = p.emit_.Factory.NewUniqueName(importProgrammer_moduleIdentifier(asset.file))
+  }
+  return asset.binding.Clone(p.emit_.Factory)
+}
+
 // member builds `<namespace>.<name>` for the file, where <namespace> is the
 // generated name tsgo's module-transform binds to `require(file)`.
 func (p *ImportProgrammer) member(asset *importProgrammer_asset, name string) *shimast.Node {
   return p.emit_.Factory.NewPropertyAccessExpression(
-    p.emit_.Factory.NewGeneratedNameForNode(p.moduleSpecifier(asset)),
+    p.namespaceName(asset),
     nil,
     p.emit_.Factory.NewIdentifier(name),
     shimast.NodeFlagsNone,
@@ -137,7 +146,7 @@ func (p *ImportProgrammer) Namespace(props ImportProgrammer_INamespace) *shimast
     asset.namespace = &copy
   }
   if p.emit_ != nil {
-    return p.emit_.Factory.NewGeneratedNameForNode(p.moduleSpecifier(asset))
+    return p.namespaceName(asset)
   }
   return EmitFactory(p.emit_, importProgrammer_factory).NewIdentifier(asset.namespace.Name)
 }
@@ -222,7 +231,7 @@ func (p *ImportProgrammer) ToStatements() []*shimast.Node {
         p.emit_.Factory.NewImportClause(
           0,
           nil,
-          p.emit_.Factory.NewNamespaceImport(p.emit_.Factory.NewGeneratedNameForNode(modSpec)),
+          p.emit_.Factory.NewNamespaceImport(p.namespaceName(asset)),
         ),
         modSpec,
         nil,
@@ -332,6 +341,31 @@ func importProgrammer_fileRank(file string) int {
     return 900
   }
   return 500
+}
+
+func importProgrammer_moduleIdentifier(file string) string {
+  if index := strings.LastIndexAny(file, "/\\"); index != -1 {
+    file = file[index+1:]
+  }
+  if file == "" {
+    return "module"
+  }
+  var builder strings.Builder
+  for i := 0; i < len(file); i++ {
+    ch := file[i]
+    if i == 0 && '0' <= ch && ch <= '9' {
+      builder.WriteByte('_')
+    }
+    if ('a' <= ch && ch <= 'z') ||
+      ('A' <= ch && ch <= 'Z') ||
+      ('0' <= ch && ch <= '9') ||
+      ch == '_' {
+      builder.WriteByte(ch)
+    } else {
+      builder.WriteByte('_')
+    }
+  }
+  return builder.String()
 }
 
 func (p *ImportProgrammer) take(file string) *importProgrammer_asset {

--- a/packages/typia/native/core/context/import_programmer_module_identifier_test.go
+++ b/packages/typia/native/core/context/import_programmer_module_identifier_test.go
@@ -1,0 +1,29 @@
+//go:build typia_native_internal
+// +build typia_native_internal
+
+package context
+
+import "testing"
+
+// TestImportProgrammerModuleIdentifier verifies module names become valid bases.
+//
+// Unique generated names still need a readable JavaScript identifier base.
+// Scoped packages, punctuation, leading digits, and Windows-style separators
+// must not reintroduce invalid namespace import bindings.
+//
+// 1. Convert representative internal, scoped, numeric, and empty module names.
+// 2. Assert each result matches the identifier base used by the printer.
+func TestImportProgrammerModuleIdentifier(t *testing.T) {
+	cases := map[string]string{
+		"typia/lib/internal/_randomNumber": "_randomNumber",
+		"@scope/package-name":              "package_name",
+		"123-module":                       "_123_module",
+		`scope\windows-name`:               "windows_name",
+		"":                                 "module",
+	}
+	for input, expected := range cases {
+		if actual := importProgrammer_moduleIdentifier(input); actual != expected {
+			t.Fatalf("identifier mismatch for %q: expected %q, got %q", input, expected, actual)
+		}
+	}
+}

--- a/packages/typia/native/core/context/import_programmer_module_identifier_test.go
+++ b/packages/typia/native/core/context/import_programmer_module_identifier_test.go
@@ -14,16 +14,16 @@ import "testing"
 // 1. Convert representative internal, scoped, numeric, and empty module names.
 // 2. Assert each result matches the identifier base used by the printer.
 func TestImportProgrammerModuleIdentifier(t *testing.T) {
-	cases := map[string]string{
-		"typia/lib/internal/_randomNumber": "_randomNumber",
-		"@scope/package-name":              "package_name",
-		"123-module":                       "_123_module",
-		`scope\windows-name`:               "windows_name",
-		"":                                 "module",
-	}
-	for input, expected := range cases {
-		if actual := importProgrammer_moduleIdentifier(input); actual != expected {
-			t.Fatalf("identifier mismatch for %q: expected %q, got %q", input, expected, actual)
-		}
-	}
+  cases := map[string]string{
+    "typia/lib/internal/_randomNumber": "_randomNumber",
+    "@scope/package-name":              "package_name",
+    "123-module":                       "_123_module",
+    `scope\windows-name`:               "windows_name",
+    "":                                 "module",
+  }
+  for input, expected := range cases {
+    if actual := importProgrammer_moduleIdentifier(input); actual != expected {
+      t.Fatalf("identifier mismatch for %q: expected %q, got %q", input, expected, actual)
+    }
+  }
 }

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/tests/test-typia-cli/src/index.ts
+++ b/tests/test-typia-cli/src/index.ts
@@ -3,6 +3,8 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
+import { test_downlevel_internal_import } from "./test_downlevel_internal_import";
+
 interface ICommandResult {
   status: number | null;
   output: string;
@@ -337,6 +339,7 @@ const testRecursiveDynamicCloneEmit = (): void => {
 const main = (): void => {
   testGenericTransformDiagnostic();
   testRecursiveDynamicCloneEmit();
+  test_downlevel_internal_import();
   console.log("Success");
 };
 main();

--- a/tests/test-typia-cli/src/test_downlevel_internal_import.ts
+++ b/tests/test-typia-cli/src/test_downlevel_internal_import.ts
@@ -148,7 +148,7 @@ const writeProject = (project: string): void => {
       `import typia from "typia";`,
       `interface Sample { value: number; }`,
       `const data = typia.random<Sample>();`,
-      `if (typeof data.value !== "number") throw new Error("invalid random value");`,
+      `if (data.value !== 42) throw new Error("random helper did not run");`,
       `export { data };`,
       ``,
     ].join("\n"),
@@ -193,7 +193,7 @@ export const test_downlevel_internal_import = (): void => {
       "utf8",
     );
     const binding: RegExpMatchArray | null = output.match(
-      /const\s+([A-Za-z_$][\w$]*)\s*=.*require\(["']typia\/lib\/internal\/_randomNumber["']\)/,
+      /const\s+([A-Za-z_$][\w$]*)\s*=\s*[^;]*require\(\s*["']typia\/lib\/internal\/_randomNumber["']\s*\)[^;]*;/,
     );
     if (binding === null)
       throw new Error(`Random helper import was not emitted:\n${output}`);

--- a/tests/test-typia-cli/src/test_downlevel_internal_import.ts
+++ b/tests/test-typia-cli/src/test_downlevel_internal_import.ts
@@ -1,0 +1,216 @@
+import cp from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+interface ICommandResult {
+  status: number | null;
+  output: string;
+}
+
+const root: string = path.resolve(__dirname, "..");
+const ttscCache: string =
+  process.env.TTSC_CACHE_DIR ??
+  path.resolve(root, "..", "..", "node_modules", ".cache", "ttsc");
+
+const run = (args: string[], cwd: string = root): ICommandResult => {
+  const result: cp.SpawnSyncReturns<string> = cp.spawnSync(
+    args[0]!,
+    args.slice(1),
+    {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        TTSC_CACHE_DIR: ttscCache,
+      },
+      shell: process.platform === "win32" && args[0] === "pnpm",
+      timeout: 600_000,
+    },
+  );
+  const error: string =
+    result.error instanceof Error
+      ? `\n${result.error.name}: ${result.error.message}`
+      : "";
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}\n${result.stderr ?? ""}${error}`.replace(
+      /\\/g,
+      "/",
+    ),
+  };
+};
+
+const writeJson = (file: string, value: unknown): void => {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const writeProject = (project: string): void => {
+  const source: string = path.join(project, "src");
+  const typia: string = path.join(project, "node_modules", "typia");
+  const lib: string = path.join(typia, "lib");
+  const internal: string = path.join(lib, "internal");
+  fs.mkdirSync(source, { recursive: true });
+  fs.mkdirSync(internal, { recursive: true });
+
+  writeJson(path.join(project, "tsconfig.json"), {
+    compilerOptions: {
+      target: "ES2015",
+      lib: ["ES2015"],
+      outDir: "bin",
+      rootDir: "src",
+      noEmit: false,
+      esModuleInterop: true,
+      module: "nodenext",
+      moduleResolution: "nodenext",
+      strict: true,
+      skipLibCheck: true,
+      types: [],
+      plugins: [{ transform: "typia/lib/transform" }],
+    },
+    include: ["src"],
+  });
+  writeJson(path.join(typia, "package.json"), {
+    name: "typia",
+    main: "./lib/module.js",
+    types: "./lib/module.d.ts",
+    exports: {
+      ".": {
+        types: "./lib/module.d.ts",
+        default: "./lib/module.js",
+      },
+      "./lib/internal/*": "./lib/internal/*.js",
+      "./lib/transform": "./lib/transform.js",
+      "./package.json": "./package.json",
+    },
+    ttsc: {
+      plugin: { transform: "typia/lib/transform" },
+    },
+  });
+  fs.writeFileSync(
+    path.join(lib, "module.d.ts"),
+    [
+      `declare namespace typia {`,
+      `  interface IRandomGenerator {`,
+      `    number(schema: unknown): number;`,
+      `  }`,
+      `  type Resolved<T> = T;`,
+      `  function random<T>(generator?: Partial<IRandomGenerator>): Resolved<T>;`,
+      `}`,
+      `declare const typia: { random: typeof typia.random };`,
+      `export default typia;`,
+      `export declare function random<T>(`,
+      `  generator?: Partial<typia.IRandomGenerator>,`,
+      `): typia.Resolved<T>;`,
+      ``,
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(lib, "module.js"),
+    `exports.random = () => { throw new Error("typia.random was not transformed"); };\n`,
+  );
+  fs.writeFileSync(
+    path.join(internal, "_randomNumber.js"),
+    `exports._randomNumber = () => 42;\n`,
+  );
+  fs.writeFileSync(
+    path.join(lib, "transform.js"),
+    [
+      `"use strict";`,
+      `Object.defineProperty(exports, "__esModule", { value: true });`,
+      `exports.default = createTtscPlugin;`,
+      `function createTtscPlugin() {`,
+      `  return {`,
+      `    name: "typia",`,
+      `    source: ${JSON.stringify(
+        path
+          .resolve(
+            root,
+            "..",
+            "..",
+            "packages",
+            "typia",
+            "native",
+            "cmd",
+            "ttsc-typia",
+          )
+          .replace(/\\/g, "/"),
+      )},`,
+      `  };`,
+      `}`,
+      ``,
+    ].join("\n"),
+  );
+  fs.writeFileSync(path.join(lib, "transform.d.ts"), `export {};\n`);
+  fs.writeFileSync(
+    path.join(source, "random.ts"),
+    [
+      `import typia from "typia";`,
+      `interface Sample { value: number; }`,
+      `const data = typia.random<Sample>();`,
+      `if (typeof data.value !== "number") throw new Error("invalid random value");`,
+      `export { data };`,
+      ``,
+    ].join("\n"),
+  );
+};
+
+/**
+ * Verifies downlevel transforms keep internal import aliases unshadowed.
+ *
+ * ES2015-ES2019 lowering introduces function-scoped temporary variables for
+ * optional chaining and nullish coalescing. Internal helper imports must use
+ * unique names rather than the same temporary-name channel, or a generated
+ * random function reads the local undefined temporary instead of its import.
+ *
+ * 1. Create a minimal typia project targeting ES2015 with a random number helper.
+ * 2. Compile a typia.random call through the native ttsc plugin.
+ * 3. Assert the helper import is not temp-named and execute the emitted module.
+ */
+export const test_downlevel_internal_import = (): void => {
+  const project: string = fs.mkdtempSync(
+    path.join(os.tmpdir(), "typia-downlevel-import-"),
+  );
+  try {
+    writeProject(project);
+    const compilation: ICommandResult = run([
+      "pnpm",
+      "exec",
+      "ttsc",
+      "--emit",
+      "--cwd",
+      project,
+      "-p",
+      "tsconfig.json",
+    ]);
+    if (compilation.status !== 0)
+      throw new Error(
+        `Downlevel internal import compilation failed:\n${compilation.output}`,
+      );
+
+    const output: string = fs.readFileSync(
+      path.join(project, "bin", "random.js"),
+      "utf8",
+    );
+    const binding: RegExpMatchArray | null = output.match(
+      /const\s+([A-Za-z_$][\w$]*)\s*=.*require\(["']typia\/lib\/internal\/_randomNumber["']\)/,
+    );
+    if (binding === null)
+      throw new Error(`Random helper import was not emitted:\n${output}`);
+    if (/^_[a-z]$/.test(binding[1]!))
+      throw new Error(
+        `Random helper import used a temporary-style alias ${binding[1]}:\n${output}`,
+      );
+
+    const execution: ICommandResult = run(
+      [process.execPath, path.join(project, "bin", "random.js")],
+      project,
+    );
+    if (execution.status !== 0)
+      throw new Error(
+        `Downlevel random execution failed:\n${execution.output}`,
+      );
+  } finally {
+    fs.rmSync(project, { recursive: true, force: true });
+  }
+};


### PR DESCRIPTION
## Summary

- replace temp-channel namespace import aliases with cloned unique generated names derived from module specifiers
- keep every import declaration and member reference on the same generated-name id without sharing AST parents
- add an ES2015 compile-and-run regression for `typia.random()` and unit coverage for module-name sanitization
- bump the `typia` package to 13.0.2 because the published native source changed

## Root cause

`ImportProgrammer` passed a module-specifier string literal to `NewGeneratedNameForNode`. TypeScript-Go treats that unsupported node kind as a temporary variable name, so ES2015-ES2019 lowering could allocate the same `_a`-style name inside generated functions and shadow the module-level helper import.

## Validation

- `pnpm format`
- `go -C packages/typia/test test -tags typia_native_internal ../native/core/context`
- `pnpm --filter ./tests/test-typia-cli start`

The focused regression and context tests pass locally. The mandatory Research Review Round, full repository test suite, and GitHub CI are still pending.

Fixes #2017
