### PR TITLE
fix(adapters): reject final tool-name collisions

### DIFF
--- a/packages/langchain/src/internal/LangChainToolsRegistrar.ts
+++ b/packages/langchain/src/internal/LangChainToolsRegistrar.ts
@@ -21,17 +21,23 @@ export namespace LangChainToolsRegistrar {
     const tools: DynamicStructuredTool[] = [];
 
     // check duplicate tool names
-    if (prefix === false && props.controllers.length >= 2) {
+    if (props.controllers.length >= 2) {
       const names: Map<string, string> = new Map();
       const duplicates: string[] = [];
       for (const controller of props.controllers) {
         for (const func of controller.application.functions) {
-          const existing: string | undefined = names.get(func.name);
+          const toolName: string = getToolName(
+            controller.name,
+            func.name,
+            prefix,
+          );
+          const existing: string | undefined = names.get(toolName);
+          const origin: string = `${controller.protocol} controller "${controller.name}" function "${func.name}"`;
           if (existing !== undefined)
             duplicates.push(
-              `"${func.name}" in "${controller.name}" (conflicts with "${existing}")`,
+              `"${toolName}" from ${origin} (conflicts with ${existing})`,
             );
-          else names.set(func.name, controller.name);
+          else names.set(toolName, origin);
         }
       }
       if (duplicates.length > 0)
@@ -60,9 +66,7 @@ export namespace LangChainToolsRegistrar {
     const execute: Record<string, unknown> = controller.execute;
 
     for (const func of controller.application.functions) {
-      const toolName: string = prefix
-        ? `${controller.name}_${func.name}`
-        : func.name;
+      const toolName: string = getToolName(controller.name, func.name, prefix);
 
       const method: unknown = execute[func.name];
       if (typeof method !== "function") {
@@ -90,9 +94,7 @@ export namespace LangChainToolsRegistrar {
     const connection = controller.connection;
 
     for (const func of application.functions) {
-      const toolName: string = prefix
-        ? `${controller.name}_${func.name}`
-        : func.name;
+      const toolName: string = getToolName(controller.name, func.name, prefix);
 
       tools.push(
         createTool({
@@ -164,6 +166,12 @@ export namespace LangChainToolsRegistrar {
         schema: entry.function.parameters,
       },
     );
+
+  const getToolName = (
+    controllerName: string,
+    functionName: string,
+    prefix: boolean,
+  ): string => (prefix ? `${controllerName}_${functionName}` : functionName);
 }
 
 type ITryResult =

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -25,17 +25,23 @@ export namespace VercelToolsRegistrar {
     const tools: Record<string, Tool> = {};
 
     // check duplicate tool names
-    if (prefix === false && props.controllers.length >= 2) {
+    if (props.controllers.length >= 2) {
       const names: Map<string, string> = new Map();
       const duplicates: string[] = [];
       for (const controller of props.controllers) {
         for (const func of controller.application.functions) {
-          const existing: string | undefined = names.get(func.name);
+          const toolName: string = getToolName(
+            controller.name,
+            func.name,
+            prefix,
+          );
+          const existing: string | undefined = names.get(toolName);
+          const origin: string = `${controller.protocol} controller "${controller.name}" function "${func.name}"`;
           if (existing !== undefined)
             duplicates.push(
-              `"${func.name}" in "${controller.name}" (conflicts with "${existing}")`,
+              `"${toolName}" from ${origin} (conflicts with ${existing})`,
             );
-          else names.set(func.name, controller.name);
+          else names.set(toolName, origin);
         }
       }
       if (duplicates.length > 0)
@@ -65,9 +71,7 @@ export namespace VercelToolsRegistrar {
     const execute: Record<string, unknown> = controller.execute;
 
     for (const func of controller.application.functions) {
-      const toolName: string = prefix
-        ? `${controller.name}_${func.name}`
-        : func.name;
+      const toolName: string = getToolName(controller.name, func.name, prefix);
 
       const method: unknown = execute[func.name];
       if (typeof method !== "function") {
@@ -94,9 +98,7 @@ export namespace VercelToolsRegistrar {
     const connection = controller.connection;
 
     for (const func of application.functions) {
-      const toolName: string = prefix
-        ? `${controller.name}_${func.name}`
-        : func.name;
+      const toolName: string = getToolName(controller.name, func.name, prefix);
 
       tools[toolName] = createTool({
         name: toolName,
@@ -174,6 +176,12 @@ export namespace VercelToolsRegistrar {
       },
     });
   };
+
+  const getToolName = (
+    controllerName: string,
+    functionName: string,
+    prefix: boolean,
+  ): string => (prefix ? `${controllerName}_${functionName}` : functionName);
 }
 
 type ITryResult =

--- a/tests/test-langchain/src/features/test_langchain_prefixed_tool_name_namespace.ts
+++ b/tests/test-langchain/src/features/test_langchain_prefixed_tool_name_namespace.ts
@@ -1,0 +1,131 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { TestValidator } from "@nestia/e2e";
+import { IHttpLlmController, ILlmController, OpenApi } from "@typia/interface";
+import { toLangChainTools } from "@typia/langchain";
+import { HttpLlm } from "@typia/utils";
+import typia from "typia";
+
+class CollisionController {
+  /** Echo an input value. */
+  run_post(input: { value: string }): { value: string } {
+    return input;
+  }
+}
+
+/**
+ * Verifies LangChain validates the final prefixed tool-name namespace.
+ *
+ * Prefixing normally separates controllers, but controllers with the same name
+ * can still emit the same tool name. This regression pins both protocol orders
+ * so registration cannot depend on which controller type is visited first.
+ *
+ * 1. Create class and HTTP controllers that both expose `run_post`.
+ * 2. Reject every colliding class/HTTP combination in deterministic order.
+ * 3. Accept mixed controllers when their prefixes make the final names unique.
+ */
+export const test_langchain_prefixed_tool_name_namespace = (): void => {
+  const classController: ILlmController<CollisionController> =
+    typia.llm.controller<CollisionController>(
+      "same",
+      new CollisionController(),
+    );
+  const httpController: IHttpLlmController = createHttpController("same");
+  TestValidator.equals(
+    "HTTP function name",
+    httpController.application.functions.map((func) => func.name),
+    ["run_post"],
+  );
+
+  const cases: Array<{
+    name: string;
+    controllers: Array<ILlmController | IHttpLlmController>;
+    duplicate: string;
+  }> = [
+    {
+      name: "class then class",
+      controllers: [classController, classController],
+      duplicate:
+        '"same_run_post" from class controller "same" function "run_post" (conflicts with class controller "same" function "run_post")',
+    },
+    {
+      name: "HTTP then HTTP",
+      controllers: [httpController, httpController],
+      duplicate:
+        '"same_run_post" from http controller "same" function "run_post" (conflicts with http controller "same" function "run_post")',
+    },
+    {
+      name: "class then HTTP",
+      controllers: [classController, httpController],
+      duplicate:
+        '"same_run_post" from http controller "same" function "run_post" (conflicts with class controller "same" function "run_post")',
+    },
+    {
+      name: "HTTP then class",
+      controllers: [httpController, classController],
+      duplicate:
+        '"same_run_post" from class controller "same" function "run_post" (conflicts with http controller "same" function "run_post")',
+    },
+  ];
+  for (const testCase of cases)
+    TestValidator.equals(
+      testCase.name,
+      captureDuplicate([...testCase.controllers]),
+      `Duplicate tool names found:\n  - ${testCase.duplicate}`,
+    );
+
+  const tools: DynamicStructuredTool[] = toLangChainTools(
+    [
+      { ...classController, name: "class" },
+      { ...httpController, name: "http" },
+    ],
+    { prefix: true },
+  );
+  TestValidator.equals(
+    "unique prefixed names",
+    tools.map((tool) => tool.name).sort(),
+    ["class_run_post", "http_run_post"],
+  );
+};
+
+const captureDuplicate = (
+  controllers: Array<ILlmController | IHttpLlmController>,
+): string => {
+  try {
+    toLangChainTools(controllers, { prefix: true });
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("Expected duplicate tool-name error");
+};
+
+const createHttpController = (name: string): IHttpLlmController =>
+  HttpLlm.controller({
+    name,
+    document: {
+      openapi: "3.2.0",
+      "x-typia-emended-v12": true,
+      components: {},
+      paths: {
+        "/run": {
+          post: {
+            operationId: "run",
+            responses: {
+              "200": {
+                description: "Echo response",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: { value: { type: "string" } },
+                      required: ["value"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } satisfies OpenApi.IDocument,
+    connection: { host: "http://localhost:3000" },
+  });

--- a/tests/test-vercel/src/features/test_vercel_prefixed_tool_name_namespace.ts
+++ b/tests/test-vercel/src/features/test_vercel_prefixed_tool_name_namespace.ts
@@ -1,0 +1,130 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpLlmController, ILlmController, OpenApi } from "@typia/interface";
+import { HttpLlm } from "@typia/utils";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+import typia from "typia";
+
+class CollisionController {
+  /** Echo an input value. */
+  run_post(input: { value: string }): { value: string } {
+    return input;
+  }
+}
+
+/**
+ * Verifies Vercel validates the final prefixed tool-name namespace.
+ *
+ * Prefixing normally separates controllers, but controllers with the same name
+ * can still emit the same record key. This regression pins both protocol orders
+ * so a later registration cannot silently replace an earlier tool.
+ *
+ * 1. Create class and HTTP controllers that both expose `run_post`.
+ * 2. Reject every colliding class/HTTP combination in deterministic order.
+ * 3. Accept mixed controllers when their prefixes make the final names unique.
+ */
+export const test_vercel_prefixed_tool_name_namespace = (): void => {
+  const classController: ILlmController<CollisionController> =
+    typia.llm.controller<CollisionController>(
+      "same",
+      new CollisionController(),
+    );
+  const httpController: IHttpLlmController = createHttpController("same");
+  TestValidator.equals(
+    "HTTP function name",
+    httpController.application.functions.map((func) => func.name),
+    ["run_post"],
+  );
+
+  const cases: Array<{
+    name: string;
+    controllers: Array<ILlmController | IHttpLlmController>;
+    duplicate: string;
+  }> = [
+    {
+      name: "class then class",
+      controllers: [classController, classController],
+      duplicate:
+        '"same_run_post" from class controller "same" function "run_post" (conflicts with class controller "same" function "run_post")',
+    },
+    {
+      name: "HTTP then HTTP",
+      controllers: [httpController, httpController],
+      duplicate:
+        '"same_run_post" from http controller "same" function "run_post" (conflicts with http controller "same" function "run_post")',
+    },
+    {
+      name: "class then HTTP",
+      controllers: [classController, httpController],
+      duplicate:
+        '"same_run_post" from http controller "same" function "run_post" (conflicts with class controller "same" function "run_post")',
+    },
+    {
+      name: "HTTP then class",
+      controllers: [httpController, classController],
+      duplicate:
+        '"same_run_post" from class controller "same" function "run_post" (conflicts with http controller "same" function "run_post")',
+    },
+  ];
+  for (const testCase of cases)
+    TestValidator.equals(
+      testCase.name,
+      captureDuplicate([...testCase.controllers]),
+      `Duplicate tool names found:\n  - ${testCase.duplicate}`,
+    );
+
+  const tools: Record<string, Tool> = toVercelTools(
+    [
+      { ...classController, name: "class" },
+      { ...httpController, name: "http" },
+    ],
+    { prefix: true },
+  );
+  TestValidator.equals("unique prefixed names", Object.keys(tools).sort(), [
+    "class_run_post",
+    "http_run_post",
+  ]);
+};
+
+const captureDuplicate = (
+  controllers: Array<ILlmController | IHttpLlmController>,
+): string => {
+  try {
+    toVercelTools(controllers, { prefix: true });
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("Expected duplicate tool-name error");
+};
+
+const createHttpController = (name: string): IHttpLlmController =>
+  HttpLlm.controller({
+    name,
+    document: {
+      openapi: "3.2.0",
+      "x-typia-emended-v12": true,
+      components: {},
+      paths: {
+        "/run": {
+          post: {
+            operationId: "run",
+            responses: {
+              "200": {
+                description: "Echo response",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: { value: { type: "string" } },
+                      required: ["value"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } satisfies OpenApi.IDocument,
+    connection: { host: "http://localhost:3000" },
+  });

--- a/website/src/content/docs/utilization/langchain.mdx
+++ b/website/src/content/docs/utilization/langchain.mdx
@@ -108,7 +108,7 @@ const result: ChainValues = await executor.invoke({
 });
 ```
 
-Every method on `Calculator` is now a LangChain tool. JSDoc comments become tool descriptions, TypeScript types become JSON schemas. Tool names default to the bare method name; pass `{ prefix: true }` as the second argument to `toLangChainTools` to get `{controllerName}_{methodName}`. The older `toLangChainTools({ controllers: [...] })` form still works when that shape is clearer for multiple controllers.
+Every method on `Calculator` is now a LangChain tool. JSDoc comments become tool descriptions, TypeScript types become JSON schemas. Tool names default to the bare method name; pass `{ prefix: true }` as the second argument to `toLangChainTools` to get `{controllerName}_{methodName}`. Final tool names must be unique even with prefixes enabled, so controllers that still emit the same name are rejected before registration. The older `toLangChainTools({ controllers: [...] })` form still works when that shape is clearer for multiple controllers.
 
 <Tabs items={[
     <code>Calculator</code>,

--- a/website/src/content/docs/utilization/vercel.mdx
+++ b/website/src/content/docs/utilization/vercel.mdx
@@ -110,7 +110,7 @@ const result: GenerateTextResult = await generateText({
 });
 ```
 
-The JSDoc on each method becomes the tool description; the parameter type becomes the JSON schema. Every method on `Calculator` is now a Vercel `Tool`. Tool names default to the bare method name; pass `{ prefix: true }` as the second argument to `toVercelTools` to get `{controllerName}_{methodName}` instead. The older `toVercelTools({ controllers: [...] })` form still works when that shape is clearer for multiple controllers. When a method has a reflected return type, the tool also advertises an `outputSchema` for the `{ success, data/error }` result wrapper returned by `execute`.
+The JSDoc on each method becomes the tool description; the parameter type becomes the JSON schema. Every method on `Calculator` is now a Vercel `Tool`. Tool names default to the bare method name; pass `{ prefix: true }` as the second argument to `toVercelTools` to get `{controllerName}_{methodName}` instead. Final tool names must be unique even with prefixes enabled, so controllers that still emit the same name are rejected before registration. The older `toVercelTools({ controllers: [...] })` form still works when that shape is clearer for multiple controllers. When a method has a reflected return type, the tool also advertises an `outputSchema` for the `{ success, data/error }` result wrapper returned by `execute`.
 
 <Tabs items={[
     <code>Calculator</code>,


### PR DESCRIPTION
## Overview

This draft claims the adapter tool-name batch before implementation. The batch keeps LangChain and Vercel registration semantics aligned by validating collisions in the final emitted tool-name namespace.

Closes #2037

## Scope

- LangChain final tool-name collision handling.
- Vercel final tool-name collision handling.
- Focused regression coverage for colliding and non-colliding prefixed tools.

## Deferred

- Source and test changes are pending after this implementation-free claim.
- No unrelated adapter or public API changes are included in this batch.

## Verification

Pending. Focused LangChain and Vercel tests, package builds, and broader repository verification will be recorded after implementation.

Campaign CI is deliberately cancelled per exact pushed SHA; local verification is the implementation gate.
