### PR TITLE
fix(utils): preserve OpenAPI discriminators across conversion

### DIFF
--- a/packages/utils/src/converters/internal/OpenApiDiscriminatorConverter.ts
+++ b/packages/utils/src/converters/internal/OpenApiDiscriminatorConverter.ts
@@ -1,0 +1,10 @@
+import { OpenApi } from "@typia/interface";
+
+export namespace OpenApiDiscriminatorConverter {
+  export const clone = (
+    input: OpenApi.IJsonSchema.IOneOf.IDiscriminator,
+  ): OpenApi.IJsonSchema.IOneOf.IDiscriminator => ({
+    propertyName: input.propertyName,
+    ...(input.mapping !== undefined ? { mapping: { ...input.mapping } } : {}),
+  });
+}

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -220,6 +220,8 @@ export namespace OpenApiV3Downgrader {
         OpenApiTypeChecker.isOneOf(input) && input.discriminator !== undefined
           ? OpenApiDiscriminatorConverter.clone(input.discriminator)
           : undefined;
+      let preserveDiscriminator: boolean =
+        discriminator !== undefined && nullable === false;
       const attribute: OpenApiV3.IJsonSchema.__IAttribute = {
         title: input.title,
         description: input.description,
@@ -300,8 +302,16 @@ export namespace OpenApiV3Downgrader {
                   : schema.additionalProperties,
             required: schema.required,
           });
-        } else if (OpenApiTypeChecker.isOneOf(schema))
-          schema.oneOf.forEach(visit);
+        } else if (OpenApiTypeChecker.isOneOf(schema)) {
+          const tracked: boolean =
+            schema === input && discriminator !== undefined;
+          for (const branch of schema.oneOf) {
+            const previous: number = union.length;
+            visit(branch);
+            if (tracked && union.length !== previous + 1)
+              preserveDiscriminator = false;
+          }
+        }
       };
       const visitConstant = (schema: OpenApi.IJsonSchema): void => {
         const insert = (value: any): void => {
@@ -335,7 +345,9 @@ export namespace OpenApiV3Downgrader {
             ? { ...union[0] }
             : {
                 oneOf: union,
-                ...(discriminator !== undefined ? { discriminator } : {}),
+                ...(preserveDiscriminator && discriminator !== undefined
+                  ? { discriminator }
+                  : {}),
               }),
         ...attribute,
       };

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -1,6 +1,7 @@
 import { OpenApi, OpenApiV3 } from "@typia/interface";
 
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
+import { OpenApiDiscriminatorConverter } from "./OpenApiDiscriminatorConverter";
 
 export namespace OpenApiV3Downgrader {
   export interface IComponentsCollection {
@@ -213,6 +214,12 @@ export namespace OpenApiV3Downgrader {
         input,
       );
       const union: OpenApiV3.IJsonSchema[] = [];
+      const discriminator:
+        | OpenApiV3.IJsonSchema.IOneOf.IDiscriminator
+        | undefined =
+        OpenApiTypeChecker.isOneOf(input) && input.discriminator !== undefined
+          ? OpenApiDiscriminatorConverter.clone(input.discriminator)
+          : undefined;
       const attribute: OpenApiV3.IJsonSchema.__IAttribute = {
         title: input.title,
         description: input.description,
@@ -326,7 +333,10 @@ export namespace OpenApiV3Downgrader {
           ? { type: undefined }
           : union.length === 1
             ? { ...union[0] }
-            : { oneOf: union }),
+            : {
+                oneOf: union,
+                ...(discriminator !== undefined ? { discriminator } : {}),
+              }),
         ...attribute,
       };
     };

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -319,6 +319,7 @@ export namespace OpenApiV3Upgrader {
         OpenApiV3TypeChecker.isOneOf(input) && input.discriminator !== undefined
           ? OpenApiDiscriminatorConverter.clone(input.discriminator)
           : undefined;
+      let preserveDiscriminator: boolean = discriminator !== undefined;
       const attribute: IJsonSchemaAttribute = {
         title: input.title,
         description: input.description,
@@ -349,9 +350,22 @@ export namespace OpenApiV3Upgrader {
           nullable.value ||= true;
         // UNION TYPE CASE
         if (OpenApiV3TypeChecker.isAnyOf(schema)) schema.anyOf.forEach(visit);
-        else if (OpenApiV3TypeChecker.isOneOf(schema))
-          schema.oneOf.forEach(visit);
-        else if (OpenApiV3TypeChecker.isAllOf(schema))
+        else if (OpenApiV3TypeChecker.isOneOf(schema)) {
+          const tracked: boolean =
+            schema === input && discriminator !== undefined;
+          if (tracked && nullable.value) preserveDiscriminator = false;
+          for (const branch of schema.oneOf) {
+            const previous: number = union.length;
+            const previousNullable: boolean = nullable.value;
+            visit(branch);
+            if (
+              tracked &&
+              (union.length !== previous + 1 ||
+                nullable.value !== previousNullable)
+            )
+              preserveDiscriminator = false;
+          }
+        } else if (OpenApiV3TypeChecker.isAllOf(schema))
           if (schema.allOf.length === 1) visit(schema.allOf[0]!);
           else union.push(convertAllOfSchema(components)(schema));
         // ATOMIC TYPE CASE (CONSIDER ENUM VALUES)
@@ -478,7 +492,9 @@ export namespace OpenApiV3Upgrader {
             ? { ...union[0] }
             : {
                 oneOf: union.map((u) => ({ ...u, nullable: undefined })),
-                ...(discriminator !== undefined ? { discriminator } : {}),
+                ...(preserveDiscriminator && discriminator !== undefined
+                  ? { discriminator }
+                  : {}),
               }),
         ...attribute,
         ...{ nullable: undefined },

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -2,6 +2,7 @@ import { IJsonSchemaAttribute, OpenApi, OpenApiV3 } from "@typia/interface";
 
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { OpenApiV3TypeChecker } from "../../validators/OpenApiV3TypeChecker";
+import { OpenApiDiscriminatorConverter } from "./OpenApiDiscriminatorConverter";
 import { OpenApiExclusiveEmender } from "./OpenApiExclusiveEmender";
 
 export namespace OpenApiV3Upgrader {
@@ -312,6 +313,12 @@ export namespace OpenApiV3Upgrader {
         default: undefined,
       };
       const union: OpenApi.IJsonSchema[] = [];
+      const discriminator:
+        | OpenApi.IJsonSchema.IOneOf.IDiscriminator
+        | undefined =
+        OpenApiV3TypeChecker.isOneOf(input) && input.discriminator !== undefined
+          ? OpenApiDiscriminatorConverter.clone(input.discriminator)
+          : undefined;
       const attribute: IJsonSchemaAttribute = {
         title: input.title,
         description: input.description,
@@ -469,7 +476,10 @@ export namespace OpenApiV3Upgrader {
           ? { type: undefined }
           : union.length === 1
             ? { ...union[0] }
-            : { oneOf: union.map((u) => ({ ...u, nullable: undefined })) }),
+            : {
+                oneOf: union.map((u) => ({ ...u, nullable: undefined })),
+                ...(discriminator !== undefined ? { discriminator } : {}),
+              }),
         ...attribute,
         ...{ nullable: undefined },
       };

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -1,6 +1,7 @@
 import { OpenApi, OpenApiV3_1 } from "@typia/interface";
 
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
+import { OpenApiDiscriminatorConverter } from "./OpenApiDiscriminatorConverter";
 
 export namespace OpenApiV3_1Downgrader {
   export interface IComponentsCollection {
@@ -228,6 +229,12 @@ export namespace OpenApiV3_1Downgrader {
     (collection: IComponentsCollection) =>
     (input: OpenApi.IJsonSchema): OpenApiV3_1.IJsonSchema => {
       const union: OpenApiV3_1.IJsonSchema[] = [];
+      const discriminator:
+        | OpenApiV3_1.IJsonSchema.IOneOf.IDiscriminator
+        | undefined =
+        OpenApiTypeChecker.isOneOf(input) && input.discriminator !== undefined
+          ? OpenApiDiscriminatorConverter.clone(input.discriminator)
+          : undefined;
       const attribute: OpenApiV3_1.IJsonSchema.__IAttribute = {
         title: input.title,
         description: input.description,
@@ -305,7 +312,10 @@ export namespace OpenApiV3_1Downgrader {
           ? { type: undefined }
           : union.length === 1
             ? { ...union[0] }
-            : { oneOf: union }),
+            : {
+                oneOf: union,
+                ...(discriminator !== undefined ? { discriminator } : {}),
+              }),
         ...attribute,
       };
     };

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -235,6 +235,7 @@ export namespace OpenApiV3_1Downgrader {
         OpenApiTypeChecker.isOneOf(input) && input.discriminator !== undefined
           ? OpenApiDiscriminatorConverter.clone(input.discriminator)
           : undefined;
+      let preserveDiscriminator: boolean = discriminator !== undefined;
       const attribute: OpenApiV3_1.IJsonSchema.__IAttribute = {
         title: input.title,
         description: input.description,
@@ -303,8 +304,16 @@ export namespace OpenApiV3_1Downgrader {
                   : schema.additionalProperties,
             required: schema.required,
           });
-        else if (OpenApiTypeChecker.isOneOf(schema))
-          schema.oneOf.forEach(visit);
+        else if (OpenApiTypeChecker.isOneOf(schema)) {
+          const tracked: boolean =
+            schema === input && discriminator !== undefined;
+          for (const branch of schema.oneOf) {
+            const previous: number = union.length;
+            visit(branch);
+            if (tracked && union.length !== previous + 1)
+              preserveDiscriminator = false;
+          }
+        }
       };
       visit(input);
       return {
@@ -314,7 +323,9 @@ export namespace OpenApiV3_1Downgrader {
             ? { ...union[0] }
             : {
                 oneOf: union,
-                ...(discriminator !== undefined ? { discriminator } : {}),
+                ...(preserveDiscriminator && discriminator !== undefined
+                  ? { discriminator }
+                  : {}),
               }),
         ...attribute,
       };

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -349,6 +349,7 @@ export namespace OpenApiV3_1Upgrader {
         input.discriminator !== undefined
           ? OpenApiDiscriminatorConverter.clone(input.discriminator)
           : undefined;
+      let preserveDiscriminator: boolean = discriminator !== undefined;
       const attribute: IJsonSchemaAttribute = {
         title: input.title,
         description: input.description,
@@ -460,9 +461,22 @@ export namespace OpenApiV3_1Upgrader {
             else visit({ ...schema, type: type as any });
         }
         // UNION TYPE CASE
-        else if (OpenApiV3_1TypeChecker.isOneOf(schema))
-          schema.oneOf.forEach(visit);
-        else if (OpenApiV3_1TypeChecker.isAnyOf(schema))
+        else if (OpenApiV3_1TypeChecker.isOneOf(schema)) {
+          const tracked: boolean =
+            schema === input && discriminator !== undefined;
+          if (tracked && nullable.value) preserveDiscriminator = false;
+          for (const branch of schema.oneOf) {
+            const previous: number = union.length;
+            const previousNullable: boolean = nullable.value;
+            visit(branch);
+            if (
+              tracked &&
+              (union.length !== previous + 1 ||
+                nullable.value !== previousNullable)
+            )
+              preserveDiscriminator = false;
+          }
+        } else if (OpenApiV3_1TypeChecker.isAnyOf(schema))
           schema.anyOf.forEach(visit);
         else if (OpenApiV3_1TypeChecker.isAllOf(schema))
           if (schema.allOf.length === 1) visit(schema.allOf[0]!);
@@ -691,7 +705,9 @@ export namespace OpenApiV3_1Upgrader {
                   nullable: undefined,
                   $defs: undefined,
                 })),
-                ...(discriminator !== undefined ? { discriminator } : {}),
+                ...(preserveDiscriminator && discriminator !== undefined
+                  ? { discriminator }
+                  : {}),
               }),
         ...attribute,
         ...{

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -2,6 +2,7 @@ import { IJsonSchemaAttribute, OpenApi, OpenApiV3_1 } from "@typia/interface";
 
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { OpenApiV3_1TypeChecker } from "../../validators/OpenApiV3_1TypeChecker";
+import { OpenApiDiscriminatorConverter } from "./OpenApiDiscriminatorConverter";
 import { OpenApiExclusiveEmender } from "./OpenApiExclusiveEmender";
 
 export namespace OpenApiV3_1Upgrader {
@@ -340,6 +341,14 @@ export namespace OpenApiV3_1Upgrader {
     (components: OpenApiV3_1.IComponents) =>
     (input: OpenApiV3_1.IJsonSchema): OpenApi.IJsonSchema => {
       const union: OpenApi.IJsonSchema[] = [];
+      const discriminator:
+        | OpenApi.IJsonSchema.IOneOf.IDiscriminator
+        | undefined =
+        OpenApiV3_1TypeChecker.isMixed(input) === false &&
+        OpenApiV3_1TypeChecker.isOneOf(input) &&
+        input.discriminator !== undefined
+          ? OpenApiDiscriminatorConverter.clone(input.discriminator)
+          : undefined;
       const attribute: IJsonSchemaAttribute = {
         title: input.title,
         description: input.description,
@@ -682,6 +691,7 @@ export namespace OpenApiV3_1Upgrader {
                   nullable: undefined,
                   $defs: undefined,
                 })),
+                ...(discriminator !== undefined ? { discriminator } : {}),
               }),
         ...attribute,
         ...{

--- a/tests/test-utils/src/features/openapi/test_openapi_converter_discriminator.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_converter_discriminator.ts
@@ -1,0 +1,326 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3, OpenApiV3_1, OpenApiV3_2 } from "@typia/interface";
+import { OpenApiConverter } from "@typia/utils";
+import typia, { IJsonSchemaCollection } from "typia";
+
+/**
+ * Verifies OpenAPI 3.x conversion preserves valid discriminators.
+ *
+ * The v3.1 schema upgrader normalizes composite schemas into a fresh `oneOf`. A
+ * discriminator belongs to that topology only while a source `oneOf` still
+ * produces a `oneOf`; synthetic or collapsed unions must not inherit it.
+ *
+ * 1. Upgrade and downgrade a generated tagged union through every 3.x path.
+ * 2. Exercise mapping-less and nested discriminators plus input immutability.
+ * 3. Assert synthetic, collapsed, and Swagger 2.0 controls stay untagged.
+ */
+export const test_openapi_converter_discriminator = (): void => {
+  for (const version of ["3.0", "3.1", "3.2"] as const) {
+    const fixture: IFixture = createFixture();
+    const before: string = JSON.stringify(fixture.components);
+    const outputs: OpenApi.IJsonSchema[] =
+      version === "3.0"
+        ? upgradeV30(fixture)
+        : version === "3.1"
+          ? upgradeV31(fixture)
+          : upgradeV32(fixture);
+
+    for (const [index, output] of outputs.entries())
+      TestValidator.equals(
+        `${version} public upgrade path ${index}`,
+        clean(output),
+        clean(fixture.choice),
+      );
+    TestValidator.equals(
+      `${version} mapping order`,
+      Object.entries(
+        (outputs[0] as OpenApi.IJsonSchema.IOneOf).discriminator!.mapping!,
+      ),
+      [
+        ["a", "#/components/schemas/IOptionA"],
+        ["b", "#/components/schemas/IOptionB"],
+      ],
+    );
+    TestValidator.equals(
+      `${version} input immutability`,
+      JSON.stringify(fixture.components),
+      before,
+    );
+    TestValidator.predicate(
+      `${version} discriminator is copied`,
+      (outputs[0] as OpenApi.IJsonSchema.IOneOf).discriminator !==
+        fixture.choice.discriminator,
+    );
+    TestValidator.predicate(
+      `${version} mapping is copied`,
+      (outputs[0] as OpenApi.IJsonSchema.IOneOf).discriminator!.mapping !==
+        fixture.choice.discriminator!.mapping,
+    );
+  }
+  for (const version of ["3.0", "3.1"] as const) {
+    const fixture: IFixture = createFixture();
+    const before: string = JSON.stringify(fixture.components);
+    const outputs: Array<OpenApiV3.IJsonSchema | OpenApiV3_1.IJsonSchema> =
+      version === "3.0" ? downgradeV30(fixture) : downgradeV31(fixture);
+
+    for (const [index, output] of outputs.entries())
+      TestValidator.equals(
+        `${version} public downgrade path ${index}`,
+        clean(output),
+        clean(fixture.choice),
+      );
+    TestValidator.equals(
+      `${version} downgrade input immutability`,
+      JSON.stringify(fixture.components),
+      before,
+    );
+    TestValidator.predicate(
+      `${version} downgraded discriminator is copied`,
+      (outputs[0] as OpenApiV3.IJsonSchema.IOneOf).discriminator !==
+        fixture.choice.discriminator,
+    );
+  }
+
+  const nestedFixture: IFixture = createFixture();
+  const nestedInput: OpenApiV3_1.IJsonSchema.IObject = {
+    type: "object",
+    properties: {
+      explicit: toV31Schema(nestedFixture.choice),
+      implicit: {
+        oneOf: nestedFixture.choice.oneOf.map(toV31Schema),
+        discriminator: {
+          propertyName: "category",
+        },
+      },
+    },
+    required: ["explicit", "implicit"],
+  };
+  const nested: OpenApi.IJsonSchema = OpenApiConverter.upgradeSchema({
+    components: toV31Components(nestedFixture.components),
+    schema: nestedInput,
+  });
+  TestValidator.equals("nested discriminators", clean(nested), {
+    type: "object",
+    properties: {
+      explicit: clean(nestedFixture.choice),
+      implicit: {
+        oneOf: clean(nestedFixture.choice.oneOf),
+        discriminator: {
+          propertyName: "category",
+        },
+      },
+    },
+    required: ["explicit", "implicit"],
+  });
+
+  TestValidator.equals(
+    "nullable atomic union",
+    clean(
+      OpenApiConverter.upgradeSchema({
+        components: {},
+        schema: { type: "string", nullable: true },
+      }),
+    ),
+    {
+      oneOf: [{ type: "string" }, { type: "null" }],
+    },
+  );
+  TestValidator.equals(
+    "ordinary anyOf union",
+    clean(
+      OpenApiConverter.upgradeSchema({
+        components: {},
+        schema: { anyOf: [{ type: "string" }, { type: "number" }] },
+      }),
+    ),
+    {
+      oneOf: [{ type: "string" }, { type: "number" }],
+    },
+  );
+  TestValidator.equals(
+    "enum-derived union",
+    clean(
+      OpenApiConverter.upgradeSchema({
+        components: {},
+        schema: { type: "string", enum: ["alpha", "beta"] },
+      }),
+    ),
+    {
+      oneOf: [{ const: "alpha" }, { const: "beta" }],
+    },
+  );
+
+  const collapsedFixture: IFixture = createFixture();
+  const branch: OpenApi.IJsonSchema = collapsedFixture.choice.oneOf[0]!;
+  TestValidator.equals(
+    "collapsed oneOf",
+    clean(
+      OpenApiConverter.upgradeSchema({
+        components: toV31Components(collapsedFixture.components),
+        schema: {
+          oneOf: [toV31Schema(branch)],
+          discriminator: {
+            propertyName: "kind",
+            mapping: { a: "#/components/schemas/IOptionA" },
+          },
+        },
+      }),
+    ),
+    clean(branch),
+  );
+
+  const swaggerFixture: IFixture = createFixture();
+  const swagger = OpenApiConverter.downgradeSchema({
+    components: swaggerFixture.components,
+    schema: swaggerFixture.choice,
+    version: "2.0",
+    downgraded: {},
+  });
+  TestValidator.predicate(
+    "Swagger 2.0 does not misrepresent OpenAPI mapping metadata",
+    !("discriminator" in swagger),
+  );
+};
+
+interface IOptionA {
+  kind: "a";
+  value: string;
+}
+
+interface IOptionB {
+  kind: "b";
+  label: string;
+}
+
+interface IFixture {
+  components: OpenApi.IComponents;
+  choice: OpenApi.IJsonSchema.IOneOf;
+}
+
+const createFixture = (): IFixture => {
+  const collection: IJsonSchemaCollection =
+    typia.json.schemas<[IOptionA | IOptionB]>();
+  const generated: OpenApi.IJsonSchema = collection.schemas[0]!;
+  if (!("oneOf" in generated))
+    throw new Error("Failed to generate the IOptionA | IOptionB union schema.");
+
+  const choice: OpenApi.IJsonSchema.IOneOf = {
+    oneOf: generated.oneOf,
+    discriminator: {
+      propertyName: "kind",
+      mapping: {
+        a: "#/components/schemas/IOptionA",
+        b: "#/components/schemas/IOptionB",
+      },
+    },
+  };
+  return {
+    components: {
+      ...collection.components,
+      schemas: {
+        ...collection.components.schemas,
+        Choice: choice,
+      },
+    },
+    choice,
+  };
+};
+
+const upgradeV31 = (fixture: IFixture): OpenApi.IJsonSchema[] => {
+  const components: OpenApiV3_1.IComponents = toV31Components(
+    fixture.components,
+  );
+  const schema: OpenApiV3_1.IJsonSchema = toV31Schema(fixture.choice);
+  return [
+    OpenApiConverter.upgradeSchema({ components, schema }),
+    OpenApiConverter.upgradeComponents(components).schemas!.Choice!,
+    OpenApiConverter.upgradeDocument({
+      openapi: "3.1.1",
+      components,
+      paths: {},
+    }).components.schemas!.Choice!,
+  ];
+};
+
+const upgradeV30 = (fixture: IFixture): OpenApi.IJsonSchema[] => {
+  const components: OpenApiV3.IComponents = toV30Components(fixture.components);
+  const schema: OpenApiV3.IJsonSchema = toV30Schema(fixture.choice);
+  return [
+    OpenApiConverter.upgradeSchema({ components, schema }),
+    OpenApiConverter.upgradeComponents(components).schemas!.Choice!,
+    OpenApiConverter.upgradeDocument({
+      openapi: "3.0.4",
+      components,
+      paths: {},
+    }).components.schemas!.Choice!,
+  ];
+};
+
+const upgradeV32 = (fixture: IFixture): OpenApi.IJsonSchema[] => {
+  const components: OpenApiV3_2.IComponents = toV32Components(
+    fixture.components,
+  );
+  const schema: OpenApiV3_2.IJsonSchema = toV32Schema(fixture.choice);
+  return [
+    OpenApiConverter.upgradeSchema({ components, schema }),
+    OpenApiConverter.upgradeComponents(components).schemas!.Choice!,
+    OpenApiConverter.upgradeDocument({
+      openapi: "3.2.0",
+      components,
+      paths: {},
+    }).components.schemas!.Choice!,
+  ];
+};
+
+const downgradeV30 = (fixture: IFixture): OpenApiV3.IJsonSchema[] => [
+  OpenApiConverter.downgradeSchema({
+    components: fixture.components,
+    schema: fixture.choice,
+    version: "3.0",
+    downgraded: {},
+  }),
+  OpenApiConverter.downgradeComponents(fixture.components, "3.0").schemas!
+    .Choice!,
+  OpenApiConverter.downgradeDocument(createDocument(fixture), "3.0").components!
+    .schemas!.Choice!,
+];
+
+const downgradeV31 = (fixture: IFixture): OpenApiV3_1.IJsonSchema[] => [
+  OpenApiConverter.downgradeSchema({
+    components: fixture.components,
+    schema: fixture.choice,
+    version: "3.1",
+    downgraded: {},
+  }),
+  OpenApiConverter.downgradeComponents(fixture.components, "3.1").schemas!
+    .Choice!,
+  OpenApiConverter.downgradeDocument(createDocument(fixture), "3.1").components!
+    .schemas!.Choice!,
+];
+
+const createDocument = (fixture: IFixture): OpenApi.IDocument => ({
+  openapi: "3.2.0",
+  "x-typia-emended-v12": true,
+  components: fixture.components,
+  paths: {},
+});
+
+const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const toV31Components = (input: OpenApi.IComponents): OpenApiV3_1.IComponents =>
+  typia.assert<OpenApiV3_1.IComponents>(input);
+
+const toV30Components = (input: OpenApi.IComponents): OpenApiV3.IComponents =>
+  typia.assert<OpenApiV3.IComponents>(input);
+
+const toV32Components = (input: OpenApi.IComponents): OpenApiV3_2.IComponents =>
+  typia.assert<OpenApiV3_2.IComponents>(input);
+
+const toV31Schema = (input: OpenApi.IJsonSchema): OpenApiV3_1.IJsonSchema =>
+  typia.assert<OpenApiV3_1.IJsonSchema>(input);
+
+const toV30Schema = (input: OpenApi.IJsonSchema): OpenApiV3.IJsonSchema =>
+  typia.assert<OpenApiV3.IJsonSchema>(input);
+
+const toV32Schema = (input: OpenApi.IJsonSchema): OpenApiV3_2.IJsonSchema =>
+  typia.assert<OpenApiV3_2.IJsonSchema>(input);

--- a/tests/test-utils/src/features/openapi/test_openapi_converter_discriminator.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_converter_discriminator.ts
@@ -15,15 +15,11 @@ import typia, { IJsonSchemaCollection } from "typia";
  * 3. Assert synthetic, collapsed, and Swagger 2.0 controls stay untagged.
  */
 export const test_openapi_converter_discriminator = (): void => {
-  for (const version of ["3.0", "3.1", "3.2"] as const) {
+  for (const version of ["3.1", "3.2"] as const) {
     const fixture: IFixture = createFixture();
     const before: string = JSON.stringify(fixture.components);
     const outputs: OpenApi.IJsonSchema[] =
-      version === "3.0"
-        ? upgradeV30(fixture)
-        : version === "3.1"
-          ? upgradeV31(fixture)
-          : upgradeV32(fixture);
+      version === "3.1" ? upgradeV31(fixture) : upgradeV32(fixture);
 
     for (const [index, output] of outputs.entries())
       TestValidator.equals(
@@ -55,6 +51,38 @@ export const test_openapi_converter_discriminator = (): void => {
       `${version} mapping is copied`,
       (outputs[0] as OpenApi.IJsonSchema.IOneOf).discriminator!.mapping !==
         fixture.choice.discriminator!.mapping,
+    );
+  }
+  {
+    const fixture: IV30Fixture = createV30Fixture();
+    const before: string = JSON.stringify(fixture.components);
+    const outputs: OpenApi.IJsonSchema[] = upgradeV30(fixture);
+
+    for (const [index, output] of outputs.entries())
+      TestValidator.equals(
+        `3.0 public upgrade path ${index}`,
+        clean(output),
+        clean(fixture.choice),
+      );
+    TestValidator.equals(
+      "3.0 mapping order",
+      Object.entries(
+        (outputs[0] as OpenApi.IJsonSchema.IOneOf).discriminator!.mapping!,
+      ),
+      [
+        ["a", "#/components/schemas/IOptionA"],
+        ["b", "#/components/schemas/IOptionB"],
+      ],
+    );
+    TestValidator.equals(
+      "3.0 input immutability",
+      JSON.stringify(fixture.components),
+      before,
+    );
+    TestValidator.predicate(
+      "3.0 discriminator is copied",
+      (outputs[0] as OpenApi.IJsonSchema.IOneOf).discriminator !==
+        fixture.choice.discriminator,
     );
   }
   for (const version of ["3.0", "3.1"] as const) {
@@ -150,6 +178,60 @@ export const test_openapi_converter_discriminator = (): void => {
     },
   );
 
+  const rewrittenFixture: IFixture = createFixture();
+  const rewritten: OpenApi.IJsonSchema = OpenApiConverter.upgradeSchema({
+    components: toV31Components(rewrittenFixture.components),
+    schema: {
+      oneOf: [
+        { type: "string", enum: ["alpha", "beta"] },
+        toV31Schema(rewrittenFixture.choice.oneOf[0]!),
+      ],
+      discriminator: rewrittenFixture.choice.discriminator,
+    },
+  });
+  TestValidator.equals("rewritten oneOf branch count", clean(rewritten), {
+    oneOf: [
+      { const: "alpha" },
+      { const: "beta" },
+      clean(rewrittenFixture.choice.oneOf[0]!),
+    ],
+  });
+
+  const nullableFixture: IFixture = createFixture();
+  const nullable: OpenApi.IJsonSchema = OpenApiConverter.upgradeSchema({
+    components: toV31Components(nullableFixture.components),
+    schema: {
+      oneOf: [
+        { type: "string", nullable: true },
+        toV31Schema(nullableFixture.choice.oneOf[0]!),
+      ],
+      discriminator: nullableFixture.choice.discriminator,
+    },
+  });
+  TestValidator.predicate(
+    "nullable oneOf rewrite drops discriminator",
+    Object.hasOwn(clean(nullable), "discriminator") === false,
+  );
+
+  const downgradedRewriteFixture: IFixture = createFixture();
+  const downgradedRewrite = OpenApiConverter.downgradeSchema({
+    components: downgradedRewriteFixture.components,
+    schema: {
+      oneOf: [
+        { const: "alpha" },
+        { const: "beta" },
+        downgradedRewriteFixture.choice.oneOf[0]!,
+      ],
+      discriminator: downgradedRewriteFixture.choice.discriminator,
+    },
+    version: "3.0",
+    downgraded: {},
+  });
+  TestValidator.predicate(
+    "v3.0 constant rewrite drops discriminator",
+    Object.hasOwn(clean(downgradedRewrite), "discriminator") === false,
+  );
+
   const collapsedFixture: IFixture = createFixture();
   const branch: OpenApi.IJsonSchema = collapsedFixture.choice.oneOf[0]!;
   TestValidator.equals(
@@ -168,6 +250,40 @@ export const test_openapi_converter_discriminator = (): void => {
     ),
     clean(branch),
   );
+  for (const version of ["3.0", "3.1"] as const)
+    TestValidator.equals(
+      `${version} downgraded collapsed oneOf`,
+      JSON.stringify(
+        clean(
+          version === "3.0"
+            ? OpenApiConverter.downgradeSchema({
+                components: collapsedFixture.components,
+                schema: {
+                  oneOf: [branch],
+                  discriminator: {
+                    propertyName: "kind",
+                    mapping: { a: "#/components/schemas/IOptionA" },
+                  },
+                },
+                version: "3.0",
+                downgraded: {},
+              })
+            : OpenApiConverter.downgradeSchema({
+                components: collapsedFixture.components,
+                schema: {
+                  oneOf: [branch],
+                  discriminator: {
+                    propertyName: "kind",
+                    mapping: { a: "#/components/schemas/IOptionA" },
+                  },
+                },
+                version: "3.1",
+                downgraded: {},
+              }),
+        ),
+      ),
+      JSON.stringify(clean(branch)),
+    );
 
   const swaggerFixture: IFixture = createFixture();
   const swagger = OpenApiConverter.downgradeSchema({
@@ -197,6 +313,11 @@ interface IFixture {
   choice: OpenApi.IJsonSchema.IOneOf;
 }
 
+interface IV30Fixture {
+  components: OpenApiV3.IComponents;
+  choice: OpenApiV3.IJsonSchema.IOneOf;
+}
+
 const createFixture = (): IFixture => {
   const collection: IJsonSchemaCollection =
     typia.json.schemas<[IOptionA | IOptionB]>();
@@ -205,6 +326,34 @@ const createFixture = (): IFixture => {
     throw new Error("Failed to generate the IOptionA | IOptionB union schema.");
 
   const choice: OpenApi.IJsonSchema.IOneOf = {
+    oneOf: generated.oneOf,
+    discriminator: {
+      propertyName: "kind",
+      mapping: {
+        a: "#/components/schemas/IOptionA",
+        b: "#/components/schemas/IOptionB",
+      },
+    },
+  };
+  return {
+    components: {
+      ...collection.components,
+      schemas: {
+        ...collection.components.schemas,
+        Choice: choice,
+      },
+    },
+    choice,
+  };
+};
+
+const createV30Fixture = (): IV30Fixture => {
+  const collection = typia.json.schemas<[IOptionA | IOptionB], "3.0">();
+  const generated: OpenApiV3.IJsonSchema = collection.schemas[0]!;
+  if (!("oneOf" in generated))
+    throw new Error("Failed to generate the IOptionA | IOptionB union schema.");
+
+  const choice: OpenApiV3.IJsonSchema.IOneOf = {
     oneOf: generated.oneOf,
     discriminator: {
       propertyName: "kind",
@@ -242,9 +391,9 @@ const upgradeV31 = (fixture: IFixture): OpenApi.IJsonSchema[] => {
   ];
 };
 
-const upgradeV30 = (fixture: IFixture): OpenApi.IJsonSchema[] => {
-  const components: OpenApiV3.IComponents = toV30Components(fixture.components);
-  const schema: OpenApiV3.IJsonSchema = toV30Schema(fixture.choice);
+const upgradeV30 = (fixture: IV30Fixture): OpenApi.IJsonSchema[] => {
+  const components: OpenApiV3.IComponents = fixture.components;
+  const schema: OpenApiV3.IJsonSchema = fixture.choice;
   return [
     OpenApiConverter.upgradeSchema({ components, schema }),
     OpenApiConverter.upgradeComponents(components).schemas!.Choice!,
@@ -310,17 +459,11 @@ const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));
 const toV31Components = (input: OpenApi.IComponents): OpenApiV3_1.IComponents =>
   typia.assert<OpenApiV3_1.IComponents>(input);
 
-const toV30Components = (input: OpenApi.IComponents): OpenApiV3.IComponents =>
-  typia.assert<OpenApiV3.IComponents>(input);
-
 const toV32Components = (input: OpenApi.IComponents): OpenApiV3_2.IComponents =>
   typia.assert<OpenApiV3_2.IComponents>(input);
 
 const toV31Schema = (input: OpenApi.IJsonSchema): OpenApiV3_1.IJsonSchema =>
   typia.assert<OpenApiV3_1.IJsonSchema>(input);
-
-const toV30Schema = (input: OpenApi.IJsonSchema): OpenApiV3.IJsonSchema =>
-  typia.assert<OpenApiV3.IJsonSchema>(input);
 
 const toV32Schema = (input: OpenApi.IJsonSchema): OpenApiV3_2.IJsonSchema =>
   typia.assert<OpenApiV3_2.IJsonSchema>(input);

--- a/tests/test-utils/src/features/openapi/test_openapi_converter_discriminator.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_converter_discriminator.ts
@@ -178,7 +178,7 @@ export const test_openapi_converter_discriminator = (): void => {
   });
   TestValidator.predicate(
     "Swagger 2.0 does not misrepresent OpenAPI mapping metadata",
-    !("discriminator" in swagger),
+    Object.hasOwn(clean(swagger), "discriminator") === false,
   );
 };
 


### PR DESCRIPTION
## Summary

- preserve discriminator `propertyName` and ordered `mapping` entries through OpenAPI 3.0/3.1/3.2 upgrade paths
- preserve them through emended-to-3.0 and emended-to-3.1 downgrade paths
- retain the discriminator only when every source `oneOf` branch remains exactly one output branch
- clone discriminator metadata so output mutation cannot mutate the input

The regression fixture uses `typia.json.schemas<[IOptionA | IOptionB]>()` for real component and branch schemas, then adds only the discriminator under test.

## Root cause

The converter family flattens composite schemas into a fresh union array and rebuilds `oneOf`, but the rebuilt owner copied only generic schema attributes. Valid discriminator metadata therefore lost its owner even when branch topology remained unchanged.

## Self-review

The first implementation preserved the discriminator whenever the final union still had multiple branches. Self-review found that insufficient: enum expansion, mixed-type expansion, nullable absorption, or constant downgrade can retain a final `oneOf` while changing the source branch topology. The follow-up guard now preserves metadata only when each immediate source branch contributes exactly one output branch and nullable state remains stable. Collapse and topology-rewrite cases explicitly assert no orphan discriminator remains.

Swagger 2.0 remains an intentional lossy boundary because its discriminator is a string used with inheritance and it has neither OpenAPI 3 mapping objects nor standard `oneOf`.

## Scoped validation

- `pnpm --filter @typia/utils build`
- `pnpm --filter @typia/test-utils start -- --include openapi_converter_discriminator`
- targeted Prettier on the six changed source/test files
- `git diff --check`
- `typos . --config ./typos.toml`
- GitHub Actions: build, test, spell-check, all Ubuntu jobs, and external security checks green

The focused test covers public schema/components/document upgrades for 3.0/3.1/3.2; schema/components/document downgrades for 3.0/3.1; nested and mapping-less discriminators; mapping order and clone ownership; nullable/anyOf/enum controls; topology rewrites; collapse; input immutability; and the Swagger 2.0 boundary.

Fixes #2024