### PR TITLE
fix(http): preserve migration request and response contracts

### DIFF
--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "13.1.2",
+  "version": "13.1.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/interface/src/http/IHttpLlmController.ts
+++ b/packages/interface/src/http/IHttpLlmController.ts
@@ -80,9 +80,11 @@ export interface IHttpLlmController {
          * It is an object of key-value pairs of the API function's parameters.
          * The property keys are composed by below rules:
          *
-         * - Parameter names
-         * - Query parameter as an object type if exists
-         * - Body parameter if exists
+         * - Path parameter names
+         * - Header parameter group if it exists
+         * - Cookie parameter group if it exists
+         * - Query parameter group if it exists
+         * - Body parameter if it exists
          */
         arguments: object;
       }) => Promise<IHttpResponse>);

--- a/packages/interface/src/http/IHttpMigrateRoute.ts
+++ b/packages/interface/src/http/IHttpMigrateRoute.ts
@@ -152,6 +152,9 @@ export namespace IHttpMigrateRoute {
     /** Object properties owned by an object parameter. */
     properties: string[] | null;
 
+    /** Required properties owned by an object parameter. */
+    requiredProperties?: string[] | null;
+
     /** Whether the object parameter accepts undeclared properties. */
     additionalProperties?: boolean;
 

--- a/packages/interface/src/http/IHttpMigrateRoute.ts
+++ b/packages/interface/src/http/IHttpMigrateRoute.ts
@@ -125,6 +125,9 @@ export namespace IHttpMigrateRoute {
     /** Source parameter serialization metadata. */
     parameters?: IHttpMigrateRoute.ISerialization[];
 
+    /** Whole-query media metadata for OpenAPI 3.2 `querystring`. */
+    querystring?: IHttpMigrateRoute.IQuerystring;
+
     /** Returns title. */
     title: () => string | undefined;
 
@@ -136,6 +139,15 @@ export namespace IHttpMigrateRoute {
 
     /** Returns named examples. */
     examples: () => Record<string, any> | undefined;
+  }
+
+  /** Whole-query media metadata. */
+  export interface IQuerystring {
+    /** Normalized media type used to serialize the complete query string. */
+    type: string;
+
+    /** Returns the source media type definition. */
+    media: () => OpenApi.IOperation.IMediaType;
   }
 
   /** Cookie metadata. */

--- a/packages/interface/src/http/IHttpMigrateRoute.ts
+++ b/packages/interface/src/http/IHttpMigrateRoute.ts
@@ -6,7 +6,7 @@ import { OpenApi } from "../openapi/OpenApi";
  * `IHttpMigrateRoute` represents a single API endpoint with all
  * request/response schemas resolved and ready for code generation. Contains
  * {@link parameters} for URL path variables, {@link query} for query strings,
- * {@link headers}, {@link body} for request payload, and
+ * {@link headers}, {@link cookies}, {@link body} for request payload, and
  * {@link success}/{@link exceptions} for responses.
  *
  * @author Jeongho Nam - https://github.com/samchon
@@ -36,7 +36,7 @@ export interface IHttpMigrateRoute {
   headers: IHttpMigrateRoute.IHeaders | null;
 
   /** Combined cookies as single object. Null if none. */
-  cookies: IHttpMigrateRoute.ICookies | null;
+  cookies?: IHttpMigrateRoute.ICookies | null;
 
   /** Combined query parameters as single object. Null if none. */
   query: IHttpMigrateRoute.IQuery | null;
@@ -68,11 +68,11 @@ export namespace IHttpMigrateRoute {
     /** Parameter type schema. */
     schema: OpenApi.IJsonSchema;
 
-    /** Effective serialization style. */
-    style: "matrix" | "label" | "simple";
+    /** Effective serialization style. Defaults to `simple`. */
+    style?: "matrix" | "label" | "simple";
 
-    /** Effective explode behavior. */
-    explode: boolean;
+    /** Effective explode behavior. Defaults to `false`. */
+    explode?: boolean;
 
     /** Returns source parameter definition. */
     parameter: () => OpenApi.IOperation.IParameter;
@@ -90,10 +90,10 @@ export namespace IHttpMigrateRoute {
     schema: OpenApi.IJsonSchema;
 
     /** Whether the combined headers argument is required. */
-    required: boolean;
+    required?: boolean;
 
     /** Source parameter serialization metadata. */
-    parameters: IHttpMigrateRoute.ISerialization[];
+    parameters?: IHttpMigrateRoute.ISerialization[];
 
     /** Returns title. */
     title: () => string | undefined;
@@ -120,10 +120,10 @@ export namespace IHttpMigrateRoute {
     schema: OpenApi.IJsonSchema;
 
     /** Whether the combined query argument is required. */
-    required: boolean;
+    required?: boolean;
 
     /** Source parameter serialization metadata. */
-    parameters: IHttpMigrateRoute.ISerialization[];
+    parameters?: IHttpMigrateRoute.ISerialization[];
 
     /** Returns title. */
     title: () => string | undefined;
@@ -152,8 +152,16 @@ export namespace IHttpMigrateRoute {
     /** Object properties owned by an object parameter. */
     properties: string[] | null;
 
+    /** Whether the object parameter accepts undeclared properties. */
+    additionalProperties?: boolean;
+
     /** Effective serialization style. */
-    style: "form" | "simple" | "spaceDelimited" | "pipeDelimited" | "deepObject";
+    style:
+      | "form"
+      | "simple"
+      | "spaceDelimited"
+      | "pipeDelimited"
+      | "deepObject";
 
     /** Effective explode behavior. */
     explode: boolean;
@@ -174,6 +182,7 @@ export namespace IHttpMigrateRoute {
     type:
       | "text/plain"
       | "application/json"
+      | `application/${string}+json`
       | "application/x-www-form-urlencoded"
       | "multipart/form-data";
 
@@ -181,7 +190,7 @@ export namespace IHttpMigrateRoute {
     schema: OpenApi.IJsonSchema;
 
     /** Whether the request body is required. */
-    required: boolean;
+    required?: boolean;
 
     /** Returns description. */
     description: () => string | undefined;

--- a/packages/interface/src/http/IHttpMigrateRoute.ts
+++ b/packages/interface/src/http/IHttpMigrateRoute.ts
@@ -35,13 +35,16 @@ export interface IHttpMigrateRoute {
   /** Combined headers as single object. Null if none. */
   headers: IHttpMigrateRoute.IHeaders | null;
 
+  /** Combined cookies as single object. Null if none. */
+  cookies: IHttpMigrateRoute.ICookies | null;
+
   /** Combined query parameters as single object. Null if none. */
   query: IHttpMigrateRoute.IQuery | null;
 
   /** Request body metadata. Null if none. */
   body: IHttpMigrateRoute.IBody | null;
 
-  /** Success response (200/201). Null if void return. */
+  /** Representative success response for the declared 2xx class. */
   success: IHttpMigrateRoute.ISuccess | null;
 
   /** Exception responses keyed by status code. */
@@ -65,6 +68,12 @@ export namespace IHttpMigrateRoute {
     /** Parameter type schema. */
     schema: OpenApi.IJsonSchema;
 
+    /** Effective serialization style. */
+    style: "matrix" | "label" | "simple";
+
+    /** Effective explode behavior. */
+    explode: boolean;
+
     /** Returns source parameter definition. */
     parameter: () => OpenApi.IOperation.IParameter;
   }
@@ -79,6 +88,12 @@ export namespace IHttpMigrateRoute {
 
     /** Combined headers schema. */
     schema: OpenApi.IJsonSchema;
+
+    /** Whether the combined headers argument is required. */
+    required: boolean;
+
+    /** Source parameter serialization metadata. */
+    parameters: IHttpMigrateRoute.ISerialization[];
 
     /** Returns title. */
     title: () => string | undefined;
@@ -104,6 +119,12 @@ export namespace IHttpMigrateRoute {
     /** Combined query schema. */
     schema: OpenApi.IJsonSchema;
 
+    /** Whether the combined query argument is required. */
+    required: boolean;
+
+    /** Source parameter serialization metadata. */
+    parameters: IHttpMigrateRoute.ISerialization[];
+
     /** Returns title. */
     title: () => string | undefined;
 
@@ -115,6 +136,30 @@ export namespace IHttpMigrateRoute {
 
     /** Returns named examples. */
     examples: () => Record<string, any> | undefined;
+  }
+
+  /** Cookie metadata. */
+  export interface ICookies extends IHeaders {}
+
+  /** Serialization metadata for a grouped request parameter. */
+  export interface ISerialization {
+    /** OpenAPI parameter name sent on the wire. */
+    name: string;
+
+    /** Property key in the grouped argument, or null for an object parameter. */
+    key: string | null;
+
+    /** Object properties owned by an object parameter. */
+    properties: string[] | null;
+
+    /** Effective serialization style. */
+    style: "form" | "simple" | "spaceDelimited" | "pipeDelimited" | "deepObject";
+
+    /** Effective explode behavior. */
+    explode: boolean;
+
+    /** Returns source parameter definition. */
+    parameter: () => OpenApi.IOperation.IParameter;
   }
 
   /** Request body metadata. */
@@ -134,6 +179,9 @@ export namespace IHttpMigrateRoute {
 
     /** Body type schema. */
     schema: OpenApi.IJsonSchema;
+
+    /** Whether the request body is required. */
+    required: boolean;
 
     /** Returns description. */
     description: () => string | undefined;

--- a/packages/interface/src/http/IHttpMigrateRoute.ts
+++ b/packages/interface/src/http/IHttpMigrateRoute.ts
@@ -161,6 +161,7 @@ export namespace IHttpMigrateRoute {
     /** Effective serialization style. */
     style:
       | "form"
+      | "cookie"
       | "simple"
       | "spaceDelimited"
       | "pipeDelimited"

--- a/packages/interface/src/openapi/OpenApi.ts
+++ b/packages/interface/src/openapi/OpenApi.ts
@@ -242,8 +242,11 @@ export namespace OpenApi {
       /** Parameter location. */
       in: "path" | "query" | "querystring" | "header" | "cookie";
 
-      /** Parameter schema. */
+      /** Normalized parameter schema. */
       schema: IJsonSchema;
+
+      /** Source media types for a content-backed querystring parameter. */
+      content?: IContent;
 
       /** Whether required. */
       required?: boolean;

--- a/packages/interface/src/openapi/OpenApi.ts
+++ b/packages/interface/src/openapi/OpenApi.ts
@@ -248,6 +248,19 @@ export namespace OpenApi {
       /** Whether required. */
       required?: boolean;
 
+      /** OpenAPI parameter serialization style. */
+      style?:
+        | "matrix"
+        | "label"
+        | "form"
+        | "simple"
+        | "spaceDelimited"
+        | "pipeDelimited"
+        | "deepObject";
+
+      /** Whether arrays and objects are exploded during serialization. */
+      explode?: boolean;
+
       /** Parameter description. */
       description?: string;
 

--- a/packages/interface/src/openapi/OpenApi.ts
+++ b/packages/interface/src/openapi/OpenApi.ts
@@ -253,6 +253,7 @@ export namespace OpenApi {
         | "matrix"
         | "label"
         | "form"
+        | "cookie"
         | "simple"
         | "spaceDelimited"
         | "pipeDelimited"

--- a/packages/interface/src/openapi/OpenApiV3.ts
+++ b/packages/interface/src/openapi/OpenApiV3.ts
@@ -221,6 +221,19 @@ export namespace OpenApiV3 {
       /** Whether required. */
       required?: boolean;
 
+      /** Parameter serialization style. */
+      style?:
+        | "matrix"
+        | "label"
+        | "form"
+        | "simple"
+        | "spaceDelimited"
+        | "pipeDelimited"
+        | "deepObject";
+
+      /** Whether arrays and objects are exploded during serialization. */
+      explode?: boolean;
+
       /** Parameter description. */
       description?: string;
 

--- a/packages/interface/src/openapi/OpenApiV3_1.ts
+++ b/packages/interface/src/openapi/OpenApiV3_1.ts
@@ -237,6 +237,19 @@ export namespace OpenApiV3_1 {
       /** Whether required. */
       required?: boolean;
 
+      /** Parameter serialization style. */
+      style?:
+        | "matrix"
+        | "label"
+        | "form"
+        | "simple"
+        | "spaceDelimited"
+        | "pipeDelimited"
+        | "deepObject";
+
+      /** Whether arrays and objects are exploded during serialization. */
+      explode?: boolean;
+
       /** Parameter description. */
       description?: string;
 

--- a/packages/interface/src/openapi/OpenApiV3_2.ts
+++ b/packages/interface/src/openapi/OpenApiV3_2.ts
@@ -240,8 +240,11 @@ export namespace OpenApiV3_2 {
       /** Parameter location. */
       in: "path" | "query" | "querystring" | "header" | "cookie";
 
-      /** Parameter schema. */
-      schema: IJsonSchema;
+      /** Parameter schema for every location except `querystring`. */
+      schema?: IJsonSchema;
+
+      /** Media types for a content-backed `querystring` parameter. */
+      content?: Record<string, IMediaType>;
 
       /** Whether required. */
       required?: boolean;

--- a/packages/interface/src/openapi/OpenApiV3_2.ts
+++ b/packages/interface/src/openapi/OpenApiV3_2.ts
@@ -246,6 +246,19 @@ export namespace OpenApiV3_2 {
       /** Whether required. */
       required?: boolean;
 
+      /** Parameter serialization style. */
+      style?:
+        | "matrix"
+        | "label"
+        | "form"
+        | "simple"
+        | "spaceDelimited"
+        | "pipeDelimited"
+        | "deepObject";
+
+      /** Whether arrays and objects are exploded during serialization. */
+      explode?: boolean;
+
       /** Parameter description. */
       description?: string;
 

--- a/packages/interface/src/openapi/OpenApiV3_2.ts
+++ b/packages/interface/src/openapi/OpenApiV3_2.ts
@@ -251,6 +251,7 @@ export namespace OpenApiV3_2 {
         | "matrix"
         | "label"
         | "form"
+        | "cookie"
         | "simple"
         | "spaceDelimited"
         | "pipeDelimited"

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.2",
+  "version": "13.1.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/src/internal/_httpQueryParseURLSearchParams.ts
+++ b/packages/typia/src/internal/_httpQueryParseURLSearchParams.ts
@@ -4,19 +4,30 @@ export const _httpQueryParseURLSearchParams = (
   input: string | IReadableURLSearchParams,
 ): IReadableURLSearchParams => {
   if (typeof input === "string") {
-    if (input.startsWith("?")) input = input.substring(1);
-    else {
+    let url: boolean = false;
+    if (input.startsWith("?")) {
+      input = input.substring(1);
+      url = true;
+    } else {
       const index: number = input.indexOf("?");
-      if (index !== -1 && isUrlPrefix(input.substring(0, index)))
+      if (index !== -1 && isUrlPrefix(input.substring(0, index))) {
         input = input.substring(index + 1);
-      else if (index === -1 && isUrlPrefix(input)) input = "";
+        url = true;
+      } else if (index === -1 && isUrlPrefix(input)) {
+        input = "";
+        url = true;
+      }
     }
-    const fragment: number = input.indexOf("#");
-    if (fragment !== -1) input = input.substring(0, fragment);
+    if (url) {
+      const fragment: number = input.indexOf("#");
+      if (fragment !== -1) input = input.substring(0, fragment);
+    }
     return new URLSearchParams(input);
   }
   return input;
 };
 
 const isUrlPrefix = (prefix: string): boolean =>
-  /^[a-z][a-z\d+.-]*:/i.test(prefix) || prefix.includes("/");
+  /^[a-z][a-z\d+.-]*:/i.test(prefix) ||
+  /^(?:\/\/|\/|\.{1,2}\/)/.test(prefix) ||
+  (prefix.length !== 0 && !/[=&]/.test(prefix));

--- a/packages/typia/src/internal/_httpQueryParseURLSearchParams.ts
+++ b/packages/typia/src/internal/_httpQueryParseURLSearchParams.ts
@@ -4,9 +4,19 @@ export const _httpQueryParseURLSearchParams = (
   input: string | IReadableURLSearchParams,
 ): IReadableURLSearchParams => {
   if (typeof input === "string") {
-    const index: number = input.indexOf("?");
-    input = index === -1 ? "" : input.substring(index + 1);
+    if (input.startsWith("?")) input = input.substring(1);
+    else {
+      const index: number = input.indexOf("?");
+      if (index !== -1 && isUrlPrefix(input.substring(0, index)))
+        input = input.substring(index + 1);
+      else if (index === -1 && isUrlPrefix(input)) input = "";
+    }
+    const fragment: number = input.indexOf("#");
+    if (fragment !== -1) input = input.substring(0, fragment);
     return new URLSearchParams(input);
   }
   return input;
 };
+
+const isUrlPrefix = (prefix: string): boolean =>
+  /^[a-z][a-z\d+.-]*:/i.test(prefix) || prefix.includes("/");

--- a/packages/typia/src/internal/_httpQueryParseURLSearchParams.ts
+++ b/packages/typia/src/internal/_httpQueryParseURLSearchParams.ts
@@ -13,7 +13,7 @@ export const _httpQueryParseURLSearchParams = (
       if (index !== -1 && isUrlPrefix(input.substring(0, index))) {
         input = input.substring(index + 1);
         url = true;
-      } else if (index === -1 && isUrlPrefix(input)) {
+      } else if (index === -1 && isExplicitUrlPrefix(input)) {
         input = "";
         url = true;
       }
@@ -28,6 +28,7 @@ export const _httpQueryParseURLSearchParams = (
 };
 
 const isUrlPrefix = (prefix: string): boolean =>
-  /^[a-z][a-z\d+.-]*:/i.test(prefix) ||
-  /^(?:\/\/|\/|\.{1,2}\/)/.test(prefix) ||
-  (prefix.length !== 0 && !/[=&]/.test(prefix));
+  isExplicitUrlPrefix(prefix) || (prefix.length !== 0 && !/[=&]/.test(prefix));
+
+const isExplicitUrlPrefix = (prefix: string): boolean =>
+  /^[a-z][a-z\d+.-]*:/i.test(prefix) || /^(?:\/\/|\/|\.{1,2}\/)/.test(prefix);

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "13.1.2",
+  "version": "13.1.1",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -119,13 +119,15 @@ export namespace OpenApiV3Downgrader {
 
   const downgradeParameter =
     (collection: IComponentsCollection) =>
-    (
-      input: OpenApi.IOperation.IParameter,
-    ): OpenApiV3.IOperation.IParameter => ({
-      ...input,
-      in: input.in === "querystring" ? "query" : input.in,
-      schema: downgradeSchema(collection)(input.schema),
-    });
+    (input: OpenApi.IOperation.IParameter): OpenApiV3.IOperation.IParameter => {
+      const { style, ...rest } = input;
+      return {
+        ...rest,
+        in: input.in === "querystring" ? "query" : input.in,
+        style: style === "cookie" ? "form" : style,
+        schema: downgradeSchema(collection)(input.schema),
+      };
+    };
 
   const downgradeRequestBody =
     (collection: IComponentsCollection) =>
@@ -150,11 +152,12 @@ export namespace OpenApiV3Downgrader {
             Object.entries(input.headers)
               .filter(([_, v]) => v !== undefined)
               .map(([key, value]) => {
-                const { name: _name, in: _in, ...rest } = value;
+                const { name: _name, in: _in, style, ...rest } = value;
                 return [
                   key,
                   {
                     ...rest,
+                    style: style === "cookie" ? "form" : style,
                     schema: downgradeSchema(collection)(value.schema),
                   },
                 ];

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -120,7 +120,7 @@ export namespace OpenApiV3Downgrader {
   const downgradeParameter =
     (collection: IComponentsCollection) =>
     (input: OpenApi.IOperation.IParameter): OpenApiV3.IOperation.IParameter => {
-      const { style, ...rest } = input;
+      const { style, content: _content, ...rest } = input;
       return {
         ...rest,
         in: input.in === "querystring" ? "query" : input.in,

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -145,12 +145,27 @@ export namespace OpenApiV3Upgrader {
     operationParameters: OpenApiV3.IOperation.IParameter[],
   ): OpenApiV3.IOperation.IParameter[] => {
     const map: Map<string, OpenApiV3.IOperation.IParameter> = new Map();
+    const duplicates = (
+      parameters: OpenApiV3.IOperation.IParameter[],
+    ): OpenApiV3.IOperation.IParameter[] => {
+      const seen: Set<string> = new Set();
+      return parameters.filter((parameter) => {
+        const key: string = `${parameter.in}:${parameter.name}`;
+        if (seen.has(key)) return true;
+        seen.add(key);
+        return false;
+      });
+    };
     const emplace = (parameter: OpenApiV3.IOperation.IParameter): void => {
       map.set(`${parameter.in}:${parameter.name}`, parameter);
     };
     pathParameters.forEach(emplace);
     operationParameters.forEach(emplace);
-    return [...map.values()];
+    return [
+      ...map.values(),
+      ...duplicates(pathParameters),
+      ...duplicates(operationParameters),
+    ];
   };
 
   const convertParameter =

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -133,11 +133,15 @@ export namespace OpenApiV3_1Downgrader {
     (collection: IComponentsCollection) =>
     (
       input: OpenApi.IOperation.IParameter,
-    ): OpenApiV3_1.IOperation.IParameter => ({
-      ...input,
-      in: input.in === "querystring" ? "query" : input.in,
-      schema: downgradeSchema(collection)(input.schema),
-    });
+    ): OpenApiV3_1.IOperation.IParameter => {
+      const { style, ...rest } = input;
+      return {
+        ...rest,
+        in: input.in === "querystring" ? "query" : input.in,
+        style: style === "cookie" ? "form" : style,
+        schema: downgradeSchema(collection)(input.schema),
+      };
+    };
 
   const downgradeRequestBody =
     (collection: IComponentsCollection) =>
@@ -164,11 +168,12 @@ export namespace OpenApiV3_1Downgrader {
             Object.entries(input.headers)
               .filter(([_, v]) => v !== undefined)
               .map(([key, value]) => {
-                const { name: _name, in: _in, ...rest } = value;
+                const { name: _name, in: _in, style, ...rest } = value;
                 return [
                   key,
                   {
                     ...rest,
+                    style: style === "cookie" ? "form" : style,
                     schema: downgradeSchema(collection)(value.schema),
                   },
                 ];

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -134,7 +134,7 @@ export namespace OpenApiV3_1Downgrader {
     (
       input: OpenApi.IOperation.IParameter,
     ): OpenApiV3_1.IOperation.IParameter => {
-      const { style, ...rest } = input;
+      const { style, content: _content, ...rest } = input;
       return {
         ...rest,
         in: input.in === "querystring" ? "query" : input.in,

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -175,12 +175,27 @@ export namespace OpenApiV3_1Upgrader {
     operationParameters: OpenApiV3_1.IOperation.IParameter[],
   ): OpenApiV3_1.IOperation.IParameter[] => {
     const map: Map<string, OpenApiV3_1.IOperation.IParameter> = new Map();
+    const duplicates = (
+      parameters: OpenApiV3_1.IOperation.IParameter[],
+    ): OpenApiV3_1.IOperation.IParameter[] => {
+      const seen: Set<string> = new Set();
+      return parameters.filter((parameter) => {
+        const key: string = `${parameter.in}:${parameter.name}`;
+        if (seen.has(key)) return true;
+        seen.add(key);
+        return false;
+      });
+    };
     const emplace = (parameter: OpenApiV3_1.IOperation.IParameter): void => {
       map.set(`${parameter.in}:${parameter.name}`, parameter);
     };
     pathParameters.forEach(emplace);
     operationParameters.forEach(emplace);
-    return [...map.values()];
+    return [
+      ...map.values(),
+      ...duplicates(pathParameters),
+      ...duplicates(operationParameters),
+    ];
   };
 
   const convertParameter =

--- a/packages/utils/src/converters/internal/OpenApiV3_2Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_2Upgrader.ts
@@ -217,10 +217,17 @@ export namespace OpenApiV3_2Upgrader {
       const { required: inputRequired, ...rest } = input;
       const required: boolean | undefined =
         input.in === "path" ? true : inputRequired;
+      const content: OpenApi.IOperation.IContent | undefined = input.content
+        ? convertContent(components)(input.content)
+        : undefined;
       return {
         ...rest,
         ...(required !== undefined ? { required } : {}),
-        schema: convertSchema(components)(input.schema),
+        schema:
+          input.schema !== undefined
+            ? convertSchema(components)(input.schema)
+            : (Object.values(content ?? {})[0]?.schema ?? {}),
+        content,
         examples: input.examples
           ? Object.fromEntries(
               Object.entries(input.examples)

--- a/packages/utils/src/converters/internal/OpenApiV3_2Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_2Upgrader.ts
@@ -186,12 +186,27 @@ export namespace OpenApiV3_2Upgrader {
     operationParameters: OpenApiV3_2.IOperation.IParameter[],
   ): OpenApiV3_2.IOperation.IParameter[] => {
     const map: Map<string, OpenApiV3_2.IOperation.IParameter> = new Map();
+    const duplicates = (
+      parameters: OpenApiV3_2.IOperation.IParameter[],
+    ): OpenApiV3_2.IOperation.IParameter[] => {
+      const seen: Set<string> = new Set();
+      return parameters.filter((parameter) => {
+        const key: string = `${parameter.in}:${parameter.name}`;
+        if (seen.has(key)) return true;
+        seen.add(key);
+        return false;
+      });
+    };
     const emplace = (parameter: OpenApiV3_2.IOperation.IParameter): void => {
       map.set(`${parameter.in}:${parameter.name}`, parameter);
     };
     pathParameters.forEach(emplace);
     operationParameters.forEach(emplace);
-    return [...map.values()];
+    return [
+      ...map.values(),
+      ...duplicates(pathParameters),
+      ...duplicates(operationParameters),
+    ];
   };
 
   const convertParameter =

--- a/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
@@ -144,6 +144,7 @@ export namespace SwaggerV2Downgrader {
       const {
         schema,
         required,
+        content: _content,
         style: _style,
         explode: _explode,
         example: _example,

--- a/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
@@ -144,6 +144,8 @@ export namespace SwaggerV2Downgrader {
       const {
         schema,
         required,
+        style: _style,
+        explode: _explode,
         example: _example,
         examples: _examples,
         ...rest
@@ -192,6 +194,8 @@ export namespace SwaggerV2Downgrader {
                   name: _name,
                   in: _in,
                   required: _required,
+                  style: _style,
+                  explode: _explode,
                   example: _example,
                   examples: _examples,
                   schema,

--- a/packages/utils/src/http/HttpError.ts
+++ b/packages/utils/src/http/HttpError.ts
@@ -6,8 +6,8 @@
  * Contains the full HTTP context: method, path, status, headers, and response
  * body.
  *
- * The response body is available via {@link message} (raw string) or
- * {@link toJSON} (parsed JSON). For non-throwing behavior, use
+ * The human-readable error text is available via {@link message}, while
+ * {@link toJSON} preserves the parsed response body. For non-throwing behavior, use
  * {@link HttpLlm.propagate} or {@link HttpMigration.propagate} instead.
  *
  * @author Jeongho Nam - https://github.com/samchon
@@ -32,28 +32,29 @@ export class HttpError extends Error {
   /** Response headers from server. */
   public readonly headers: Record<string, string | string[]>;
 
-  /** @internal */
-  private body_: any = NOT_YET;
+  /** Parsed response body. */
+  private readonly body_: unknown;
 
   /**
    * @param method HTTP method
    * @param path Request path or URL
    * @param status HTTP status code
    * @param headers Response headers
-   * @param message Error message (response body)
+   * @param body Parsed response body
    */
   public constructor(
     method: "GET" | "QUERY" | "DELETE" | "POST" | "PUT" | "PATCH" | "HEAD",
     path: string,
     status: number,
     headers: Record<string, string | string[]>,
-    message: string,
+    body: unknown,
   ) {
-    super(message);
+    super(stringifyBody(body));
     this.method = method;
     this.path = path;
     this.status = status;
     this.headers = headers;
+    this.body_ = body;
 
     // INHERITANCE POLYFILL
     const proto: HttpError = new.target.prototype;
@@ -64,25 +65,16 @@ export class HttpError extends Error {
   /**
    * Serialize to JSON-compatible object.
    *
-   * Lazily parses JSON message body on first call. If parsing fails, returns
-   * the original string.
-   *
    * @template T Expected response body type
    * @returns Structured HTTP error information
    */
   public toJSON<T>(): HttpError.IProps<T> {
-    if (this.body_ === NOT_YET)
-      try {
-        this.body_ = JSON.parse(this.message);
-      } catch {
-        this.body_ = this.message;
-      }
     return {
       method: this.method,
       path: this.path,
       status: this.status,
       headers: this.headers,
-      message: this.body_,
+      message: this.body_ as T,
     };
   }
 }
@@ -110,5 +102,14 @@ export namespace HttpError {
   }
 }
 
-/** @internal */
-const NOT_YET = {} as any;
+const stringifyBody = (body: unknown): string => {
+  if (typeof body === "string") return body;
+  if (body === undefined) return "";
+  if (body instanceof URLSearchParams) return body.toString();
+  try {
+    const output: string | undefined = JSON.stringify(body);
+    return output ?? String(body);
+  } catch {
+    return String(body);
+  }
+};

--- a/packages/utils/src/http/HttpError.ts
+++ b/packages/utils/src/http/HttpError.ts
@@ -7,8 +7,8 @@
  * body.
  *
  * The human-readable error text is available via {@link message}, while
- * {@link toJSON} preserves the parsed response body. For non-throwing behavior, use
- * {@link HttpLlm.propagate} or {@link HttpMigration.propagate} instead.
+ * {@link toJSON} preserves the parsed response body. For non-throwing behavior,
+ * use {@link HttpLlm.propagate} or {@link HttpMigration.propagate} instead.
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
@@ -33,7 +33,7 @@ export class HttpError extends Error {
   public readonly headers: Record<string, string | string[]>;
 
   /** Parsed response body. */
-  private readonly body_: unknown;
+  private body_: unknown = NOT_YET;
 
   /**
    * @param method HTTP method
@@ -41,6 +41,8 @@ export class HttpError extends Error {
    * @param status HTTP status code
    * @param headers Response headers
    * @param body Parsed response body
+   * @param parsed Whether a string body has already been classified by media
+   *   type
    */
   public constructor(
     method: "GET" | "QUERY" | "DELETE" | "POST" | "PUT" | "PATCH" | "HEAD",
@@ -48,13 +50,14 @@ export class HttpError extends Error {
     status: number,
     headers: Record<string, string | string[]>,
     body: unknown,
+    parsed: boolean = false,
   ) {
     super(stringifyBody(body));
     this.method = method;
     this.path = path;
     this.status = status;
     this.headers = headers;
-    this.body_ = body;
+    if (typeof body !== "string" || parsed) this.body_ = body;
 
     // INHERITANCE POLYFILL
     const proto: HttpError = new.target.prototype;
@@ -69,6 +72,12 @@ export class HttpError extends Error {
    * @returns Structured HTTP error information
    */
   public toJSON<T>(): HttpError.IProps<T> {
+    if (this.body_ === NOT_YET)
+      try {
+        this.body_ = JSON.parse(this.message);
+      } catch {
+        this.body_ = this.message;
+      }
     return {
       method: this.method,
       path: this.path,
@@ -113,3 +122,6 @@ const stringifyBody = (body: unknown): string => {
     return String(body);
   }
 };
+
+/** @internal */
+const NOT_YET = Symbol("not-yet");

--- a/packages/utils/src/http/HttpMigration.ts
+++ b/packages/utils/src/http/HttpMigration.ts
@@ -86,7 +86,7 @@ export namespace HttpMigration {
       | Record<string, HttpMigration.ParameterValue>;
 
     /** Query parameters. */
-    query?: object | undefined;
+    query?: unknown;
 
     /** Request headers declared by the route. */
     headers?: object | undefined;

--- a/packages/utils/src/http/HttpMigration.ts
+++ b/packages/utils/src/http/HttpMigration.ts
@@ -82,13 +82,29 @@ export namespace HttpMigration {
 
     /** Path parameters. */
     parameters:
-      | Array<string | number | boolean | bigint | null>
-      | Record<string, string | number | boolean | bigint | null>;
+      | HttpMigration.ParameterValue[]
+      | Record<string, HttpMigration.ParameterValue>;
 
     /** Query parameters. */
     query?: object | undefined;
 
+    /** Request headers declared by the route. */
+    headers?: object | undefined;
+
+    /** Request cookies declared by the route. */
+    cookies?: object | undefined;
+
     /** Request body. */
     body?: object | undefined;
   }
+
+  /** OpenAPI path parameter value. */
+  export type ParameterValue =
+    | string
+    | number
+    | boolean
+    | bigint
+    | null
+    | Array<string | number | boolean | bigint | null>
+    | Record<string, string | number | boolean | bigint | null>;
 }

--- a/packages/utils/src/http/HttpMigration.ts
+++ b/packages/utils/src/http/HttpMigration.ts
@@ -95,7 +95,7 @@ export namespace HttpMigration {
     cookies?: object | undefined;
 
     /** Request body. */
-    body?: object | undefined;
+    body?: unknown;
   }
 
   /** OpenAPI path parameter value. */

--- a/packages/utils/src/http/internal/HttpLlmApplicationComposer.ts
+++ b/packages/utils/src/http/internal/HttpLlmApplicationComposer.ts
@@ -149,7 +149,7 @@ export namespace HttpLlmApplicationComposer {
     //----
     // CONSTRUCT SCHEMAS
     //----
-    // merge path parameters, query, and body into a single object schema
+    // merge path parameters and grouped request inputs into one object schema
     const parameters: OpenApi.IJsonSchema.IObject = {
       type: "object",
       properties: Object.fromEntries([
@@ -164,6 +164,40 @@ export namespace HttpLlmApplicationComposer {
               },
             ] as const,
         ),
+        // header parameters
+        ...(props.route.headers
+          ? [
+              [
+                props.route.headers.key,
+                {
+                  ...props.route.headers.schema,
+                  title:
+                    props.route.headers.title() ??
+                    props.route.headers.schema.title,
+                  description:
+                    props.route.headers.description() ??
+                    props.route.headers.schema.description,
+                },
+              ] as const,
+            ]
+          : []),
+        // cookie parameters
+        ...(props.route.cookies
+          ? [
+              [
+                props.route.cookies.key,
+                {
+                  ...props.route.cookies.schema,
+                  title:
+                    props.route.cookies.title() ??
+                    props.route.cookies.schema.title,
+                  description:
+                    props.route.cookies.description() ??
+                    props.route.cookies.schema.description,
+                },
+              ] as const,
+            ]
+          : []),
         // query parameters
         ...(props.route.query
           ? [
@@ -196,7 +230,14 @@ export namespace HttpLlmApplicationComposer {
           : []),
       ]),
     };
-    parameters.required = Object.keys(parameters.properties ?? {});
+    const required: string[] = [
+      ...props.route.parameters.map((parameter) => parameter.key),
+      ...(props.route.headers?.required ? [props.route.headers.key] : []),
+      ...(props.route.cookies?.required ? [props.route.cookies.key] : []),
+      ...(props.route.query?.required ? [props.route.query.key] : []),
+      ...(props.route.body?.required ? [props.route.body.key] : []),
+    ];
+    if (required.length !== 0) parameters.required = required;
 
     // convert merged object schema to LLM parameters
     const llmParameters: IResult<

--- a/packages/utils/src/http/internal/HttpLlmApplicationComposer.ts
+++ b/packages/utils/src/http/internal/HttpLlmApplicationComposer.ts
@@ -232,10 +232,18 @@ export namespace HttpLlmApplicationComposer {
     };
     const required: string[] = [
       ...props.route.parameters.map((parameter) => parameter.key),
-      ...(props.route.headers?.required ? [props.route.headers.key] : []),
-      ...(props.route.cookies?.required ? [props.route.cookies.key] : []),
-      ...(props.route.query?.required ? [props.route.query.key] : []),
-      ...(props.route.body?.required ? [props.route.body.key] : []),
+      ...(props.route.headers && props.route.headers.required !== false
+        ? [props.route.headers.key]
+        : []),
+      ...(props.route.cookies && props.route.cookies.required !== false
+        ? [props.route.cookies.key]
+        : []),
+      ...(props.route.query && props.route.query.required !== false
+        ? [props.route.query.key]
+        : []),
+      ...(props.route.body && props.route.body.required !== false
+        ? [props.route.body.key]
+        : []),
     ];
     if (required.length !== 0) parameters.required = required;
 

--- a/packages/utils/src/http/internal/HttpLlmApplicationComposer.ts
+++ b/packages/utils/src/http/internal/HttpLlmApplicationComposer.ts
@@ -6,6 +6,7 @@ import {
   IJsonSchemaTransformError,
   ILlmSchema,
   IResult,
+  IValidation,
   OpenApi,
 } from "@typia/interface";
 
@@ -301,6 +302,46 @@ export namespace HttpLlmApplicationComposer {
       return null;
     }
 
+    const validate = OpenApiValidator.create({
+      components: props.components,
+      schema: parameters,
+      required: true,
+      equals: props.config.equals ?? false,
+    });
+    // The normal non-equals validator intentionally ignores additional
+    // properties. For a flattened optional object, that would let the absent
+    // union branch hide missing fields after any object-owned key is supplied.
+    const conditionalGroups = [
+      props.route.headers,
+      props.route.cookies,
+      props.route.query,
+    ].flatMap((group) => {
+      if (group === null || group === undefined) return [];
+      const serializations = group.parameters ?? [];
+      const object = serializations.find(
+        (parameter) =>
+          parameter.key === null &&
+          parameter.parameter().required !== true &&
+          (parameter.requiredProperties?.length ?? 0) !== 0,
+      );
+      if (object === undefined || serializations.length === 1) return [];
+      const schema = resolveSchema(props.components)(group.schema);
+      if (!("oneOf" in schema) || schema.oneOf[1] === undefined) return [];
+      return [
+        {
+          key: group.key,
+          object,
+          serializations,
+          validate: OpenApiValidator.create({
+            components: props.components,
+            schema: schema.oneOf[1],
+            required: true,
+            equals: props.config.equals ?? false,
+          }),
+        },
+      ];
+    });
+
     // assemble the LLM function
     return {
       method: props.route.method as "get",
@@ -313,15 +354,85 @@ export namespace HttpLlmApplicationComposer {
       tags: operation.tags,
       parse: (input: string) => LlmJson.parse(input, llmParameters.value),
       coerce: (input: unknown) => LlmJson.coerce(input, llmParameters.value),
-      validate: OpenApiValidator.create({
-        components: props.components,
-        schema: parameters,
-        required: true,
-        equals: props.config.equals ?? false,
-      }),
+      validate: (input: unknown): IValidation<unknown> => {
+        const result: IValidation<unknown> = validate(input);
+        if (result.success === false || conditionalGroups.length === 0)
+          return result;
+        const record = result.data as Record<string, unknown>;
+        for (const group of conditionalGroups) {
+          const value = record[group.key];
+          if (
+            typeof value !== "object" ||
+            value === null ||
+            Array.isArray(value)
+          )
+            continue;
+          if (
+            isObjectParameterProvided({
+              input: value as Record<string, unknown>,
+              object: group.object,
+              serializations: group.serializations,
+            }) === false
+          )
+            continue;
+          const exact: IValidation<unknown> = group.validate(value);
+          if (exact.success === false)
+            return {
+              ...exact,
+              data: result.data,
+              errors: exact.errors.map((error) => ({
+                ...error,
+                path: error.path.replace("$input", `$input.${group.key}`),
+              })),
+            };
+        }
+        return result;
+      },
       route: () => props.route as any,
       operation: () => props.route.operation(),
     };
+  };
+
+  const resolveSchema =
+    (components: OpenApi.IComponents) =>
+    (input: OpenApi.IJsonSchema): OpenApi.IJsonSchema => {
+      let schema: OpenApi.IJsonSchema = input;
+      const visited: Set<string> = new Set();
+      while ("$ref" in schema) {
+        const key: string = schema.$ref.replace("#/components/schemas/", "");
+        if (
+          key === schema.$ref ||
+          visited.has(key) ||
+          components.schemas?.[key] === undefined
+        )
+          break;
+        visited.add(key);
+        schema = components.schemas[key]!;
+      }
+      return schema;
+    };
+
+  const isObjectParameterProvided = (props: {
+    input: Record<string, unknown>;
+    object: IHttpMigrateRoute.ISerialization;
+    serializations: IHttpMigrateRoute.ISerialization[];
+  }): boolean => {
+    const properties = new Set(props.object.properties ?? []);
+    const occupied = new Set(
+      props.serializations
+        .filter((parameter) => parameter !== props.object)
+        .flatMap((parameter) =>
+          parameter.key !== null
+            ? [parameter.key]
+            : (parameter.properties ?? []),
+        ),
+    );
+    return Object.entries(props.input).some(
+      ([key, value]) =>
+        value !== undefined &&
+        (properties.has(key) ||
+          (props.object.additionalProperties === true && !occupied.has(key))),
+    );
   };
 
   /**

--- a/packages/utils/src/http/internal/HttpLlmFunctionFetcher.ts
+++ b/packages/utils/src/http/internal/HttpLlmFunctionFetcher.ts
@@ -30,8 +30,10 @@ export namespace HttpLlmFunctionFetcher {
       parameters: Object.fromEntries(
         route.parameters.map((p) => [p.key, input[p.key]] as const),
       ),
-      query: input.query,
-      body: input.body,
+      headers: route.headers ? input[route.headers.key] : undefined,
+      cookies: route.cookies ? input[route.cookies.key] : undefined,
+      query: route.query ? input[route.query.key] : undefined,
+      body: route.body ? input[route.body.key] : undefined,
     };
   };
 }

--- a/packages/utils/src/http/internal/HttpMigrateRouteAccessor.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteAccessor.ts
@@ -8,9 +8,18 @@ export namespace HttpMigrateRouteAccessor {
   export const overwrite = (routes: IHttpMigrateRoute[]): void => {
     const predefined: Map<string, number> = getPredefinedAccessors(routes);
     const dict: Map<string, IElement> = collect((op) =>
-      op.emendedPath
+      op.path
         .split("/")
-        .filter((str) => !!str.length && str[0] !== ":")
+        .map((str) => ({
+          original: str,
+          static: str.replace(/\{[^{}]+\}/g, ""),
+        }))
+        .filter(
+          (str) =>
+            str.static.length !== 0 &&
+            (str.original === str.static || /[a-zA-Z0-9_$]/.test(str.static)),
+        )
+        .map((str) => str.static)
         .map(EndpointUtil.normalize)
         .map((str) => (NamingConvention.variable(str) ? str : `_${str}`)),
     )(routes) as Map<string, IElement>;

--- a/packages/utils/src/http/internal/HttpMigrateRouteAccessor.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteAccessor.ts
@@ -28,6 +28,7 @@ export namespace HttpMigrateRouteAccessor {
           ...entry.route.parameters,
           ...(entry.route.body ? [entry.route.body] : []),
           ...(entry.route.headers ? [entry.route.headers] : []),
+          ...(entry.route.cookies ? [entry.route.cookies] : []),
           ...(entry.route.query ? [entry.route.query] : []),
         ];
         parameters.forEach(

--- a/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
@@ -54,11 +54,11 @@ export namespace HttpMigrateRouteComposer {
     const failures: string[] = [];
     if (body === false)
       failures.push(
-        `supports only "application/json", "application/x-www-form-urlencoded", "multipart/form-data" and "text/plain" content type in the request body.`,
+        `supports only JSON, "application/x-www-form-urlencoded", "multipart/form-data" and "text/plain" content types in the request body.`,
       );
     if (success === false)
       failures.push(
-        `supports only "application/json", "application/x-www-form-urlencoded" and "text/plain" content type in the response body.`,
+        `supports only JSON, "application/x-www-form-urlencoded" and "text/plain" content types in the response body.`,
       );
 
     //----
@@ -84,50 +84,36 @@ export namespace HttpMigrateRouteComposer {
         failures.push(`${type} typed parameters must have a name`);
         return false;
       }
-      if (
-        new Set(named.map((p) => canonical(p.name!))).size !== named.length
-      ) {
+      if (new Set(named.map((p) => canonical(p.name!))).size !== named.length) {
         failures.push(`${type} typed parameter names must be unique`);
         return false;
       }
 
       // CHECK PARAMETER TYPES -> TO BE OBJECT
-      const objectParameters = parameters
-        .map((p) =>
-          OpenApiTypeChecker.isObject(p.schema)
-            ? { parameter: p, schema: p.schema }
-            : OpenApiTypeChecker.isReference(p.schema) &&
-                OpenApiTypeChecker.isObject(
-                  props.document.components.schemas?.[
-                    p.schema.$ref.replace(`#/components/schemas/`, ``)
-                  ] ?? {},
-                )
-              ? {
-                  parameter: p,
-                  schema: props.document.components.schemas?.[
-                    p.schema.$ref.replace(`#/components/schemas/`, ``)
-                  ]! as OpenApi.IJsonSchema.IObject,
-                }
-              : null!,
-        )
-        .filter((s) => !!s);
-      const primitives = parameters.filter(
-        (p) =>
-          OpenApiTypeChecker.isBoolean(p.schema) ||
-          OpenApiTypeChecker.isInteger(p.schema) ||
-          OpenApiTypeChecker.isNumber(p.schema) ||
-          OpenApiTypeChecker.isString(p.schema) ||
-          OpenApiTypeChecker.isArray(p.schema) ||
-          OpenApiTypeChecker.isTuple(p.schema),
-      );
+      const parameterEntries = parameters.map((parameter) => ({
+        parameter,
+        schema: resolveSchema(props.document)(parameter.schema),
+      }));
+      const objectParameters = parameterEntries.filter((entry) =>
+        OpenApiTypeChecker.isObject(entry.schema),
+      ) as {
+        parameter: OpenApi.IOperation.IParameter;
+        schema: OpenApi.IJsonSchema.IObject;
+      }[];
+      const primitives = parameterEntries
+        .filter((entry) => !OpenApiTypeChecker.isObject(entry.schema))
+        .map((entry) => entry.parameter);
       const serialization: IHttpMigrateRoute.ISerialization[] = parameters.map(
         (parameter) => {
           const object = objectParameters.find(
             (entry) => entry.parameter === parameter,
           );
+          const schema =
+            parameterEntries.find((entry) => entry.parameter === parameter)
+              ?.schema ?? parameter.schema;
           const style =
-            parameter.style ??
-            (type === "header" ? "simple" : "form");
+            parameter.style ?? (type === "header" ? "simple" : "form");
+          const explode = parameter.explode ?? style === "form";
           const allowed =
             type === "header"
               ? style === "simple"
@@ -143,18 +129,30 @@ export namespace HttpMigrateRouteComposer {
             failures.push(
               `${type} parameter ${JSON.stringify(parameter.name)} does not support ${JSON.stringify(style)} style`,
             );
-          if (style === "deepObject" && object === undefined)
-            failures.push(
-              `query parameter ${JSON.stringify(parameter.name)} requires an object schema for deepObject style`,
-            );
-          if (
-            (style === "spaceDelimited" || style === "pipeDelimited") &&
-            !OpenApiTypeChecker.isArray(parameter.schema) &&
-            !OpenApiTypeChecker.isTuple(parameter.schema)
-          )
-            failures.push(
-              `query parameter ${JSON.stringify(parameter.name)} requires an array schema for ${style} style`,
-            );
+          if (style === "deepObject") {
+            if (object === undefined)
+              failures.push(
+                `query parameter ${JSON.stringify(parameter.name)} requires an object schema for deepObject style`,
+              );
+            if (explode === false)
+              failures.push(
+                `query parameter ${JSON.stringify(parameter.name)} requires explode: true for deepObject style`,
+              );
+          }
+          if (style === "spaceDelimited" || style === "pipeDelimited") {
+            if (
+              !OpenApiTypeChecker.isArray(schema) &&
+              !OpenApiTypeChecker.isTuple(schema) &&
+              !OpenApiTypeChecker.isObject(schema)
+            )
+              failures.push(
+                `query parameter ${JSON.stringify(parameter.name)} requires an array or object schema for ${style} style`,
+              );
+            if (explode)
+              failures.push(
+                `query parameter ${JSON.stringify(parameter.name)} requires explode: false for ${style} style`,
+              );
+          }
           return {
             name: parameter.name!,
             key: object === undefined ? parameter.name! : null,
@@ -162,8 +160,12 @@ export namespace HttpMigrateRouteComposer {
               object === undefined
                 ? null
                 : Object.keys(object.schema.properties ?? {}),
+            additionalProperties:
+              object !== undefined &&
+              object.schema.additionalProperties !== undefined &&
+              object.schema.additionalProperties !== false,
             style: style as IHttpMigrateRoute.ISerialization["style"],
-            explode: parameter.explode ?? style === "form",
+            explode,
             parameter: () => parameter,
           };
         },
@@ -223,9 +225,12 @@ export namespace HttpMigrateRouteComposer {
           required: [
             ...new Set([
               ...primitives.filter((p) => p.required).map((p) => p.name!),
-              ...(dto?.required ?? []),
+              ...(objectParameters[0]?.parameter.required
+                ? (dto?.required ?? [])
+                : []),
             ]),
           ],
+          additionalProperties: dto?.additionalProperties,
         });
       return parameters.length === 0
         ? null
@@ -241,13 +246,13 @@ export namespace HttpMigrateRouteComposer {
                 properties: Object.fromEntries([
                   ...new Map<string, OpenApi.IJsonSchema>(
                     Object.entries(entire.properties ?? {}).map(
-                      ([name, schema]) => [
-                        name,
-                        { ...schema } as OpenApi.IJsonSchema,
-                      ] as const),
+                      ([name, schema]) =>
+                        [name, { ...schema } as OpenApi.IJsonSchema] as const,
+                    ),
                   ),
                 ]),
                 required: [...new Set(entire.required ?? [])],
+                additionalProperties: entire.additionalProperties,
               } satisfies OpenApi.IJsonSchema.IObject),
             }),
           });
@@ -478,14 +483,20 @@ export namespace HttpMigrateRouteComposer {
       ).filter(([_, v]) => !!v) as [string, OpenApi.IOperation.IMediaType][];
       const json = entries.find((e) =>
         meta["x-nestia-encrypted"] === true
-          ? e[0].includes("text/plain") || e[0].includes("application/json")
-          : e[0].includes("application/json") || e[0].includes("*/*"),
+          ? normalizeMediaType(e[0]) === "text/plain" || isJsonMediaType(e[0])
+          : isJsonMediaType(e[0]),
       );
       if (json) {
         const schema = sanitizeMediaSchema(document)(json[1]);
         return schema
           ? {
-              type: "application/json",
+              type:
+                normalizeMediaType(json[0]) === "*/*" ||
+                normalizeMediaType(json[0]) === "text/plain"
+                  ? "application/json"
+                  : (normalizeMediaType(
+                      json[0],
+                    ) as IHttpMigrateRoute.IBody["type"]),
               name: "body",
               key: "body",
               required: from === "request" && meta.required === true,
@@ -591,10 +602,7 @@ export namespace HttpMigrateRouteComposer {
     Object.entries(content ?? {}).find(
       (entry): entry is [string, OpenApi.IOperation.IMediaType] => {
         const [type, media] = entry;
-        return (
-          media !== undefined &&
-          (type.includes("application/json") || type.includes("*/*"))
-        );
+        return media !== undefined && isJsonMediaType(type);
       },
     );
 
@@ -620,6 +628,25 @@ export namespace HttpMigrateRouteComposer {
       ...parameter,
       schema: sanitizeSchema(document)(parameter.schema),
     });
+
+  const resolveSchema =
+    (document: OpenApi.IDocument) =>
+    (input: OpenApi.IJsonSchema): OpenApi.IJsonSchema => {
+      let schema: OpenApi.IJsonSchema = input;
+      const visited: Set<string> = new Set();
+      while (OpenApiTypeChecker.isReference(schema)) {
+        const key: string = schema.$ref.replace("#/components/schemas/", "");
+        if (
+          key === schema.$ref ||
+          visited.has(key) ||
+          document.components.schemas?.[key] === undefined
+        )
+          break;
+        visited.add(key);
+        schema = document.components.schemas[key]!;
+      }
+      return schema;
+    };
 
   const sanitizeSchema =
     (document: OpenApi.IDocument) =>
@@ -688,6 +715,18 @@ export namespace HttpMigrateRouteComposer {
     (OpenApiTypeChecker.isOneOf(schema) &&
       schema.oneOf.every(isNotObjectLiteral)) ||
     (OpenApiTypeChecker.isArray(schema) && isNotObjectLiteral(schema.items));
+
+  const normalizeMediaType = (type: string): string =>
+    type.split(";", 1)[0]!.trim().toLowerCase();
+
+  const isJsonMediaType = (type: string): boolean => {
+    const normalized: string = normalizeMediaType(type);
+    return (
+      normalized === "application/json" ||
+      normalized.endsWith("+json") ||
+      normalized === "*/*"
+    );
+  };
 }
 
 const isSuccessStatus = (status: string): boolean =>
@@ -710,8 +749,8 @@ const selectSuccessResponse = (
             : 300;
     return priority(x) - priority(y) || x.localeCompare(y);
   });
-  return entries[0] ??
-    (responses?.default
-      ? (["default", responses.default] as const)
-      : undefined);
+  return (
+    entries[0] ??
+    (responses?.default ? (["default", responses.default] as const) : undefined)
+  );
 };

--- a/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
@@ -77,6 +77,21 @@ export namespace HttpMigrateRouteComposer {
       );
       if (parameters.length === 0) return null;
 
+      if (type === "query") {
+        const querystrings = parameters.filter((p) => p.in === "querystring");
+        const queries = parameters.filter((p) => p.in === "query");
+        if (querystrings.length > 1) {
+          failures.push("querystring parameter must appear at most once");
+          return false;
+        }
+        if (querystrings.length !== 0 && queries.length !== 0) {
+          failures.push(
+            "querystring parameter cannot coexist with query parameters",
+          );
+          return false;
+        }
+      }
+
       const canonical = (name: string): string =>
         type === "header" ? name.toLowerCase() : name;
       const named = parameters.filter((p) => p.name !== undefined);
@@ -87,6 +102,85 @@ export namespace HttpMigrateRouteComposer {
       if (new Set(named.map((p) => canonical(p.name!))).size !== named.length) {
         failures.push(`${type} typed parameter names must be unique`);
         return false;
+      }
+
+      const out = (
+        elem: {
+          schema: OpenApi.IJsonSchema;
+          title?: string;
+          description?: string;
+          example?: any;
+          examples?: Record<string, any>;
+          querystring?: IHttpMigrateRoute.IQuerystring;
+        },
+        serializations: IHttpMigrateRoute.ISerialization[],
+      ) =>
+        ({
+          ...elem,
+          name: type,
+          key: type,
+          required: parameters.some((p) => p.required === true),
+          parameters: serializations,
+          title: () => elem.title,
+          description: () => elem.description,
+          example: () => elem.example,
+          examples: () => elem.examples,
+        }) satisfies IHttpMigrateRoute.IHeaders;
+
+      if (
+        type === "query" &&
+        parameters[0]?.in === "querystring" &&
+        parameters[0].content !== undefined
+      ) {
+        const parameter = parameters[0];
+        const entries = Object.entries(parameter.content ?? {}).filter(
+          (entry): entry is [string, OpenApi.IOperation.IMediaType] =>
+            entry[1] !== undefined,
+        );
+        if (entries.length !== 1) {
+          failures.push(
+            "querystring parameter must define exactly one content media type",
+          );
+          return false;
+        }
+        const [mediaType, media] = entries[0]!;
+        const normalized: string = normalizeMediaType(mediaType);
+        const schema: OpenApi.IJsonSchema = resolveSchema(props.document)(
+          parameter.schema,
+        );
+        if (
+          normalized === "application/x-www-form-urlencoded" &&
+          OpenApiTypeChecker.isObject(schema) === false
+        ) {
+          failures.push(
+            "application/x-www-form-urlencoded querystring parameter requires an object schema",
+          );
+          return false;
+        }
+        if (
+          normalized !== "application/x-www-form-urlencoded" &&
+          isJsonMediaType(normalized) === false &&
+          OpenApiTypeChecker.isBoolean(schema) === false &&
+          OpenApiTypeChecker.isInteger(schema) === false &&
+          OpenApiTypeChecker.isNumber(schema) === false &&
+          OpenApiTypeChecker.isString(schema) === false
+        ) {
+          failures.push(
+            `querystring media type ${JSON.stringify(normalized)} requires a scalar schema or JSON representation`,
+          );
+          return false;
+        }
+        return out(
+          {
+            ...parameter,
+            schema: sanitizeSchema(props.document)(parameter.schema),
+            querystring: {
+              type: normalized,
+              media: () => media,
+            },
+          },
+          [],
+        );
       }
 
       // CHECK PARAMETER TYPES -> TO BE OBJECT
@@ -165,7 +259,6 @@ export namespace HttpMigrateRouteComposer {
               object === undefined ? null : (object.schema.required ?? []),
             additionalProperties:
               object !== undefined &&
-              object.schema.additionalProperties !== undefined &&
               object.schema.additionalProperties !== false,
             style: style as IHttpMigrateRoute.ISerialization["style"],
             explode,
@@ -173,27 +266,11 @@ export namespace HttpMigrateRouteComposer {
           };
         },
       );
-      const out = (elem: {
-        schema: OpenApi.IJsonSchema;
-        title?: string;
-        description?: string;
-        example?: any;
-        examples?: Record<string, any>;
-      }) =>
-        ({
-          ...elem,
-          name: type,
-          key: type,
-          required: parameters.some((p) => p.required === true),
-          parameters: serialization,
-          title: () => elem.title,
-          description: () => elem.description,
-          example: () => elem.example,
-          examples: () => elem.examples,
-        }) satisfies IHttpMigrateRoute.IHeaders;
-
       if (objectParameters.length === 1 && primitives.length === 0)
-        return out(sanitizeParameter(props.document)(parameters[0]!));
+        return out(
+          sanitizeParameter(props.document)(parameters[0]!),
+          serialization,
+        );
       else if (objectParameters.length > 1) {
         failures.push(`${type} typed parameters must be only one object type`);
         return false;
@@ -265,16 +342,19 @@ export namespace HttpMigrateRouteComposer {
           : entire;
       return parameters.length === 0
         ? null
-        : out({
-            schema: emplaceReference({
-              document: props.document,
-              name:
-                EndpointUtil.pascal(`I/Api/${props.path}`) +
-                "." +
-                EndpointUtil.pascal(`${props.method}/${type}`),
-              schema,
-            }),
-          });
+        : out(
+            {
+              schema: emplaceReference({
+                document: props.document,
+                name:
+                  EndpointUtil.pascal(`I/Api/${props.path}`) +
+                  "." +
+                  EndpointUtil.pascal(`${props.method}/${type}`),
+                schema,
+              }),
+            },
+            serialization,
+          );
     });
 
     //----
@@ -594,6 +674,7 @@ export namespace HttpMigrateRouteComposer {
     (operation: OpenApi.IOperation): void => {
       operation.parameters?.forEach((parameter) => {
         parameter.schema = sanitizeSchema(document)(parameter.schema);
+        sanitizeContentSchemas(document)(parameter.content);
       });
       sanitizeContentSchemas(document)(operation.requestBody?.content);
       Object.values(operation.responses ?? {}).forEach((response) =>

--- a/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
@@ -160,6 +160,8 @@ export namespace HttpMigrateRouteComposer {
               object === undefined
                 ? null
                 : Object.keys(object.schema.properties ?? {}),
+            requiredProperties:
+              object === undefined ? null : (object.schema.required ?? []),
             additionalProperties:
               object !== undefined &&
               object.schema.additionalProperties !== undefined &&
@@ -209,22 +211,29 @@ export namespace HttpMigrateRouteComposer {
         );
         return false;
       }
+      const primitiveProperties: Record<string, OpenApi.IJsonSchema> =
+        Object.fromEntries(
+          primitives.map((p) => [
+            p.name,
+            {
+              ...p.schema,
+              description: p.schema.description ?? p.description,
+            },
+          ]),
+        );
+      const primitiveRequired: string[] = primitives
+        .filter((p) => p.required)
+        .map((p) => p.name!);
       const entire: OpenApi.IJsonSchema.IObject =
         OpenApiSchemaSanitizer.omitEmptyRequired({
           type: "object",
           properties: Object.fromEntries([
-            ...primitives.map((p) => [
-              p.name,
-              {
-                ...p.schema,
-                description: p.schema.description ?? p.description,
-              },
-            ]),
+            ...Object.entries(primitiveProperties),
             ...(dto ? Object.entries(dto.properties ?? {}) : []),
           ]),
           required: [
             ...new Set([
-              ...primitives.filter((p) => p.required).map((p) => p.name!),
+              ...primitiveRequired,
               ...(objectParameters[0]?.parameter.required
                 ? (dto?.required ?? [])
                 : []),
@@ -232,6 +241,27 @@ export namespace HttpMigrateRouteComposer {
           ],
           additionalProperties: dto?.additionalProperties,
         });
+      const schema: OpenApi.IJsonSchema =
+        objectParameters[0] !== undefined &&
+        objectParameters[0].parameter.required !== true &&
+        (dto?.required?.length ?? 0) !== 0
+          ? {
+              // Omission is valid, but once an object-owned key is supplied
+              // the object's own required fields apply again.
+              oneOf: [
+                OpenApiSchemaSanitizer.omitEmptyRequired({
+                  type: "object",
+                  properties: primitiveProperties,
+                  required: primitiveRequired,
+                  additionalProperties: false,
+                }),
+                OpenApiSchemaSanitizer.omitEmptyRequired({
+                  ...entire,
+                  required: [...primitiveRequired, ...(dto?.required ?? [])],
+                }),
+              ],
+            }
+          : entire;
       return parameters.length === 0
         ? null
         : out({
@@ -241,19 +271,7 @@ export namespace HttpMigrateRouteComposer {
                 EndpointUtil.pascal(`I/Api/${props.path}`) +
                 "." +
                 EndpointUtil.pascal(`${props.method}/${type}`),
-              schema: OpenApiSchemaSanitizer.omitEmptyRequired({
-                type: "object",
-                properties: Object.fromEntries([
-                  ...new Map<string, OpenApi.IJsonSchema>(
-                    Object.entries(entire.properties ?? {}).map(
-                      ([name, schema]) =>
-                        [name, { ...schema } as OpenApi.IJsonSchema] as const,
-                    ),
-                  ),
-                ]),
-                required: [...new Set(entire.required ?? [])],
-                additionalProperties: entire.additionalProperties,
-              } satisfies OpenApi.IJsonSchema.IObject),
+              schema,
             }),
           });
     });
@@ -261,10 +279,9 @@ export namespace HttpMigrateRouteComposer {
     //----
     // PATH PARAMETERS
     //----
-    const parameterNames: string[] = props.path
-      .split("/")
-      .filter((str) => str.startsWith("{") && str.endsWith("}"))
-      .map((str) => str.substring(1, str.length - 1));
+    const parameterNames: string[] = [
+      ...props.path.matchAll(/\{([^{}]+)\}/g),
+    ].map((match) => match[1]!);
     const uniqueParameterNames: string[] = [...new Set(parameterNames)];
     const pathParameters: OpenApi.IOperation.IParameter[] = (
       props.operation.parameters ?? []
@@ -510,8 +527,8 @@ export namespace HttpMigrateRouteComposer {
           : null;
       }
 
-      const query = entries.find((e) =>
-        e[0].includes("application/x-www-form-urlencoded"),
+      const query = entries.find(
+        (e) => normalizeMediaType(e[0]) === "application/x-www-form-urlencoded",
       );
       if (query) {
         const schema = sanitizeMediaSchema(document)(query[1]);
@@ -530,7 +547,9 @@ export namespace HttpMigrateRouteComposer {
           : null;
       }
 
-      const text = entries.find((e) => e[0].includes("text/plain"));
+      const text = entries.find(
+        (e) => normalizeMediaType(e[0]) === "text/plain",
+      );
       if (text)
         return {
           type: "text/plain",
@@ -543,8 +562,8 @@ export namespace HttpMigrateRouteComposer {
         };
 
       if (from === "request") {
-        const multipart = entries.find((e) =>
-          e[0].includes("multipart/form-data"),
+        const multipart = entries.find(
+          (e) => normalizeMediaType(e[0]) === "multipart/form-data",
         );
         if (multipart) {
           const schema = sanitizeMediaSchema(document)(multipart[1]);

--- a/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
@@ -70,11 +70,20 @@ export namespace HttpMigrateRouteComposer {
       // FIND TARGET PARAMETERS
       const parameters: OpenApi.IOperation.IParameter[] = (
         props.operation.parameters ?? []
-      ).filter((p) =>
-        type === "query"
-          ? p.in === "query" || p.in === "querystring"
-          : p.in === type,
-      );
+      ).filter((p) => {
+        const matches: boolean =
+          type === "query"
+            ? p.in === "query" || p.in === "querystring"
+            : p.in === type;
+        return (
+          matches &&
+          !(
+            type === "header" &&
+            p.name !== undefined &&
+            IGNORED_HEADER_PARAMETERS.has(p.name.toLowerCase())
+          )
+        );
+      });
       if (parameters.length === 0) return null;
 
       if (type === "query") {
@@ -858,3 +867,9 @@ const selectSuccessResponse = (
     (responses?.default ? (["default", responses.default] as const) : undefined)
   );
 };
+
+const IGNORED_HEADER_PARAMETERS = new Set([
+  "accept",
+  "authorization",
+  "content-type",
+]);

--- a/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
@@ -113,12 +113,13 @@ export namespace HttpMigrateRouteComposer {
               ?.schema ?? parameter.schema;
           const style =
             parameter.style ?? (type === "header" ? "simple" : "form");
-          const explode = parameter.explode ?? style === "form";
+          const explode =
+            parameter.explode ?? (style === "form" || style === "cookie");
           const allowed =
             type === "header"
               ? style === "simple"
               : type === "cookie"
-                ? style === "form"
+                ? style === "form" || style === "cookie"
                 : [
                     "form",
                     "spaceDelimited",
@@ -333,7 +334,10 @@ export namespace HttpMigrateRouteComposer {
     const usedParameterKeys = new Set<string>();
     const parameters: IHttpMigrateRoute.IParameter[] = pathParameters.map(
       (parameter) => {
-        let key: string = EndpointUtil.normalize(parameter.name!);
+        let key: string = EndpointUtil.normalize(parameter.name!).replace(
+          /[^a-zA-Z0-9_$]/g,
+          "_",
+        );
         while (
           NamingConvention.variable(key) === false ||
           usedParameterKeys.has(key)

--- a/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
@@ -31,6 +31,7 @@ export namespace HttpMigrateRouteComposer {
         schema,
       }),
     )(props.operation.requestBody);
+    const successResponse = selectSuccessResponse(props.operation.responses);
     const success: false | null | IHttpMigrateRoute.ISuccess = (() => {
       const body = emplaceBodySchema(props.document)("response")((schema) =>
         emplaceReference({
@@ -41,19 +42,11 @@ export namespace HttpMigrateRouteComposer {
             EndpointUtil.pascal(`${props.method}/Response`),
           schema,
         }),
-      )(
-        props.operation.responses?.["201"] ??
-          props.operation.responses?.["200"] ??
-          props.operation.responses?.default,
-      );
+      )(successResponse?.[1]);
       return body
         ? {
             ...body,
-            status: props.operation.responses?.["201"]
-              ? "201"
-              : props.operation.responses?.["200"]
-                ? "200"
-                : "default",
+            status: successResponse![0],
           }
         : body;
     })();
@@ -71,7 +64,9 @@ export namespace HttpMigrateRouteComposer {
     //----
     // HEADERS AND QUERY
     //---
-    const [headers, query] = ["header", "query"].map((type) => {
+    const [headers, query, cookies] = (
+      ["header", "query", "cookie"] as const
+    ).map((type) => {
       // FIND TARGET PARAMETERS
       const parameters: OpenApi.IOperation.IParameter[] = (
         props.operation.parameters ?? []
@@ -82,18 +77,37 @@ export namespace HttpMigrateRouteComposer {
       );
       if (parameters.length === 0) return null;
 
+      const canonical = (name: string): string =>
+        type === "header" ? name.toLowerCase() : name;
+      const named = parameters.filter((p) => p.name !== undefined);
+      if (named.length !== parameters.length) {
+        failures.push(`${type} typed parameters must have a name`);
+        return false;
+      }
+      if (
+        new Set(named.map((p) => canonical(p.name!))).size !== named.length
+      ) {
+        failures.push(`${type} typed parameter names must be unique`);
+        return false;
+      }
+
       // CHECK PARAMETER TYPES -> TO BE OBJECT
-      const objects = parameters
+      const objectParameters = parameters
         .map((p) =>
           OpenApiTypeChecker.isObject(p.schema)
-            ? p.schema
+            ? { parameter: p, schema: p.schema }
             : OpenApiTypeChecker.isReference(p.schema) &&
                 OpenApiTypeChecker.isObject(
                   props.document.components.schemas?.[
                     p.schema.$ref.replace(`#/components/schemas/`, ``)
                   ] ?? {},
                 )
-              ? p.schema
+              ? {
+                  parameter: p,
+                  schema: props.document.components.schemas?.[
+                    p.schema.$ref.replace(`#/components/schemas/`, ``)
+                  ]! as OpenApi.IJsonSchema.IObject,
+                }
               : null!,
         )
         .filter((s) => !!s);
@@ -106,6 +120,54 @@ export namespace HttpMigrateRouteComposer {
           OpenApiTypeChecker.isArray(p.schema) ||
           OpenApiTypeChecker.isTuple(p.schema),
       );
+      const serialization: IHttpMigrateRoute.ISerialization[] = parameters.map(
+        (parameter) => {
+          const object = objectParameters.find(
+            (entry) => entry.parameter === parameter,
+          );
+          const style =
+            parameter.style ??
+            (type === "header" ? "simple" : "form");
+          const allowed =
+            type === "header"
+              ? style === "simple"
+              : type === "cookie"
+                ? style === "form"
+                : [
+                    "form",
+                    "spaceDelimited",
+                    "pipeDelimited",
+                    "deepObject",
+                  ].includes(style);
+          if (allowed === false)
+            failures.push(
+              `${type} parameter ${JSON.stringify(parameter.name)} does not support ${JSON.stringify(style)} style`,
+            );
+          if (style === "deepObject" && object === undefined)
+            failures.push(
+              `query parameter ${JSON.stringify(parameter.name)} requires an object schema for deepObject style`,
+            );
+          if (
+            (style === "spaceDelimited" || style === "pipeDelimited") &&
+            !OpenApiTypeChecker.isArray(parameter.schema) &&
+            !OpenApiTypeChecker.isTuple(parameter.schema)
+          )
+            failures.push(
+              `query parameter ${JSON.stringify(parameter.name)} requires an array schema for ${style} style`,
+            );
+          return {
+            name: parameter.name!,
+            key: object === undefined ? parameter.name! : null,
+            properties:
+              object === undefined
+                ? null
+                : Object.keys(object.schema.properties ?? {}),
+            style: style as IHttpMigrateRoute.ISerialization["style"],
+            explode: parameter.explode ?? style === "form",
+            parameter: () => parameter,
+          };
+        },
+      );
       const out = (elem: {
         schema: OpenApi.IJsonSchema;
         title?: string;
@@ -117,38 +179,35 @@ export namespace HttpMigrateRouteComposer {
           ...elem,
           name: type,
           key: type,
+          required: parameters.some((p) => p.required === true),
+          parameters: serialization,
           title: () => elem.title,
           description: () => elem.description,
           example: () => elem.example,
           examples: () => elem.examples,
         }) satisfies IHttpMigrateRoute.IHeaders;
 
-      if (objects.length === 1 && primitives.length === 0)
+      if (objectParameters.length === 1 && primitives.length === 0)
         return out(sanitizeParameter(props.document)(parameters[0]!));
-      else if (objects.length > 1) {
+      else if (objectParameters.length > 1) {
         failures.push(`${type} typed parameters must be only one object type`);
         return false;
       }
 
       // GATHER TO OBJECT TYPE
-      const dto: OpenApi.IJsonSchema.IObject | null = objects[0]
-        ? OpenApiTypeChecker.isObject(objects[0])
-          ? objects[0]
-          : ((props.document.components.schemas ?? {})[
-              (objects[0] as OpenApi.IJsonSchema.IReference).$ref.replace(
-                `#/components/schemas/`,
-                ``,
-              )
-            ] as OpenApi.IJsonSchema.IObject)
-        : null;
-      const entire: OpenApi.IJsonSchema.IObject[] = [
-        ...objects.map((o) =>
-          OpenApiTypeChecker.isObject(o)
-            ? o
-            : (props.document.components.schemas?.[
-                o.$ref.replace(`#/components/schemas/`, ``)
-              ]! as OpenApi.IJsonSchema.IObject),
-        ),
+      const dto: OpenApi.IJsonSchema.IObject | null =
+        objectParameters[0]?.schema ?? null;
+      const primitiveNames = new Set(primitives.map((p) => canonical(p.name!)));
+      const collisions = Object.keys(dto?.properties ?? {}).filter((name) =>
+        primitiveNames.has(canonical(name)),
+      );
+      if (collisions.length !== 0) {
+        failures.push(
+          `${type} typed parameter properties conflict: ${collisions.join(", ")}`,
+        );
+        return false;
+      }
+      const entire: OpenApi.IJsonSchema.IObject =
         OpenApiSchemaSanitizer.omitEmptyRequired({
           type: "object",
           properties: Object.fromEntries([
@@ -167,8 +226,7 @@ export namespace HttpMigrateRouteComposer {
               ...(dto?.required ?? []),
             ]),
           ],
-        }),
-      ];
+        });
       return parameters.length === 0
         ? null
         : out({
@@ -182,26 +240,14 @@ export namespace HttpMigrateRouteComposer {
                 type: "object",
                 properties: Object.fromEntries([
                   ...new Map<string, OpenApi.IJsonSchema>(
-                    entire
-                      .map((o) =>
-                        Object.entries(o.properties ?? {}).map(
-                          ([name, schema]) =>
-                            [
-                              name,
-                              {
-                                ...schema,
-                                description:
-                                  schema.description ?? schema.description,
-                              } as OpenApi.IJsonSchema,
-                            ] as const,
-                        ),
-                      )
-                      .flat(),
+                    Object.entries(entire.properties ?? {}).map(
+                      ([name, schema]) => [
+                        name,
+                        { ...schema } as OpenApi.IJsonSchema,
+                      ] as const),
                   ),
                 ]),
-                required: [
-                  ...new Set(entire.map((o) => o.required ?? []).flat()),
-                ],
+                required: [...new Set(entire.required ?? [])],
               } satisfies OpenApi.IJsonSchema.IObject),
             }),
           });
@@ -210,90 +256,96 @@ export namespace HttpMigrateRouteComposer {
     //----
     // PATH PARAMETERS
     //----
-    const parameterNames: string[] = EndpointUtil.splitWithNormalization(
-      props.emendedPath,
-    )
-      .filter((str) => str[0] === ":")
-      .map((str) => str.substring(1));
+    const parameterNames: string[] = props.path
+      .split("/")
+      .filter((str) => str.startsWith("{") && str.endsWith("}"))
+      .map((str) => str.substring(1, str.length - 1));
+    const uniqueParameterNames: string[] = [...new Set(parameterNames)];
     const pathParameters: OpenApi.IOperation.IParameter[] = (
       props.operation.parameters ?? []
     ).filter((p) => p.in === "path");
-    if (parameterNames.length !== pathParameters.length)
-      if (
-        pathParameters.length < parameterNames.length &&
-        pathParameters.every(
-          (p) => p.name !== undefined && parameterNames.includes(p.name),
-        )
-      ) {
-        for (const name of parameterNames)
-          if (pathParameters.find((p) => p.name === name) === undefined)
-            pathParameters.push({
-              name,
-              in: "path",
-              schema: { type: "string" },
-            });
-        pathParameters.sort(
-          (a, b) =>
-            parameterNames.indexOf(a.name!) - parameterNames.indexOf(b.name!),
-        );
-        props.operation.parameters = [
-          ...pathParameters,
-          ...(props.operation.parameters ?? []).filter((p) => p.in !== "path"),
-        ];
-      } else
-        failures.push(
-          "number of path parameters are not matched with its full path.",
-        );
+    const duplicatePathNames: string[] = pathParameters
+      .map((p) => p.name)
+      .filter(
+        (name, index, array): name is string =>
+          name !== undefined && array.indexOf(name) !== index,
+      );
+    if (duplicatePathNames.length !== 0)
+      failures.push(
+        `path parameter names must be unique: ${[...new Set(duplicatePathNames)].join(", ")}`,
+      );
+    if (
+      pathParameters.some(
+        (p) => p.name === undefined || !uniqueParameterNames.includes(p.name),
+      )
+    )
+      failures.push("path parameter names are not matched with its full path.");
+    else {
+      for (const name of uniqueParameterNames)
+        if (pathParameters.find((p) => p.name === name) === undefined)
+          pathParameters.push({
+            name,
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          });
+      pathParameters.sort(
+        (a, b) =>
+          uniqueParameterNames.indexOf(a.name!) -
+          uniqueParameterNames.indexOf(b.name!),
+      );
+      for (const parameter of pathParameters) {
+        const style = parameter.style ?? "simple";
+        if (!["matrix", "label", "simple"].includes(style))
+          failures.push(
+            `path parameter ${JSON.stringify(parameter.name)} does not support ${JSON.stringify(style)} style`,
+          );
+      }
+      props.operation.parameters = [
+        ...pathParameters,
+        ...(props.operation.parameters ?? []).filter((p) => p.in !== "path"),
+      ];
+    }
     if (failures.length) return failures;
 
-    const parameters: IHttpMigrateRoute.IParameter[] = (
-      props.operation.parameters ?? []
-    )
-      .filter((p) => p.in === "path")
-      .map((p, i) => ({
-        // FILL KEY NAME IF NOT EXISTS
-        name: parameterNames[i]!,
-        key: (() => {
-          let key: string = EndpointUtil.normalize(parameterNames[i]!);
-          if (NamingConvention.variable(key)) return key;
-          while (true) {
-            key = "_" + key;
-            if (!parameterNames.some((s) => s === key)) return key;
-          }
-        })(),
-        schema: p.schema,
-        parameter: () => p,
-      }));
+    const usedParameterKeys = new Set<string>();
+    const parameters: IHttpMigrateRoute.IParameter[] = pathParameters.map(
+      (parameter) => {
+        let key: string = EndpointUtil.normalize(parameter.name!);
+        while (
+          NamingConvention.variable(key) === false ||
+          usedParameterKeys.has(key)
+        )
+          key = `_${key}`;
+        usedParameterKeys.add(key);
+        const style = parameter.style ?? "simple";
+        return {
+          name: parameter.name!,
+          key,
+          schema: parameter.schema,
+          style: style as IHttpMigrateRoute.IParameter["style"],
+          explode: parameter.explode ?? false,
+          parameter: () => parameter,
+        };
+      },
+    );
     return {
       method: props.method,
       path: props.path,
       emendedPath: props.emendedPath,
       accessor: ["@lazy"],
-      parameters: (props.operation.parameters ?? [])
-        .filter((p) => p.in === "path")
-        .map((p, i) => ({
-          // FILL KEY NAME IF NOT EXISTS
-          name: parameterNames[i]!,
-          key: (() => {
-            let key: string = EndpointUtil.normalize(parameterNames[i]!);
-            if (NamingConvention.variable(key)) return key;
-            while (true) {
-              key = "_" + key;
-              if (!parameterNames.some((s) => s === key)) return key;
-            }
-          })(),
-          schema: p.schema,
-          parameter: () => p,
-        })),
+      parameters,
       headers: headers || null,
+      cookies: cookies || null,
       query: query || null,
       body: body || null,
       success: success || null,
       exceptions: Object.fromEntries(
         Object.entries(props.operation.responses ?? {})
-          .filter(
-            ([key]) => key !== "200" && key !== "201" && key !== "default",
-          )
+          .filter(([key]) => {
+            if (isSuccessStatus(key)) return false;
+            return key !== "default" || successResponse?.[0] !== "default";
+          })
           .map(([status, response]) => {
             const media = findJsonMedia(response.content);
             const schema =
@@ -416,6 +468,7 @@ export namespace HttpMigrateRouteComposer {
     (meta?: {
       description?: string;
       content?: Partial<Record<string, OpenApi.IOperation.IMediaType>>; // ISwaggerRouteBodyContent;
+      required?: boolean;
       "x-nestia-encrypted"?: boolean;
     }): false | null | IHttpMigrateRoute.IBody => {
       if (!meta?.content) return null;
@@ -435,6 +488,7 @@ export namespace HttpMigrateRouteComposer {
               type: "application/json",
               name: "body",
               key: "body",
+              required: from === "request" && meta.required === true,
               schema: isNotObjectLiteral(schema)
                 ? sanitizeSchema(document)(schema)
                 : emplacer(schema),
@@ -455,6 +509,7 @@ export namespace HttpMigrateRouteComposer {
               type: "application/x-www-form-urlencoded",
               name: "body",
               key: "body",
+              required: from === "request" && meta.required === true,
               schema: isNotObjectLiteral(schema)
                 ? sanitizeSchema(document)(schema)
                 : emplacer(schema),
@@ -470,6 +525,7 @@ export namespace HttpMigrateRouteComposer {
           type: "text/plain",
           name: "body",
           key: "body",
+          required: from === "request" && meta.required === true,
           schema: { type: "string" },
           description: () => meta.description,
           media: () => text[1],
@@ -485,6 +541,7 @@ export namespace HttpMigrateRouteComposer {
             type: "multipart/form-data",
             name: "body",
             key: "body",
+            required: meta.required === true,
             schema: schema
               ? isNotObjectLiteral(schema)
                 ? sanitizeSchema(document)(schema)
@@ -632,3 +689,29 @@ export namespace HttpMigrateRouteComposer {
       schema.oneOf.every(isNotObjectLiteral)) ||
     (OpenApiTypeChecker.isArray(schema) && isNotObjectLiteral(schema.items));
 }
+
+const isSuccessStatus = (status: string): boolean =>
+  /^2\d\d$/.test(status) || /^2xx$/i.test(status);
+
+const selectSuccessResponse = (
+  responses: Record<string, OpenApi.IOperation.IResponse> | undefined,
+): [string, OpenApi.IOperation.IResponse] | undefined => {
+  const entries = Object.entries(responses ?? {}).filter(([status]) =>
+    isSuccessStatus(status),
+  );
+  entries.sort(([x], [y]) => {
+    const priority = (status: string): number =>
+      status === "200"
+        ? 0
+        : status === "201"
+          ? 1
+          : /^2\d\d$/.test(status)
+            ? Number(status)
+            : 300;
+    return priority(x) - priority(y) || x.localeCompare(y);
+  });
+  return entries[0] ??
+    (responses?.default
+      ? (["default", responses.default] as const)
+      : undefined);
+};

--- a/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
@@ -239,16 +239,20 @@ const getPath = (
       },
     ]),
   );
-  let path: string = props.route.emendedPath
-    .split("/")
-    .map((segment) => {
-      if (!segment.startsWith(":")) return segment;
-      const found = byName.get(segment.substring(1));
-      return found === undefined
-        ? segment
-        : serializePath(found.parameter, found.value);
-    })
-    .join("/");
+  let path: string =
+    // Preserve legacy/custom emended static paths, while parameterized paths
+    // use source expressions so embedded and repeated names stay unambiguous.
+    props.route.parameters.length === 0
+      ? props.route.emendedPath
+      : props.route.path.replace(
+          /\{([^{}]+)\}/g,
+          (expression, name: string) => {
+            const found = byName.get(name);
+            return found === undefined
+              ? expression
+              : serializePath(found.parameter, found.value);
+          },
+        );
   if (props.route.query && props.query)
     path += getQueryPath(error, props.route.query, props.query);
   return path;
@@ -302,7 +306,10 @@ const parameterValue = (
       (properties.has(key) ||
         (metadata.additionalProperties === true && !occupied.has(key))),
   );
-  return entries.length !== 0 || (metadata.properties?.length ?? 0) === 0
+  return entries.length !== 0 ||
+    (metadata.properties?.length ?? 0) === 0 ||
+    (metadata.parameter().required === true &&
+      metadata.requiredProperties?.length === 0)
     ? Object.fromEntries(entries)
     : undefined;
 };

--- a/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
@@ -199,7 +199,12 @@ const requestHeaders =
                   );
                 return [];
               }
-              return serializeCookie(metadata.name, value, metadata.explode);
+              return serializeCookie(
+                metadata.name,
+                value,
+                metadata.explode,
+                metadata.style,
+              );
             });
       if (supplied.length !== 0) {
         const replaced = new Set(supplied.map(([name]) => name));
@@ -361,7 +366,8 @@ const serializePath = (
   metadata: IHttpMigrateRoute.IParameter,
   value: unknown,
 ): string => {
-  const encode = (input: unknown): string => encodeURIComponent(String(input));
+  const encode = encodeRfc3986;
+  const name: string = encode(metadata.name);
   const style = metadata.style ?? "simple";
   const explode = metadata.explode ?? false;
   const array = Array.isArray(value) ? value.map(encode) : null;
@@ -371,13 +377,13 @@ const serializePath = (
   if (style === "matrix") {
     if (array)
       return explode
-        ? array.map((elem) => `;${metadata.name}=${elem}`).join("")
-        : `;${metadata.name}=${array.join(",")}`;
+        ? array.map((elem) => `;${name}=${elem}`).join("")
+        : `;${name}=${array.join(",")}`;
     if (object)
       return explode
         ? object.map(([key, elem]) => `;${key}=${elem}`).join("")
-        : `;${metadata.name}=${object.flat().join(",")}`;
-    return `;${metadata.name}=${encode(value)}`;
+        : `;${name}=${object.flat().join(",")}`;
+    return `;${name}=${encode(value)}`;
   }
   if (style === "label") {
     if (array) return `.${array.join(explode ? "." : ",")}`;
@@ -412,24 +418,29 @@ const serializeCookie = (
   name: string,
   value: unknown,
   explode: boolean,
+  style: IHttpMigrateRoute.ISerialization["style"] = "form",
 ): [string, string][] => {
-  const encode = (input: unknown): string => encodeURIComponent(String(input));
+  const encode = (input: unknown): string =>
+    style === "cookie" ? String(input) : encodeRfc3986(input);
+  const encodedName: string = encode(name);
   if (Array.isArray(value))
     return explode
-      ? value.map((elem) => [name, encode(elem)])
-      : [[name, value.map(encode).join(",")]];
+      ? value.map((elem) => [encodedName, encode(elem)])
+      : [[encodedName, value.map(encode).join(",")]];
   if (isRecord(value)) {
     const entries = objectEntries(value);
     return explode
-      ? entries.map(([key, elem]) => [key, encode(elem)])
+      ? entries.map(([key, elem]) => [encode(key), encode(elem)])
       : [
           [
-            name,
-            entries.flatMap(([key, elem]) => [key, encode(elem)]).join(","),
+            encodedName,
+            entries
+              .flatMap(([key, elem]) => [encode(key), encode(elem)])
+              .join(","),
           ],
         ];
   }
-  return [[name, encode(value)]];
+  return [[encodedName, encode(value)]];
 };
 
 const requestQueryBody = (input: object): URLSearchParams => {
@@ -514,3 +525,9 @@ const objectEntries = (value: unknown): [string, unknown][] =>
   isRecord(value)
     ? Object.entries(value).filter((entry) => entry[1] !== undefined)
     : [];
+
+const encodeRfc3986 = (input: unknown): string =>
+  encodeURIComponent(String(input)).replace(
+    /[!'()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );

--- a/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
@@ -46,7 +46,12 @@ const propagateRequest = async (
 
   validateGroup(error)("headers", props.route.headers, props.headers);
   validateGroup(error)("cookies", props.route.cookies ?? null, props.cookies);
-  validateGroup(error)("query", props.route.query, props.query);
+  validateGroup(error)(
+    "query",
+    props.route.query,
+    props.query,
+    props.route.query?.querystring === undefined,
+  );
   validateBody(error)(props.route.body, props.body);
 
   const headers: Headers = requestHeaders(error)(props);
@@ -114,7 +119,8 @@ const validateGroup =
       | IHttpMigrateRoute.ICookies
       | IHttpMigrateRoute.IBody
       | null,
-    input: object | undefined,
+    input: unknown,
+    objectOnly: boolean = true,
   ): void => {
     if (metadata === null) {
       if (input !== undefined) throw error(`${name} is not matched.`);
@@ -123,6 +129,7 @@ const validateGroup =
     if ((metadata.required ?? true) && input === undefined)
       throw error(`${name} is not matched.`);
     if (
+      objectOnly &&
       input !== undefined &&
       (typeof input !== "object" || input === null || Array.isArray(input))
     )
@@ -258,9 +265,35 @@ const getPath = (
               : serializePath(found.parameter, found.value);
           },
         );
-  if (props.route.query && props.query)
-    path += getQueryPath(error, props.route.query, props.query);
+  if (props.route.query && props.query !== undefined)
+    path +=
+      props.route.query.querystring !== undefined
+        ? getQuerystringPath(error, props.route.query, props.query)
+        : getQueryPath(error, props.route.query, props.query as object);
   return path;
+};
+
+const getQuerystringPath = (
+  error: (message: string) => Error,
+  route: IHttpMigrateRoute.IQuery,
+  query: unknown,
+): string => {
+  const type: string = route.querystring!.type;
+  let serialized: string;
+  if (type === "application/x-www-form-urlencoded") {
+    if (!isRecord(query)) throw error(`query must be an object for ${type}.`);
+    serialized = requestQueryBody(query).toString();
+  } else if (isJsonMediaType(type)) {
+    const value: string | undefined = JSON.stringify(query);
+    if (value === undefined)
+      throw error(`query cannot be serialized as ${type}.`);
+    serialized = encodeRfc3986(value);
+  } else {
+    if (typeof query === "object" && query !== null)
+      throw error(`query must be a scalar for ${type}.`);
+    serialized = encodeRfc3986(query);
+  }
+  return serialized.length === 0 ? "" : `?${serialized}`;
 };
 
 const getQueryPath = (
@@ -268,8 +301,8 @@ const getQueryPath = (
   route: IHttpMigrateRoute.IQuery,
   query: object,
 ): string => {
-  const variables = new URLSearchParams();
   if (route.parameters === undefined) {
+    const variables = new URLSearchParams();
     for (const [key, value] of Object.entries(query))
       if (value === undefined) continue;
       else if (Array.isArray(value))
@@ -277,6 +310,7 @@ const getQueryPath = (
       else variables.set(key, String(value));
     return variables.size === 0 ? "" : `?${variables.toString()}`;
   }
+  const variables: string[] = [];
   for (const metadata of route.parameters) {
     const value = parameterValue(metadata, query, route.parameters);
     if (value === undefined) {
@@ -284,10 +318,9 @@ const getQueryPath = (
         throw error(`query ${JSON.stringify(metadata.name)} is required.`);
       continue;
     }
-    for (const [key, elem] of serializeQuery(metadata, value))
-      variables.append(key, elem);
+    variables.push(...serializeQuery(metadata, value));
   }
-  return variables.size === 0 ? "" : `?${variables.toString()}`;
+  return variables.length === 0 ? "" : `?${variables.join("&")}`;
 };
 
 const parameterValue = (
@@ -322,44 +355,47 @@ const parameterValue = (
 const serializeQuery = (
   metadata: IHttpMigrateRoute.ISerialization,
   value: unknown,
-): [string, string][] => {
+): string[] => {
+  const encode = encodeRfc3986;
+  const name: string = encode(metadata.name);
+  const pair = (key: unknown, elem: unknown): string =>
+    `${encode(key)}=${encode(elem)}`;
   if (metadata.style === "deepObject")
-    return objectEntries(value).map(([key, elem]) => [
-      `${metadata.name}[${key}]`,
-      String(elem),
-    ]);
+    return objectEntries(value).map(
+      ([key, elem]) => `${name}[${encode(key)}]=${encode(elem)}`,
+    );
   if (
     metadata.style === "spaceDelimited" ||
     metadata.style === "pipeDelimited"
   ) {
     const delimiter = metadata.style === "spaceDelimited" ? " " : "|";
     return [
-      [
-        metadata.name,
+      `${name}=${
         isRecord(value)
           ? objectEntries(value)
-              .flatMap(([key, elem]) => [key, String(elem)])
-              .join(delimiter)
-          : arrayValues(value).map(String).join(delimiter),
-      ],
+              .flatMap(([key, elem]) => [encode(key), encode(elem)])
+              .join(delimiter === " " ? "%20" : delimiter)
+          : arrayValues(value)
+              .map(encode)
+              .join(delimiter === " " ? "%20" : delimiter)
+      }`,
     ];
   }
   if (Array.isArray(value))
     return metadata.explode
-      ? value.map((elem) => [metadata.name, String(elem)])
-      : [[metadata.name, value.map(String).join(",")]];
+      ? value.map((elem) => `${name}=${encode(elem)}`)
+      : [`${name}=${value.map(encode).join(",")}`];
   if (isRecord(value)) {
     const entries = objectEntries(value);
     return metadata.explode
-      ? entries.map(([key, elem]) => [key, String(elem)])
+      ? entries.map(([key, elem]) => pair(key, elem))
       : [
-          [
-            metadata.name,
-            entries.flatMap(([key, elem]) => [key, String(elem)]).join(","),
-          ],
+          `${name}=${entries
+            .flatMap(([key, elem]) => [encode(key), encode(elem)])
+            .join(",")}`,
         ];
   }
-  return [[metadata.name, String(value)]];
+  return [`${name}=${encode(value)}`];
 };
 
 const serializePath = (

--- a/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
@@ -362,22 +362,20 @@ const serializeQuery = (
     `${encode(key)}=${encode(elem)}`;
   if (metadata.style === "deepObject")
     return objectEntries(value).map(
-      ([key, elem]) => `${name}[${encode(key)}]=${encode(elem)}`,
+      ([key, elem]) => `${name}%5B${encode(key)}%5D=${encode(elem)}`,
     );
   if (
     metadata.style === "spaceDelimited" ||
     metadata.style === "pipeDelimited"
   ) {
-    const delimiter = metadata.style === "spaceDelimited" ? " " : "|";
+    const delimiter = metadata.style === "spaceDelimited" ? "%20" : "%7C";
     return [
       `${name}=${
         isRecord(value)
           ? objectEntries(value)
               .flatMap(([key, elem]) => [encode(key), encode(elem)])
-              .join(delimiter === " " ? "%20" : delimiter)
-          : arrayValues(value)
-              .map(encode)
-              .join(delimiter === " " ? "%20" : delimiter)
+              .join(delimiter)
+          : arrayValues(value).map(encode).join(delimiter)
       }`,
     ];
   }

--- a/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
@@ -1,4 +1,7 @@
-import { IHttpConnection, IHttpResponse } from "@typia/interface";
+import {
+  IHttpMigrateRoute,
+  IHttpResponse,
+} from "@typia/interface";
 
 import { HttpError } from "../HttpError";
 import type { HttpMigration } from "../HttpMigration";
@@ -7,184 +10,398 @@ export namespace HttpMigrateRouteFetcher {
   export const execute = async (
     props: HttpMigration.IFetchProps,
   ): Promise<unknown> => {
-    const result: IHttpResponse = await _Propagate("request", props);
-    props.route.success?.media;
-    if (result.status !== 200 && result.status !== 201)
+    const result: IHttpResponse = await propagateRequest("request", props);
+    if (result.status < 200 || result.status >= 300)
       throw new HttpError(
         props.route.method.toUpperCase() as "GET",
         props.route.path,
         result.status,
         result.headers,
-        result.body as string,
+        result.body,
       );
     return result.body;
   };
 
   export const propagate = (
     props: HttpMigration.IFetchProps,
-  ): Promise<IHttpResponse> => _Propagate("propagate", props);
+  ): Promise<IHttpResponse> => propagateRequest("propagate", props);
 }
 
-const _Propagate = async (
+const propagateRequest = async (
   from: string,
   props: HttpMigration.IFetchProps,
 ): Promise<IHttpResponse> => {
-  // VALIDATE PARAMETERS
   const error = (message: string) =>
     new Error(`Error on MigrateRouteFetcher.${from}(): ${message}`);
   if (Array.isArray(props.parameters)) {
     if (props.route.parameters.length !== props.parameters.length)
       throw error(`number of parameters is not matched.`);
-  } else if (
-    props.route.parameters.every(
-      (p) => (props.parameters as Record<string, any>)[p.key] !== undefined,
-    ) === false
-  )
-    throw error(`number of parameters is not matched.`);
+  } else {
+    const parameters = props.parameters;
+    if (
+      props.route.parameters.every(
+        (parameter) => parameters[parameter.key] !== undefined,
+      ) === false
+    )
+      throw error(`number of parameters is not matched.`);
+  }
 
-  // VALIDATE QUERY
-  if (!!props.route.query !== !!props.query)
-    throw error(`query is not matched.`);
-  else if (!!props.route.body !== (props.body !== undefined))
-    throw error(`body is not matched.`);
+  validateGroup(error)("headers", props.route.headers, props.headers);
+  validateGroup(error)("cookies", props.route.cookies, props.cookies);
+  validateGroup(error)("query", props.route.query, props.query);
+  validateGroup(error)("body", props.route.body, props.body);
 
-  // INIT REQUEST DATA
-  const headers: Record<string, IHttpConnection.HeaderValue | undefined> = {
-    ...(props.connection.headers ?? {}),
-    ...(props.route.body?.type &&
-    props.route.body.type !== "multipart/form-data"
-      ? { "Content-Type": props.route.body.type }
-      : {}),
-  };
+  const headers: Headers = requestHeaders(error)(props);
   const init: RequestInit = {
     ...(props.connection.options ?? {}),
     method: props.route.method.toUpperCase(),
-    headers: (() => {
-      const output: [string, string][] = [];
-      for (const [key, value] of Object.entries(headers))
-        if (value === undefined) continue;
-        else if (Array.isArray(value))
-          for (const v of value) output.push([key, String(v)]);
-        else output.push([key, String(value)]);
-      return output;
-    })(),
+    headers,
   };
   if (props.body !== undefined)
     init.body = (
       props.route.body?.type === "application/x-www-form-urlencoded"
         ? requestQueryBody(props.body)
         : props.route.body?.type === "multipart/form-data"
-          ? requestFormDataBody(props.body)
+          ? requestFormDataBody(props.body as Record<string, any>)
           : props.route.body?.type === "application/json"
             ? JSON.stringify(props.body)
             : props.body
-    ) as any;
+    ) as BodyInit;
 
-  // DO REQUEST
-  const resolvedPath: string =
-    props.connection.host.endsWith("/") === false &&
-    props.route.emendedPath.startsWith("/") === false
-      ? `/${getPath(props)}`
-      : getPath(props);
-  const url: URL = new URL(`${props.connection.host}${resolvedPath}`);
-
-  const response: Response = await (props.connection.fetch ?? fetch)(url, init);
-  const status: number = response.status;
+  const path: string = getPath(error, props);
+  const host: string = props.connection.host;
+  const joined: string =
+    host.endsWith("/") && path.startsWith("/")
+      ? host + path.substring(1)
+      : !host.endsWith("/") && !path.startsWith("/")
+        ? `${host}/${path}`
+        : host + path;
+  const response: Response = await (props.connection.fetch ?? fetch)(
+    new URL(joined),
+    init,
+  );
   const out = (body: unknown): IHttpResponse => ({
-    status,
+    status: response.status,
     headers: responseHeaders(response.headers),
     body,
   });
 
-  if (status === 200 || status === 201) {
-    // SUCCESS CASE
-    if (props.route.method.toUpperCase() === "HEAD") return out(undefined);
-    else if (
-      props.route.success === null ||
-      props.route.success.type === "text/plain"
+  if (response.status >= 200 && response.status < 300) {
+    if (
+      props.route.method === "head" ||
+      response.status === 204 ||
+      response.status === 205
     )
-      return out(await response.text());
-    else if (props.route.success.type === "application/json") {
-      const text: string = await response.text();
-      return out(text.length ? JSON.parse(text) : undefined);
-    } else if (props.route.success.type === "application/x-www-form-urlencoded")
-      return out(new URLSearchParams(await response.text()));
-    else if (props.route.success.type === "multipart/form-data")
-      return out(await response.formData());
-    throw error("Unsupported response body type.");
-  } else {
-    // FAILURE CASE
-    const type: string = (
-      response.headers.get("content-type") ??
-      response.headers.get("Content-Type") ??
-      ""
-    )
-      .split(";")[0]!
-      .trim();
-    if (type === "" || type.startsWith("text/"))
-      return out(await response.text());
-    else if (type === "application/json") return out(await response.json());
-    else if (type === "application/x-www-form-urlencoded")
-      return out(new URLSearchParams(await response.text()));
-    else if (type === "multipart/form-data")
-      return out(await response.formData());
-    else if (type === "application/octet-stream")
-      return out(await response.blob());
-    return out(await response.text());
-  }
-};
-
-const getPath = (
-  props: Pick<HttpMigration.IFetchProps, "route" | "parameters" | "query">,
-): string => {
-  let path: string = props.route.emendedPath;
-  props.route.parameters.forEach((p, i) => {
-    path = path.replace(
-      `:${p.key}`,
-      encodeURIComponent(
-        String(
-          (Array.isArray(props.parameters)
-            ? props.parameters[i]
-            : props.parameters[p.key]) ?? "null",
-        ),
+      return out(undefined);
+    return out(
+      await parseResponseBody(
+        response,
+        contentType(response.headers) ||
+          props.route.success?.type ||
+          "text/plain",
       ),
     );
-  });
-  if (props.route.query) path += getQueryPath(props.query ?? {});
+  }
+  const type: string = contentType(response.headers);
+  return out(await parseResponseBody(response, type));
+};
+
+const validateGroup =
+  (error: (message: string) => Error) =>
+  (
+    name: string,
+    metadata:
+      | IHttpMigrateRoute.IHeaders
+      | IHttpMigrateRoute.IQuery
+      | IHttpMigrateRoute.ICookies
+      | IHttpMigrateRoute.IBody
+      | null,
+    input: object | undefined,
+  ): void => {
+    if (metadata === null) {
+      if (input !== undefined) throw error(`${name} is not matched.`);
+      return;
+    }
+    if (metadata.required && input === undefined)
+      throw error(`${name} is not matched.`);
+    if (
+      input !== undefined &&
+      (typeof input !== "object" || input === null || Array.isArray(input))
+    )
+      throw error(`${name} must be an object.`);
+  };
+
+const requestHeaders =
+  (error: (message: string) => Error) =>
+  (props: HttpMigration.IFetchProps): Headers => {
+    const output = new Headers();
+    for (const [key, value] of Object.entries(props.connection.headers ?? {}))
+      if (value === undefined) continue;
+      else if (Array.isArray(value))
+        value.forEach((elem) => output.append(key, String(elem)));
+      else output.append(key, String(value));
+
+    if (props.route.headers && props.headers)
+      for (const metadata of props.route.headers.parameters) {
+        const value = parameterValue(metadata, props.headers);
+        if (value === undefined) {
+          if (metadata.parameter().required)
+            throw error(`header ${JSON.stringify(metadata.name)} is required.`);
+          continue;
+        }
+        output.set(metadata.name, serializeSimple(value, metadata.explode));
+      }
+
+    if (props.route.cookies && props.cookies) {
+      const supplied = props.route.cookies.parameters.flatMap((metadata) => {
+        const value = parameterValue(metadata, props.cookies!);
+        if (value === undefined) {
+          if (metadata.parameter().required)
+            throw error(`cookie ${JSON.stringify(metadata.name)} is required.`);
+          return [];
+        }
+        return serializeCookie(metadata.name, value, metadata.explode);
+      });
+      if (supplied.length !== 0) {
+        const replaced = new Set(supplied.map(([name]) => name));
+        const inherited = (output.get("cookie") ?? "")
+          .split(";")
+          .map((part) => part.trim())
+          .filter((part) => part.length !== 0)
+          .filter((part) => !replaced.has(part.split("=", 1)[0]!));
+        output.set(
+          "Cookie",
+          [...inherited, ...supplied.map(([name, value]) => `${name}=${value}`)]
+            .filter((part) => part.length !== 0)
+            .join("; "),
+        );
+      }
+    }
+
+    if (
+      props.body !== undefined &&
+      props.route.body?.type &&
+      props.route.body.type !== "multipart/form-data"
+    )
+      output.set("Content-Type", props.route.body.type);
+    return output;
+  };
+
+const getPath = (
+  error: (message: string) => Error,
+  props: Pick<HttpMigration.IFetchProps, "route" | "parameters" | "query">,
+): string => {
+  const byName = new Map(
+    props.route.parameters.map((parameter, index) => [
+      parameter.name,
+      {
+        parameter,
+        value: Array.isArray(props.parameters)
+          ? props.parameters[index]
+          : props.parameters[parameter.key],
+      },
+    ]),
+  );
+  let path: string = props.route.emendedPath
+    .split("/")
+    .map((segment) => {
+      if (!segment.startsWith(":")) return segment;
+      const found = byName.get(segment.substring(1));
+      return found === undefined
+        ? segment
+        : serializePath(found.parameter, found.value);
+    })
+    .join("/");
+  if (props.route.query && props.query)
+    path += getQueryPath(error, props.route.query, props.query);
   return path;
 };
 
-const getQueryPath = (query: Record<string, any>): string => {
+const getQueryPath = (
+  error: (message: string) => Error,
+  route: IHttpMigrateRoute.IQuery,
+  query: object,
+): string => {
   const variables = new URLSearchParams();
-  for (const [key, value] of Object.entries(query))
-    if (undefined === value) continue;
-    else if (Array.isArray(value))
-      value.forEach((elem: any) => variables.append(key, String(elem)));
-    else variables.set(key, String(value));
-  return 0 === variables.size ? "" : `?${variables.toString()}`;
+  for (const metadata of route.parameters) {
+    const value = parameterValue(metadata, query);
+    if (value === undefined) {
+      if (metadata.parameter().required)
+        throw error(`query ${JSON.stringify(metadata.name)} is required.`);
+      continue;
+    }
+    for (const [key, elem] of serializeQuery(metadata, value))
+      variables.append(key, elem);
+  }
+  return variables.size === 0 ? "" : `?${variables.toString()}`;
 };
 
-const requestQueryBody = (input: any): URLSearchParams => {
-  const q: URLSearchParams = new URLSearchParams();
+const parameterValue = (
+  metadata: IHttpMigrateRoute.ISerialization,
+  input: object,
+): unknown => {
+  const record = input as Record<string, unknown>;
+  if (metadata.key !== null) return record[metadata.key];
+  const entries = (metadata.properties ?? [])
+    .filter((key) => record[key] !== undefined)
+    .map((key) => [key, record[key]] as const);
+  return entries.length !== 0 || (metadata.properties?.length ?? 0) === 0
+    ? Object.fromEntries(entries)
+    : undefined;
+};
+
+const serializeQuery = (
+  metadata: IHttpMigrateRoute.ISerialization,
+  value: unknown,
+): [string, string][] => {
+  if (metadata.style === "deepObject")
+    return objectEntries(value).map(([key, elem]) => [
+      `${metadata.name}[${key}]`,
+      String(elem),
+    ]);
+  if (
+    metadata.style === "spaceDelimited" ||
+    metadata.style === "pipeDelimited"
+  )
+    return [
+      [
+        metadata.name,
+        arrayValues(value)
+          .map(String)
+          .join(metadata.style === "spaceDelimited" ? " " : "|"),
+      ],
+    ];
+  if (Array.isArray(value))
+    return metadata.explode
+      ? value.map((elem) => [metadata.name, String(elem)])
+      : [[metadata.name, value.map(String).join(",")]];
+  if (isRecord(value)) {
+    const entries = objectEntries(value);
+    return metadata.explode
+      ? entries.map(([key, elem]) => [key, String(elem)])
+      : [
+          [
+            metadata.name,
+            entries.flatMap(([key, elem]) => [key, String(elem)]).join(","),
+          ],
+        ];
+  }
+  return [[metadata.name, String(value)]];
+};
+
+const serializePath = (
+  metadata: IHttpMigrateRoute.IParameter,
+  value: unknown,
+): string => {
+  const encode = (input: unknown): string => encodeURIComponent(String(input));
+  const array = Array.isArray(value) ? value.map(encode) : null;
+  const object = isRecord(value)
+    ? objectEntries(value).map(([key, elem]) => [encode(key), encode(elem)])
+    : null;
+  if (metadata.style === "matrix") {
+    if (array)
+      return metadata.explode
+        ? array.map((elem) => `;${metadata.name}=${elem}`).join("")
+        : `;${metadata.name}=${array.join(",")}`;
+    if (object)
+      return metadata.explode
+        ? object.map(([key, elem]) => `;${key}=${elem}`).join("")
+        : `;${metadata.name}=${object.flat().join(",")}`;
+    return `;${metadata.name}=${encode(value)}`;
+  }
+  if (metadata.style === "label") {
+    if (array) return `.${array.join(metadata.explode ? "." : ",")}`;
+    if (object)
+      return `.${
+        metadata.explode
+          ? object.map(([key, elem]) => `${key}=${elem}`).join(".")
+          : object.flat().join(",")
+      }`;
+    return `.${encode(value)}`;
+  }
+  if (array) return array.join(",");
+  if (object)
+    return metadata.explode
+      ? object.map(([key, elem]) => `${key}=${elem}`).join(",")
+      : object.flat().join(",");
+  return encode(value);
+};
+
+const serializeSimple = (value: unknown, explode: boolean): string => {
+  if (Array.isArray(value)) return value.map(String).join(",");
+  if (isRecord(value)) {
+    const entries = objectEntries(value);
+    return explode
+      ? entries.map(([key, elem]) => `${key}=${String(elem)}`).join(",")
+      : entries.flatMap(([key, elem]) => [key, String(elem)]).join(",");
+  }
+  return String(value);
+};
+
+const serializeCookie = (
+  name: string,
+  value: unknown,
+  explode: boolean,
+): [string, string][] => {
+  const encode = (input: unknown): string => encodeURIComponent(String(input));
+  if (Array.isArray(value))
+    return explode
+      ? value.map((elem) => [name, encode(elem)])
+      : [[name, value.map(encode).join(",")]];
+  if (isRecord(value)) {
+    const entries = objectEntries(value);
+    return explode
+      ? entries.map(([key, elem]) => [key, encode(elem)])
+      : [
+          [
+            name,
+            entries.flatMap(([key, elem]) => [key, encode(elem)]).join(","),
+          ],
+        ];
+  }
+  return [[name, encode(value)]];
+};
+
+const requestQueryBody = (input: object): URLSearchParams => {
+  const output = new URLSearchParams();
   for (const [key, value] of Object.entries(input))
     if (value === undefined) continue;
     else if (Array.isArray(value))
-      value.forEach((elem) => q.append(key, String(elem)));
-    else q.set(key, String(value));
-  return q;
+      value.forEach((elem) => output.append(key, String(elem)));
+    else output.set(key, String(value));
+  return output;
 };
+
 const requestFormDataBody = (input: Record<string, any>): FormData => {
-  const encoded: FormData = new FormData();
+  const output = new FormData();
   const append = (key: string) => (value: any) => {
     if (value === undefined) return;
-    else if (typeof File === "function" && value instanceof File)
-      encoded.append(key, value, value.name);
-    else encoded.append(key, value);
+    if (typeof File === "function" && value instanceof File)
+      output.append(key, value, value.name);
+    else output.append(key, value);
   };
   for (const [key, value] of Object.entries(input))
-    if (Array.isArray(value)) value.map(append(key));
+    if (Array.isArray(value)) value.forEach(append(key));
     else append(key)(value);
-  return encoded;
+  return output;
+};
+
+const contentType = (headers: Headers): string =>
+  (headers.get("content-type") ?? "").split(";", 1)[0]!.trim().toLowerCase();
+
+const parseResponseBody = async (
+  response: Response,
+  type: string,
+): Promise<unknown> => {
+  if (type === "application/json" || type.endsWith("+json")) {
+    const text: string = await response.text();
+    return text.length === 0 ? undefined : JSON.parse(text);
+  }
+  if (type === "application/x-www-form-urlencoded")
+    return new URLSearchParams(await response.text());
+  if (type === "multipart/form-data") return response.formData();
+  if (type === "application/octet-stream") return response.blob();
+  return response.text();
 };
 
 const responseHeaders = (
@@ -192,12 +409,30 @@ const responseHeaders = (
 ): Record<string, string | string[]> => {
   const output: Record<string, string | string[]> = {};
   headers.forEach((value, key) => {
-    if (key === "set-cookie") {
-      output[key] ??= [];
-      (output[key] as string[]).push(
-        ...value.split(";").map((str) => str.trim()),
-      );
-    } else output[key] = value;
+    if (key !== "set-cookie") output[key] = value;
   });
+  const getter = (
+    headers as Headers & {
+      getSetCookie?: () => string[];
+    }
+  ).getSetCookie;
+  const cookies: string[] =
+    typeof getter === "function"
+      ? getter.call(headers)
+      : headers.get("set-cookie") !== null
+        ? [headers.get("set-cookie")!]
+        : [];
+  if (cookies.length !== 0) output["set-cookie"] = cookies;
   return output;
 };
+
+const arrayValues = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : [value];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const objectEntries = (value: unknown): [string, unknown][] =>
+  isRecord(value)
+    ? Object.entries(value).filter((entry) => entry[1] !== undefined)
+    : [];

--- a/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteFetcher.ts
@@ -1,7 +1,4 @@
-import {
-  IHttpMigrateRoute,
-  IHttpResponse,
-} from "@typia/interface";
+import { IHttpMigrateRoute, IHttpResponse } from "@typia/interface";
 
 import { HttpError } from "../HttpError";
 import type { HttpMigration } from "../HttpMigration";
@@ -18,6 +15,7 @@ export namespace HttpMigrateRouteFetcher {
         result.status,
         result.headers,
         result.body,
+        true,
       );
     return result.body;
   };
@@ -47,9 +45,9 @@ const propagateRequest = async (
   }
 
   validateGroup(error)("headers", props.route.headers, props.headers);
-  validateGroup(error)("cookies", props.route.cookies, props.cookies);
+  validateGroup(error)("cookies", props.route.cookies ?? null, props.cookies);
   validateGroup(error)("query", props.route.query, props.query);
-  validateGroup(error)("body", props.route.body, props.body);
+  validateBody(error)(props.route.body, props.body);
 
   const headers: Headers = requestHeaders(error)(props);
   const init: RequestInit = {
@@ -60,10 +58,10 @@ const propagateRequest = async (
   if (props.body !== undefined)
     init.body = (
       props.route.body?.type === "application/x-www-form-urlencoded"
-        ? requestQueryBody(props.body)
+        ? requestQueryBody(props.body as object)
         : props.route.body?.type === "multipart/form-data"
           ? requestFormDataBody(props.body as Record<string, any>)
-          : props.route.body?.type === "application/json"
+          : isJsonMediaType(props.route.body?.type)
             ? JSON.stringify(props.body)
             : props.body
     ) as BodyInit;
@@ -122,13 +120,31 @@ const validateGroup =
       if (input !== undefined) throw error(`${name} is not matched.`);
       return;
     }
-    if (metadata.required && input === undefined)
+    if ((metadata.required ?? true) && input === undefined)
       throw error(`${name} is not matched.`);
     if (
       input !== undefined &&
       (typeof input !== "object" || input === null || Array.isArray(input))
     )
       throw error(`${name} must be an object.`);
+  };
+
+const validateBody =
+  (error: (message: string) => Error) =>
+  (metadata: IHttpMigrateRoute.IBody | null, input: unknown): void => {
+    if (metadata === null) {
+      if (input !== undefined) throw error(`body is not matched.`);
+      return;
+    }
+    if ((metadata.required ?? true) && input === undefined)
+      throw error(`body is not matched.`);
+    if (
+      input !== undefined &&
+      (metadata.type === "application/x-www-form-urlencoded" ||
+        metadata.type === "multipart/form-data") &&
+      (typeof input !== "object" || input === null || Array.isArray(input))
+    )
+      throw error(`body must be an object for ${metadata.type}.`);
   };
 
 const requestHeaders =
@@ -141,27 +157,50 @@ const requestHeaders =
         value.forEach((elem) => output.append(key, String(elem)));
       else output.append(key, String(value));
 
-    if (props.route.headers && props.headers)
-      for (const metadata of props.route.headers.parameters) {
-        const value = parameterValue(metadata, props.headers);
-        if (value === undefined) {
-          if (metadata.parameter().required)
-            throw error(`header ${JSON.stringify(metadata.name)} is required.`);
-          continue;
+    if (props.route.headers && props.headers) {
+      const parameters = props.route.headers.parameters;
+      if (parameters === undefined) {
+        for (const [key, value] of Object.entries(props.headers))
+          if (value !== undefined)
+            output.set(key, serializeSimple(value, false));
+      } else {
+        const serializations: IHttpMigrateRoute.ISerialization[] = parameters;
+        for (const metadata of serializations) {
+          const value = parameterValue(metadata, props.headers, serializations);
+          if (value === undefined) {
+            if (metadata.parameter().required)
+              throw error(
+                `header ${JSON.stringify(metadata.name)} is required.`,
+              );
+            continue;
+          }
+          output.set(metadata.name, serializeSimple(value, metadata.explode));
         }
-        output.set(metadata.name, serializeSimple(value, metadata.explode));
       }
+    }
 
     if (props.route.cookies && props.cookies) {
-      const supplied = props.route.cookies.parameters.flatMap((metadata) => {
-        const value = parameterValue(metadata, props.cookies!);
-        if (value === undefined) {
-          if (metadata.parameter().required)
-            throw error(`cookie ${JSON.stringify(metadata.name)} is required.`);
-          return [];
-        }
-        return serializeCookie(metadata.name, value, metadata.explode);
-      });
+      const parameters = props.route.cookies.parameters;
+      const supplied =
+        parameters === undefined
+          ? Object.entries(props.cookies).flatMap(([name, value]) =>
+              value === undefined ? [] : serializeCookie(name, value, true),
+            )
+          : parameters.flatMap((metadata) => {
+              const value = parameterValue(
+                metadata,
+                props.cookies!,
+                parameters,
+              );
+              if (value === undefined) {
+                if (metadata.parameter().required)
+                  throw error(
+                    `cookie ${JSON.stringify(metadata.name)} is required.`,
+                  );
+                return [];
+              }
+              return serializeCookie(metadata.name, value, metadata.explode);
+            });
       if (supplied.length !== 0) {
         const replaced = new Set(supplied.map(([name]) => name));
         const inherited = (output.get("cookie") ?? "")
@@ -178,12 +217,10 @@ const requestHeaders =
       }
     }
 
-    if (
-      props.body !== undefined &&
-      props.route.body?.type &&
-      props.route.body.type !== "multipart/form-data"
-    )
-      output.set("Content-Type", props.route.body.type);
+    if (props.body !== undefined && props.route.body?.type)
+      if (props.route.body.type === "multipart/form-data")
+        output.delete("Content-Type");
+      else output.set("Content-Type", props.route.body.type);
     return output;
   };
 
@@ -223,8 +260,16 @@ const getQueryPath = (
   query: object,
 ): string => {
   const variables = new URLSearchParams();
+  if (route.parameters === undefined) {
+    for (const [key, value] of Object.entries(query))
+      if (value === undefined) continue;
+      else if (Array.isArray(value))
+        value.forEach((elem) => variables.append(key, String(elem)));
+      else variables.set(key, String(value));
+    return variables.size === 0 ? "" : `?${variables.toString()}`;
+  }
   for (const metadata of route.parameters) {
-    const value = parameterValue(metadata, query);
+    const value = parameterValue(metadata, query, route.parameters);
     if (value === undefined) {
       if (metadata.parameter().required)
         throw error(`query ${JSON.stringify(metadata.name)} is required.`);
@@ -239,12 +284,24 @@ const getQueryPath = (
 const parameterValue = (
   metadata: IHttpMigrateRoute.ISerialization,
   input: object,
+  parameters: IHttpMigrateRoute.ISerialization[],
 ): unknown => {
   const record = input as Record<string, unknown>;
   if (metadata.key !== null) return record[metadata.key];
-  const entries = (metadata.properties ?? [])
-    .filter((key) => record[key] !== undefined)
-    .map((key) => [key, record[key]] as const);
+  const properties = new Set(metadata.properties ?? []);
+  const occupied = new Set(
+    parameters
+      .filter((parameter) => parameter !== metadata)
+      .flatMap((parameter) =>
+        parameter.key !== null ? [parameter.key] : (parameter.properties ?? []),
+      ),
+  );
+  const entries = Object.entries(record).filter(
+    ([key, value]) =>
+      value !== undefined &&
+      (properties.has(key) ||
+        (metadata.additionalProperties === true && !occupied.has(key))),
+  );
   return entries.length !== 0 || (metadata.properties?.length ?? 0) === 0
     ? Object.fromEntries(entries)
     : undefined;
@@ -262,15 +319,19 @@ const serializeQuery = (
   if (
     metadata.style === "spaceDelimited" ||
     metadata.style === "pipeDelimited"
-  )
+  ) {
+    const delimiter = metadata.style === "spaceDelimited" ? " " : "|";
     return [
       [
         metadata.name,
-        arrayValues(value)
-          .map(String)
-          .join(metadata.style === "spaceDelimited" ? " " : "|"),
+        isRecord(value)
+          ? objectEntries(value)
+              .flatMap(([key, elem]) => [key, String(elem)])
+              .join(delimiter)
+          : arrayValues(value).map(String).join(delimiter),
       ],
     ];
+  }
   if (Array.isArray(value))
     return metadata.explode
       ? value.map((elem) => [metadata.name, String(elem)])
@@ -294,26 +355,28 @@ const serializePath = (
   value: unknown,
 ): string => {
   const encode = (input: unknown): string => encodeURIComponent(String(input));
+  const style = metadata.style ?? "simple";
+  const explode = metadata.explode ?? false;
   const array = Array.isArray(value) ? value.map(encode) : null;
   const object = isRecord(value)
     ? objectEntries(value).map(([key, elem]) => [encode(key), encode(elem)])
     : null;
-  if (metadata.style === "matrix") {
+  if (style === "matrix") {
     if (array)
-      return metadata.explode
+      return explode
         ? array.map((elem) => `;${metadata.name}=${elem}`).join("")
         : `;${metadata.name}=${array.join(",")}`;
     if (object)
-      return metadata.explode
+      return explode
         ? object.map(([key, elem]) => `;${key}=${elem}`).join("")
         : `;${metadata.name}=${object.flat().join(",")}`;
     return `;${metadata.name}=${encode(value)}`;
   }
-  if (metadata.style === "label") {
-    if (array) return `.${array.join(metadata.explode ? "." : ",")}`;
+  if (style === "label") {
+    if (array) return `.${array.join(explode ? "." : ",")}`;
     if (object)
       return `.${
-        metadata.explode
+        explode
           ? object.map(([key, elem]) => `${key}=${elem}`).join(".")
           : object.flat().join(",")
       }`;
@@ -321,7 +384,7 @@ const serializePath = (
   }
   if (array) return array.join(",");
   if (object)
-    return metadata.explode
+    return explode
       ? object.map(([key, elem]) => `${key}=${elem}`).join(",")
       : object.flat().join(",");
   return encode(value);
@@ -388,6 +451,14 @@ const requestFormDataBody = (input: Record<string, any>): FormData => {
 
 const contentType = (headers: Headers): string =>
   (headers.get("content-type") ?? "").split(";", 1)[0]!.trim().toLowerCase();
+
+const isJsonMediaType = (type: string | undefined): boolean => {
+  const normalized: string = (type ?? "")
+    .split(";", 1)[0]!
+    .trim()
+    .toLowerCase();
+  return normalized === "application/json" || normalized.endsWith("+json");
+};
 
 const parseResponseBody = async (
   response: Response,

--- a/packages/utils/src/utils/internal/EndpointUtil.ts
+++ b/packages/utils/src/utils/internal/EndpointUtil.ts
@@ -17,14 +17,7 @@ export namespace EndpointUtil {
       .filter((str) => !!str.length);
 
   export const reJoinWithDecimalParameters = (path: string) => {
-    path = path
-      .split("/")
-      .map((str) =>
-        str[0] === "{" && str[str.length - 1] === "}"
-          ? `:${str.substring(1, str.length - 1)}`
-          : str,
-      )
-      .join("/");
+    path = path.replace(/\{([^{}]+)\}/g, ":$1");
     return `${path.startsWith("/") ? "" : "/"}${path}`;
   };
 

--- a/tests/test-typia-schema/src/features/http.query/test_http_query_raw_strings.ts
+++ b/tests/test-typia-schema/src/features/http.query/test_http_query_raw_strings.ts
@@ -1,0 +1,63 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+/**
+ * Verifies every HTTP query decoder accepts raw and URL-shaped strings.
+ *
+ * The shared runtime parser previously replaced a string without `?` with an
+ * empty query, so every direct and factory operation lost normal raw input.
+ *
+ * 1. Decode raw, prefixed, absolute-URL, relative-URL, and encoded-question inputs.
+ * 2. Exercise direct and factory forms of query/assert/is/validate.
+ * 3. Require identical typed values and preserve encoded question marks.
+ */
+export const test_http_query_raw_strings = (): void => {
+  const expected: IQuery = {
+    name: "typia",
+    count: 2,
+    tags: ["a", "b"],
+    token: "a?b",
+  };
+  const raw = "name=typia&count=2&tags=a&tags=b&token=a%3Fb";
+  const inputs: string[] = [
+    raw,
+    `?${raw}`,
+    `https://example.com/items?${raw}#fragment`,
+    `/items?${raw}#fragment`,
+  ];
+  const factories = [
+    typia.http.createQuery<IQuery>(),
+    typia.http.createAssertQuery<IQuery>(),
+    (input: string) => typia.http.createIsQuery<IQuery>()(input),
+    (input: string) => {
+      const result = typia.http.createValidateQuery<IQuery>()(input);
+      return result.success ? result.data : null;
+    },
+  ];
+  for (const input of inputs) {
+    const direct = [
+      typia.http.query<IQuery>(input),
+      typia.http.assertQuery<IQuery>(input),
+      typia.http.isQuery<IQuery>(input),
+      (() => {
+        const result = typia.http.validateQuery<IQuery>(input);
+        return result.success ? result.data : null;
+      })(),
+    ];
+    for (const [index, value] of [...direct, ...factories.map((fn) => fn(input))].entries())
+      TestValidator.equals(`decoder ${index} for ${input}`, expected, value);
+  }
+  TestValidator.equals(
+    "URL without query",
+    true,
+    typia.http.isQuery<Partial<IQuery>>("https://example.com/items#fragment")
+      ?.name === undefined,
+  );
+};
+
+interface IQuery {
+  name: string;
+  count: number;
+  tags: string[];
+  token: string;
+}

--- a/tests/test-typia-schema/src/features/http.query/test_http_query_raw_strings.ts
+++ b/tests/test-typia-schema/src/features/http.query/test_http_query_raw_strings.ts
@@ -7,7 +7,7 @@ import typia from "typia";
  * The shared runtime parser previously replaced a string without `?` with an
  * empty query, so every direct and factory operation lost normal raw input.
  *
- * 1. Decode raw, prefixed, absolute-URL, relative-URL, and encoded-question inputs.
+ * 1. Decode raw, prefixed, absolute-URL, relative-URL, and URL-valued inputs.
  * 2. Exercise direct and factory forms of query/assert/is/validate.
  * 3. Require identical typed values and preserve encoded question marks.
  */
@@ -24,6 +24,7 @@ export const test_http_query_raw_strings = (): void => {
     `?${raw}`,
     `https://example.com/items?${raw}#fragment`,
     `/items?${raw}#fragment`,
+    `items?${raw}#fragment`,
   ];
   const factories = [
     typia.http.createQuery<IQuery>(),
@@ -44,7 +45,10 @@ export const test_http_query_raw_strings = (): void => {
         return result.success ? result.data : null;
       })(),
     ];
-    for (const [index, value] of [...direct, ...factories.map((fn) => fn(input))].entries())
+    for (const [index, value] of [
+      ...direct,
+      ...factories.map((fn) => fn(input)),
+    ].entries())
       TestValidator.equals(`decoder ${index} for ${input}`, expected, value);
   }
   TestValidator.equals(
@@ -53,6 +57,37 @@ export const test_http_query_raw_strings = (): void => {
     typia.http.isQuery<Partial<IQuery>>("https://example.com/items#fragment")
       ?.name === undefined,
   );
+
+  const rawValues =
+    "path=/users/1&url=https://example.com/items?x=1&fragment=a#b";
+  const rawExpected: IRawValues = {
+    path: "/users/1",
+    url: "https://example.com/items?x=1",
+    fragment: "a#b",
+  };
+  const rawDecoders = [
+    (input: string) => typia.http.query<IRawValues>(input),
+    (input: string) => typia.http.assertQuery<IRawValues>(input),
+    (input: string) => typia.http.isQuery<IRawValues>(input),
+    (input: string) => {
+      const result = typia.http.validateQuery<IRawValues>(input);
+      return result.success ? result.data : null;
+    },
+    typia.http.createQuery<IRawValues>(),
+    typia.http.createAssertQuery<IRawValues>(),
+    (input: string) => typia.http.createIsQuery<IRawValues>()(input),
+    (input: string) => {
+      const result = typia.http.createValidateQuery<IRawValues>()(input);
+      return result.success ? result.data : null;
+    },
+  ];
+  rawDecoders.forEach((decode, index) =>
+    TestValidator.equals(
+      `raw URL-valued decoder ${index}`,
+      rawExpected,
+      decode(rawValues),
+    ),
+  );
 };
 
 interface IQuery {
@@ -60,4 +95,10 @@ interface IQuery {
   count: number;
   tags: string[];
   token: string;
+}
+
+interface IRawValues {
+  path: string;
+  url: string;
+  fragment: string;
 }

--- a/tests/test-typia-schema/src/features/http.query/test_http_query_raw_strings.ts
+++ b/tests/test-typia-schema/src/features/http.query/test_http_query_raw_strings.ts
@@ -88,6 +88,35 @@ export const test_http_query_raw_strings = (): void => {
       decode(rawValues),
     ),
   );
+
+  const keyOnlyDecoders = [
+    (input: string) => typia.http.query<IKeyOnlyQuery>(input),
+    (input: string) => typia.http.assertQuery<IKeyOnlyQuery>(input),
+    (input: string) => typia.http.isQuery<IKeyOnlyQuery>(input),
+    (input: string) => {
+      const result = typia.http.validateQuery<IKeyOnlyQuery>(input);
+      return result.success ? result.data : null;
+    },
+    typia.http.createQuery<IKeyOnlyQuery>(),
+    typia.http.createAssertQuery<IKeyOnlyQuery>(),
+    (input: string) => typia.http.createIsQuery<IKeyOnlyQuery>()(input),
+    (input: string) => {
+      const result = typia.http.createValidateQuery<IKeyOnlyQuery>()(input);
+      return result.success ? result.data : null;
+    },
+  ];
+  for (const [input, expected] of [
+    ["flag", { flag: "" }],
+    ["a%3Fb", { "a?b": "" }],
+    ["flag#tail", { "flag#tail": "" }],
+  ] as const)
+    keyOnlyDecoders.forEach((decode, index) =>
+      TestValidator.equals(
+        `key-only raw decoder ${index} for ${input}`,
+        expected as IKeyOnlyQuery,
+        decode(input),
+      ),
+    );
 };
 
 interface IQuery {
@@ -101,4 +130,10 @@ interface IRawValues {
   path: string;
   url: string;
   fragment: string;
+}
+
+interface IKeyOnlyQuery {
+  flag?: string;
+  "a?b"?: string;
+  "flag#tail"?: string;
 }

--- a/tests/test-utils/src/features/llm/http/test_http_llm_application.ts
+++ b/tests/test-utils/src/features/llm/http/test_http_llm_application.ts
@@ -25,6 +25,8 @@ export const test_http_llm_application = async (): Promise<void> => {
       "properties",
       [
         ...route.parameters.map((p) => p.key),
+        ...(route.headers ? [route.headers.key] : []),
+        ...(route.cookies ? [route.cookies.key] : []),
         ...(route.query ? ["query"] : []),
         ...(route.body ? ["body"] : []),
       ],

--- a/tests/test-utils/src/features/migrate/test_http_migrate_body_media_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_body_media_contract.ts
@@ -92,6 +92,35 @@ export const test_http_migrate_body_media_contract =
       "properties" in suffix.exceptions["400"]!.schema &&
         suffix.exceptions["400"]!.schema.properties?.error !== undefined,
     );
+
+    await execute("/mixed-text", "hello");
+    TestValidator.equals(
+      "mixed-case text canonicalized",
+      "text/plain",
+      contentType(captured),
+    );
+    TestValidator.equals(
+      "mixed-case response canonicalized",
+      "text/plain",
+      findRoute(application.routes, "/mixed-text").success?.type,
+    );
+    await execute("/mixed-form", { name: "typia" });
+    TestValidator.equals(
+      "mixed-case form canonicalized",
+      "application/x-www-form-urlencoded",
+      contentType(captured),
+    );
+    TestValidator.equals(
+      "mixed-case form body",
+      "name=typia",
+      String(captured!.init.body),
+    );
+    await execute("/mixed-multipart", { name: "typia" });
+    TestValidator.equals(
+      "mixed-case multipart delegates boundary",
+      true,
+      contentType(captured) === null,
+    );
   };
 
 const contentType = (
@@ -160,12 +189,26 @@ const document: OpenApiV3_1.IDocument = {
         },
       },
     },
+    "/mixed-text": operation(
+      "Text/Plain; Charset=UTF-8",
+      { type: "string" },
+      "Text/Plain; Charset=UTF-8",
+    ),
+    "/mixed-form": operation("Application/X-WWW-Form-Urlencoded", {
+      type: "object",
+      properties: { name: { type: "string" } },
+    }),
+    "/mixed-multipart": operation("Multipart/Form-Data", {
+      type: "object",
+      properties: { name: { type: "string" } },
+    }),
   },
 };
 
 function operation(
   type: string,
   schema: OpenApiV3_1.IJsonSchema,
+  responseType?: string,
 ): OpenApiV3_1.IPath {
   return {
     post: {
@@ -173,7 +216,14 @@ function operation(
         required: true,
         content: { [type]: { schema } },
       },
-      responses: { "200": { description: "OK" } },
+      responses: {
+        "200": {
+          description: "OK",
+          ...(responseType
+            ? { content: { [responseType]: { schema: { type: "string" } } } }
+            : {}),
+        },
+      },
     },
   };
 }

--- a/tests/test-utils/src/features/migrate/test_http_migrate_body_media_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_body_media_contract.ts
@@ -1,0 +1,179 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpMigrateRoute, OpenApiV3_1 } from "@typia/interface";
+import { HttpMigration } from "@typia/utils";
+
+/**
+ * Verifies migrated bodies preserve JSON values and declared media types.
+ *
+ * Body validation previously required every payload to be an object, inherited
+ * content types leaked into multipart requests, and JSON-suffix media types
+ * were rejected during composition even though the fetcher could parse them.
+ *
+ * 1. Compose text, scalar/array/null JSON, multipart, and JSON-suffix routes.
+ * 2. Capture the outgoing body and content type for each request.
+ * 3. Require primitive preservation, multipart boundary delegation, and schemas.
+ */
+export const test_http_migrate_body_media_contract =
+  async (): Promise<void> => {
+    const application = HttpMigration.application(document);
+    TestValidator.equals("composition errors", 0, application.errors.length);
+
+    let captured: { url: URL; init: RequestInit } | undefined;
+    const connection = {
+      host: "https://example.com",
+      headers: { "Content-Type": "application/json" },
+      fetch: (async (input: string | URL | Request, init?: RequestInit) => {
+        captured = { url: new URL(String(input)), init: init! };
+        return new Response('{"ok":true}', {
+          status: 200,
+          headers: { "Content-Type": "application/problem+json" },
+        });
+      }) as typeof fetch,
+    };
+    const execute = async (path: string, body: unknown): Promise<void> => {
+      await HttpMigration.execute({
+        connection,
+        route: findRoute(application.routes, path),
+        parameters: [],
+        body,
+      });
+    };
+
+    await execute("/text", "hello");
+    TestValidator.equals(
+      "text content type",
+      "text/plain",
+      contentType(captured),
+    );
+    TestValidator.equals("text body", "hello", String(captured!.init.body));
+
+    await execute("/array", ["a", "b"]);
+    TestValidator.equals(
+      "array JSON",
+      '["a","b"]',
+      String(captured!.init.body),
+    );
+
+    await execute("/null", null);
+    TestValidator.equals("null JSON", "null", String(captured!.init.body));
+
+    await execute("/multipart", { name: "typia" });
+    TestValidator.equals(
+      "multipart content type delegated",
+      true,
+      contentType(captured) === null,
+    );
+    TestValidator.equals(
+      "multipart body",
+      true,
+      captured!.init.body instanceof FormData,
+    );
+
+    await execute("/suffix", { value: "patched" });
+    TestValidator.equals(
+      "JSON suffix content type",
+      "application/merge-patch+json",
+      contentType(captured),
+    );
+    TestValidator.equals(
+      "JSON suffix body",
+      '{"value":"patched"}',
+      String(captured!.init.body),
+    );
+    const suffix = findRoute(application.routes, "/suffix");
+    TestValidator.equals(
+      "JSON suffix success type",
+      "application/problem+json",
+      suffix.success?.type,
+    );
+    TestValidator.equals(
+      "JSON suffix exception schema",
+      true,
+      "properties" in suffix.exceptions["400"]!.schema &&
+        suffix.exceptions["400"]!.schema.properties?.error !== undefined,
+    );
+  };
+
+const contentType = (
+  captured: { url: URL; init: RequestInit } | undefined,
+): string | null => new Headers(captured!.init.headers).get("content-type");
+
+const findRoute = (
+  routes: IHttpMigrateRoute[],
+  path: string,
+): IHttpMigrateRoute => routes.find((route) => route.path === path)!;
+
+const document: OpenApiV3_1.IDocument = {
+  openapi: "3.1.0",
+  info: { title: "HTTP body media contract", version: "1.0.0" },
+  components: { schemas: {} },
+  paths: {
+    "/text": operation("text/plain", { type: "string" }),
+    "/array": operation("application/json", {
+      type: "array",
+      items: { type: "string" },
+    }),
+    "/null": operation("application/json", { type: "null" }),
+    "/multipart": operation("multipart/form-data", {
+      type: "object",
+      properties: { name: { type: "string" } },
+    }),
+    "/suffix": {
+      post: {
+        requestBody: {
+          required: true,
+          content: {
+            "application/merge-patch+json": {
+              schema: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/problem+json": {
+                schema: {
+                  type: "object",
+                  properties: { ok: { type: "boolean" } },
+                  required: ["ok"],
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/problem+json": {
+                schema: {
+                  type: "object",
+                  properties: { error: { type: "string" } },
+                  required: ["error"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+function operation(
+  type: string,
+  schema: OpenApiV3_1.IJsonSchema,
+): OpenApiV3_1.IPath {
+  return {
+    post: {
+      requestBody: {
+        required: true,
+        content: { [type]: { schema } },
+      },
+      responses: { "200": { description: "OK" } },
+    },
+  };
+}

--- a/tests/test-utils/src/features/migrate/test_http_migrate_cookie_key_collision.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_cookie_key_collision.ts
@@ -1,0 +1,94 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiV3_1 } from "@typia/interface";
+import { HttpLlm, HttpMigration } from "@typia/utils";
+
+/**
+ * Verifies cookie groups cannot overwrite another request argument key.
+ *
+ * Cookie descriptors were omitted from route accessor collision resolution, so
+ * a path parameter named `cookie` replaced its own LLM property with the cookie
+ * group schema and made execution read the same argument twice.
+ *
+ * 1. Compose a route with colliding path and cookie group names.
+ * 2. Check that the LLM schema advertises two distinct required properties.
+ * 3. Execute both arguments and require the correct path and Cookie header.
+ */
+export const test_http_migrate_cookie_key_collision =
+  async (): Promise<void> => {
+    const migration = HttpMigration.application(document);
+    TestValidator.equals("composition errors", 0, migration.errors.length);
+    const route = migration.routes[0]!;
+    TestValidator.equals(
+      "distinct route keys",
+      true,
+      route.parameters[0]!.key !== route.cookies!.key,
+    );
+
+    const llm = HttpLlm.application({ document });
+    TestValidator.equals("LLM errors", 0, llm.errors.length);
+    const properties = Object.keys(llm.functions[0]!.parameters.properties!);
+    TestValidator.equals(
+      "distinct LLM properties",
+      [route.parameters[0]!.key, route.cookies!.key],
+      properties,
+    );
+    TestValidator.equals(
+      "distinct LLM requirements",
+      properties,
+      llm.functions[0]!.parameters.required,
+    );
+
+    let captured: { url: URL; headers: Headers } | undefined;
+    await HttpMigration.execute({
+      connection: {
+        host: "https://example.com",
+        fetch: (async (input: string | URL | Request, init?: RequestInit) => {
+          captured = {
+            url: new URL(String(input)),
+            headers: new Headers(init!.headers),
+          };
+          return new Response(null, { status: 204 });
+        }) as typeof fetch,
+      },
+      route,
+      parameters: { [route.parameters[0]!.key]: "samchon" },
+      cookies: { sid: "token" },
+    });
+    TestValidator.equals(
+      "path argument",
+      "/users/samchon",
+      captured!.url.pathname,
+    );
+    TestValidator.equals(
+      "cookie argument",
+      "sid=token",
+      captured!.headers.get("cookie"),
+    );
+  };
+
+const document: OpenApiV3_1.IDocument = {
+  openapi: "3.1.0",
+  info: { title: "Cookie key collision", version: "1.0.0" },
+  components: { schemas: {} },
+  paths: {
+    "/users/{cookie}": {
+      get: {
+        parameters: [
+          {
+            name: "cookie",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "sid",
+            in: "cookie",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+  },
+};

--- a/tests/test-utils/src/features/migrate/test_http_migrate_cookie_serialization_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_cookie_serialization_contract.ts
@@ -1,0 +1,156 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiV3_2 } from "@typia/interface";
+import { HttpLlm, HttpMigration, OpenApiConverter } from "@typia/utils";
+
+/**
+ * Verifies OpenAPI 3.2 cookie styles preserve their distinct encoding rules.
+ *
+ * OpenAPI 3.2 `style: cookie` passes pre-escaped data through unchanged, while
+ * the legacy/default `style: form` applies RFC 3986 percent-encoding. The
+ * migration serializer previously rejected the new style and emitted form
+ * parameter names and exploded object keys without encoding.
+ *
+ * 1. Compose form and cookie styles in one required cookie group.
+ * 2. Downgrade the serialization metadata without leaking unsupported fields.
+ * 3. Require LLM validation to advertise and accept every flattened value.
+ * 4. Execute the route and compare the exact merged Cookie header.
+ */
+export const test_http_migrate_cookie_serialization_contract =
+  async (): Promise<void> => {
+    const migration = HttpMigration.application(document);
+    TestValidator.equals("composition errors", 0, migration.errors.length);
+    const route = migration.routes[0]!;
+    TestValidator.equals(
+      "cookie styles",
+      ["cookie", "form", "form"],
+      route.cookies?.parameters?.map((parameter) => parameter.style),
+    );
+    TestValidator.equals(
+      "cookie explode defaults",
+      [true, true, true],
+      route.cookies?.parameters?.map((parameter) => parameter.explode),
+    );
+
+    for (const [version, downgraded] of [
+      ["3.0", OpenApiConverter.downgradeDocument(migration.document(), "3.0")],
+      ["3.1", OpenApiConverter.downgradeDocument(migration.document(), "3.1")],
+    ] as const)
+      TestValidator.equals(
+        `${version} cookie style downgrade`,
+        "form",
+        (
+          downgraded.paths?.["/cookies"]?.get?.parameters?.[0] as
+            | { style?: string }
+            | undefined
+        )?.style,
+      );
+    const swagger = OpenApiConverter.downgradeDocument(
+      migration.document(),
+      "2.0",
+    );
+    const swaggerParameter = swagger.paths?.["/cookies"]?.get?.parameters?.[0];
+    TestValidator.equals(
+      "Swagger parameter serialization fields omitted",
+      false,
+      swaggerParameter !== undefined &&
+        ("style" in swaggerParameter || "explode" in swaggerParameter),
+    );
+    const swaggerResponse = swagger.paths?.["/cookies"]?.get?.responses?.[
+      "204"
+    ] as
+      | { headers?: Record<string, Record<string, unknown> | undefined> }
+      | undefined;
+    const swaggerHeader = swaggerResponse?.headers?.["X-Trace"];
+    TestValidator.equals(
+      "Swagger response header serialization fields omitted",
+      false,
+      swaggerHeader !== undefined &&
+        ("style" in swaggerHeader || "explode" in swaggerHeader),
+    );
+
+    const input = {
+      raw: "Hello%2C%20world!",
+      "session id": "a b!",
+      "theme mode": "dark!",
+    };
+    const llm = HttpLlm.application({ document });
+    TestValidator.equals("LLM errors", 0, llm.errors.length);
+    TestValidator.equals(
+      "LLM cookie validation",
+      true,
+      llm.functions[0]!.validate({ cookie: input }).success,
+    );
+
+    let captured: Headers | undefined;
+    await HttpMigration.execute({
+      connection: {
+        host: "https://example.com",
+        headers: {
+          Cookie: "session%20id=old; inherited=yes",
+        },
+        fetch: (async (_input, init) => {
+          captured = new Headers(init!.headers);
+          return new Response(null, { status: 204 });
+        }) as typeof fetch,
+      },
+      route,
+      parameters: [],
+      cookies: input,
+    });
+    TestValidator.equals(
+      "cookie wire format",
+      "inherited=yes; raw=Hello%2C%20world!; session%20id=a%20b%21; theme%20mode=dark%21",
+      captured!.get("cookie"),
+    );
+  };
+
+const document: OpenApiV3_2.IDocument = {
+  openapi: "3.2.0",
+  info: { title: "Cookie serialization", version: "1.0.0" },
+  components: { schemas: {} },
+  paths: {
+    "/cookies": {
+      get: {
+        parameters: [
+          {
+            name: "raw",
+            in: "cookie",
+            required: true,
+            style: "cookie",
+            schema: { type: "string" },
+          },
+          {
+            name: "session id",
+            in: "cookie",
+            required: true,
+            style: "form",
+            schema: { type: "string" },
+          },
+          {
+            name: "preferences",
+            in: "cookie",
+            required: true,
+            style: "form",
+            schema: {
+              type: "object",
+              properties: { "theme mode": { type: "string" } },
+              required: ["theme mode"],
+            },
+          },
+        ],
+        responses: {
+          "204": {
+            description: "No Content",
+            headers: {
+              "X-Trace": {
+                style: "simple",
+                explode: false,
+                schema: { type: "array", items: { type: "string" } },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/tests/test-utils/src/features/migrate/test_http_migrate_parameter_serialization_edges.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_parameter_serialization_edges.ts
@@ -1,0 +1,211 @@
+import { TestValidator } from "@nestia/e2e";
+import {
+  IHttpLlmFunction,
+  IHttpMigrateRoute,
+  OpenApiV3_1,
+} from "@typia/interface";
+import { HttpLlm, HttpMigration } from "@typia/utils";
+
+/**
+ * Verifies parameter schemas and style metadata survive edge-case migration.
+ *
+ * Referenced arrays disappeared from LLM schemas, delimited object styles were
+ * rejected, open object entries were dropped, and optional object members were
+ * promoted to unconditional group requirements.
+ *
+ * 1. Compose referenced arrays, delimited/open objects, and optional objects.
+ * 2. Exercise direct serialization and the corresponding LLM validators.
+ * 3. Reject undefined explode combinations with deterministic diagnostics.
+ */
+export const test_http_migrate_parameter_serialization_edges =
+  async (): Promise<void> => {
+    const migration = HttpMigration.application(document);
+    TestValidator.equals("valid routes", 3, migration.routes.length);
+    TestValidator.equals("invalid style routes", 2, migration.errors.length);
+    TestValidator.equals(
+      "invalid style diagnostics",
+      [
+        'query parameter "bad" requires explode: false for spaceDelimited style',
+        'query parameter "bad" requires explode: true for deepObject style',
+      ],
+      migration.errors.flatMap((error) => error.messages),
+    );
+
+    let captured: URL | undefined;
+    const connection = {
+      host: "https://example.com",
+      fetch: (async (input: string | URL | Request) => {
+        captured = new URL(String(input));
+        return new Response(null, { status: 204 });
+      }) as typeof fetch,
+    };
+    await HttpMigration.execute({
+      connection,
+      route: findRoute(migration.routes, "/delimited"),
+      parameters: [],
+      query: { a: "x", b: "y", tags: ["red", "green"] },
+    });
+    TestValidator.equals(
+      "space-delimited object",
+      "a x b y",
+      captured!.searchParams.get("space"),
+    );
+    TestValidator.equals(
+      "referenced pipe-delimited array",
+      "red|green",
+      captured!.searchParams.get("tags"),
+    );
+
+    await HttpMigration.execute({
+      connection,
+      route: findRoute(migration.routes, "/open"),
+      parameters: [],
+      query: { arbitrary: "preserved", count: 2 },
+    });
+    TestValidator.equals(
+      "open object property",
+      "preserved",
+      captured!.searchParams.get("arbitrary"),
+    );
+    TestValidator.equals(
+      "primitive beside open object",
+      "2",
+      captured!.searchParams.get("count"),
+    );
+
+    const llm = HttpLlm.application({ document });
+    TestValidator.equals("LLM errors", 2, llm.errors.length);
+    const delimited = findFunction(llm.functions, "/delimited");
+    TestValidator.equals(
+      "referenced array advertised",
+      true,
+      delimited.validate({ query: { tags: ["red"] } }).success,
+    );
+    const optional = findFunction(llm.functions, "/optional");
+    TestValidator.equals(
+      "optional object omitted",
+      true,
+      optional.validate({ query: { limit: 1 } }).success,
+    );
+  };
+
+const findRoute = (
+  routes: IHttpMigrateRoute[],
+  path: string,
+): IHttpMigrateRoute => routes.find((route) => route.path === path)!;
+
+const findFunction = (
+  functions: IHttpLlmFunction[],
+  path: string,
+): IHttpLlmFunction => functions.find((func) => func.path === path)!;
+
+const document: OpenApiV3_1.IDocument = {
+  openapi: "3.1.0",
+  info: { title: "HTTP parameter edges", version: "1.0.0" },
+  components: {
+    schemas: {
+      Tags: { type: "array", items: { type: "string" } },
+    },
+  },
+  paths: {
+    "/delimited": {
+      get: {
+        parameters: [
+          {
+            name: "space",
+            in: "query",
+            style: "spaceDelimited",
+            explode: false,
+            schema: {
+              type: "object",
+              properties: { a: { type: "string" }, b: { type: "string" } },
+            },
+          },
+          {
+            name: "tags",
+            in: "query",
+            style: "pipeDelimited",
+            explode: false,
+            schema: { $ref: "#/components/schemas/Tags" },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+    "/open": {
+      get: {
+        parameters: [
+          {
+            name: "filter",
+            in: "query",
+            style: "form",
+            explode: true,
+            schema: {
+              type: "object",
+              additionalProperties: { type: "string" },
+            },
+          },
+          {
+            name: "count",
+            in: "query",
+            schema: { type: "integer" },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+    "/optional": {
+      get: {
+        parameters: [
+          {
+            name: "dto",
+            in: "query",
+            required: false,
+            schema: {
+              type: "object",
+              properties: { nested: { type: "string" } },
+              required: ["nested"],
+            },
+          },
+          {
+            name: "limit",
+            in: "query",
+            required: true,
+            schema: { type: "integer" },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+    "/invalid-space": {
+      get: {
+        parameters: [
+          {
+            name: "bad",
+            in: "query",
+            style: "spaceDelimited",
+            explode: true,
+            schema: { type: "array", items: { type: "string" } },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+    "/invalid-deep": {
+      get: {
+        parameters: [
+          {
+            name: "bad",
+            in: "query",
+            style: "deepObject",
+            schema: {
+              type: "object",
+              properties: { value: { type: "string" } },
+            },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+  },
+};

--- a/tests/test-utils/src/features/migrate/test_http_migrate_parameter_serialization_edges.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_parameter_serialization_edges.ts
@@ -4,7 +4,7 @@ import {
   IHttpMigrateRoute,
   OpenApiV3_1,
 } from "@typia/interface";
-import { HttpLlm, HttpMigration } from "@typia/utils";
+import { HttpLlm, HttpMigration, LlmJson } from "@typia/utils";
 
 /**
  * Verifies parameter schemas and style metadata survive edge-case migration.
@@ -20,7 +20,7 @@ import { HttpLlm, HttpMigration } from "@typia/utils";
 export const test_http_migrate_parameter_serialization_edges =
   async (): Promise<void> => {
     const migration = HttpMigration.application(document);
-    TestValidator.equals("valid routes", 3, migration.routes.length);
+    TestValidator.equals("valid routes", 5, migration.routes.length);
     TestValidator.equals("invalid style routes", 2, migration.errors.length);
     TestValidator.equals(
       "invalid style diagnostics",
@@ -73,6 +73,30 @@ export const test_http_migrate_parameter_serialization_edges =
       captured!.searchParams.get("count"),
     );
 
+    await HttpMigration.execute({
+      connection,
+      route: findRoute(migration.routes, "/required-empty"),
+      parameters: [],
+      query: {},
+    });
+    TestValidator.equals("required empty object", "", captured!.search);
+    let requiredMemberError = false;
+    try {
+      await HttpMigration.execute({
+        connection,
+        route: findRoute(migration.routes, "/required-member"),
+        parameters: [],
+        query: {},
+      });
+    } catch {
+      requiredMemberError = true;
+    }
+    TestValidator.equals(
+      "required object member remains required",
+      true,
+      requiredMemberError,
+    );
+
     const llm = HttpLlm.application({ document });
     TestValidator.equals("LLM errors", 2, llm.errors.length);
     const delimited = findFunction(llm.functions, "/delimited");
@@ -86,6 +110,25 @@ export const test_http_migrate_parameter_serialization_edges =
       "optional object omitted",
       true,
       optional.validate({ query: { limit: 1 } }).success,
+    );
+    TestValidator.equals(
+      "optional object partial input rejected",
+      false,
+      optional.validate({ query: { limit: 1, other: "x" } }).success,
+    );
+    TestValidator.equals(
+      "adapter-style optional object partial input rejected",
+      false,
+      LlmJson.validateArguments(optional, {
+        query: { limit: "1", other: "x" },
+      }).success,
+    );
+    TestValidator.equals(
+      "optional object complete input accepted",
+      true,
+      optional.validate({
+        query: { limit: 1, nested: "x", other: "y" },
+      }).success,
     );
   };
 
@@ -163,7 +206,10 @@ const document: OpenApiV3_1.IDocument = {
             required: false,
             schema: {
               type: "object",
-              properties: { nested: { type: "string" } },
+              properties: {
+                nested: { type: "string" },
+                other: { type: "string" },
+              },
               required: ["nested"],
             },
           },
@@ -172,6 +218,43 @@ const document: OpenApiV3_1.IDocument = {
             in: "query",
             required: true,
             schema: { type: "integer" },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+    "/required-empty": {
+      get: {
+        parameters: [
+          {
+            name: "filter",
+            in: "query",
+            required: true,
+            style: "deepObject",
+            explode: true,
+            schema: {
+              type: "object",
+              properties: { term: { type: "string" } },
+            },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+    "/required-member": {
+      get: {
+        parameters: [
+          {
+            name: "filter",
+            in: "query",
+            required: true,
+            style: "deepObject",
+            explode: true,
+            schema: {
+              type: "object",
+              properties: { term: { type: "string" } },
+              required: ["term"],
+            },
           },
         ],
         responses: { "204": { description: "No Content" } },

--- a/tests/test-utils/src/features/migrate/test_http_migrate_parameter_serialization_edges.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_parameter_serialization_edges.ts
@@ -75,6 +75,18 @@ export const test_http_migrate_parameter_serialization_edges =
 
     await HttpMigration.execute({
       connection,
+      route: findRoute(migration.routes, "/optional"),
+      parameters: [],
+      query: { limit: 1, nested: "x", arbitrary: "preserved" },
+    });
+    TestValidator.equals(
+      "implicit additional property",
+      "preserved",
+      captured!.searchParams.get("arbitrary"),
+    );
+
+    await HttpMigration.execute({
+      connection,
       route: findRoute(migration.routes, "/required-empty"),
       parameters: [],
       query: {},
@@ -117,6 +129,11 @@ export const test_http_migrate_parameter_serialization_edges =
       optional.validate({ query: { limit: 1, other: "x" } }).success,
     );
     TestValidator.equals(
+      "implicit open object partial input rejected",
+      false,
+      optional.validate({ query: { limit: 1, arbitrary: "x" } }).success,
+    );
+    TestValidator.equals(
       "adapter-style optional object partial input rejected",
       false,
       LlmJson.validateArguments(optional, {
@@ -127,7 +144,7 @@ export const test_http_migrate_parameter_serialization_edges =
       "optional object complete input accepted",
       true,
       optional.validate({
-        query: { limit: 1, nested: "x", other: "y" },
+        query: { limit: 1, nested: "x", other: "y", arbitrary: "z" },
       }).success,
     );
   };

--- a/tests/test-utils/src/features/migrate/test_http_migrate_path_parameter_names.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_path_parameter_names.ts
@@ -1,5 +1,5 @@
 import { TestValidator } from "@nestia/e2e";
-import { OpenApi } from "@typia/interface";
+import { OpenApiV3, OpenApiV3_1, OpenApiV3_2 } from "@typia/interface";
 import { HttpMigration } from "@typia/utils";
 
 /**
@@ -30,10 +30,11 @@ export const test_http_migrate_path_parameter_names = (): void => {
   );
 
   const missing = HttpMigration.application(createDocument("missing"));
-  TestValidator.equals("missing path synthesized", [
-    "userId",
-    "postId",
-  ], missing.routes[0]!.parameters.map((parameter) => parameter.name));
+  TestValidator.equals(
+    "missing path synthesized",
+    ["userId", "postId"],
+    missing.routes[0]!.parameters.map((parameter) => parameter.name),
+  );
   TestValidator.equals(
     "synthesized schema",
     { type: "string" },
@@ -47,24 +48,42 @@ export const test_http_migrate_path_parameter_names = (): void => {
     repeated.routes[0]!.parameters.map((parameter) => parameter.name),
   );
 
-  for (const mode of ["duplicate", "wrong"] as const) {
-    const app = HttpMigration.application(createDocument(mode));
-    TestValidator.equals(`${mode} route omitted`, 0, app.routes.length);
-    TestValidator.equals(`${mode} error`, true, app.errors.length === 1);
-  }
+  const wrong = HttpMigration.application(createDocument("wrong"));
+  TestValidator.equals("wrong route omitted", 0, wrong.routes.length);
+  TestValidator.equals("wrong error", true, wrong.errors.length === 1);
+
+  const duplicate = createDocument("duplicate");
+  const duplicateVersions = [
+    { ...duplicate, openapi: "3.0.3" } as OpenApiV3.IDocument,
+    duplicate,
+    { ...duplicate, openapi: "3.2.0" } as OpenApiV3_2.IDocument,
+  ];
+  duplicateVersions.forEach((document) => {
+    const app = HttpMigration.application(document);
+    TestValidator.equals(
+      `${document.openapi} duplicate route omitted`,
+      0,
+      app.routes.length,
+    );
+    TestValidator.equals(
+      `${document.openapi} duplicate diagnostic`,
+      ["path parameter names must be unique: userId"],
+      app.errors[0]?.messages,
+    );
+  });
 };
 
 const createDocument = (
   mode: "ordered" | "reversed" | "missing" | "duplicate" | "wrong" | "repeated",
-): OpenApi.IDocument => {
-  const user: OpenApi.IOperation.IParameter = {
+): OpenApiV3_1.IDocument => {
+  const user: OpenApiV3_1.IOperation.IParameter = {
     name: "userId",
     in: "path",
     required: true,
     description: "USER ID",
     schema: { type: "string" },
   };
-  const post: OpenApi.IOperation.IParameter = {
+  const post: OpenApiV3_1.IOperation.IParameter = {
     name: mode === "wrong" ? "articleId" : "postId",
     in: "path",
     required: true,
@@ -86,8 +105,7 @@ const createDocument = (
       ? "/users/{userId}/friends/{userId}"
       : "/users/{userId}/posts/{postId}";
   return {
-    openapi: "3.2.0",
-    "x-typia-emended-v12": true,
+    openapi: "3.1.0",
     info: { title: "Path parameters", version: "1.0.0" },
     components: { schemas: {} },
     paths: {

--- a/tests/test-utils/src/features/migrate/test_http_migrate_path_parameter_names.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_path_parameter_names.ts
@@ -77,14 +77,14 @@ export const test_http_migrate_path_parameter_names =
     TestValidator.equals("embedded errors", 0, embedded.errors.length);
     TestValidator.equals(
       "embedded parameter names",
-      [["name", "ext"], ["id"]],
+      [["name", "ext"], ["id"], ["coords!"]],
       embedded.routes.map((route) =>
         route.parameters.map((parameter) => parameter.name),
       ),
     );
     TestValidator.equals(
       "embedded emended paths",
-      ["/files/:name.:ext", "/prefix-:id"],
+      ["/files/:name.:ext", "/prefix-:id", "/matrix/:coords!"],
       embedded.routes.map((route) => route.emendedPath),
     );
     TestValidator.equals(
@@ -92,6 +92,7 @@ export const test_http_migrate_path_parameter_names =
       [
         ["files", "getByNameAndExt"],
         ["prefix_", "getById"],
+        ["matrix", "getByCoords_"],
       ],
       embedded.routes.map((route) => route.accessor),
     );
@@ -107,16 +108,27 @@ export const test_http_migrate_path_parameter_names =
     await HttpMigration.execute({
       connection,
       route: embedded.routes[0]!,
-      parameters: { name: "report", ext: "json" },
+      parameters: { name: "report!", ext: "json" },
     });
     await HttpMigration.execute({
       connection,
       route: embedded.routes[1]!,
       parameters: { id: 7 },
     });
+    const matrix = embedded.routes[2]!;
+    TestValidator.equals(
+      "special parameter key",
+      "coords_",
+      matrix.parameters[0]?.key,
+    );
+    await HttpMigration.execute({
+      connection,
+      route: matrix,
+      parameters: { [matrix.parameters[0]!.key]: "a!" },
+    });
     TestValidator.equals(
       "embedded request paths",
-      ["/files/report.json", "/prefix-7"],
+      ["/files/report%21.json", "/prefix-7", "/matrix/;coords%21=a%21"],
       requests.map((url) => url.pathname),
     );
   };
@@ -153,6 +165,20 @@ const embeddedDocument: OpenApiV3_1.IDocument = {
             in: "path",
             required: true,
             schema: { type: "integer" },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+    "/matrix/{coords!}": {
+      get: {
+        parameters: [
+          {
+            name: "coords!",
+            in: "path",
+            required: true,
+            style: "matrix",
+            schema: { type: "string" },
           },
         ],
         responses: { "204": { description: "No Content" } },

--- a/tests/test-utils/src/features/migrate/test_http_migrate_path_parameter_names.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_path_parameter_names.ts
@@ -1,0 +1,99 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { HttpMigration } from "@typia/utils";
+
+/**
+ * Verifies path placeholders join OpenAPI parameters by name.
+ *
+ * Positional association silently cross-wired schemas when a valid OpenAPI
+ * operation declared path parameters in a different order than its template.
+ *
+ * 1. Compose ordered, reversed, missing, duplicate, and wrong-name declarations.
+ * 2. Compare the resulting placeholder schemas and synthesized parameter.
+ * 3. Require deterministic errors for duplicate and incompatible name sets.
+ */
+export const test_http_migrate_path_parameter_names = (): void => {
+  const ordered = HttpMigration.application(createDocument("ordered"));
+  const reversed = HttpMigration.application(createDocument("reversed"));
+  TestValidator.equals(
+    "reversed route schemas",
+    ordered.routes[0]!.parameters.map((parameter) => ({
+      name: parameter.name,
+      schema: parameter.schema,
+      description: parameter.parameter().description,
+    })),
+    reversed.routes[0]!.parameters.map((parameter) => ({
+      name: parameter.name,
+      schema: parameter.schema,
+      description: parameter.parameter().description,
+    })),
+  );
+
+  const missing = HttpMigration.application(createDocument("missing"));
+  TestValidator.equals("missing path synthesized", [
+    "userId",
+    "postId",
+  ], missing.routes[0]!.parameters.map((parameter) => parameter.name));
+  TestValidator.equals(
+    "synthesized schema",
+    { type: "string" },
+    missing.routes[0]!.parameters[1]!.schema as { type: string },
+  );
+
+  const repeated = HttpMigration.application(createDocument("repeated"));
+  TestValidator.equals(
+    "repeated placeholder shares one argument",
+    ["userId"],
+    repeated.routes[0]!.parameters.map((parameter) => parameter.name),
+  );
+
+  for (const mode of ["duplicate", "wrong"] as const) {
+    const app = HttpMigration.application(createDocument(mode));
+    TestValidator.equals(`${mode} route omitted`, 0, app.routes.length);
+    TestValidator.equals(`${mode} error`, true, app.errors.length === 1);
+  }
+};
+
+const createDocument = (
+  mode: "ordered" | "reversed" | "missing" | "duplicate" | "wrong" | "repeated",
+): OpenApi.IDocument => {
+  const user: OpenApi.IOperation.IParameter = {
+    name: "userId",
+    in: "path",
+    required: true,
+    description: "USER ID",
+    schema: { type: "string" },
+  };
+  const post: OpenApi.IOperation.IParameter = {
+    name: mode === "wrong" ? "articleId" : "postId",
+    in: "path",
+    required: true,
+    description: "POST ID",
+    schema: { type: "integer" },
+  };
+  const parameters =
+    mode === "ordered"
+      ? [user, post]
+      : mode === "reversed"
+        ? [post, user]
+        : mode === "missing" || mode === "repeated"
+          ? [user]
+          : mode === "duplicate"
+            ? [user, { ...user }]
+            : [user, post];
+  const path =
+    mode === "repeated"
+      ? "/users/{userId}/friends/{userId}"
+      : "/users/{userId}/posts/{postId}";
+  return {
+    openapi: "3.2.0",
+    "x-typia-emended-v12": true,
+    info: { title: "Path parameters", version: "1.0.0" },
+    components: { schemas: {} },
+    paths: {
+      [path]: {
+        get: { parameters, responses: { "200": { description: "OK" } } },
+      },
+    },
+  };
+};

--- a/tests/test-utils/src/features/migrate/test_http_migrate_path_parameter_names.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_path_parameter_names.ts
@@ -12,65 +12,153 @@ import { HttpMigration } from "@typia/utils";
  * 2. Compare the resulting placeholder schemas and synthesized parameter.
  * 3. Require deterministic errors for duplicate and incompatible name sets.
  */
-export const test_http_migrate_path_parameter_names = (): void => {
-  const ordered = HttpMigration.application(createDocument("ordered"));
-  const reversed = HttpMigration.application(createDocument("reversed"));
-  TestValidator.equals(
-    "reversed route schemas",
-    ordered.routes[0]!.parameters.map((parameter) => ({
-      name: parameter.name,
-      schema: parameter.schema,
-      description: parameter.parameter().description,
-    })),
-    reversed.routes[0]!.parameters.map((parameter) => ({
-      name: parameter.name,
-      schema: parameter.schema,
-      description: parameter.parameter().description,
-    })),
-  );
-
-  const missing = HttpMigration.application(createDocument("missing"));
-  TestValidator.equals(
-    "missing path synthesized",
-    ["userId", "postId"],
-    missing.routes[0]!.parameters.map((parameter) => parameter.name),
-  );
-  TestValidator.equals(
-    "synthesized schema",
-    { type: "string" },
-    missing.routes[0]!.parameters[1]!.schema as { type: string },
-  );
-
-  const repeated = HttpMigration.application(createDocument("repeated"));
-  TestValidator.equals(
-    "repeated placeholder shares one argument",
-    ["userId"],
-    repeated.routes[0]!.parameters.map((parameter) => parameter.name),
-  );
-
-  const wrong = HttpMigration.application(createDocument("wrong"));
-  TestValidator.equals("wrong route omitted", 0, wrong.routes.length);
-  TestValidator.equals("wrong error", true, wrong.errors.length === 1);
-
-  const duplicate = createDocument("duplicate");
-  const duplicateVersions = [
-    { ...duplicate, openapi: "3.0.3" } as OpenApiV3.IDocument,
-    duplicate,
-    { ...duplicate, openapi: "3.2.0" } as OpenApiV3_2.IDocument,
-  ];
-  duplicateVersions.forEach((document) => {
-    const app = HttpMigration.application(document);
+export const test_http_migrate_path_parameter_names =
+  async (): Promise<void> => {
+    const ordered = HttpMigration.application(createDocument("ordered"));
+    const reversed = HttpMigration.application(createDocument("reversed"));
     TestValidator.equals(
-      `${document.openapi} duplicate route omitted`,
-      0,
-      app.routes.length,
+      "reversed route schemas",
+      ordered.routes[0]!.parameters.map((parameter) => ({
+        name: parameter.name,
+        schema: parameter.schema,
+        description: parameter.parameter().description,
+      })),
+      reversed.routes[0]!.parameters.map((parameter) => ({
+        name: parameter.name,
+        schema: parameter.schema,
+        description: parameter.parameter().description,
+      })),
+    );
+
+    const missing = HttpMigration.application(createDocument("missing"));
+    TestValidator.equals(
+      "missing path synthesized",
+      ["userId", "postId"],
+      missing.routes[0]!.parameters.map((parameter) => parameter.name),
     );
     TestValidator.equals(
-      `${document.openapi} duplicate diagnostic`,
-      ["path parameter names must be unique: userId"],
-      app.errors[0]?.messages,
+      "synthesized schema",
+      { type: "string" },
+      missing.routes[0]!.parameters[1]!.schema as { type: string },
     );
-  });
+
+    const repeated = HttpMigration.application(createDocument("repeated"));
+    TestValidator.equals(
+      "repeated placeholder shares one argument",
+      ["userId"],
+      repeated.routes[0]!.parameters.map((parameter) => parameter.name),
+    );
+
+    const wrong = HttpMigration.application(createDocument("wrong"));
+    TestValidator.equals("wrong route omitted", 0, wrong.routes.length);
+    TestValidator.equals("wrong error", true, wrong.errors.length === 1);
+
+    const duplicate = createDocument("duplicate");
+    const duplicateVersions = [
+      { ...duplicate, openapi: "3.0.3" } as OpenApiV3.IDocument,
+      duplicate,
+      { ...duplicate, openapi: "3.2.0" } as OpenApiV3_2.IDocument,
+    ];
+    duplicateVersions.forEach((document) => {
+      const app = HttpMigration.application(document);
+      TestValidator.equals(
+        `${document.openapi} duplicate route omitted`,
+        0,
+        app.routes.length,
+      );
+      TestValidator.equals(
+        `${document.openapi} duplicate diagnostic`,
+        ["path parameter names must be unique: userId"],
+        app.errors[0]?.messages,
+      );
+    });
+
+    const embedded = HttpMigration.application(embeddedDocument);
+    TestValidator.equals("embedded errors", 0, embedded.errors.length);
+    TestValidator.equals(
+      "embedded parameter names",
+      [["name", "ext"], ["id"]],
+      embedded.routes.map((route) =>
+        route.parameters.map((parameter) => parameter.name),
+      ),
+    );
+    TestValidator.equals(
+      "embedded emended paths",
+      ["/files/:name.:ext", "/prefix-:id"],
+      embedded.routes.map((route) => route.emendedPath),
+    );
+    TestValidator.equals(
+      "embedded accessors",
+      [
+        ["files", "getByNameAndExt"],
+        ["prefix_", "getById"],
+      ],
+      embedded.routes.map((route) => route.accessor),
+    );
+
+    const requests: URL[] = [];
+    const connection = {
+      host: "https://example.com",
+      fetch: (async (input: string | URL | Request) => {
+        requests.push(new URL(String(input)));
+        return new Response(null, { status: 204 });
+      }) as typeof fetch,
+    };
+    await HttpMigration.execute({
+      connection,
+      route: embedded.routes[0]!,
+      parameters: { name: "report", ext: "json" },
+    });
+    await HttpMigration.execute({
+      connection,
+      route: embedded.routes[1]!,
+      parameters: { id: 7 },
+    });
+    TestValidator.equals(
+      "embedded request paths",
+      ["/files/report.json", "/prefix-7"],
+      requests.map((url) => url.pathname),
+    );
+  };
+
+const embeddedDocument: OpenApiV3_1.IDocument = {
+  openapi: "3.1.0",
+  info: { title: "Embedded path parameters", version: "1.0.0" },
+  components: { schemas: {} },
+  paths: {
+    "/files/{name}.{ext}": {
+      get: {
+        parameters: [
+          {
+            name: "ext",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "name",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+    "/prefix-{id}": {
+      get: {
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "integer" },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+  },
 };
 
 const createDocument = (

--- a/tests/test-utils/src/features/migrate/test_http_migrate_querystring_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_querystring_contract.ts
@@ -1,0 +1,378 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3_2 } from "@typia/interface";
+import { HttpLlm, HttpMigration, OpenApiConverter } from "@typia/utils";
+
+/**
+ * Verifies OpenAPI 3.2 whole-query parameters retain their content contract.
+ *
+ * A querystring parameter uses one Media Type Object for the entire URL query
+ * string. It is not a named query parameter, cannot be repeated, and cannot be
+ * combined with ordinary query parameters.
+ *
+ * 1. Compose and advertise one form-urlencoded querystring parameter.
+ * 2. Execute it with media-type encoding and compare the exact query text.
+ * 3. Reject invalid declarations and retain canonical schema compatibility.
+ */
+export const test_http_migrate_querystring_contract =
+  async (): Promise<void> => {
+    const migration = HttpMigration.application(validDocument);
+    TestValidator.equals("composition errors", 0, migration.errors.length);
+    const route = migration.routes[0]!;
+    TestValidator.equals(
+      "querystring media type",
+      "application/x-www-form-urlencoded",
+      route.query?.querystring?.type,
+    );
+
+    const llm = HttpLlm.application({ document: validDocument });
+    TestValidator.equals("LLM errors", 0, llm.errors.length);
+    TestValidator.equals(
+      "LLM whole-query input",
+      true,
+      llm.functions[0]!.validate({
+        query: { foo: "a + b", bar: true },
+      }).success,
+    );
+
+    let captured: URL | undefined;
+    await HttpMigration.execute({
+      connection: {
+        host: "https://example.com",
+        fetch: (async (input: string | URL | Request) => {
+          captured = new URL(String(input));
+          return new Response(null, { status: 204 });
+        }) as typeof fetch,
+      },
+      route,
+      parameters: [],
+      query: { foo: "a + b", bar: true },
+    });
+    TestValidator.equals(
+      "form querystring wire",
+      "?foo=a+%2B+b&bar=true",
+      captured!.search,
+    );
+
+    TestValidator.equals(
+      "JSON querystring wire",
+      "?%7B%22foo%22%3A%22a%20%2B%20b%22%7D",
+      await executeQuerystring(jsonDocument, { foo: "a + b" }),
+    );
+    const textLlm = HttpLlm.application({ document: textDocument });
+    TestValidator.equals(
+      "scalar querystring LLM input",
+      true,
+      textLlm.functions[0]!.validate({ query: "a + b" }).success,
+    );
+    TestValidator.equals(
+      "text querystring wire",
+      "?a%20%2B%20b",
+      await executeQuerystring(textDocument, "a + b"),
+    );
+
+    const canonical = OpenApiConverter.upgradeDocument(validDocument);
+    TestValidator.equals(
+      "canonical querystring content",
+      ["application/x-www-form-urlencoded"],
+      Object.keys(
+        canonical.paths!["/search"]!.get!.parameters![0]!.content ?? {},
+      ),
+    );
+    const downgraded: [string, unknown][] = [
+      [
+        "3.1",
+        OpenApiConverter.downgradeDocument(canonical, "3.1").paths!["/search"]!
+          .get!.parameters![0]!,
+      ],
+      [
+        "3.0",
+        OpenApiConverter.downgradeDocument(canonical, "3.0").paths!["/search"]!
+          .get!.parameters![0]!,
+      ],
+      [
+        "2.0",
+        OpenApiConverter.downgradeDocument(canonical, "2.0").paths!["/search"]!
+          .get!.parameters![0]!,
+      ],
+    ];
+    for (const [version, value] of downgraded) {
+      const parameter = value as Record<string, unknown>;
+      TestValidator.equals(
+        `${version} query location`,
+        "query",
+        parameter.in as string | undefined,
+      );
+      TestValidator.equals(
+        `${version} content removed`,
+        false,
+        "content" in parameter,
+      );
+    }
+
+    const mixed = HttpMigration.application(mixedDocument);
+    TestValidator.equals("mixed route omitted", 0, mixed.routes.length);
+    TestValidator.equals(
+      "mixed diagnostic",
+      ["querystring parameter cannot coexist with query parameters"],
+      mixed.errors[0]?.messages,
+    );
+
+    const duplicate = HttpMigration.application(duplicateDocument);
+    TestValidator.equals("duplicate route omitted", 0, duplicate.routes.length);
+    TestValidator.equals(
+      "duplicate diagnostic",
+      ["querystring parameter must appear at most once"],
+      duplicate.errors[0]?.messages,
+    );
+
+    expectCompositionError(
+      "empty content",
+      emptyContentDocument,
+      "querystring parameter must define exactly one content media type",
+    );
+    expectCompositionError(
+      "multiple content",
+      multipleContentDocument,
+      "querystring parameter must define exactly one content media type",
+    );
+    expectCompositionError(
+      "form scalar",
+      formScalarDocument,
+      "application/x-www-form-urlencoded querystring parameter requires an object schema",
+    );
+    expectCompositionError(
+      "text object",
+      textObjectDocument,
+      'querystring media type "text/plain" requires a scalar schema or JSON representation',
+    );
+
+    const legacy = HttpMigration.application(legacyDocument);
+    TestValidator.equals("legacy composition errors", 0, legacy.errors.length);
+    TestValidator.equals(
+      "legacy schema serialization",
+      "?search=a%20b",
+      await executeRoute(legacy.routes[0]!, { search: "a b" }),
+    );
+    TestValidator.equals(
+      "legacy whole-query metadata absent",
+      false,
+      legacy.routes[0]!.query?.querystring !== undefined,
+    );
+  };
+
+const querystring: OpenApiV3_2.IOperation.IParameter = {
+  name: "wholeQuery",
+  in: "querystring",
+  required: true,
+  content: {
+    "application/x-www-form-urlencoded": {
+      schema: {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+          bar: { type: "boolean" },
+        },
+        required: ["foo", "bar"],
+      },
+    },
+  },
+};
+
+const operation = (
+  parameters: OpenApiV3_2.IOperation.IParameter[],
+): OpenApiV3_2.IPath => ({
+  get: {
+    parameters,
+    responses: { "204": { description: "No Content" } },
+  },
+});
+
+const validDocument: OpenApiV3_2.IDocument = {
+  openapi: "3.2.0",
+  info: { title: "Querystring contract", version: "1.0.0" },
+  components: { schemas: {} },
+  paths: { "/search": operation([querystring]) },
+};
+
+const mixedDocument: OpenApiV3_2.IDocument = {
+  ...validDocument,
+  paths: {
+    "/search": operation([
+      querystring,
+      {
+        name: "page",
+        in: "query",
+        schema: { type: "integer" },
+      },
+    ]),
+  },
+};
+
+const duplicateDocument: OpenApiV3_2.IDocument = {
+  ...validDocument,
+  paths: {
+    "/search": operation([
+      querystring,
+      { ...querystring, name: "otherWholeQuery" },
+    ]),
+  },
+};
+
+const emptyContentDocument: OpenApiV3_2.IDocument = {
+  ...validDocument,
+  paths: {
+    "/search": operation([{ ...querystring, content: {} }]),
+  },
+};
+
+const multipleContentDocument: OpenApiV3_2.IDocument = {
+  ...validDocument,
+  paths: {
+    "/search": operation([
+      {
+        ...querystring,
+        content: {
+          ...querystring.content,
+          "application/json": { schema: { type: "object" } },
+        },
+      },
+    ]),
+  },
+};
+
+const formScalarDocument: OpenApiV3_2.IDocument = {
+  ...validDocument,
+  paths: {
+    "/search": operation([
+      {
+        ...querystring,
+        content: {
+          "application/x-www-form-urlencoded": {
+            schema: { type: "string" },
+          },
+        },
+      },
+    ]),
+  },
+};
+
+const textObjectDocument: OpenApiV3_2.IDocument = {
+  ...validDocument,
+  paths: {
+    "/search": operation([
+      {
+        ...querystring,
+        content: {
+          "text/plain": { schema: { type: "object" } },
+        },
+      },
+    ]),
+  },
+};
+
+const jsonDocument: OpenApiV3_2.IDocument = {
+  ...validDocument,
+  paths: {
+    "/search": operation([
+      {
+        name: "wholeQuery",
+        in: "querystring",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: { foo: { type: "string" } },
+              required: ["foo"],
+            },
+          },
+        },
+      },
+    ]),
+  },
+};
+
+const textDocument: OpenApiV3_2.IDocument = {
+  ...validDocument,
+  paths: {
+    "/search": operation([
+      {
+        name: "wholeQuery",
+        in: "querystring",
+        required: true,
+        content: {
+          "text/plain": {
+            schema: { type: "string" },
+          },
+        },
+      },
+    ]),
+  },
+};
+
+const legacyDocument: OpenApi.IDocument = {
+  openapi: "3.2.0",
+  "x-typia-emended-v12": true,
+  info: { title: "Legacy querystring contract", version: "1.0.0" },
+  components: { schemas: {} },
+  paths: {
+    "/search": {
+      get: {
+        parameters: [
+          {
+            name: "wholeQuery",
+            in: "querystring",
+            schema: {
+              type: "object",
+              properties: { search: { type: "string" } },
+              required: ["search"],
+            },
+          },
+        ],
+        responses: { "204": { description: "No Content" } },
+      },
+    },
+  },
+};
+
+const expectCompositionError = (
+  name: string,
+  document: OpenApiV3_2.IDocument,
+  message: string,
+): void => {
+  const migration = HttpMigration.application(document);
+  TestValidator.equals(`${name} route omitted`, 0, migration.routes.length);
+  TestValidator.equals(
+    `${name} diagnostic`,
+    [message],
+    migration.errors[0]?.messages,
+  );
+};
+
+const executeQuerystring = async (
+  document: OpenApiV3_2.IDocument,
+  query: unknown,
+): Promise<string> => {
+  const migration = HttpMigration.application(document);
+  return executeRoute(migration.routes[0]!, query);
+};
+
+const executeRoute = async (
+  route: ReturnType<typeof HttpMigration.application>["routes"][number],
+  query: unknown,
+): Promise<string> => {
+  let captured: URL | undefined;
+  await HttpMigration.execute({
+    connection: {
+      host: "https://example.com",
+      fetch: (async (input: string | URL | Request) => {
+        captured = new URL(String(input));
+        return new Response(null, { status: 204 });
+      }) as typeof fetch,
+    },
+    route,
+    parameters: [],
+    query,
+  });
+  return captured!.search;
+};

--- a/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
@@ -122,10 +122,10 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
     cookies: { session: "new", theme: "dark" },
     query: {
       ids: [1, 2],
-      tags: ["a", "b"],
+      tags: ["a!", "b*"],
       points: [1, 2],
-      colors: ["red", "blue"],
-      role: "admin",
+      colors: ["red~", "blue!"],
+      "role!": "admin!",
       active: true,
     },
     body: { title: "hello" },
@@ -139,7 +139,7 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
   );
   TestValidator.equals(
     "pipe delimited",
-    "a|b",
+    "a!|b*",
     sent.url.searchParams.get("tags"),
   );
   TestValidator.equals(
@@ -149,18 +149,23 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
   );
   TestValidator.equals(
     "form explode true",
-    ["red", "blue"],
+    ["red~", "blue!"],
     sent.url.searchParams.getAll("colors"),
   );
   TestValidator.equals(
     "deep object role",
-    "admin",
-    sent.url.searchParams.get("filter[role]"),
+    "admin!",
+    sent.url.searchParams.get("filter[role!]"),
   );
   TestValidator.equals(
     "deep object active",
     "true",
     sent.url.searchParams.get("filter[active]"),
+  );
+  TestValidator.equals(
+    "exact query wire format",
+    "?ids=1,2&tags=a%21|b%2A&colors=red~&colors=blue%21&points=1%202&filter[role%21]=admin%21&filter[active]=true",
+    sent.url.search,
   );
   TestValidator.equals(
     "content type wins",
@@ -296,7 +301,7 @@ const document: OpenApiV3_1.IDocument = {
             schema: {
               type: "object",
               properties: {
-                role: { type: "string" },
+                "role!": { type: "string" },
                 active: { type: "boolean" },
               },
             },

--- a/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
@@ -1,0 +1,317 @@
+import { TestValidator } from "@nestia/e2e";
+import {
+  IHttpLlmFunction,
+  IHttpMigrateRoute,
+  OpenApiV3_1,
+} from "@typia/interface";
+import { HttpLlm, HttpMigration } from "@typia/utils";
+
+/**
+ * Verifies migrated requests preserve location, optionality, and serialization.
+ *
+ * The route model previously dropped headers and cookies, required every query
+ * and body group, and serialized every query array as repeated keys.
+ *
+ * 1. Compose required and optional header, cookie, query, and body inputs.
+ * 2. Check the LLM schema required set and validation boundary.
+ * 3. Capture request headers, cookies, body, and style/explode query output.
+ */
+export const test_http_migrate_request_contract = async (): Promise<void> => {
+  const migration = HttpMigration.application(document);
+  TestValidator.equals("composition errors", 0, migration.errors.length);
+  const route: IHttpMigrateRoute = migration.routes[0]!;
+  TestValidator.equals("route groups", {
+    headers: true,
+    cookies: true,
+    query: true,
+    body: true,
+  }, {
+    headers: route.headers !== null,
+    cookies: route.cookies !== null,
+    query: route.query !== null,
+    body: route.body !== null,
+  });
+  TestValidator.equals("group requiredness", {
+    headers: true,
+    cookies: true,
+    query: false,
+    body: false,
+  }, {
+    headers: route.headers!.required,
+    cookies: route.cookies!.required,
+    query: route.query!.required,
+    body: route.body!.required,
+  });
+
+  const application = HttpLlm.application({ document });
+  TestValidator.equals("LLM errors", 0, application.errors.length);
+  const func: IHttpLlmFunction = application.functions[0]!;
+  TestValidator.equals("LLM properties", [
+    "userId",
+    "header",
+    "cookie",
+    "query",
+    "body",
+  ], Object.keys(func.parameters.properties ?? {}));
+  TestValidator.equals("LLM required groups", [
+    "userId",
+    "header",
+    "cookie",
+  ], func.parameters.required);
+  TestValidator.equals(
+    "optional query and body validate",
+    true,
+    func.validate({
+      userId: "samchon",
+      header: { "X-Token": "request", trace: "abc" },
+      cookie: { session: "token" },
+    }).success,
+  );
+
+  let captured: { url: URL; init: RequestInit } | undefined;
+  const connection = {
+    host: "https://example.com/api/",
+    headers: {
+      "X-Token": "connection",
+      Cookie: "session=old; inherited=yes",
+    },
+    fetch: (async (input: string | URL | Request, init?: RequestInit) => {
+      captured = { url: new URL(String(input)), init: init! };
+      return new Response('{"ok":true}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch,
+  };
+  await HttpMigration.execute({
+    connection,
+    route,
+    parameters: { userId: "samchon" },
+    headers: { "X-Token": "request", trace: "abc" },
+    cookies: { session: "new", theme: "dark" },
+  });
+  let sent = captured!;
+  let headers = new Headers(sent.init.headers);
+  TestValidator.equals("path", "/api/users/samchon", sent.url.pathname);
+  TestValidator.equals("header override", "request", headers.get("x-token"));
+  TestValidator.equals("object header", "trace,abc", headers.get("x-meta"));
+  TestValidator.equals(
+    "cookie merge and override",
+    "inherited=yes; session=new; theme=dark",
+    headers.get("cookie"),
+  );
+  TestValidator.equals("optional query omitted", "", sent.url.search);
+  TestValidator.equals("optional body omitted", true, sent.init.body == null);
+  TestValidator.equals(
+    "optional body content type omitted",
+    true,
+    headers.get("content-type") === null,
+  );
+
+  await HttpMigration.execute({
+    connection,
+    route,
+    parameters: { userId: "samchon" },
+    headers: { "X-Token": "request", trace: "abc" },
+    cookies: { session: "new", theme: "dark" },
+    query: {
+      ids: [1, 2],
+      tags: ["a", "b"],
+      points: [1, 2],
+      colors: ["red", "blue"],
+      role: "admin",
+      active: true,
+    },
+    body: { title: "hello" },
+  });
+  sent = captured!;
+  headers = new Headers(sent.init.headers);
+  TestValidator.equals("form explode false", "1,2", sent.url.searchParams.get("ids"));
+  TestValidator.equals("pipe delimited", "a|b", sent.url.searchParams.get("tags"));
+  TestValidator.equals("space delimited", "1 2", sent.url.searchParams.get("points"));
+  TestValidator.equals("form explode true", ["red", "blue"], sent.url.searchParams.getAll("colors"));
+  TestValidator.equals("deep object role", "admin", sent.url.searchParams.get("filter[role]"));
+  TestValidator.equals("deep object active", "true", sent.url.searchParams.get("filter[active]"));
+  TestValidator.equals("content type wins", "application/json", headers.get("content-type"));
+  TestValidator.equals("JSON body", '{"title":"hello"}', String(sent.init.body));
+
+  let requiredError = false;
+  try {
+    await HttpMigration.execute({
+      connection,
+      route,
+      parameters: { userId: "samchon" },
+    });
+  } catch {
+    requiredError = true;
+  }
+  TestValidator.equals("required groups rejected", true, requiredError);
+
+  const matrix = migration.routes.find((candidate) => candidate.path === "/matrix/{coords}")!;
+  await HttpMigration.execute({ connection, route: matrix, parameters: [[1, 2]] });
+  TestValidator.equals("matrix path", "/api/matrix/;coords=1;coords=2", captured!.url.pathname);
+  const label = migration.routes.find((candidate) => candidate.path === "/label/{coords}")!;
+  await HttpMigration.execute({
+    connection,
+    route: label,
+    parameters: [{ x: 1, y: 2 }],
+  });
+  TestValidator.equals("label path", "/api/label/.x=1.y=2", captured!.url.pathname);
+};
+
+const document: OpenApiV3_1.IDocument = {
+  openapi: "3.1.0",
+  info: { title: "HTTP request contract", version: "1.0.0" },
+  components: { schemas: {} },
+  paths: {
+    "/users/{userId}": {
+      post: {
+        parameters: [
+          {
+            name: "userId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "X-Token",
+            in: "header",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "X-Meta",
+            in: "header",
+            style: "simple",
+            explode: false,
+            schema: {
+              type: "object",
+              properties: { trace: { type: "string" } },
+              required: ["trace"],
+            },
+          },
+          {
+            name: "session",
+            in: "cookie",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "preferences",
+            in: "cookie",
+            style: "form",
+            explode: true,
+            schema: {
+              type: "object",
+              properties: { theme: { type: "string" } },
+            },
+          },
+          {
+            name: "ids",
+            in: "query",
+            style: "form",
+            explode: false,
+            schema: { type: "array", items: { type: "integer" } },
+          },
+          {
+            name: "tags",
+            in: "query",
+            style: "pipeDelimited",
+            explode: false,
+            schema: { type: "array", items: { type: "string" } },
+          },
+          {
+            name: "colors",
+            in: "query",
+            style: "form",
+            explode: true,
+            schema: { type: "array", items: { type: "string" } },
+          },
+          {
+            name: "points",
+            in: "query",
+            style: "spaceDelimited",
+            explode: false,
+            schema: { type: "array", items: { type: "integer" } },
+          },
+          {
+            name: "filter",
+            in: "query",
+            style: "deepObject",
+            explode: true,
+            schema: {
+              type: "object",
+              properties: {
+                role: { type: "string" },
+                active: { type: "boolean" },
+              },
+            },
+          },
+        ],
+        requestBody: {
+          required: false,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: { title: { type: "string" } },
+                required: ["title"],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { ok: { type: "boolean" } },
+                  required: ["ok"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/matrix/{coords}": {
+      get: {
+        parameters: [
+          {
+            name: "coords",
+            in: "path",
+            required: true,
+            style: "matrix",
+            explode: true,
+            schema: { type: "array", items: { type: "integer" } },
+          },
+        ],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    "/label/{coords}": {
+      get: {
+        parameters: [
+          {
+            name: "coords",
+            in: "path",
+            required: true,
+            style: "label",
+            explode: true,
+            schema: {
+              type: "object",
+              properties: {
+                x: { type: "integer" },
+                y: { type: "integer" },
+              },
+              required: ["x", "y"],
+            },
+          },
+        ],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+  },
+};

--- a/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
@@ -191,11 +191,11 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
   await HttpMigration.execute({
     connection,
     route: matrix,
-    parameters: [[1, 2]],
+    parameters: [["a!", "b*"]],
   });
   TestValidator.equals(
     "matrix path",
-    "/api/matrix/;coords=1;coords=2",
+    "/api/matrix/;coords=a%21;coords=b%2A",
     captured!.url.pathname,
   );
   const label = migration.routes.find(
@@ -204,11 +204,11 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
   await HttpMigration.execute({
     connection,
     route: label,
-    parameters: [{ x: 1, y: 2 }],
+    parameters: [{ "x!": "a!", "y*": "b*" }],
   });
   TestValidator.equals(
     "label path",
-    "/api/label/.x=1.y=2",
+    "/api/label/.x%21=a%21.y%2A=b%2A",
     captured!.url.pathname,
   );
 };
@@ -339,7 +339,7 @@ const document: OpenApiV3_1.IDocument = {
             required: true,
             style: "matrix",
             explode: true,
-            schema: { type: "array", items: { type: "integer" } },
+            schema: { type: "array", items: { type: "string" } },
           },
         ],
         responses: { "200": { description: "OK" } },
@@ -357,10 +357,10 @@ const document: OpenApiV3_1.IDocument = {
             schema: {
               type: "object",
               properties: {
-                x: { type: "integer" },
-                y: { type: "integer" },
+                "x!": { type: "string" },
+                "y*": { type: "string" },
               },
-              required: ["x", "y"],
+              required: ["x!", "y*"],
             },
           },
         ],

--- a/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
@@ -20,44 +20,50 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
   const migration = HttpMigration.application(document);
   TestValidator.equals("composition errors", 0, migration.errors.length);
   const route: IHttpMigrateRoute = migration.routes[0]!;
-  TestValidator.equals("route groups", {
-    headers: true,
-    cookies: true,
-    query: true,
-    body: true,
-  }, {
-    headers: route.headers !== null,
-    cookies: route.cookies !== null,
-    query: route.query !== null,
-    body: route.body !== null,
-  });
-  TestValidator.equals("group requiredness", {
-    headers: true,
-    cookies: true,
-    query: false,
-    body: false,
-  }, {
-    headers: route.headers!.required,
-    cookies: route.cookies!.required,
-    query: route.query!.required,
-    body: route.body!.required,
-  });
+  TestValidator.equals(
+    "route groups",
+    {
+      headers: true,
+      cookies: true,
+      query: true,
+      body: true,
+    },
+    {
+      headers: route.headers !== null,
+      cookies: route.cookies !== null,
+      query: route.query !== null,
+      body: route.body !== null,
+    },
+  );
+  TestValidator.equals(
+    "group requiredness",
+    {
+      headers: true,
+      cookies: true,
+      query: false,
+      body: false,
+    },
+    {
+      headers: route.headers!.required!,
+      cookies: route.cookies!.required!,
+      query: route.query!.required!,
+      body: route.body!.required!,
+    },
+  );
 
   const application = HttpLlm.application({ document });
   TestValidator.equals("LLM errors", 0, application.errors.length);
   const func: IHttpLlmFunction = application.functions[0]!;
-  TestValidator.equals("LLM properties", [
-    "userId",
-    "header",
-    "cookie",
-    "query",
-    "body",
-  ], Object.keys(func.parameters.properties ?? {}));
-  TestValidator.equals("LLM required groups", [
-    "userId",
-    "header",
-    "cookie",
-  ], func.parameters.required);
+  TestValidator.equals(
+    "LLM properties",
+    ["userId", "header", "cookie", "query", "body"],
+    Object.keys(func.parameters.properties ?? {}),
+  );
+  TestValidator.equals(
+    "LLM required groups",
+    ["userId", "header", "cookie"],
+    func.parameters.required,
+  );
   TestValidator.equals(
     "optional query and body validate",
     true,
@@ -126,14 +132,46 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
   });
   sent = captured!;
   headers = new Headers(sent.init.headers);
-  TestValidator.equals("form explode false", "1,2", sent.url.searchParams.get("ids"));
-  TestValidator.equals("pipe delimited", "a|b", sent.url.searchParams.get("tags"));
-  TestValidator.equals("space delimited", "1 2", sent.url.searchParams.get("points"));
-  TestValidator.equals("form explode true", ["red", "blue"], sent.url.searchParams.getAll("colors"));
-  TestValidator.equals("deep object role", "admin", sent.url.searchParams.get("filter[role]"));
-  TestValidator.equals("deep object active", "true", sent.url.searchParams.get("filter[active]"));
-  TestValidator.equals("content type wins", "application/json", headers.get("content-type"));
-  TestValidator.equals("JSON body", '{"title":"hello"}', String(sent.init.body));
+  TestValidator.equals(
+    "form explode false",
+    "1,2",
+    sent.url.searchParams.get("ids"),
+  );
+  TestValidator.equals(
+    "pipe delimited",
+    "a|b",
+    sent.url.searchParams.get("tags"),
+  );
+  TestValidator.equals(
+    "space delimited",
+    "1 2",
+    sent.url.searchParams.get("points"),
+  );
+  TestValidator.equals(
+    "form explode true",
+    ["red", "blue"],
+    sent.url.searchParams.getAll("colors"),
+  );
+  TestValidator.equals(
+    "deep object role",
+    "admin",
+    sent.url.searchParams.get("filter[role]"),
+  );
+  TestValidator.equals(
+    "deep object active",
+    "true",
+    sent.url.searchParams.get("filter[active]"),
+  );
+  TestValidator.equals(
+    "content type wins",
+    "application/json",
+    headers.get("content-type"),
+  );
+  TestValidator.equals(
+    "JSON body",
+    '{"title":"hello"}',
+    String(sent.init.body),
+  );
 
   let requiredError = false;
   try {
@@ -147,16 +185,32 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
   }
   TestValidator.equals("required groups rejected", true, requiredError);
 
-  const matrix = migration.routes.find((candidate) => candidate.path === "/matrix/{coords}")!;
-  await HttpMigration.execute({ connection, route: matrix, parameters: [[1, 2]] });
-  TestValidator.equals("matrix path", "/api/matrix/;coords=1;coords=2", captured!.url.pathname);
-  const label = migration.routes.find((candidate) => candidate.path === "/label/{coords}")!;
+  const matrix = migration.routes.find(
+    (candidate) => candidate.path === "/matrix/{coords}",
+  )!;
+  await HttpMigration.execute({
+    connection,
+    route: matrix,
+    parameters: [[1, 2]],
+  });
+  TestValidator.equals(
+    "matrix path",
+    "/api/matrix/;coords=1;coords=2",
+    captured!.url.pathname,
+  );
+  const label = migration.routes.find(
+    (candidate) => candidate.path === "/label/{coords}",
+  )!;
   await HttpMigration.execute({
     connection,
     route: label,
     parameters: [{ x: 1, y: 2 }],
   });
-  TestValidator.equals("label path", "/api/label/.x=1.y=2", captured!.url.pathname);
+  TestValidator.equals(
+    "label path",
+    "/api/label/.x=1.y=2",
+    captured!.url.pathname,
+  );
 };
 
 const document: OpenApiV3_1.IDocument = {

--- a/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_request_contract.ts
@@ -13,7 +13,7 @@ import { HttpLlm, HttpMigration } from "@typia/utils";
  * and body group, and serialized every query array as repeated keys.
  *
  * 1. Compose required and optional header, cookie, query, and body inputs.
- * 2. Check the LLM schema required set and validation boundary.
+ * 2. Ignore reserved OpenAPI headers and check the LLM validation boundary.
  * 3. Capture request headers, cookies, body, and style/explode query output.
  */
 export const test_http_migrate_request_contract = async (): Promise<void> => {
@@ -79,6 +79,7 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
     host: "https://example.com/api/",
     headers: {
       "X-Token": "connection",
+      Authorization: "Bearer connection",
       Cookie: "session=old; inherited=yes",
     },
     fetch: (async (input: string | URL | Request, init?: RequestInit) => {
@@ -100,6 +101,11 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
   let headers = new Headers(sent.init.headers);
   TestValidator.equals("path", "/api/users/samchon", sent.url.pathname);
   TestValidator.equals("header override", "request", headers.get("x-token"));
+  TestValidator.equals(
+    "ignored parameter keeps connection authorization",
+    "Bearer connection",
+    headers.get("authorization"),
+  );
   TestValidator.equals("object header", "trace,abc", headers.get("x-meta"));
   TestValidator.equals(
     "cookie merge and override",
@@ -164,7 +170,7 @@ export const test_http_migrate_request_contract = async (): Promise<void> => {
   );
   TestValidator.equals(
     "exact query wire format",
-    "?ids=1,2&tags=a%21|b%2A&colors=red~&colors=blue%21&points=1%202&filter[role%21]=admin%21&filter[active]=true",
+    "?ids=1,2&tags=a%21%7Cb%2A&colors=red~&colors=blue%21&points=1%202&filter%5Brole%21%5D=admin%21&filter%5Bactive%5D=true",
     sent.url.search,
   );
   TestValidator.equals(
@@ -229,6 +235,24 @@ const document: OpenApiV3_1.IDocument = {
           {
             name: "userId",
             in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "ACCEPT",
+            in: "header",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "content-type",
+            in: "header",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "authorization",
+            in: "header",
             required: true,
             schema: { type: "string" },
           },

--- a/tests/test-utils/src/features/migrate/test_http_migrate_response_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_response_contract.ts
@@ -1,24 +1,34 @@
 import { TestValidator } from "@nestia/e2e";
-import {
-  IHttpMigrateRoute,
-  IHttpResponse,
-  OpenApi,
-} from "@typia/interface";
+import { IHttpMigrateRoute, IHttpResponse, OpenApi } from "@typia/interface";
 import { HttpError, HttpMigration } from "@typia/utils";
 
 /**
- * Verifies migrated HTTP responses preserve the complete status and metadata contract.
+ * Verifies migrated HTTP responses preserve the complete status and metadata
+ * contract.
  *
  * The migration fetcher previously treated only 200 and 201 as successful,
  * widened structured failures into strings, split cookie attributes, and joined
  * base URLs with a duplicate slash.
  *
- * 1. Exercise success statuses, no-content responses, and all supported failure bodies.
+ * 1. Exercise success statuses, no-content responses, and all supported failure
+ *    bodies.
  * 2. Read repeated Set-Cookie fields and structured HttpError JSON.
  * 3. Check every host/path slash boundary without rewriting the base path.
  */
 export const test_http_migrate_response_contract = async (): Promise<void> => {
-  const route: IHttpMigrateRoute = HttpMigration.application(document).routes[0]!;
+  const application = HttpMigration.application(document);
+  const route: IHttpMigrateRoute = application.routes[0]!;
+  TestValidator.equals("representative success", "202", route.success?.status);
+  TestValidator.equals(
+    "2xx excluded from exceptions",
+    false,
+    "204" in route.exceptions,
+  );
+  TestValidator.equals(
+    "declared error retained",
+    true,
+    "400" in route.exceptions,
+  );
   const requests: string[] = [];
   let response: Response = jsonResponse(202, { accepted: true });
   const connection = {
@@ -114,10 +124,14 @@ export const test_http_migrate_response_contract = async (): Promise<void> => {
     { code: "BAD" },
     propagated.body as { code: string },
   );
-  TestValidator.equals("set-cookie fields", [
-    "sid=abc; Path=/; HttpOnly",
-    "theme=dark; Expires=Wed, 21 Oct 2026 07:28:00 GMT",
-  ], propagated.headers["set-cookie"] as string[]);
+  TestValidator.equals(
+    "set-cookie fields",
+    [
+      "sid=abc; Path=/; HttpOnly",
+      "theme=dark; Expires=Wed, 21 Oct 2026 07:28:00 GMT",
+    ],
+    propagated.headers["set-cookie"] as string[],
+  );
   let error: HttpError | undefined;
   try {
     await HttpMigration.execute({ connection, route, parameters: [] });
@@ -129,6 +143,29 @@ export const test_http_migrate_response_contract = async (): Promise<void> => {
     "HttpError structured body",
     { code: "BAD" },
     error?.toJSON<{ code: string }>().message,
+  );
+  TestValidator.equals(
+    "legacy HttpError JSON string",
+    { legacy: true },
+    new HttpError("GET", "/items", 400, {}, '{"legacy":true}').toJSON<{
+      legacy: boolean;
+    }>().message,
+  );
+
+  response = new Response('{"looks":"json"}', {
+    status: 400,
+    headers: { "Content-Type": "text/plain" },
+  });
+  let textError: HttpError | undefined;
+  try {
+    await HttpMigration.execute({ connection, route, parameters: [] });
+  } catch (exp) {
+    if (exp instanceof HttpError) textError = exp;
+  }
+  TestValidator.equals(
+    "classified text remains text",
+    '{"looks":"json"}',
+    textError?.toJSON<string>().message,
   );
 
   for (const value of [["BAD"], 7, null] as const) {
@@ -145,7 +182,11 @@ export const test_http_migrate_response_contract = async (): Promise<void> => {
   multipart.set("code", "BAD");
 
   const failureCases: Array<[string, Response, (body: unknown) => boolean]> = [
-    ["text", new Response("failure", { status: 400 }), (body) => body === "failure"],
+    [
+      "text",
+      new Response("failure", { status: 400 }),
+      (body) => body === "failure",
+    ],
     [
       "form",
       new Response("code=BAD", {
@@ -216,7 +257,7 @@ const document: OpenApi.IDocument = {
           "202": {
             description: "Accepted",
             content: {
-              "application/json": {
+              "application/problem+json": {
                 schema: {
                   type: "object",
                   properties: { accepted: { type: "boolean" } },

--- a/tests/test-utils/src/features/migrate/test_http_migrate_response_contract.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_response_contract.ts
@@ -1,0 +1,245 @@
+import { TestValidator } from "@nestia/e2e";
+import {
+  IHttpMigrateRoute,
+  IHttpResponse,
+  OpenApi,
+} from "@typia/interface";
+import { HttpError, HttpMigration } from "@typia/utils";
+
+/**
+ * Verifies migrated HTTP responses preserve the complete status and metadata contract.
+ *
+ * The migration fetcher previously treated only 200 and 201 as successful,
+ * widened structured failures into strings, split cookie attributes, and joined
+ * base URLs with a duplicate slash.
+ *
+ * 1. Exercise success statuses, no-content responses, and all supported failure bodies.
+ * 2. Read repeated Set-Cookie fields and structured HttpError JSON.
+ * 3. Check every host/path slash boundary without rewriting the base path.
+ */
+export const test_http_migrate_response_contract = async (): Promise<void> => {
+  const route: IHttpMigrateRoute = HttpMigration.application(document).routes[0]!;
+  const requests: string[] = [];
+  let response: Response = jsonResponse(202, { accepted: true });
+  const connection = {
+    host: "https://example.com/api/",
+    fetch: (async (input: string | URL | Request) => {
+      requests.push(String(input));
+      return response.clone();
+    }) as typeof fetch,
+  };
+  const call = (target: IHttpMigrateRoute = route): Promise<IHttpResponse> =>
+    HttpMigration.propagate({
+      connection,
+      route: target,
+      parameters: [],
+    });
+
+  TestValidator.equals(
+    "202 body",
+    { accepted: true },
+    (await call()).body as { accepted: boolean },
+  );
+  TestValidator.equals(
+    "base path boundary",
+    "https://example.com/api/items",
+    requests.at(-1),
+  );
+
+  for (const status of [200, 201, 206] as const) {
+    response = jsonResponse(status, { status });
+    TestValidator.equals(
+      `${status} execute`,
+      { status } as { status: number },
+      (await HttpMigration.execute({
+        connection,
+        route,
+        parameters: [],
+      })) as { status: number },
+    );
+  }
+
+  response = new Response('{"problem":true}', {
+    status: 206,
+    headers: { "Content-Type": "application/problem+json" },
+  });
+  TestValidator.equals(
+    "runtime success media type",
+    { problem: true },
+    (await HttpMigration.execute({
+      connection,
+      route: { ...route, success: null },
+      parameters: [],
+    })) as { problem: boolean },
+  );
+
+  response = jsonResponse(299, { edge: true });
+  TestValidator.equals(
+    "299 execute",
+    { edge: true },
+    (await HttpMigration.execute({
+      connection,
+      route,
+      parameters: [],
+    })) as { edge: boolean },
+  );
+
+  response = new Response(null, { status: 204 });
+  TestValidator.equals("204 body", true, (await call()).body === undefined);
+  response = new Response(null, { status: 205 });
+  TestValidator.equals("205 body", true, (await call()).body === undefined);
+
+  response = new Response("redirect", { status: 300 });
+  let redirectError: HttpError | undefined;
+  try {
+    await HttpMigration.execute({ connection, route, parameters: [] });
+  } catch (exp) {
+    if (exp instanceof HttpError) redirectError = exp;
+  }
+  TestValidator.equals("300 is not success", 300, redirectError?.status);
+
+  const cookieHeaders = new Headers({ "Content-Type": "application/json" });
+  cookieHeaders.append("Set-Cookie", "sid=abc; Path=/; HttpOnly");
+  cookieHeaders.append(
+    "Set-Cookie",
+    "theme=dark; Expires=Wed, 21 Oct 2026 07:28:00 GMT",
+  );
+  response = new Response('{"code":"BAD"}', {
+    status: 400,
+    headers: cookieHeaders,
+  });
+  const propagated = await call();
+  TestValidator.equals(
+    "failure JSON",
+    { code: "BAD" },
+    propagated.body as { code: string },
+  );
+  TestValidator.equals("set-cookie fields", [
+    "sid=abc; Path=/; HttpOnly",
+    "theme=dark; Expires=Wed, 21 Oct 2026 07:28:00 GMT",
+  ], propagated.headers["set-cookie"] as string[]);
+  let error: HttpError | undefined;
+  try {
+    await HttpMigration.execute({ connection, route, parameters: [] });
+  } catch (exp) {
+    if (exp instanceof HttpError) error = exp;
+  }
+  TestValidator.equals("HttpError status", 400, error?.status);
+  TestValidator.equals(
+    "HttpError structured body",
+    { code: "BAD" },
+    error?.toJSON<{ code: string }>().message,
+  );
+
+  for (const value of [["BAD"], 7, null] as const) {
+    response = jsonResponse(400, value);
+    const body = (await call()).body;
+    TestValidator.equals(
+      `JSON ${JSON.stringify(value)}`,
+      JSON.stringify(value),
+      JSON.stringify(body),
+    );
+  }
+
+  const multipart = new FormData();
+  multipart.set("code", "BAD");
+
+  const failureCases: Array<[string, Response, (body: unknown) => boolean]> = [
+    ["text", new Response("failure", { status: 400 }), (body) => body === "failure"],
+    [
+      "form",
+      new Response("code=BAD", {
+        status: 400,
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      }),
+      (body) => body instanceof URLSearchParams && body.get("code") === "BAD",
+    ],
+    [
+      "multipart",
+      new Response(multipart, { status: 400 }),
+      (body) => body instanceof FormData && body.get("code") === "BAD",
+    ],
+    [
+      "binary",
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 400,
+        headers: { "Content-Type": "application/octet-stream" },
+      }),
+      (body) => body instanceof Blob && body.size === 3,
+    ],
+    [
+      "empty JSON",
+      new Response(null, {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }),
+      (body) => body === undefined,
+    ],
+  ];
+  for (const [name, value, predicate] of failureCases) {
+    response = value;
+    TestValidator.equals(name, true, predicate((await call()).body));
+  }
+
+  response = jsonResponse(200, { ok: true });
+  for (const [host, path, expected] of [
+    ["https://example.com/api", "/items", "https://example.com/api/items"],
+    ["https://example.com/api/", "/items", "https://example.com/api/items"],
+    ["https://example.com/api", "items", "https://example.com/api/items"],
+    ["https://example.com/api/", "items", "https://example.com/api/items"],
+  ] as const) {
+    connection.host = host;
+    await call({ ...route, emendedPath: path });
+    TestValidator.equals(
+      `URL ${host} ${path}`,
+      expected as string,
+      requests.at(-1),
+    );
+  }
+};
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const document: OpenApi.IDocument = {
+  openapi: "3.2.0",
+  "x-typia-emended-v12": true,
+  info: { title: "HTTP response contract", version: "1.0.0" },
+  components: { schemas: {} },
+  paths: {
+    "/items": {
+      get: {
+        responses: {
+          "202": {
+            description: "Accepted",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { accepted: { type: "boolean" } },
+                  required: ["accepted"],
+                },
+              },
+            },
+          },
+          "204": { description: "No Content" },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { code: { type: "string" } },
+                  required: ["code"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/website/src/content/docs/llm/http.mdx
+++ b/website/src/content/docs/llm/http.mdx
@@ -135,7 +135,7 @@ flowchart
 
 Path parameters, headers, cookies, query parameters, and request bodies remain separate argument groups in each generated function. OpenAPI `required`, `style`, and `explode` metadata controls both the LLM schema and the executed request, so optional query or body groups may be omitted and arrays or objects use their declared wire format.
 
-Connection headers provide defaults, operation arguments override matching headers, and a serialized body selects its final `Content-Type`. Cookie arguments are merged by cookie name with any connection-level `Cookie` header; browsers may still prevent JavaScript from setting restricted headers such as `Cookie`.
+Connection headers provide defaults, operation arguments override matching headers, and a serialized body selects its final `Content-Type`. Cookie arguments are merged by cookie name with any connection-level `Cookie` header. The default `form` cookie style percent-encodes names and values, while OpenAPI 3.2's `cookie` style passes pre-escaped data through unchanged. Browsers may still prevent JavaScript from setting restricted headers such as `Cookie`.
 
 Every `2xx` response is treated as successful, including bodyless `204` and `205` responses. Failed responses retain their parsed JSON, form, multipart, binary, or text body in `HttpError`, and repeated `Set-Cookie` fields are exposed as separate response-header values when the runtime provides that information.
 

--- a/website/src/content/docs/llm/http.mdx
+++ b/website/src/content/docs/llm/http.mdx
@@ -135,6 +135,8 @@ flowchart
 
 Path parameters, headers, cookies, query parameters, and request bodies remain separate argument groups in each generated function. OpenAPI `required`, `style`, and `explode` metadata controls both the LLM schema and the executed request, so optional query or body groups may be omitted and arrays or objects use their declared wire format.
 
+Ordinary styled query parameters preserve OpenAPI's structural delimiters while encoding names and values with RFC 3986 rules. An OpenAPI 3.2 `querystring` parameter instead represents the complete query as one content-backed value; for example, `application/x-www-form-urlencoded` uses form encoding, including `+` for spaces.
+
 Connection headers provide defaults, operation arguments override matching headers, and a serialized body selects its final `Content-Type`. Cookie arguments are merged by cookie name with any connection-level `Cookie` header. The default `form` cookie style percent-encodes names and values, while OpenAPI 3.2's `cookie` style passes pre-escaped data through unchanged. Browsers may still prevent JavaScript from setting restricted headers such as `Cookie`.
 
 Every `2xx` response is treated as successful, including bodyless `204` and `205` responses. Failed responses retain their parsed JSON, form, multipart, binary, or text body in `HttpError`, and repeated `Set-Cookie` fields are exposed as separate response-header values when the runtime provides that information.

--- a/website/src/content/docs/llm/http.mdx
+++ b/website/src/content/docs/llm/http.mdx
@@ -135,7 +135,7 @@ flowchart
 
 Path parameters, headers, cookies, query parameters, and request bodies remain separate argument groups in each generated function. OpenAPI `required`, `style`, and `explode` metadata controls both the LLM schema and the executed request, so optional query or body groups may be omitted and arrays or objects use their declared wire format.
 
-Ordinary styled query parameters preserve OpenAPI's structural delimiters while encoding names and values with RFC 3986 rules. An OpenAPI 3.2 `querystring` parameter instead represents the complete query as one content-backed value; for example, `application/x-www-form-urlencoded` uses form encoding, including `+` for spaces.
+Ordinary styled query parameters preserve OpenAPI's structural syntax while encoding names, values, and URI-required delimiters with RFC 3986 rules. An OpenAPI 3.2 `querystring` parameter instead represents the complete query as one content-backed value; for example, `application/x-www-form-urlencoded` uses form encoding, including `+` for spaces.
 
 Connection headers provide defaults, operation arguments override matching headers, and a serialized body selects its final `Content-Type`. Cookie arguments are merged by cookie name with any connection-level `Cookie` header. The default `form` cookie style percent-encodes names and values, while OpenAPI 3.2's `cookie` style passes pre-escaped data through unchanged. Browsers may still prevent JavaScript from setting restricted headers such as `Cookie`.
 

--- a/website/src/content/docs/llm/http.mdx
+++ b/website/src/content/docs/llm/http.mdx
@@ -131,6 +131,14 @@ flowchart
 
 `HttpLlm` first normalizes every OpenAPI dialect into one internal representation (emended OpenAPI 3.2), then converts each operation into an `IHttpLlmFunction`. The intermediate representation is what makes "any version in, any LLM provider out" possible without combinatorial conversion code.
 
+## HTTP request and response contracts
+
+Path parameters, headers, cookies, query parameters, and request bodies remain separate argument groups in each generated function. OpenAPI `required`, `style`, and `explode` metadata controls both the LLM schema and the executed request, so optional query or body groups may be omitted and arrays or objects use their declared wire format.
+
+Connection headers provide defaults, operation arguments override matching headers, and a serialized body selects its final `Content-Type`. Cookie arguments are merged by cookie name with any connection-level `Cookie` header; browsers may still prevent JavaScript from setting restricted headers such as `Cookie`.
+
+Every `2xx` response is treated as successful, including bodyless `204` and `205` responses. Failed responses retain their parsed JSON, form, multipart, binary, or text body in `HttpError`, and repeated `Set-Cookie` fields are exposed as separate response-header values when the runtime provides that information.
+
 ## Framework adapters
 
 The same controller plugs into any supported framework. Pick whichever your app already uses:

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -476,7 +476,7 @@ namespace http {
 
 `http.query` decodes a query string (or any `IReadableURLSearchParams`-shaped object — the standard `URLSearchParams` works, as does Hono's and other duck-typed shims) into a typed object. Numeric and boolean properties are coerced from their string form automatically.
 
-String inputs may be a raw query (`id=1`), a question-prefixed query (`?id=1`), or a complete URL. A literal `#` starts a URL fragment and is excluded from parsing, while percent-encoded data such as `%3F` remains part of the query value.
+String inputs may be a raw query (`id=1`), a question-prefixed query (`?id=1`), or a complete URL. In question-prefixed or URL-shaped inputs, a literal `#` starts a fragment and is excluded from parsing; in raw query text it remains part of the value. Percent-encoded data such as `%3F` remains part of the query value in every form.
 
 **Restrictions** (typia rejects at compile time):
 

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -476,6 +476,8 @@ namespace http {
 
 `http.query` decodes a query string (or any `IReadableURLSearchParams`-shaped object — the standard `URLSearchParams` works, as does Hono's and other duck-typed shims) into a typed object. Numeric and boolean properties are coerced from their string form automatically.
 
+String inputs may be a raw query (`id=1`), a question-prefixed query (`?id=1`), or a complete URL. A literal `#` starts a URL fragment and is excluded from parsing, while percent-encoded data such as `%3F` remains part of the query value.
+
 **Restrictions** (typia rejects at compile time):
 
 1. `T` must be an object type


### PR DESCRIPTION
## Intent

Restore the HTTP migration boundary so composed OpenAPI request contracts and observed HTTP responses survive execution without being reordered, dropped, or misclassified.

## Scope

- Treat the complete 2xx class as successful, preserve structured error bodies and repeated cookies, and normalize only the host/path join boundary.
- Associate path parameters by OpenAPI name instead of array position.
- Accept raw query strings, leading-question-mark strings, and full URL query inputs consistently across direct and factory decoders.
- Carry header/cookie parameters, request optionality, and supported OpenAPI query serialization metadata through `HttpMigration` and `HttpLlm`.
- Preserve OpenAPI 3.2 `querystring`, cookie-style pass-through, required delimiter encoding, and reserved-header rules discovered during review.

## Deferred

- No unrelated OpenAPI converter, validator, or non-HTTP runtime changes.
- Repository-wide formatting remains deferred to the campaign Post-Campaign Cleanup pull request.
- The website production build remains excluded under the campaign's recorded packaging prerequisite.

## Verification

- `pnpm --filter @typia/interface build`
- `pnpm --filter @typia/utils build`
- `pnpm --filter typia build`
- `pnpm --filter @typia/test-utils start`
- `pnpm --filter @typia/test-typia-schema start`
- `git diff --check origin/master...HEAD`
- Six complete solo Self-Review rounds, with all accepted findings remediated and the terminal round clean.

Automatic GitHub Actions for campaign commits were deliberately cancelled by exact SHA. Local verification is the implementation gate under the issue-campaign procedure.

Closes #2029
Closes #2030
Closes #2031
Closes #2050
