### PR TITLE
fix(validation): preserve complete reporting diagnostics

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -75,10 +75,14 @@ func ttscTypiaTestRewriteCommonJS(t *testing.T, js string) string {
 }
 
 const ttscTypiaTestValidateReportStub = `module.exports._validateReport = (array) => {
+  const isAncestor = (ancestor, descendant) =>
+    descendant === ancestor ||
+    descendant.startsWith(ancestor + ".") ||
+    descendant.startsWith(ancestor + "[");
   const reportable = (path) => {
     if (array.length === 0) return true;
     const last = array[array.length - 1].path;
-    return path.length > last.length || last.substring(0, path.length) !== path;
+    return !isAncestor(path, last) && !isAncestor(last, path);
   };
   return (exceptable, error) => {
     if (exceptable && reportable(error.path)) {

--- a/packages/typia/src/internal/_createStandardSchema.ts
+++ b/packages/typia/src/internal/_createStandardSchema.ts
@@ -17,7 +17,7 @@ export const _createStandardSchema = <T>(
         } else {
           return {
             issues: result.errors.map((error) => ({
-              message: `expected ${error.expected}, got ${error.value}`,
+              message: `expected ${error.expected}, got ${formatValue(error.value)}`,
               path: typiaPathToStandardSchemaPath(error.path),
             })),
           } satisfies StandardSchemaV1.FailureResult;
@@ -25,6 +25,20 @@ export const _createStandardSchema = <T>(
       },
     },
   } satisfies StandardSchemaV1<T, T>);
+
+const formatValue = (value: unknown): string => {
+  if (typeof value === "object") {
+    if (value === null) return "null";
+    try {
+      if (Array.isArray(value)) return "[object Array]";
+    } catch {
+      // A revoked proxy can throw even for Array.isArray().
+    }
+    return "[object Object]";
+  }
+  if (typeof value === "function") return "[function]";
+  return String(value);
+};
 
 enum PathParserState {
   // Start of a new segment

--- a/packages/typia/src/internal/_validateReport.ts
+++ b/packages/typia/src/internal/_validateReport.ts
@@ -1,10 +1,14 @@
 import { IValidation } from "@typia/interface";
 
 export const _validateReport = (array: IValidation.IError[]) => {
+  const isAncestor = (ancestor: string, descendant: string): boolean =>
+    descendant === ancestor ||
+    descendant.startsWith(`${ancestor}.`) ||
+    descendant.startsWith(`${ancestor}[`);
   const reportable = (path: string): boolean => {
     if (array.length === 0) return true;
     const last: string = array[array.length - 1]!.path;
-    return path.length > last.length || last.substring(0, path.length) !== path;
+    return isAncestor(path, last) === false && isAncestor(last, path) === false;
   };
   return (exceptable: boolean, error: IValidation.IError): false => {
     if (exceptable && reportable(error.path)) {

--- a/packages/utils/src/validators/OpenApiValidator.ts
+++ b/packages/utils/src/validators/OpenApiValidator.ts
@@ -61,11 +61,15 @@ export namespace OpenApiValidator {
   };
 
   const createReporter = (array: IValidation.IError[]) => {
+    const isAncestor = (ancestor: string, descendant: string): boolean =>
+      descendant === ancestor ||
+      descendant.startsWith(`${ancestor}.`) ||
+      descendant.startsWith(`${ancestor}[`);
     const reportable = (path: string): boolean => {
       if (array.length === 0) return true;
       const last: string = array[array.length - 1]!.path;
       return (
-        path.length > last.length || last.substring(0, path.length) !== path
+        isAncestor(path, last) === false && isAncestor(last, path) === false
       );
     };
     return (

--- a/packages/utils/src/validators/internal/OpenApiArrayValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiArrayValidator.ts
@@ -10,17 +10,6 @@ export namespace OpenApiArrayValidator {
   ): boolean => {
     if (Array.isArray(ctx.value) === false) return ctx.report(ctx);
     return [
-      ctx.value
-        .map((value, i) =>
-          OpenApiStationValidator.validate({
-            ...ctx,
-            schema: ctx.schema.items,
-            value,
-            path: `${ctx.path}[${i}]`,
-            required: true,
-          }),
-        )
-        .every((v) => v),
       ctx.schema.minItems !== undefined
         ? ctx.value.length >= ctx.schema.minItems ||
           ctx.report({
@@ -44,6 +33,17 @@ export namespace OpenApiArrayValidator {
             })
           : true
         : true,
+      ctx.value
+        .map((value, i) =>
+          OpenApiStationValidator.validate({
+            ...ctx,
+            schema: ctx.schema.items,
+            value,
+            path: `${ctx.path}[${i}]`,
+            required: true,
+          }),
+        )
+        .every((v) => v),
     ].every((v) => v);
   };
 }

--- a/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
@@ -93,13 +93,7 @@ export namespace OpenApiOneOfValidator {
     );
     const branches: IDiscriminatorBranch[] = [
       ...(tuples.length === 0 && arrays.length !== 0
-        ? discriminateArrays(
-            ctx,
-            significant.filter(
-              (flat): flat is IFlatSchema<OpenApi.IJsonSchema.IArray> =>
-                OpenApiTypeChecker.isArray(flat.schema),
-            ),
-          )
+        ? discriminateArrays(ctx, arrays)
         : []),
       ...discriminateObjects(
         ctx,

--- a/tests/test-typia-automated/src/internal/_test_standardSchema_validate.ts
+++ b/tests/test-typia-automated/src/internal/_test_standardSchema_validate.ts
@@ -1,7 +1,18 @@
 import { StandardSchemaV1 } from "@standard-schema/spec";
 import { TestStructure } from "@typia/template";
+import { NamingConvention } from "@typia/utils";
 import typia from "typia";
 
+/**
+ * Verifies Standard Schema validation against independent spoiler oracles.
+ *
+ * Issue counts cannot detect a reporter that substitutes or omits paths. This
+ * helper reconstructs typia paths from Standard Schema segments so the same
+ * fixture contract proves both the adapter's success type and exact failures.
+ *
+ * 1. Assert the successful result preserves both its static and runtime value.
+ * 2. Apply every fixture spoiler and compare exact sorted issue paths.
+ */
 export const _test_standardSchema_validate =
   (name: string) =>
   <T>(factory: TestStructure<T>) =>
@@ -16,9 +27,7 @@ export const _test_standardSchema_validate =
       throw new Error(
         `Bug on typia.createValidate["~standard"].validate(): failed to archive the input value.`,
       );
-    // This does not compile.
-    // TODO: Fix this.
-    // typia.assertEquals<StandardSchemaV1.SuccessResult<T>>(valid);
+    valid satisfies StandardSchemaV1.SuccessResult<T>;
 
     const wrong: ISpoiled[] = [];
     for (const spoil of factory.SPOILERS ?? []) {
@@ -34,12 +43,15 @@ export const _test_standardSchema_validate =
       typia.assertEquals(valid);
       expected.sort();
       const issues = [...valid.issues];
+      const actual: string[] = issues.map(issuePath).sort();
 
-      // It's difficult to compare the paths, so we'll just compare the number of issues.
-      if (issues.length !== expected.length)
+      if (
+        actual.length !== expected.length ||
+        actual.every((path, i) => path === expected[i]) === false
+      )
         wrong.push({
           expected,
-          actual: issues.map((e) => e.path?.join(".") ?? ""),
+          actual,
         });
     }
     if (wrong.length !== 0) {
@@ -54,3 +66,13 @@ interface ISpoiled {
   expected: string[];
   actual: string[];
 }
+
+const issuePath = (issue: StandardSchemaV1.Issue): string =>
+  (issue.path ?? []).reduce<string>((path, segment) => {
+    const key: PropertyKey =
+      typeof segment === "object" ? segment.key : segment;
+    if (typeof key === "number") return `${path}[${key}]`;
+    if (typeof key === "string" && NamingConvention.variable(key))
+      return `${path}.${key}`;
+    return `${path}[${JSON.stringify(key)}]`;
+  }, "$input");

--- a/tests/test-typia-schema/src/features/standardSchema/test_standard_schema_unknown_diagnostics.ts
+++ b/tests/test-typia-schema/src/features/standardSchema/test_standard_schema_unknown_diagnostics.ts
@@ -1,0 +1,104 @@
+import { TestValidator } from "@nestia/e2e";
+import { StandardSchemaV1 } from "@standard-schema/spec";
+import typia from "typia";
+
+interface IValue {
+  value: string;
+}
+
+/**
+ * Verifies Standard Schema diagnostics are total for arbitrary unknown values.
+ *
+ * Validation itself accepts `unknown`, but message construction previously
+ * invoked user coercion and could throw after a normal failure. The adapter
+ * must return stable issues for roots and properties through both validators.
+ *
+ * 1. Validate symbols, null-prototype objects, cycles, and hostile proxies.
+ * 2. Exercise both createValidate and createValidateEquals at root/property paths.
+ * 3. Preserve readable primitive/object messages and ordinary success results.
+ */
+export const test_standard_schema_unknown_diagnostics = (): void => {
+  const cyclic: Record<string, unknown> = { bigint: 1n };
+  cyclic.self = cyclic;
+  const hostile = {
+    [Symbol.toPrimitive]: (): never => {
+      throw new Error("coercion must not escape");
+    },
+    toString: (): never => {
+      throw new Error("toString must not escape");
+    },
+    valueOf: (): never => {
+      throw new Error("valueOf must not escape");
+    },
+  };
+  const throwingProxy = new Proxy(
+    {},
+    {
+      get: (): never => {
+        throw new Error("proxy access must not escape");
+      },
+    },
+  );
+  const revocable = Proxy.revocable({}, {});
+  revocable.revoke();
+  const values: readonly unknown[] = [
+    Symbol("symbol"),
+    Object.create(null),
+    cyclic,
+    hostile,
+    throwingProxy,
+    revocable.proxy,
+  ];
+
+  const rootValidators = [
+    typia.createValidate<string>(),
+    typia.createValidateEquals<string>(),
+  ];
+  const propertyValidators = [
+    typia.createValidate<IValue>(),
+    typia.createValidateEquals<IValue>(),
+  ];
+  for (const [index, value] of values.entries()) {
+    for (const validator of rootValidators)
+      assertFailure(`root ${index}`, validator, value, []);
+    for (const validator of propertyValidators)
+      assertFailure(`property ${index}`, validator, { value }, [
+        { key: "value" },
+      ]);
+  }
+
+  const ordinary = rootValidators[0]!["~standard"].validate({ plain: true });
+  if (ordinary instanceof Promise || ordinary.issues === undefined)
+    throw new Error(
+      "Expected an ordinary object to return Standard Schema issues.",
+    );
+  TestValidator.equals(
+    "ordinary object message",
+    "expected string, got [object Object]",
+    ordinary.issues[0]?.message,
+  );
+
+  const success = propertyValidators[0]!["~standard"].validate({ value: "ok" });
+  if (success instanceof Promise || !("value" in success))
+    throw new Error(
+      "Expected a valid object to return a Standard Schema value.",
+    );
+  TestValidator.equals("success value", { value: "ok" }, success.value);
+};
+
+const assertFailure = <T>(
+  label: string,
+  validator: StandardSchemaV1<T, T>,
+  input: unknown,
+  path: ReadonlyArray<PropertyKey | StandardSchemaV1.PathSegment>,
+): void => {
+  const result = validator["~standard"].validate(input);
+  if (result instanceof Promise || result.issues === undefined)
+    throw new Error(`Expected ${label} to return Standard Schema issues.`);
+  TestValidator.equals(`${label} issue count`, 1, result.issues.length);
+  TestValidator.predicate(
+    `${label} message`,
+    () => typeof result.issues[0]?.message === "string",
+  );
+  TestValidator.equals(`${label} path`, path, result.issues[0]?.path);
+};

--- a/tests/test-typia-schema/src/features/standardSchema/test_standard_schema_unknown_diagnostics.ts
+++ b/tests/test-typia-schema/src/features/standardSchema/test_standard_schema_unknown_diagnostics.ts
@@ -78,6 +78,17 @@ export const test_standard_schema_unknown_diagnostics = (): void => {
     ordinary.issues[0]?.message,
   );
 
+  const primitive = rootValidators[0]!["~standard"].validate(42);
+  if (primitive instanceof Promise || primitive.issues === undefined)
+    throw new Error(
+      "Expected an ordinary primitive to return Standard Schema issues.",
+    );
+  TestValidator.equals(
+    "ordinary primitive message",
+    "expected string, got 42",
+    primitive.issues[0]?.message,
+  );
+
   const success = propertyValidators[0]!["~standard"].validate({ value: "ok" });
   if (success instanceof Promise || !("value" in success))
     throw new Error(

--- a/tests/test-typia-schema/src/features/validate/test_validate_report_path_boundary.ts
+++ b/tests/test-typia-schema/src/features/validate/test_validate_report_path_boundary.ts
@@ -1,0 +1,101 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { tags } from "typia";
+import { _validateReport } from "typia/lib/internal/_validateReport";
+
+interface ILongFirst {
+  ab: string;
+  a: string;
+  "a-b": string;
+  items: string[];
+  duplicates: string[] & tags.UniqueItems;
+}
+
+interface IShortFirst {
+  a: string;
+  ab: string;
+  "a-b": string;
+  items: string[];
+  duplicates: string[] & tags.UniqueItems;
+}
+
+/**
+ * Verifies generated validation reports only suppress real ancestor paths.
+ *
+ * The reporter sees errors in declaration order and historically treated a raw
+ * identifier prefix as ancestry. This pins both sibling orders plus the quoted,
+ * indexed, duplicate, and genuine parent/child path boundaries.
+ *
+ * 1. Validate equivalent invalid structures with `a` and `ab` reversed.
+ * 2. Require every independent sibling, quoted-key, and indexed error path.
+ * 3. Exercise the runtime reporter directly to retain true-parent suppression.
+ */
+export const test_validate_report_path_boundary = (): void => {
+  const input = {
+    a: 0,
+    ab: 0,
+    "a-b": 0,
+    items: new Array(11).fill(0),
+    duplicates: ["same", "same"],
+  };
+  const expected: string[] = [
+    "$input.a",
+    "$input.ab",
+    '$input["a-b"]',
+    ...input.items.map((_, index) => `$input.items[${index}]`),
+    "$input.duplicates",
+  ].sort();
+
+  assertPaths(
+    "long property first",
+    typia.validate<ILongFirst>(input),
+    expected,
+  );
+  assertPaths(
+    "short property first",
+    typia.validate<IShortFirst>(input),
+    expected,
+  );
+
+  const errors: typia.IValidation.IError[] = [];
+  const report = _validateReport(errors);
+  report(true, error("$input.items[10]"));
+  report(true, error("$input.items[1]"));
+  report(true, error("$input.items"));
+  report(true, error('$input["a-b"]'));
+  report(true, error('$input["a"]'));
+  TestValidator.equals(
+    "runtime reporter boundaries",
+    ["$input.items[10]", "$input.items[1]", '$input["a-b"]', '$input["a"]'],
+    errors.map(({ path }) => path),
+  );
+
+  const ancestorFirst: typia.IValidation.IError[] = [];
+  const reportAncestorFirst = _validateReport(ancestorFirst);
+  reportAncestorFirst(true, error("$input.items"));
+  reportAncestorFirst(true, error("$input.items[0]"));
+  TestValidator.equals(
+    "ancestor first",
+    ["$input.items"],
+    ancestorFirst.map(({ path }) => path),
+  );
+};
+
+const assertPaths = (
+  label: string,
+  result: typia.IValidation<unknown>,
+  expected: string[],
+): void => {
+  if (result.success)
+    throw new Error(`Expected ${label} input to fail validation.`);
+  TestValidator.equals(
+    label,
+    expected,
+    result.errors.map(({ path }) => path).sort(),
+  );
+};
+
+const error = (path: string): typia.IValidation.IError => ({
+  path,
+  expected: "string",
+  value: 0,
+});

--- a/tests/test-utils-automated/src/internal/_test_validate.ts
+++ b/tests/test-utils-automated/src/internal/_test_validate.ts
@@ -92,17 +92,25 @@ const normalizePaths = (props: {
   schema: OpenApi.IJsonSchema;
   value: unknown;
   paths: string[];
-}): string[] =>
-  [
-    ...new Set(
-      props.paths.map((path) =>
-        normalizePath({
-          ...props,
-          path,
-        }),
-      ),
-    ),
-  ].sort();
+}): string[] => {
+  // Distinct branch leaves can share one ambiguous union owner, but repeated
+  // occurrences of the same raw path must remain visible to the count oracle.
+  const frequencies = new Map<string, Map<string, number>>();
+  for (const original of props.paths) {
+    const normalized = normalizePath({
+      ...props,
+      path: original,
+    });
+    const originals = frequencies.get(normalized) ?? new Map<string, number>();
+    originals.set(original, (originals.get(original) ?? 0) + 1);
+    frequencies.set(normalized, originals);
+  }
+  return [...frequencies.entries()]
+    .flatMap(([path, originals]) =>
+      new Array(Math.max(...originals.values())).fill(path),
+    )
+    .sort();
+};
 
 const normalizePath = (props: {
   components: OpenApi.IComponents;
@@ -160,20 +168,25 @@ const selectOneOf = (props: {
   schema: OpenApi.IJsonSchema.IOneOf;
   value: unknown;
 }): OpenApi.IJsonSchema | undefined => {
-  const branches = props.schema.oneOf.map((schema) => ({
+  const branches: IResolvedBranch[] = props.schema.oneOf.map((schema) => ({
     original: schema,
     resolved: resolve(props.components, schema),
   }));
   const compatible = branches.filter(({ resolved }) =>
-    compatibleWith(resolved, props.value),
+    compatibleWith({
+      components: props.components,
+      schema: resolved,
+      value: props.value,
+    }),
   );
   if (compatible.length === 1) return compatible[0]!.original;
-  if (
-    typeof props.value !== "object" ||
-    props.value === null ||
-    Array.isArray(props.value)
-  )
-    return undefined;
+  if (Array.isArray(props.value))
+    return selectArray({
+      components: props.components,
+      branches: compatible,
+      value: props.value,
+    });
+  if (typeof props.value !== "object" || props.value === null) return undefined;
 
   const objects = compatible.filter(
     (
@@ -186,12 +199,14 @@ const selectOneOf = (props: {
   for (const branch of objects) {
     const candidates: string[] = [];
     for (const key of branch.resolved.required ?? []) {
-      const target = branch.resolved.properties?.[key];
-      if (target === undefined) continue;
+      const targetSchema = branch.resolved.properties?.[key];
+      if (targetSchema === undefined) continue;
+      const target = resolve(props.components, targetSchema);
       const neighbors = objects
         .filter((other) => other !== branch)
         .map(({ resolved }) => resolved.properties?.[key])
-        .filter((schema) => schema !== undefined);
+        .filter((schema) => schema !== undefined)
+        .map((schema) => resolve(props.components, schema));
       const unique = OpenApiTypeChecker.isConstant(target)
         ? neighbors.every(
             (schema) =>
@@ -204,11 +219,18 @@ const selectOneOf = (props: {
     const key =
       candidates.find((candidate) =>
         OpenApiTypeChecker.isConstant(
-          branch.resolved.properties?.[candidate] ?? {},
+          resolve(
+            props.components,
+            branch.resolved.properties?.[candidate] ?? {},
+          ),
         ),
       ) ?? candidates[0];
     if (key === undefined) continue;
-    const target = branch.resolved.properties?.[key];
+    const targetSchema = branch.resolved.properties?.[key];
+    const target =
+      targetSchema === undefined
+        ? undefined
+        : resolve(props.components, targetSchema);
     const matched =
       target !== undefined && OpenApiTypeChecker.isConstant(target)
         ? (props.value as Record<string, unknown>)[key] === target.const
@@ -218,10 +240,42 @@ const selectOneOf = (props: {
   return undefined;
 };
 
-const compatibleWith = (
-  schema: OpenApi.IJsonSchema,
-  value: unknown,
-): boolean => {
+const selectArray = (props: {
+  components: OpenApi.IComponents;
+  branches: IResolvedBranch[];
+  value: unknown[];
+}): OpenApi.IJsonSchema | undefined => {
+  const arrays = props.branches.filter(
+    (
+      branch,
+    ): branch is {
+      original: OpenApi.IJsonSchema;
+      resolved: OpenApi.IJsonSchema.IArray;
+    } => OpenApiTypeChecker.isArray(branch.resolved),
+  );
+  if (
+    arrays.length !== props.branches.length ||
+    arrays.length === 0 ||
+    props.value.length === 0
+  )
+    return undefined;
+  const candidates = arrays.filter(({ resolved }) =>
+    compatibleWith({
+      components: props.components,
+      schema: resolved.items,
+      value: props.value[0],
+    }),
+  );
+  return candidates.length === 1 ? candidates[0]!.original : undefined;
+};
+
+const compatibleWith = (props: {
+  components: OpenApi.IComponents;
+  schema: OpenApi.IJsonSchema;
+  value: unknown;
+}): boolean => {
+  const schema = resolve(props.components, props.schema);
+  const value = props.value;
   if (OpenApiTypeChecker.isUnknown(schema)) return true;
   if (OpenApiTypeChecker.isConstant(schema)) return schema.const === value;
   if (OpenApiTypeChecker.isNull(schema)) return value === null;
@@ -234,6 +288,14 @@ const compatibleWith = (
     return Array.isArray(value);
   if (OpenApiTypeChecker.isObject(schema))
     return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (OpenApiTypeChecker.isOneOf(schema))
+    return schema.oneOf.some((child) =>
+      compatibleWith({
+        components: props.components,
+        schema: child,
+        value,
+      }),
+    );
   return false;
 };
 
@@ -297,4 +359,9 @@ const findBracketClose = (path: string, start: number): number => {
 interface IPathSegment {
   key: string | number;
   accessor: string;
+}
+
+interface IResolvedBranch {
+  original: OpenApi.IJsonSchema;
+  resolved: OpenApi.IJsonSchema;
 }

--- a/tests/test-utils-automated/src/internal/_test_validate.ts
+++ b/tests/test-utils-automated/src/internal/_test_validate.ts
@@ -1,7 +1,18 @@
 import { IValidation, OpenApi } from "@typia/interface";
 import { Spoiler } from "@typia/template";
-import { OpenApiValidator } from "@typia/utils";
+import { OpenApiTypeChecker, OpenApiValidator } from "@typia/utils";
 
+/**
+ * Verifies OpenAPI validation against independent template spoiler oracles.
+ *
+ * Template spoilers define invalid paths independently of the schema validator.
+ * Predictable branches retain their leaf paths, while both sides canonicalize
+ * an ambiguous oneOf failure to its union owner. Enforcing the whole sorted
+ * canonical path set prevents omissions from hiding behind a failed result.
+ *
+ * 1. Validate a generated success value and preserve its identity.
+ * 2. Apply every fixture spoiler and compare the exact sorted failure paths.
+ */
 export const _test_validate = <T>(props: {
   schema: OpenApi.IJsonSchema;
   components: OpenApi.IComponents;
@@ -32,38 +43,258 @@ export const _test_validate = <T>(props: {
   const wrong: ISpoiled[] = [];
   for (const spoil of props.factory.SPOILERS ?? []) {
     const elem: T = props.factory.generate();
-    const expected: string[] = spoil(elem);
+    const expected: string[] = normalizePaths({
+      components: props.components,
+      schema: props.schema,
+      value: elem,
+      paths: spoil(elem),
+    });
     const valid: IValidation<unknown> = validate(elem);
 
     if (valid.success === true) {
       console.log(expected);
       throw new Error(
-        `Bug on typia.validate(): failed to detect error on the ${props.name} type.`,
+        `Bug on OpenApiValidator.validate(): failed to detect error on the ${props.name} type.`,
       );
     }
 
-    expected.sort();
-    valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
+    const actual: string[] = normalizePaths({
+      components: props.components,
+      schema: props.schema,
+      value: elem,
+      paths: valid.errors.map((error) => error.path),
+    });
 
     if (
-      valid.errors.length !== expected.length ||
-      valid.errors.every((e, i) => e.path === expected[i]) === false
+      actual.length !== expected.length ||
+      actual.every((path, i) => path === expected[i]) === false
     )
       wrong.push({
         expected,
-        actual: valid.errors.map((e) => e.path),
+        actual,
       });
   }
-  // @todo
-  // if (wrong.length !== 0) {
-  //   console.log(wrong);
-  //   throw new Error(
-  //     `Bug on typia.validate(): failed to detect error on the ${props.name} type.`,
-  //   );
-  // }
+  if (wrong.length !== 0) {
+    console.log(wrong);
+    throw new Error(
+      `Bug on OpenApiValidator.validate(): failed to detect error on the ${props.name} type.`,
+    );
+  }
 };
 
 interface ISpoiled {
   expected: string[];
   actual: string[];
+}
+
+const normalizePaths = (props: {
+  components: OpenApi.IComponents;
+  schema: OpenApi.IJsonSchema;
+  value: unknown;
+  paths: string[];
+}): string[] =>
+  [
+    ...new Set(
+      props.paths.map((path) =>
+        normalizePath({
+          ...props,
+          path,
+        }),
+      ),
+    ),
+  ].sort();
+
+const normalizePath = (props: {
+  components: OpenApi.IComponents;
+  schema: OpenApi.IJsonSchema;
+  value: unknown;
+  path: string;
+}): string => {
+  const segments: IPathSegment[] = parsePath(props.path);
+  let schema: OpenApi.IJsonSchema = props.schema;
+  let value: unknown = props.value;
+  let path = "$input";
+  for (const segment of segments) {
+    schema = resolve(props.components, schema);
+    if (OpenApiTypeChecker.isOneOf(schema)) {
+      const selected: OpenApi.IJsonSchema | undefined = selectOneOf({
+        components: props.components,
+        schema,
+        value,
+      });
+      if (selected === undefined) return path;
+      schema = resolve(props.components, selected);
+    }
+    if (OpenApiTypeChecker.isObject(schema) && typeof segment.key === "string")
+      schema =
+        schema.properties?.[segment.key] ??
+        (typeof schema.additionalProperties === "object"
+          ? schema.additionalProperties
+          : {});
+    else if (
+      OpenApiTypeChecker.isTuple(schema) &&
+      typeof segment.key === "number"
+    )
+      schema =
+        schema.prefixItems[segment.key] ??
+        (typeof schema.additionalItems === "object"
+          ? schema.additionalItems
+          : {});
+    else if (
+      OpenApiTypeChecker.isArray(schema) &&
+      typeof segment.key === "number"
+    )
+      schema = schema.items;
+    else return props.path;
+    value =
+      typeof value === "object" && value !== null
+        ? (value as Record<PropertyKey, unknown>)[segment.key]
+        : undefined;
+    path += segment.accessor;
+  }
+  return path;
+};
+
+const selectOneOf = (props: {
+  components: OpenApi.IComponents;
+  schema: OpenApi.IJsonSchema.IOneOf;
+  value: unknown;
+}): OpenApi.IJsonSchema | undefined => {
+  const branches = props.schema.oneOf.map((schema) => ({
+    original: schema,
+    resolved: resolve(props.components, schema),
+  }));
+  const compatible = branches.filter(({ resolved }) =>
+    compatibleWith(resolved, props.value),
+  );
+  if (compatible.length === 1) return compatible[0]!.original;
+  if (
+    typeof props.value !== "object" ||
+    props.value === null ||
+    Array.isArray(props.value)
+  )
+    return undefined;
+
+  const objects = compatible.filter(
+    (
+      branch,
+    ): branch is {
+      original: OpenApi.IJsonSchema;
+      resolved: OpenApi.IJsonSchema.IObject;
+    } => OpenApiTypeChecker.isObject(branch.resolved),
+  );
+  for (const branch of objects) {
+    const candidates: string[] = [];
+    for (const key of branch.resolved.required ?? []) {
+      const target = branch.resolved.properties?.[key];
+      if (target === undefined) continue;
+      const neighbors = objects
+        .filter((other) => other !== branch)
+        .map(({ resolved }) => resolved.properties?.[key])
+        .filter((schema) => schema !== undefined);
+      const unique = OpenApiTypeChecker.isConstant(target)
+        ? neighbors.every(
+            (schema) =>
+              OpenApiTypeChecker.isConstant(schema) &&
+              schema.const !== target.const,
+          )
+        : neighbors.length === 0;
+      if (unique) candidates.push(key);
+    }
+    const key =
+      candidates.find((candidate) =>
+        OpenApiTypeChecker.isConstant(
+          branch.resolved.properties?.[candidate] ?? {},
+        ),
+      ) ?? candidates[0];
+    if (key === undefined) continue;
+    const target = branch.resolved.properties?.[key];
+    const matched =
+      target !== undefined && OpenApiTypeChecker.isConstant(target)
+        ? (props.value as Record<string, unknown>)[key] === target.const
+        : (props.value as Record<string, unknown>)[key] !== undefined;
+    if (matched) return branch.original;
+  }
+  return undefined;
+};
+
+const compatibleWith = (
+  schema: OpenApi.IJsonSchema,
+  value: unknown,
+): boolean => {
+  if (OpenApiTypeChecker.isUnknown(schema)) return true;
+  if (OpenApiTypeChecker.isConstant(schema)) return schema.const === value;
+  if (OpenApiTypeChecker.isNull(schema)) return value === null;
+  if (OpenApiTypeChecker.isBoolean(schema)) return typeof value === "boolean";
+  if (OpenApiTypeChecker.isInteger(schema))
+    return typeof value === "number" && Number.isInteger(value);
+  if (OpenApiTypeChecker.isNumber(schema)) return typeof value === "number";
+  if (OpenApiTypeChecker.isString(schema)) return typeof value === "string";
+  if (OpenApiTypeChecker.isArray(schema) || OpenApiTypeChecker.isTuple(schema))
+    return Array.isArray(value);
+  if (OpenApiTypeChecker.isObject(schema))
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  return false;
+};
+
+const resolve = (
+  components: OpenApi.IComponents,
+  input: OpenApi.IJsonSchema,
+): OpenApi.IJsonSchema => {
+  let schema: OpenApi.IJsonSchema = input;
+  const visited = new Set<string>();
+  while (OpenApiTypeChecker.isReference(schema)) {
+    const key = schema.$ref.split("/").pop() ?? "";
+    if (visited.has(key)) return {};
+    visited.add(key);
+    schema = components.schemas?.[key] ?? {};
+  }
+  return schema;
+};
+
+const parsePath = (path: string): IPathSegment[] => {
+  if (path.startsWith("$input") === false)
+    throw new Error(`Invalid spoiler path: ${path}`);
+  const output: IPathSegment[] = [];
+  let index = "$input".length;
+  while (index < path.length) {
+    const start = index;
+    if (path[index] === ".") {
+      index++;
+      const keyStart = index;
+      while (index < path.length && path[index] !== "." && path[index] !== "[")
+        index++;
+      output.push({
+        key: path.slice(keyStart, index),
+        accessor: path.slice(start, index),
+      });
+    } else if (path[index] === "[") {
+      const close = findBracketClose(path, index);
+      const token = path.slice(index + 1, close);
+      output.push({
+        key: token.startsWith('"') ? JSON.parse(token) : Number(token),
+        accessor: path.slice(start, close + 1),
+      });
+      index = close + 1;
+    } else throw new Error(`Invalid spoiler path: ${path}`);
+  }
+  return output;
+};
+
+const findBracketClose = (path: string, start: number): number => {
+  let quoted = false;
+  let escaped = false;
+  for (let index = start + 1; index < path.length; index++) {
+    const char = path[index]!;
+    if (escaped) escaped = false;
+    else if (char === "\\" && quoted) escaped = true;
+    else if (char === '"') quoted = !quoted;
+    else if (char === "]" && quoted === false) return index;
+  }
+  throw new Error(`Invalid spoiler path: ${path}`);
+};
+
+interface IPathSegment {
+  key: string | number;
+  accessor: string;
 }

--- a/tests/test-utils-automated/src/internal/_test_validate.ts
+++ b/tests/test-utils-automated/src/internal/_test_validate.ts
@@ -6,9 +6,9 @@ import { OpenApiTypeChecker, OpenApiValidator } from "@typia/utils";
  * Verifies OpenAPI validation against independent template spoiler oracles.
  *
  * Template spoilers define invalid paths independently of the schema validator.
- * Predictable branches retain their leaf paths, while both sides canonicalize
- * an ambiguous oneOf failure to its union owner. Enforcing the whole sorted
- * canonical path set prevents omissions from hiding behind a failed result.
+ * Predictable branches retain their leaf paths, while ambiguous spoiler paths
+ * canonicalize to the union owner emitted by the validator. Actual errors stay
+ * raw so the whole sorted path set and its multiplicity remain exact.
  *
  * 1. Validate a generated success value and preserve its identity.
  * 2. Apply every fixture spoiler and compare the exact sorted failure paths.
@@ -58,12 +58,7 @@ export const _test_validate = <T>(props: {
       );
     }
 
-    const actual: string[] = normalizePaths({
-      components: props.components,
-      schema: props.schema,
-      value: elem,
-      paths: valid.errors.map((error) => error.path),
-    });
+    const actual: string[] = valid.errors.map((error) => error.path).sort();
 
     if (
       actual.length !== expected.length ||
@@ -93,8 +88,8 @@ const normalizePaths = (props: {
   value: unknown;
   paths: string[];
 }): string[] => {
-  // Distinct branch leaves can share one ambiguous union owner, but repeated
-  // occurrences of the same raw path must remain visible to the count oracle.
+  // Distinct spoiler leaves can share one ambiguous union owner, but repeated
+  // occurrences of the same expected path must remain visible to the oracle.
   const frequencies = new Map<string, Map<string, number>>();
   for (const original of props.paths) {
     const normalized = normalizePath({
@@ -187,8 +182,20 @@ const selectOneOf = (props: {
       value: props.value,
     });
   if (typeof props.value !== "object" || props.value === null) return undefined;
+  return selectObject({
+    components: props.components,
+    branches: compatible,
+    value: props.value as Record<string, unknown>,
+  });
+};
 
-  const objects = compatible.filter(
+const selectObject = (props: {
+  components: OpenApi.IComponents;
+  branches: IResolvedBranch[];
+  value: Record<string, unknown>;
+}): OpenApi.IJsonSchema | undefined => {
+  if (props.branches.length === 1) return props.branches[0]!.original;
+  const objects = props.branches.filter(
     (
       branch,
     ): branch is {
@@ -196,13 +203,18 @@ const selectOneOf = (props: {
       resolved: OpenApi.IJsonSchema.IObject;
     } => OpenApiTypeChecker.isObject(branch.resolved),
   );
-  for (const branch of objects) {
+  const selectable = objects.filter(
+    ({ resolved }) =>
+      resolved.properties !== undefined && resolved.required !== undefined,
+  );
+  const discriminated: IObjectDiscriminator[] = [];
+  for (const branch of selectable) {
     const candidates: string[] = [];
     for (const key of branch.resolved.required ?? []) {
       const targetSchema = branch.resolved.properties?.[key];
       if (targetSchema === undefined) continue;
       const target = resolve(props.components, targetSchema);
-      const neighbors = objects
+      const neighbors = selectable
         .filter((other) => other !== branch)
         .map(({ resolved }) => resolved.properties?.[key])
         .filter((schema) => schema !== undefined)
@@ -233,11 +245,25 @@ const selectOneOf = (props: {
         : resolve(props.components, targetSchema);
     const matched =
       target !== undefined && OpenApiTypeChecker.isConstant(target)
-        ? (props.value as Record<string, unknown>)[key] === target.const
-        : (props.value as Record<string, unknown>)[key] !== undefined;
-    if (matched) return branch.original;
+        ? props.value[key] === target.const
+        : props.value[key] !== undefined;
+    discriminated.push({
+      branch,
+      matched,
+    });
   }
-  return undefined;
+  const matched = discriminated.find(({ matched }) => matched);
+  if (matched !== undefined) return matched.branch.original;
+  if (discriminated.length === 0) return undefined;
+  const remainders = props.branches.filter(
+    (branch) => discriminated.some((item) => item.branch === branch) === false,
+  );
+  return remainders.length === 0
+    ? undefined
+    : selectObject({
+        ...props,
+        branches: remainders,
+      });
 };
 
 const selectArray = (props: {
@@ -364,4 +390,11 @@ interface IPathSegment {
 interface IResolvedBranch {
   original: OpenApi.IJsonSchema;
   resolved: OpenApi.IJsonSchema;
+}
+
+interface IObjectDiscriminator {
+  branch: IResolvedBranch & {
+    resolved: OpenApi.IJsonSchema.IObject;
+  };
+  matched: boolean;
 }

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_report_path_boundary.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_report_path_boundary.ts
@@ -11,7 +11,8 @@ import { OpenApiValidator } from "@typia/utils";
  *
  * 1. Validate the same invalid value against both `a`/`ab` property orders.
  * 2. Require every independent property and array-index failure.
- * 3. Exclude the genuine array-parent failure made redundant by child errors.
+ * 3. Make a failing array constraint suppress its redundant child failures.
+ * 4. Keep a referenced array union's selected indexed failure.
  */
 export const test_openapi_validator_report_path_boundary = (): void => {
   const input = {
@@ -43,14 +44,64 @@ export const test_openapi_validator_report_path_boundary = (): void => {
       value: input,
       required: true,
     });
-    if (result.success)
-      throw new Error(`Expected ${label} input to fail validation.`);
-    TestValidator.equals(
-      label,
-      expected,
-      result.errors.map(({ path }) => path).sort(),
-    );
+    assertPaths(label, result, expected);
   }
+
+  assertPaths(
+    "array constraint owns child failures",
+    OpenApiValidator.validate({
+      components: {},
+      schema: {
+        type: "array",
+        items: { type: "string" },
+        maxItems: 1,
+      },
+      value: [0, 0],
+      required: true,
+    }),
+    ["$input"],
+  );
+
+  assertPaths(
+    "referenced array branch",
+    OpenApiValidator.validate({
+      components: {
+        schemas: {
+          NumberArray: {
+            type: "array",
+            items: { type: "number" },
+          },
+          StringArray: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+      },
+      schema: {
+        oneOf: [
+          { $ref: "#/components/schemas/StringArray" },
+          { $ref: "#/components/schemas/NumberArray" },
+        ],
+      },
+      value: [1, "two"],
+      required: true,
+    }),
+    ["$input[1]"],
+  );
+};
+
+const assertPaths = (
+  label: string,
+  result: IValidation<unknown>,
+  expected: string[],
+): void => {
+  if (result.success)
+    throw new Error(`Expected ${label} input to fail validation.`);
+  TestValidator.equals(
+    label,
+    expected,
+    result.errors.map(({ path }) => path).sort(),
+  );
 };
 
 const propertiesOf = (

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_report_path_boundary.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_report_path_boundary.ts
@@ -1,0 +1,77 @@
+import { TestValidator } from "@nestia/e2e";
+import { IValidation, OpenApi } from "@typia/interface";
+import { OpenApiValidator } from "@typia/utils";
+
+/**
+ * Verifies OpenAPI validation reports only suppress real ancestor paths.
+ *
+ * The OpenAPI reporter mirrors typia's ordered de-duplication and used the same
+ * raw-prefix ancestry test. This matrix keeps the two reporters aligned across
+ * sibling order, quoted keys, indexes, and a redundant array parent.
+ *
+ * 1. Validate the same invalid value against both `a`/`ab` property orders.
+ * 2. Require every independent property and array-index failure.
+ * 3. Exclude the genuine array-parent failure made redundant by child errors.
+ */
+export const test_openapi_validator_report_path_boundary = (): void => {
+  const input = {
+    a: 0,
+    ab: 0,
+    "a-b": 0,
+    items: new Array(11).fill(0),
+    duplicates: ["same", "same"],
+  };
+  const expected: string[] = [
+    "$input.a",
+    "$input.ab",
+    '$input["a-b"]',
+    ...input.items.map((_, index) => `$input.items[${index}]`),
+    "$input.duplicates",
+  ].sort();
+
+  for (const [label, properties] of [
+    ["long property first", propertiesOf(["ab", "a"])],
+    ["short property first", propertiesOf(["a", "ab"])],
+  ] as const) {
+    const result: IValidation<unknown> = OpenApiValidator.validate({
+      components: {},
+      schema: {
+        type: "object",
+        properties,
+        required: Object.keys(properties),
+      },
+      value: input,
+      required: true,
+    });
+    if (result.success)
+      throw new Error(`Expected ${label} input to fail validation.`);
+    TestValidator.equals(
+      label,
+      expected,
+      result.errors.map(({ path }) => path).sort(),
+    );
+  }
+};
+
+const propertiesOf = (
+  identifiers: readonly ["ab" | "a", "ab" | "a"],
+): Record<string, OpenApi.IJsonSchema> =>
+  Object.fromEntries([
+    ...identifiers.map((key) => [key, { type: "string" }] as const),
+    ["a-b", { type: "string" }],
+    [
+      "items",
+      {
+        type: "array",
+        items: { type: "string" },
+      },
+    ],
+    [
+      "duplicates",
+      {
+        type: "array",
+        items: { type: "string" },
+        uniqueItems: true,
+      },
+    ],
+  ]);


### PR DESCRIPTION
## Intent

Make validation reporting complete and deterministic across typia, OpenAPI utilities, and Standard Schema adapters. This draft reserves one campaign batch for the shared reporting/oracle surface before implementation begins.

## Problem

- Validation reporters currently use a raw string-prefix comparison when suppressing redundant descendant errors. Independent sibling properties such as `$input.a` and `$input.ab` can therefore hide one another depending on declaration order.
- Standard Schema diagnostic construction interpolates an arbitrary `unknown` value directly. Symbols, null-prototype objects, and hostile coercion hooks can turn an ordinary validation failure into a thrown `TypeError`.
- The automated OpenAPI and Standard Schema validation oracles do not fully enforce their independently derived path and success expectations, allowing reporting regressions to remain masked.

## Scope

- Make ancestor suppression path-segment aware in both typia-generated validation reporting and `OpenApiValidator`, while preserving de-duplication for genuine parent/child paths.
- Make Standard Schema failure-message value formatting total for arbitrary `unknown` without weakening ordinary readable diagnostics.
- Restore exact deterministic path assertions and the Standard Schema success-result type oracle without changing fixture expectations.
- Add regression coverage for both sibling declaration orders, genuine descendants, quoted/indexed paths, and unsafe diagnostic values, then trace the downstream issue surfaces.

## Deferred

No unrelated reporter redesign, fixture weakening, or repository-wide formatting is included. Campaign-wide formatting remains owned by the dedicated cleanup pull request.

## Verification

Pending implementation. The implementation push will record focused and broader package/test commands here as a chronological comment. Automatic Actions runs for this campaign branch are cancelled by exact commit SHA; local verification and the later Solo Self-Review are the gates.

Closes #2033
Closes #2034
Closes #1890
