### PR TITLE
fix(native): preserve inline JSDoc link text

### DIFF
--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -407,11 +407,100 @@ func metadata_js_doc_comment_text(list *nativeast.NodeList) string {
   }
   parts := []string{}
   for _, node := range list.Nodes {
-    if node != nil {
+    if node == nil {
+      continue
+    }
+    switch node.Kind {
+    case nativeast.KindJSDocText:
       parts = append(parts, node.Text())
+    case nativeast.KindJSDocLink,
+      nativeast.KindJSDocLinkCode,
+      nativeast.KindJSDocLinkPlain:
+      parts = append(parts, metadata_js_doc_link_text(node))
     }
   }
   return metadata_clean_js_doc_text(strings.Join(parts, ""))
+}
+
+func metadata_js_doc_link_text(node *nativeast.Node) string {
+  if node == nil {
+    return ""
+  }
+  name := node.Name()
+  text := strings.Trim(node.Text(), " ")
+  if name == nil {
+    return text
+  }
+  nameText := metadata_js_doc_entity_name_text(name)
+  if (nameText == "http" || nameText == "https") && strings.HasPrefix(text, "://") {
+    target := nameText + text
+    index := strings.IndexAny(target, " |")
+    if index == -1 {
+      return target
+    }
+    label := metadata_js_doc_link_label(target[index:])
+    if label != "" {
+      return label
+    }
+    return target[:index]
+  }
+
+  suffix := ""
+  if strings.HasPrefix(text, "()") {
+    suffix = "()"
+    text = text[2:]
+  }
+  if label := metadata_js_doc_link_label(text); label != "" {
+    return label
+  }
+  return nameText + suffix
+}
+
+func metadata_js_doc_link_label(text string) string {
+  text = strings.TrimLeft(text, " ")
+  text = strings.TrimPrefix(text, "|")
+  return strings.TrimSpace(text)
+}
+
+func metadata_js_doc_entity_name_text(node *nativeast.Node) string {
+  if node == nil {
+    return ""
+  }
+  switch node.Kind {
+  case nativeast.KindIdentifier:
+    return node.Text()
+  case nativeast.KindQualifiedName:
+    name := node.AsQualifiedName()
+    if name == nil {
+      return ""
+    }
+    left := metadata_js_doc_entity_name_text(name.Left)
+    right := metadata_js_doc_entity_name_text(name.Right)
+    if left == "" {
+      return right
+    }
+    if right == "" {
+      return left
+    }
+    return left + "." + right
+  case nativeast.KindPropertyAccessExpression:
+    left := metadata_js_doc_entity_name_text(node.Expression())
+    right := metadata_js_doc_entity_name_text(node.Name())
+    if left == "" {
+      return right
+    }
+    if right == "" {
+      return left
+    }
+    return left + "." + right
+  case nativeast.KindParenthesizedExpression,
+    nativeast.KindExpressionWithTypeArguments:
+    return metadata_js_doc_entity_name_text(node.Expression())
+  case nativeast.KindJSDocNameReference:
+    return metadata_js_doc_entity_name_text(node.Name())
+  default:
+    return ""
+  }
 }
 
 func metadata_clean_js_doc_text(text string) string {

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -474,25 +474,9 @@ func metadata_js_doc_entity_name_text(node *nativeast.Node) string {
     if name == nil {
       return ""
     }
-    left := metadata_js_doc_entity_name_text(name.Left)
-    right := metadata_js_doc_entity_name_text(name.Right)
-    if left == "" {
-      return right
-    }
-    if right == "" {
-      return left
-    }
-    return left + "." + right
+    return metadata_js_doc_entity_name_text(name.Left) + "." + metadata_js_doc_entity_name_text(name.Right)
   case nativeast.KindPropertyAccessExpression:
-    left := metadata_js_doc_entity_name_text(node.Expression())
-    right := metadata_js_doc_entity_name_text(node.Name())
-    if left == "" {
-      return right
-    }
-    if right == "" {
-      return left
-    }
-    return left + "." + right
+    return metadata_js_doc_entity_name_text(node.Expression()) + "." + metadata_js_doc_entity_name_text(node.Name())
   case nativeast.KindParenthesizedExpression,
     nativeast.KindExpressionWithTypeArguments:
     return metadata_js_doc_entity_name_text(node.Expression())

--- a/packages/typia/native/core/factories/internal/metadata/js_doc_link_text_test.go
+++ b/packages/typia/native/core/factories/internal/metadata/js_doc_link_text_test.go
@@ -19,7 +19,7 @@ import (
 // metadata consumers keep qualified targets, normalized labels, URLs, and tag
 // comments without depending only on an application-programmer integration.
 //
-// 1. Parse a property comment containing plain, qualified, labelled, URL, and
+// 1. Parse a property comment containing plain, qualified, labeled, URL, and
 // unresolved links, plus a link inside a JSDoc tag.
 // 2. Reflect the property's description and tags through the metadata helpers.
 // 3. Assert the visible text and punctuation are preserved deterministically.

--- a/packages/typia/native/core/factories/internal/metadata/js_doc_link_text_test.go
+++ b/packages/typia/native/core/factories/internal/metadata/js_doc_link_text_test.go
@@ -21,7 +21,8 @@ import (
 // integration.
 //
 // 1. Parse a property comment containing plain, qualified, labeled, URL, and
-// unresolved links, empty labels, call suffixes, plus a link inside a JSDoc tag.
+// unresolved and malformed links, empty labels, call suffixes, plus a link
+// inside a JSDoc tag.
 // 2. Reflect the property's description and tags through the metadata helpers.
 // 3. Assert the visible text and punctuation are preserved deterministically.
 func TestJsDocLinkText(t *testing.T) {
@@ -37,6 +38,7 @@ interface IBox {
    * {@linkplain ITarget.value}; {@link MissingTarget};
    * {@link https://example.com/docs}; {@link https://example.com/docs | docs}.
    * {@link ITarget | }; {@link makeTarget()}; {@link makeTarget() | maker}.
+   * {@link Missing.};
    * @title {@link ITarget titled target}
    */
   field: string;
@@ -54,7 +56,7 @@ interface IBox {
   if description == nil {
     t.Fatal("description was not reflected")
   }
-  if *description != "Plain; ITarget; ITarget.value;\nlabel; ITarget;\nITarget.value; MissingTarget;\nhttps://example.com/docs; docs.\nITarget; makeTarget(); maker." {
+  if *description != "Plain; ITarget; ITarget.value;\nlabel; ITarget;\nITarget.value; MissingTarget;\nhttps://example.com/docs; docs.\nITarget; makeTarget(); maker.\nMissing.;" {
     t.Fatalf("unexpected description: %q", *description)
   }
   tags := metadata_node_js_doc_tags(symbol)

--- a/packages/typia/native/core/factories/internal/metadata/js_doc_link_text_test.go
+++ b/packages/typia/native/core/factories/internal/metadata/js_doc_link_text_test.go
@@ -16,11 +16,12 @@ import (
 //
 // JSDoc link nodes split their entity target into Name() and their optional
 // display label into Text(). This test pins the shared renderer directly so all
-// metadata consumers keep qualified targets, normalized labels, URLs, and tag
-// comments without depending only on an application-programmer integration.
+// metadata consumers keep qualified targets, normalized labels, call suffixes,
+// URLs, and tag comments without depending only on an application-programmer
+// integration.
 //
 // 1. Parse a property comment containing plain, qualified, labeled, URL, and
-// unresolved links, plus a link inside a JSDoc tag.
+// unresolved links, empty labels, call suffixes, plus a link inside a JSDoc tag.
 // 2. Reflect the property's description and tags through the metadata helpers.
 // 3. Assert the visible text and punctuation are preserved deterministically.
 func TestJsDocLinkText(t *testing.T) {
@@ -35,6 +36,7 @@ interface IBox {
    * {@link ITarget | label}; {@linkcode ITarget};
    * {@linkplain ITarget.value}; {@link MissingTarget};
    * {@link https://example.com/docs}; {@link https://example.com/docs | docs}.
+   * {@link ITarget | }; {@link makeTarget()}; {@link makeTarget() | maker}.
    * @title {@link ITarget titled target}
    */
   field: string;
@@ -52,11 +54,14 @@ interface IBox {
   if description == nil {
     t.Fatal("description was not reflected")
   }
-  if *description != "Plain; ITarget; ITarget.value;\nlabel; ITarget;\nITarget.value; MissingTarget;\nhttps://example.com/docs; docs." {
+  if *description != "Plain; ITarget; ITarget.value;\nlabel; ITarget;\nITarget.value; MissingTarget;\nhttps://example.com/docs; docs.\nITarget; makeTarget(); maker." {
     t.Fatalf("unexpected description: %q", *description)
   }
   tags := metadata_node_js_doc_tags(symbol)
   if len(tags) != 1 || tags[0].Name != "title" || len(tags[0].Text) != 1 || tags[0].Text[0].Text != "titled target" {
     t.Fatalf("unexpected tags: %#v", tags)
+  }
+  if metadata_js_doc_link_text(nil) != "" {
+    t.Fatal("nil JSDoc link should render empty text")
   }
 }

--- a/packages/typia/native/core/factories/internal/metadata/js_doc_link_text_test.go
+++ b/packages/typia/native/core/factories/internal/metadata/js_doc_link_text_test.go
@@ -1,0 +1,62 @@
+//go:build typia_native_internal
+// +build typia_native_internal
+
+package metadata
+
+import (
+  "path/filepath"
+  "testing"
+
+  nativeast "github.com/microsoft/typescript-go/shim/ast"
+  nativecore "github.com/microsoft/typescript-go/shim/core"
+  nativeparser "github.com/microsoft/typescript-go/shim/parser"
+)
+
+// TestJsDocLinkText verifies the metadata helper renders visible inline links.
+//
+// JSDoc link nodes split their entity target into Name() and their optional
+// display label into Text(). This test pins the shared renderer directly so all
+// metadata consumers keep qualified targets, normalized labels, URLs, and tag
+// comments without depending only on an application-programmer integration.
+//
+// 1. Parse a property comment containing plain, qualified, labelled, URL, and
+// unresolved links, plus a link inside a JSDoc tag.
+// 2. Reflect the property's description and tags through the metadata helpers.
+// 3. Assert the visible text and punctuation are preserved deterministically.
+func TestJsDocLinkText(t *testing.T) {
+  file := nativeparser.ParseSourceFile(
+    nativeast.SourceFileParseOptions{FileName: filepath.ToSlash(filepath.Join(t.TempDir(), "links.ts"))},
+    `interface ITarget {
+  value: string;
+}
+interface IBox {
+  /**
+   * Plain; {@link ITarget}; {@link ITarget.value};
+   * {@link ITarget | label}; {@linkcode ITarget};
+   * {@linkplain ITarget.value}; {@link MissingTarget};
+   * {@link https://example.com/docs}; {@link https://example.com/docs | docs}.
+   * @title {@link ITarget titled target}
+   */
+  field: string;
+}
+`,
+    nativecore.ScriptKindTS,
+  )
+  member := file.Statements.Nodes[1].AsInterfaceDeclaration().Members.Nodes[0]
+  symbol := &nativeast.Symbol{
+    Name:             "field",
+    ValueDeclaration: member,
+    Declarations:     []*nativeast.Node{member},
+  }
+  description := metadata_node_description(symbol)
+  if description == nil {
+    t.Fatal("description was not reflected")
+  }
+  if *description != "Plain; ITarget; ITarget.value;\nlabel; ITarget;\nITarget.value; MissingTarget;\nhttps://example.com/docs; docs." {
+    t.Fatalf("unexpected description: %q", *description)
+  }
+  tags := metadata_node_js_doc_tags(symbol)
+  if len(tags) != 1 || tags[0].Name != "title" || len(tags[0].Text) != 1 || tags[0].Text[0].Text != "titled target" {
+    t.Fatalf("unexpected tags: %#v", tags)
+  }
+}

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_jsdoc_link_text.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_jsdoc_link_text.ts
@@ -1,0 +1,159 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+interface ITarget {
+  value: string;
+}
+
+/** Status for {@link ITarget | target operations}. */
+type Status = "active" | "inactive";
+
+/**
+ * Request for {@link ITarget}; see {@link ITarget.value}.
+ *
+ * Adjacent links keep punctuation: {@link ITarget}/{@linkplain ITarget.value}.
+ */
+interface IProps {
+  /** Plain prose must remain unchanged. */
+  plain: string;
+
+  /** Must match {@link ITarget}; see {@link ITarget.value}. */
+  target: string;
+
+  /** Render {@link ITarget | the target contract}. */
+  labelled: string;
+
+  /** Render {@link ITarget the target contract}. */
+  labelledWithoutPipe: string;
+
+  /** Render {@linkcode ITarget} and {@linkplain ITarget.value}. */
+  variants: string;
+
+  /**
+   * Visit {@link https://example.com/docs} or
+   * {@link https://example.com/docs | docs}.
+   */
+  url: string;
+
+  /** Keep {@link UnresolvedTarget}. */
+  unresolved: string;
+
+  /**
+   * Titled property.
+   *
+   * @title {@link ITarget | Target title}
+   */
+  titled: string;
+
+  status: Status;
+}
+
+interface IResult {
+  status: Status;
+}
+
+/**
+ * Application for {@link ITarget}.
+ *
+ * @summary {@link ITarget | Linked application}
+ */
+interface IApplication {
+  /** Process one {@link ITarget}; see {@linkcode ITarget.value}. */
+  process(props: IProps): IResult;
+}
+
+/**
+ * Verifies reflected descriptions preserve visible inline JSDoc link text.
+ *
+ * TypeScript-Go stores a JSDoc link's entity target in `Name()` and only its
+ * trailing display text in `Text()`. The shared native metadata renderer must
+ * combine both fields before JSON Schema and LLM application generation;
+ * otherwise target-only links disappear and pipe labels leak their separator.
+ * This case also pins ordinary prose, URL, unresolved-name, adjacent-link, and
+ * JSDoc-tag behavior through the published transform surface.
+ *
+ * 1. Describe an application, function, named interface, alias, and properties
+ *    with plain, target-only, qualified, labelled, URL, and variant links.
+ * 2. Generate JSON Schema and LLM application metadata through normal typia calls.
+ * 3. Assert every reflected description keeps its visible text and punctuation
+ *    while tag labels lose the optional pipe separator.
+ */
+export const test_json_schema_jsdoc_link_text = (): void => {
+  const json = typia.json.application<IApplication>();
+  const schemas = json.components.schemas ?? {};
+  const props = schemas.IProps as
+    | {
+        description?: string;
+        properties?: Record<string, { description?: string; title?: string }>;
+      }
+    | undefined;
+  const status = schemas.Status as { description?: string } | undefined;
+
+  TestValidator.equals(
+    "named interface links",
+    props?.description,
+    [
+      "Request for ITarget; see ITarget.value.",
+      "",
+      "Adjacent links keep punctuation: ITarget/ITarget.value.",
+    ].join("\n"),
+  );
+  TestValidator.equals(
+    "named alias link label",
+    status?.description,
+    "Status for target operations.",
+  );
+  TestValidator.equals(
+    "plain prose",
+    props?.properties?.plain?.description,
+    "Plain prose must remain unchanged.",
+  );
+  TestValidator.equals(
+    "target and qualified member links",
+    props?.properties?.target?.description,
+    "Must match ITarget; see ITarget.value.",
+  );
+  TestValidator.equals(
+    "pipe label",
+    props?.properties?.labelled?.description,
+    "Render the target contract.",
+  );
+  TestValidator.equals(
+    "space label",
+    props?.properties?.labelledWithoutPipe?.description,
+    "Render the target contract.",
+  );
+  TestValidator.equals(
+    "link variants",
+    props?.properties?.variants?.description,
+    "Render ITarget and ITarget.value.",
+  );
+  TestValidator.equals(
+    "URL links",
+    props?.properties?.url?.description,
+    "Visit https://example.com/docs or docs.",
+  );
+  TestValidator.equals(
+    "unresolved target link",
+    props?.properties?.unresolved?.description,
+    "Keep UnresolvedTarget.",
+  );
+  TestValidator.equals(
+    "JSDoc tag link label",
+    props?.properties?.titled?.title,
+    "Target title",
+  );
+
+  const llm = typia.llm.application<IApplication>();
+  const func = llm.functions.find((candidate) => candidate.name === "process");
+  TestValidator.equals(
+    "application summary link label",
+    llm.description,
+    "Linked application.\n\nApplication for ITarget.",
+  );
+  TestValidator.equals(
+    "function links",
+    func?.description,
+    "Process one ITarget; see ITarget.value.",
+  );
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_jsdoc_link_text.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_jsdoc_link_text.ts
@@ -29,10 +29,7 @@ interface IProps {
   /** Render {@linkcode ITarget} and {@linkplain ITarget.value}. */
   variants: string;
 
-  /**
-   * Visit {@link https://example.com/docs} or
-   * {@link https://example.com/docs | docs}.
-   */
+  /** Visit {@link https://x.io/docs} or {@link https://x.io/docs | docs}. */
   url: string;
 
   /** Keep {@link UnresolvedTarget}. */
@@ -131,7 +128,7 @@ export const test_json_schema_jsdoc_link_text = (): void => {
   TestValidator.equals(
     "URL links",
     props?.properties?.url?.description,
-    "Visit https://example.com/docs or\ndocs.",
+    "Visit https://x.io/docs or docs.",
   );
   TestValidator.equals(
     "unresolved target link",

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_jsdoc_link_text.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_jsdoc_link_text.ts
@@ -131,7 +131,7 @@ export const test_json_schema_jsdoc_link_text = (): void => {
   TestValidator.equals(
     "URL links",
     props?.properties?.url?.description,
-    "Visit https://example.com/docs or docs.",
+    "Visit https://example.com/docs or\ndocs.",
   );
   TestValidator.equals(
     "unresolved target link",

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_jsdoc_link_text.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_jsdoc_link_text.ts
@@ -21,10 +21,10 @@ interface IProps {
   target: string;
 
   /** Render {@link ITarget | the target contract}. */
-  labelled: string;
+  labeled: string;
 
   /** Render {@link ITarget the target contract}. */
-  labelledWithoutPipe: string;
+  labeledWithoutPipe: string;
 
   /** Render {@linkcode ITarget} and {@linkplain ITarget.value}. */
   variants: string;
@@ -73,7 +73,7 @@ interface IApplication {
  * JSDoc-tag behavior through the published transform surface.
  *
  * 1. Describe an application, function, named interface, alias, and properties
- *    with plain, target-only, qualified, labelled, URL, and variant links.
+ *    with plain, target-only, qualified, labeled, URL, and variant links.
  * 2. Generate JSON Schema and LLM application metadata through normal typia calls.
  * 3. Assert every reflected description keeps its visible text and punctuation
  *    while tag labels lose the optional pipe separator.
@@ -115,12 +115,12 @@ export const test_json_schema_jsdoc_link_text = (): void => {
   );
   TestValidator.equals(
     "pipe label",
-    props?.properties?.labelled?.description,
+    props?.properties?.labeled?.description,
     "Render the target contract.",
   );
   TestValidator.equals(
     "space label",
-    props?.properties?.labelledWithoutPipe?.description,
+    props?.properties?.labeledWithoutPipe?.description,
     "Render the target contract.",
   );
   TestValidator.equals(


### PR DESCRIPTION
## Summary

- render inline JSDoc links from their AST entity name and display text in the shared native metadata helper
- preserve qualified targets, normalize pipe/space labels, retain URLs and call suffixes, and handle `link`, `linkcode`, and `linkplain` consistently as plain reflected text
- preserve malformed qualified-name punctuation consistently with TypeScript-Go
- add direct native-parser and published JSON Schema/LLM application regressions
- bump `typia` to 13.1.1 because the changed native source ships in that package

## Root cause

`metadata_js_doc_comment_text` appended only `Node.Text()`. TypeScript-Go stores a link-like JSDoc node's entity target in `Name()` while `Text()` contains trailing display text. Target-only links therefore disappeared, while labeled links exposed their parser tail instead of the visible label.

The fix stays in the common metadata path used by descriptions and JSDoc-tag comments. It traverses supported entity-name AST nodes and follows TypeScript-Go's label-prefix, URL, call-suffix, and qualified-name separator semantics; it does not inspect source strings or add consumer-specific rewriting.

## Behavior

- target-only links render their target, including qualified members
- explicit pipe or space labels render only the visible label
- `linkcode` and `linkplain` retain visible content under typia's plain-text policy
- HTTP(S) target-only links retain the URL and labeled URLs render their label
- unresolved but syntactically valid targets retain their entity name
- malformed qualified targets retain parser-significant separators
- call suffixes, empty labels, surrounding punctuation, newlines, adjacent links, ordinary text, and JSDoc tag comments are covered

## Recursive self-review

The early PR intentionally preceded final cleanup. Each follow-up restarted review from the full new HEAD:

1. CI spell-check exposed fixture/comment wording; corrected in a dedicated commit and verified with the same typos command.
2. The next full self-review found that a long URL fixture depended on Prettier wrapping. It was replaced with a formatter-stable short URL and the semantic one-line expectation restored.
3. The next full self-review found missing direct boundaries for empty labels, call suffixes, and nil input. Those cases were added to the native regression.
4. A fresh parser/LS comparison found that malformed qualified names such as `{@link Missing.}` lost their trailing dot. TypeScript-Go writes qualified-name separators unconditionally, so the renderer and direct regression were corrected in `f75ffe4f10`.
5. The resulting full diff was reread from scratch through parser node construction, language-service display semantics, the shared description/tag callers, the published JSON Schema and LLM paths, package versioning, and all assertions. Nil names, empty labels, URLs, call suffixes, whitespace, newlines, punctuation, unresolved names, and malformed links were rechecked; no further in-scope defect survived.

## Scoped validation

- `go -C packages/typia/test test -tags typia_native_internal ../native/core/factories/internal/metadata -run TestJsDocLinkText -count=1`
- `pnpm --filter ./tests/test-typia-schema start -- --include jsdoc_link_text`
- `pnpm format` with unrelated formatter drift restored
- `typos . --config ./typos.toml` with `typos-cli 1.48.0`
- `git diff --check origin/master...HEAD`
- pushed worktree clean and synchronized with the remote branch

The focused TypeScript test rebuilds the source plugin and covers both published JSON Schema and LLM application output. Per the requested validation scope, no broad/full local suite was run; GitHub Actions remains the broader pinned Node 24 gate.

## Boundary

Reflected descriptions remain plain text: link destinations are not emitted as clickable Markdown, and `linkcode` is not backtick-quoted. The change preserves visible content without changing typia's existing description-format policy.

Fixes #2023
