### PR TITLE
fix(website): surface transform failures and restore CI input coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - 'packages/**'
       - 'tests/**'
       - 'examples/**'
+      - 'config/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,11 +4,15 @@ on:
     paths:
       - .github/workflows/release.yml
       - .github/workflows/website.yml
+      - 'config/**'
       - 'examples/**'
+      - 'experiments/tarballs/**'
       - 'packages/**'
       - 'website/**'
       - 'website/package.json'
       - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,17 +26,19 @@ jobs:
           go-version: 1.26.x
       - uses: pnpm/action-setup@v4
 
-      # The wasm playground build links against samchon/ttsc via a sibling
-      # go.work file (packages/typia/native/go.work). Local layout puts ttsc
-      # next to typia; CI must reproduce that so `go build` can resolve the
-      # ttsc/* and ttsc/shim/* modules.
-      - name: Checkout ttsc sibling
-        run: git clone --depth 1 https://github.com/samchon/ttsc.git ../ttsc
-
       # website is a pnpm workspace member, so a single root `pnpm install`
       # wires its deps and the workspace symlinks to typia / @typia/*.
       - name: Install Dependencies
         run: pnpm install
+
+      # The wasm playground build links against samchon/ttsc via a sibling
+      # go.work file (packages/typia/native/go.work). Match that checkout to the
+      # installed @ttsc/wasm package so its Go host and browser API cannot drift.
+      - name: Checkout ttsc sibling
+        run: |
+          TTSC_VERSION="$(node -p "require('./website/node_modules/@ttsc/wasm/package.json').version")"
+          test -n "${TTSC_VERSION}"
+          git clone --branch "v${TTSC_VERSION}" --depth 1 https://github.com/samchon/ttsc.git ../ttsc
 
       # ttsc compiles the typia Go plugin on first use into
       # node_modules/.cache/ttsc, keyed by content (plugin source + ttsc/tsgo
@@ -55,6 +61,12 @@ jobs:
         run: |
           pnpm run build
           pnpm run package:tgz
+
+      - name: Test Playground Compiler
+        working-directory: website
+        run: |
+          pnpm run test:compiler
+          go -C compiler test ./cmd/playground
 
       - name: Build
         working-directory: website

--- a/website/compiler/cmd/playground/typia_plugin.go
+++ b/website/compiler/cmd/playground/typia_plugin.go
@@ -23,6 +23,7 @@ import (
   "encoding/json"
   "flag"
   "fmt"
+  "io"
   "os"
   "path/filepath"
   "regexp"
@@ -40,6 +41,20 @@ import (
 )
 
 type typiaPlugin struct{}
+
+type typiaCompilerDiag struct {
+  File        *string `json:"file"`
+  Category    string  `json:"category"`
+  Code        string  `json:"code"`
+  Line        int     `json:"line,omitempty"`
+  Character   int     `json:"character,omitempty"`
+  MessageText string  `json:"messageText"`
+}
+
+type typiaTransformProjectOutput struct {
+  Diagnostics []typiaCompilerDiag `json:"diagnostics,omitempty"`
+  TypeScript  map[string]string   `json:"typescript"`
+}
 
 func newTypiaPlugin() typiaPlugin { return typiaPlugin{} }
 
@@ -264,19 +279,7 @@ func runTypiaTransformProject(
   typiaTransform driver.PluginTransform,
   transformDiags *[]typiaPlaygroundDiag,
 ) int {
-  type compilerDiag struct {
-    File        *string `json:"file"`
-    Category    string  `json:"category"`
-    Code        string  `json:"code"`
-    Line        int     `json:"line,omitempty"`
-    Character   int     `json:"character,omitempty"`
-    MessageText string  `json:"messageText"`
-  }
-  type out struct {
-    Diagnostics []compilerDiag    `json:"diagnostics,omitempty"`
-    TypeScript  map[string]string `json:"typescript"`
-  }
-  res := out{TypeScript: map[string]string{}}
+  typescript := map[string]string{}
   for _, sf := range prog.SourceFiles() {
     if sf.IsDeclarationFile {
       continue
@@ -285,15 +288,25 @@ func runTypiaTransformProject(
     if filepath.IsAbs(key) || key == ".." || strings.HasPrefix(key, "../") {
       continue
     }
-    res.TypeScript[key] = transformFileToTypeScript(prog, typiaTransform, sf)
+    typescript[key] = transformFileToTypeScript(prog, typiaTransform, sf)
   }
-  for _, diag := range *transformDiags {
+  return writeTypiaTransformProjectOutput(os.Stdout, os.Stderr, typescript, *transformDiags)
+}
+
+func writeTypiaTransformProjectOutput(
+  stdout io.Writer,
+  stderr io.Writer,
+  typescript map[string]string,
+  transformDiags []typiaPlaygroundDiag,
+) int {
+  res := typiaTransformProjectOutput{TypeScript: typescript}
+  for _, diag := range transformDiags {
     var fp *string
     if diag.File != "" {
       normalized := filepath.ToSlash(diag.File)
       fp = &normalized
     }
-    res.Diagnostics = append(res.Diagnostics, compilerDiag{
+    res.Diagnostics = append(res.Diagnostics, typiaCompilerDiag{
       File:        fp,
       Category:    "error",
       Code:        diag.Code,
@@ -302,8 +315,8 @@ func runTypiaTransformProject(
       MessageText: diag.Message,
     })
   }
-  if err := json.NewEncoder(os.Stdout).Encode(res); err != nil {
-    fmt.Fprintf(os.Stderr, "typia transform: encode output: %v\n", err)
+  if err := json.NewEncoder(stdout).Encode(res); err != nil {
+    fmt.Fprintf(stderr, "typia transform: encode output: %v\n", err)
     return 3
   }
   if len(res.Diagnostics) > 0 {

--- a/website/compiler/cmd/playground/typia_transform_project_output_test.go
+++ b/website/compiler/cmd/playground/typia_transform_project_output_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"testing"
+  "bytes"
+  "encoding/json"
+  "testing"
 )
 
 // TestWriteTypiaTransformProjectOutputPreservesContract verifies the playground plugin response.
@@ -16,50 +16,50 @@ import (
 // 2. Encode a partial map with a transform diagnostic and assert status three.
 // 3. Decode both payloads and verify their browser-facing fields.
 func TestWriteTypiaTransformProjectOutputPreservesContract(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		stdout := bytes.Buffer{}
-		stderr := bytes.Buffer{}
-		code := writeTypiaTransformProjectOutput(&stdout, &stderr, map[string]string{
-			"src/playground.ts": "export const input = true;",
-			"src/helper.ts":     "export const helper = true;",
-		}, nil)
-		if code != 0 {
-			t.Fatalf("successful transform status: %d", code)
-		}
-		payload := typiaTransformProjectOutput{}
-		if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
-			t.Fatal(err)
-		}
-		if len(payload.TypeScript) != 2 || len(payload.Diagnostics) != 0 {
-			t.Fatalf("successful transform payload: %#v", payload)
-		}
-	})
+  t.Run("success", func(t *testing.T) {
+    stdout := bytes.Buffer{}
+    stderr := bytes.Buffer{}
+    code := writeTypiaTransformProjectOutput(&stdout, &stderr, map[string]string{
+      "src/playground.ts": "export const input = true;",
+      "src/helper.ts":     "export const helper = true;",
+    }, nil)
+    if code != 0 {
+      t.Fatalf("successful transform status: %d", code)
+    }
+    payload := typiaTransformProjectOutput{}
+    if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+      t.Fatal(err)
+    }
+    if len(payload.TypeScript) != 2 || len(payload.Diagnostics) != 0 {
+      t.Fatalf("successful transform payload: %#v", payload)
+    }
+  })
 
-	t.Run("diagnostic", func(t *testing.T) {
-		stdout := bytes.Buffer{}
-		stderr := bytes.Buffer{}
-		code := writeTypiaTransformProjectOutput(&stdout, &stderr, map[string]string{
-			"src/playground.ts": "export const partial = true;",
-		}, []typiaPlaygroundDiag{{
-			File:    "/work/src/playground.ts",
-			Line:    2,
-			Column:  5,
-			Code:    "typia.is",
-			Message: "unsupported type",
-		}})
-		if code != 3 {
-			t.Fatalf("diagnostic transform status: %d", code)
-		}
-		payload := typiaTransformProjectOutput{}
-		if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
-			t.Fatal(err)
-		}
-		if len(payload.TypeScript) != 1 || len(payload.Diagnostics) != 1 {
-			t.Fatalf("diagnostic transform payload: %#v", payload)
-		}
-		diagnostic := payload.Diagnostics[0]
-		if diagnostic.Category != "error" || diagnostic.Code != "typia.is" || diagnostic.Line != 2 || diagnostic.Character != 5 || diagnostic.MessageText != "unsupported type" {
-			t.Fatalf("structured diagnostic mismatch: %#v", diagnostic)
-		}
-	})
+  t.Run("diagnostic", func(t *testing.T) {
+    stdout := bytes.Buffer{}
+    stderr := bytes.Buffer{}
+    code := writeTypiaTransformProjectOutput(&stdout, &stderr, map[string]string{
+      "src/playground.ts": "export const partial = true;",
+    }, []typiaPlaygroundDiag{{
+      File:    "/work/src/playground.ts",
+      Line:    2,
+      Column:  5,
+      Code:    "typia.is",
+      Message: "unsupported type",
+    }})
+    if code != 3 {
+      t.Fatalf("diagnostic transform status: %d", code)
+    }
+    payload := typiaTransformProjectOutput{}
+    if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+      t.Fatal(err)
+    }
+    if len(payload.TypeScript) != 1 || len(payload.Diagnostics) != 1 {
+      t.Fatalf("diagnostic transform payload: %#v", payload)
+    }
+    diagnostic := payload.Diagnostics[0]
+    if diagnostic.Category != "error" || diagnostic.Code != "typia.is" || diagnostic.Line != 2 || diagnostic.Character != 5 || diagnostic.MessageText != "unsupported type" {
+      t.Fatalf("structured diagnostic mismatch: %#v", diagnostic)
+    }
+  })
 }

--- a/website/compiler/cmd/playground/typia_transform_project_output_test.go
+++ b/website/compiler/cmd/playground/typia_transform_project_output_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestWriteTypiaTransformProjectOutputPreservesContract verifies the playground plugin response.
+//
+// The worker depends on project transforms returning structured diagnostics
+// beside the TypeScript map even when the plugin exits nonzero. Losing either
+// field would force the browser to choose between partial output and stderr.
+//
+// 1. Encode successful multi-file output and assert status zero.
+// 2. Encode a partial map with a transform diagnostic and assert status three.
+// 3. Decode both payloads and verify their browser-facing fields.
+func TestWriteTypiaTransformProjectOutputPreservesContract(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		stdout := bytes.Buffer{}
+		stderr := bytes.Buffer{}
+		code := writeTypiaTransformProjectOutput(&stdout, &stderr, map[string]string{
+			"src/playground.ts": "export const input = true;",
+			"src/helper.ts":     "export const helper = true;",
+		}, nil)
+		if code != 0 {
+			t.Fatalf("successful transform status: %d", code)
+		}
+		payload := typiaTransformProjectOutput{}
+		if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+			t.Fatal(err)
+		}
+		if len(payload.TypeScript) != 2 || len(payload.Diagnostics) != 0 {
+			t.Fatalf("successful transform payload: %#v", payload)
+		}
+	})
+
+	t.Run("diagnostic", func(t *testing.T) {
+		stdout := bytes.Buffer{}
+		stderr := bytes.Buffer{}
+		code := writeTypiaTransformProjectOutput(&stdout, &stderr, map[string]string{
+			"src/playground.ts": "export const partial = true;",
+		}, []typiaPlaygroundDiag{{
+			File:    "/work/src/playground.ts",
+			Line:    2,
+			Column:  5,
+			Code:    "typia.is",
+			Message: "unsupported type",
+		}})
+		if code != 3 {
+			t.Fatalf("diagnostic transform status: %d", code)
+		}
+		payload := typiaTransformProjectOutput{}
+		if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+			t.Fatal(err)
+		}
+		if len(payload.TypeScript) != 1 || len(payload.Diagnostics) != 1 {
+			t.Fatalf("diagnostic transform payload: %#v", payload)
+		}
+		diagnostic := payload.Diagnostics[0]
+		if diagnostic.Category != "error" || diagnostic.Code != "typia.is" || diagnostic.Line != 2 || diagnostic.Character != 5 || diagnostic.MessageText != "unsupported type" {
+			t.Fatalf("structured diagnostic mismatch: %#v", diagnostic)
+		}
+	})
+}

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,8 @@
     "build:tgz": "node build/tgz",
     "build:typedoc": "node build/typedoc",
     "deploy": "node build/deploy",
-    "dev": "npm run build:compiler && npm run build:examples && next dev"
+    "dev": "npm run build:compiler && npm run build:examples && next dev",
+    "test:compiler": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test src/compiler/*.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/website/src/compiler/createTypiaWorkerCompiler.test.mjs
+++ b/website/src/compiler/createTypiaWorkerCompiler.test.mjs
@@ -25,7 +25,7 @@ const transformPayload = (overrides = {}) => ({
   ...overrides,
 });
 
-const run = async (plugin) => {
+const run = async (plugin, overrides = {}) => {
   const writes = new Map();
   let buildCalls = 0;
   const result = await runTypiaBuildPipeline({
@@ -46,7 +46,7 @@ const run = async (plugin) => {
     runTypia: true,
     workDir: "/work",
     tsconfigPath: "tsconfig.json",
-    entryFile: "src/playground.ts",
+    entryFile: overrides.entryFile ?? "src/playground.ts",
     typiaPluginName: "typia",
   });
   return { buildCalls, result, writes };
@@ -162,6 +162,39 @@ test("typia transform responses gate the ordinary build", async (t) => {
     );
     assert.equal(actual.result.type, "error");
     assert.match(actual.result.value.message, /entry file/);
+    assert.equal(actual.buildCalls, 0);
+    assert.equal(actual.writes.size, 0);
+  });
+
+  await t.test("relative entry alias", async () => {
+    const actual = await run(transformPayload(), {
+      entryFile: "./src/playground.ts",
+    });
+    assert.deepEqual(actual.result, {
+      type: "success",
+      target: "javascript",
+      value: "export const compiled = true;",
+    });
+    assert.equal(actual.buildCalls, 1);
+    assert.deepEqual(
+      [...actual.writes],
+      [["/work/src/playground.ts", "export const transformed = true;"]],
+    );
+  });
+
+  await t.test("canonical duplicate paths", async () => {
+    const actual = await run(
+      transformPayload({
+        stdout: JSON.stringify({
+          typescript: {
+            "src/playground.ts": "export const first = true;",
+            "src/./playground.ts": "export const second = true;",
+          },
+        }),
+      }),
+    );
+    assert.equal(actual.result.type, "error");
+    assert.match(actual.result.value.message, /duplicate TypeScript paths/);
     assert.equal(actual.buildCalls, 0);
     assert.equal(actual.writes.size, 0);
   });

--- a/website/src/compiler/createTypiaWorkerCompiler.test.mjs
+++ b/website/src/compiler/createTypiaWorkerCompiler.test.mjs
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runTypiaBuildPipeline } from "./createTypiaWorkerCompiler.ts";
+
+const buildSuccess = {
+  code: 0,
+  stdout: "",
+  stderr: "",
+  result: JSON.stringify({
+    diagnostics: [],
+    output: { "src/playground.js": "export const compiled = true;" },
+  }),
+};
+
+const transformPayload = (overrides = {}) => ({
+  code: 0,
+  stdout: JSON.stringify({
+    typescript: {
+      "src/playground.ts": "export const transformed = true;",
+    },
+  }),
+  stderr: "",
+  result: "",
+  ...overrides,
+});
+
+const run = async (plugin) => {
+  const writes = new Map();
+  let buildCalls = 0;
+  const result = await runTypiaBuildPipeline({
+    api: {
+      plugin: async () => {
+        if (plugin instanceof Error) throw plugin;
+        return plugin;
+      },
+      build: async () => {
+        buildCalls += 1;
+        return buildSuccess;
+      },
+    },
+    host: {
+      writeFile: (path, text) => writes.set(path, text),
+    },
+    source: "export const input = true;",
+    runTypia: true,
+    workDir: "/work",
+    tsconfigPath: "tsconfig.json",
+    entryFile: "src/playground.ts",
+    typiaPluginName: "typia",
+  });
+  return { buildCalls, result, writes };
+};
+
+/**
+ * Verifies the worker stops on every invalid typia transform response.
+ *
+ * The typia plugin owns transform diagnostics that the following ordinary
+ * TypeScript build cannot reconstruct. The worker must validate the complete
+ * response before writing any transformed file or starting that build.
+ *
+ * 1. Exercise nonzero, diagnostic, stderr, empty, malformed, and thrown failures.
+ * 2. Assert each failure skips the ordinary build and partial file writes.
+ * 3. Verify valid multi-file output and warnings still reach the build.
+ */
+test("typia transform responses gate the ordinary build", async (t) => {
+  await t.test("nonzero status", async () => {
+    const actual = await run(transformPayload({ code: 3 }));
+    assert.equal(actual.result.type, "error");
+    assert.match(actual.result.value.message, /code 3/);
+    assert.equal(actual.buildCalls, 0);
+    assert.equal(actual.writes.size, 0);
+  });
+
+  await t.test("structured transform diagnostic", async () => {
+    const actual = await run(
+      transformPayload({
+        code: 3,
+        stderr:
+          "src/playground.ts:2:5 - error TS(typia.is): unsupported type\n",
+        stdout: JSON.stringify({
+          diagnostics: [
+            {
+              file: "/work/src/playground.ts",
+              category: "error",
+              code: "typia.is",
+              line: 2,
+              character: 5,
+              messageText: "unsupported type",
+            },
+          ],
+          typescript: {
+            "src/playground.ts": "export const partiallyTransformed = true;",
+          },
+        }),
+      }),
+    );
+    assert.deepEqual(actual.result, {
+      type: "failure",
+      target: "javascript",
+      value: "",
+      diagnostics: [
+        {
+          line: 2,
+          column: 5,
+          length: 1,
+          severity: "error",
+          message: "unsupported type",
+          code: "typia.is",
+        },
+      ],
+    });
+    assert.equal(actual.buildCalls, 0);
+    assert.equal(actual.writes.size, 0);
+  });
+
+  await t.test("stderr-only failure", async () => {
+    const actual = await run(
+      transformPayload({ stderr: "typia transform: transport failed\n" }),
+    );
+    assert.equal(actual.result.type, "error");
+    assert.match(actual.result.value.message, /transport failed/);
+    assert.equal(actual.buildCalls, 0);
+    assert.equal(actual.writes.size, 0);
+  });
+
+  await t.test("empty stdout", async () => {
+    const actual = await run(transformPayload({ stdout: "" }));
+    assert.equal(actual.result.type, "error");
+    assert.match(actual.result.value.message, /empty stdout/);
+    assert.equal(actual.buildCalls, 0);
+  });
+
+  await t.test("malformed JSON", async () => {
+    const actual = await run(transformPayload({ stdout: "{" }));
+    assert.equal(actual.result.type, "error");
+    assert.match(actual.result.value.message, /valid JSON/);
+    assert.equal(actual.buildCalls, 0);
+  });
+
+  await t.test("malformed required payload", async () => {
+    const actual = await run(
+      transformPayload({
+        stdout: JSON.stringify({
+          typescript: { "../outside.ts": "export const escaped = true;" },
+        }),
+      }),
+    );
+    assert.equal(actual.result.type, "error");
+    assert.match(actual.result.value.message, /relative TypeScript paths/);
+    assert.equal(actual.buildCalls, 0);
+    assert.equal(actual.writes.size, 0);
+  });
+
+  await t.test("missing entry output", async () => {
+    const actual = await run(
+      transformPayload({
+        stdout: JSON.stringify({
+          typescript: { "src/helper.ts": "export const helper = true;" },
+        }),
+      }),
+    );
+    assert.equal(actual.result.type, "error");
+    assert.match(actual.result.value.message, /entry file/);
+    assert.equal(actual.buildCalls, 0);
+    assert.equal(actual.writes.size, 0);
+  });
+
+  await t.test("thrown plugin failure", async () => {
+    const actual = await run(new Error("plugin crashed"));
+    assert.equal(actual.result.type, "error");
+    assert.equal(actual.result.value.message, "plugin crashed");
+    assert.equal(actual.buildCalls, 0);
+  });
+
+  await t.test("valid multi-file transform", async () => {
+    const actual = await run(
+      transformPayload({
+        stdout: JSON.stringify({
+          typescript: {
+            "src/playground.ts": "export const transformed = true;",
+            "src/helper.ts": "export const helper = true;",
+          },
+        }),
+      }),
+    );
+    assert.deepEqual(actual.result, {
+      type: "success",
+      target: "javascript",
+      value: "export const compiled = true;",
+    });
+    assert.equal(actual.buildCalls, 1);
+    assert.deepEqual(
+      [...actual.writes],
+      [
+        ["/work/src/playground.ts", "export const transformed = true;"],
+        ["/work/src/helper.ts", "export const helper = true;"],
+      ],
+    );
+  });
+
+  await t.test("warning diagnostics", async () => {
+    const actual = await run(
+      transformPayload({
+        stdout: JSON.stringify({
+          diagnostics: [
+            {
+              file: "/work/src/playground.ts",
+              category: "warning",
+              code: "typia.warning",
+              line: 1,
+              character: 1,
+              messageText: "deprecated transform option",
+            },
+          ],
+          typescript: {
+            "src/playground.ts": "export const transformed = true;",
+          },
+        }),
+      }),
+    );
+    assert.equal(actual.buildCalls, 1);
+    assert.equal(actual.result.type, "failure");
+    assert.equal(actual.result.value, "export const compiled = true;");
+    assert.equal(actual.result.diagnostics[0].severity, "warning");
+  });
+});

--- a/website/src/compiler/createTypiaWorkerCompiler.ts
+++ b/website/src/compiler/createTypiaWorkerCompiler.ts
@@ -193,9 +193,13 @@ export async function runTypiaBuildPipeline(
   props: ITypiaBuildPipelineProps,
 ): Promise<ICompilerService.IResult> {
   try {
+    const entryFile = normalizeRelativePath(props.entryFile);
+    if (entryFile === null)
+      return runtimeError("playground entry file must be a relative path");
+
     let transformDiagnostics: ICompilerService.IDiagnostic[] = [];
     if (props.runTypia) {
-      const transformed = await applyTypiaTransform(props);
+      const transformed = await applyTypiaTransform(props, entryFile);
       if (!transformed.success) return transformed.result;
       transformDiagnostics = transformed.diagnostics;
     }
@@ -223,7 +227,7 @@ export async function runTypiaBuildPipeline(
         mapDiagnostic(diagnostic, props.source),
       ),
     ];
-    const js = pickEmittedJS(parsed.output ?? {}, props.entryFile) ?? "";
+    const js = pickEmittedJS(parsed.output ?? {}, entryFile) ?? "";
     // Warnings do not block emission. They use the diagnostic-bearing result
     // variant so the playground can display them beside the successful output.
     if (diagnostics.length > 0)
@@ -245,6 +249,7 @@ export async function runTypiaBuildPipeline(
 
 async function applyTypiaTransform(
   props: ITypiaBuildPipelineProps,
+  entryFile: string,
 ): Promise<
   | { success: true; diagnostics: ICompilerService.IDiagnostic[] }
   | { success: false; result: ICompilerService.IResult }
@@ -267,11 +272,7 @@ async function applyTypiaTransform(
 
   const parsed = safeParseTypiaTransform(raw.stdout);
   if (parsed.success) {
-    const entryFile = normalizeRelativePath(props.entryFile);
-    if (
-      entryFile === null ||
-      !Object.hasOwn(parsed.value.typescript, entryFile)
-    )
+    if (!Object.hasOwn(parsed.value.typescript, entryFile))
       return {
         success: false,
         result: runtimeError(
@@ -437,11 +438,17 @@ function normalizeRelativePath(path: string): string | null {
     normalized.length === 0 ||
     normalized.startsWith("/") ||
     /^[A-Za-z]:\//.test(normalized) ||
-    normalized.includes("\0") ||
-    normalized.split("/").includes("..")
+    normalized.includes("\0")
   )
     return null;
-  return normalized;
+
+  const segments: string[] = [];
+  for (const segment of normalized.split("/")) {
+    if (segment.length === 0 || segment === ".") continue;
+    if (segment === "..") return null;
+    segments.push(segment);
+  }
+  return segments.length === 0 ? null : segments.join("/");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/website/src/compiler/createTypiaWorkerCompiler.ts
+++ b/website/src/compiler/createTypiaWorkerCompiler.ts
@@ -31,8 +31,31 @@ type TypiaPluginEntry = {
   transform: string;
 } & Partial<Record<(typeof TYPIA_OPTION_KEYS)[number], boolean>>;
 
+interface ITypiaTransformDiagnostic {
+  file?: string | null;
+  category: "error" | "warning";
+  code: number | string;
+  start?: number;
+  length?: number;
+  line?: number;
+  character?: number;
+  messageText: string;
+}
+
 interface ITypiaTransformOutput {
+  diagnostics: ITypiaTransformDiagnostic[];
   typescript: Record<string, string>;
+}
+
+interface ITypiaBuildPipelineProps {
+  api: Pick<IBootResult["api"], "build" | "plugin">;
+  host: Pick<IBootResult["host"], "writeFile">;
+  source: string;
+  runTypia: boolean;
+  workDir: string;
+  tsconfigPath: string;
+  entryFile: string;
+  typiaPluginName: string;
 }
 
 export function createTypiaWorkerCompiler(
@@ -107,31 +130,6 @@ export function createTypiaWorkerCompiler(
       host.writeFile(path, text);
   };
 
-  const applyTypiaTransform = async (
-    api: IBootResult["api"],
-    host: IBootResult["host"],
-  ): Promise<void> => {
-    if (!typiaPlugin) return;
-    try {
-      const raw = await api.plugin({
-        name: typiaPluginName,
-        command: "transform",
-        cwd: workDir,
-        tsconfig: tsconfigPath,
-        output: "ts",
-      });
-      if (!raw.stdout) return;
-      const transformed = safeParseTypiaTransform(raw.stdout);
-      if (!transformed) return;
-      for (const [rel, text] of Object.entries(transformed.typescript)) {
-        host.writeFile(joinUnder(workDir, rel), text);
-      }
-    } catch {
-      // Keep the playground usable; the following build still reports tsgo
-      // diagnostics for the user's source.
-    }
-  };
-
   const runBuildPipeline = async (
     source: string,
     runTypia: boolean,
@@ -144,43 +142,16 @@ export function createTypiaWorkerCompiler(
         host,
         projectFiles(source, buildTsconfig(module, transformOptions)),
       );
-      if (runTypia) await applyTypiaTransform(api, host);
-      const raw = await api.build({
-        cwd: workDir,
-        tsconfig: tsconfigPath,
+      return runTypiaBuildPipeline({
+        api,
+        host,
+        source,
+        runTypia: runTypia && typiaPlugin !== null,
+        workDir,
+        tsconfigPath,
+        entryFile,
+        typiaPluginName,
       });
-      if (raw.code !== 0 && !raw.result) {
-        return {
-          type: "error",
-          target: "javascript",
-          value: {
-            message:
-              raw.stderr || "ttsc: build failed without a result payload",
-          },
-        };
-      }
-      const parsed = parseResult<ITtscCompileResult>(raw);
-      if (!parsed) {
-        return {
-          type: "error",
-          target: "javascript",
-          value: { message: "ttsc: result JSON could not be parsed" },
-        };
-      }
-      const diagnostics = (parsed.diagnostics ?? []).map((d) =>
-        mapDiagnostic(d, source),
-      );
-      const js = pickEmittedJS(parsed.output ?? {}, entryFile);
-      const errors = diagnostics.filter((d) => d.severity === "error");
-      if (errors.length > 0) {
-        return {
-          type: "failure",
-          target: "javascript",
-          value: js ?? "",
-          diagnostics,
-        };
-      }
-      return { type: "success", target: "javascript", value: js ?? "" };
     } catch (error) {
       return {
         type: "error",
@@ -218,6 +189,135 @@ export function createTypiaWorkerCompiler(
   };
 }
 
+export async function runTypiaBuildPipeline(
+  props: ITypiaBuildPipelineProps,
+): Promise<ICompilerService.IResult> {
+  try {
+    let transformDiagnostics: ICompilerService.IDiagnostic[] = [];
+    if (props.runTypia) {
+      const transformed = await applyTypiaTransform(props);
+      if (!transformed.success) return transformed.result;
+      transformDiagnostics = transformed.diagnostics;
+    }
+
+    const raw = await props.api.build({
+      cwd: props.workDir,
+      tsconfig: props.tsconfigPath,
+    });
+    if (raw.code !== 0 && !raw.result) {
+      return runtimeError(
+        raw.stderr || "ttsc: build failed without a result payload",
+        "typescript-build",
+      );
+    }
+    const parsed = parseResult<ITtscCompileResult>(raw);
+    if (!parsed)
+      return runtimeError(
+        "ttsc: result JSON could not be parsed",
+        "typescript-build",
+      );
+
+    const diagnostics = [
+      ...transformDiagnostics,
+      ...(parsed.diagnostics ?? []).map((diagnostic) =>
+        mapDiagnostic(diagnostic, props.source),
+      ),
+    ];
+    const js = pickEmittedJS(parsed.output ?? {}, props.entryFile) ?? "";
+    // Warnings do not block emission. They use the diagnostic-bearing result
+    // variant so the playground can display them beside the successful output.
+    if (diagnostics.length > 0)
+      return {
+        type: "failure",
+        target: "javascript",
+        value: js,
+        diagnostics,
+      };
+    return { type: "success", target: "javascript", value: js };
+  } catch (error) {
+    return {
+      type: "error",
+      target: "javascript",
+      value: normalizeError(error),
+    };
+  }
+}
+
+async function applyTypiaTransform(
+  props: ITypiaBuildPipelineProps,
+): Promise<
+  | { success: true; diagnostics: ICompilerService.IDiagnostic[] }
+  | { success: false; result: ICompilerService.IResult }
+> {
+  const raw = await props.api.plugin({
+    name: props.typiaPluginName,
+    command: "transform",
+    cwd: props.workDir,
+    tsconfig: props.tsconfigPath,
+    output: "ts",
+  });
+  if (raw.stdout.trim().length === 0) {
+    const message =
+      raw.stderr.trim() ||
+      (raw.code !== 0
+        ? `typia transform exited with code ${raw.code}`
+        : "typia transform returned empty stdout");
+    return { success: false, result: runtimeError(message) };
+  }
+
+  const parsed = safeParseTypiaTransform(raw.stdout);
+  if (parsed.success) {
+    const entryFile = normalizeRelativePath(props.entryFile);
+    if (
+      entryFile === null ||
+      !Object.hasOwn(parsed.value.typescript, entryFile)
+    )
+      return {
+        success: false,
+        result: runtimeError(
+          "typia transform payload does not contain the entry file",
+        ),
+      };
+    const diagnostics = parsed.value.diagnostics.map((diagnostic) =>
+      mapTypiaTransformDiagnostic(diagnostic),
+    );
+    if (diagnostics.some((diagnostic) => diagnostic.severity === "error"))
+      return {
+        success: false,
+        result: {
+          type: "failure",
+          target: "javascript",
+          value: "",
+          diagnostics,
+        },
+      };
+    if (raw.code !== 0)
+      return {
+        success: false,
+        result: runtimeError(
+          raw.stderr.trim() || `typia transform exited with code ${raw.code}`,
+        ),
+      };
+    if (raw.stderr.trim().length !== 0)
+      return { success: false, result: runtimeError(raw.stderr.trim()) };
+
+    for (const [relativePath, text] of Object.entries(parsed.value.typescript))
+      props.host.writeFile(joinUnder(props.workDir, relativePath), text);
+    return { success: true, diagnostics };
+  }
+
+  if (raw.code !== 0)
+    return {
+      success: false,
+      result: runtimeError(
+        raw.stderr.trim() || `typia transform exited with code ${raw.code}`,
+      ),
+    };
+  if (raw.stderr.trim().length !== 0)
+    return { success: false, result: runtimeError(raw.stderr.trim()) };
+  return { success: false, result: runtimeError(parsed.message) };
+}
+
 export function createTypiaPluginEntry(
   transformModule: string,
   options: ITransformOptions | undefined,
@@ -234,20 +334,126 @@ function shouldRunTypia(options?: ITransformOptions): boolean {
   return options?.typia !== false;
 }
 
-function safeParseTypiaTransform(text: string): ITypiaTransformOutput | null {
+function safeParseTypiaTransform(
+  text: string,
+):
+  | { success: true; value: ITypiaTransformOutput }
+  | { success: false; message: string } {
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(text) as ITypiaTransformOutput;
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      parsed.typescript &&
-      typeof parsed.typescript === "object"
-    )
-      return parsed;
-    return null;
+    parsed = JSON.parse(text);
   } catch {
-    return null;
+    return {
+      success: false,
+      message: "typia transform stdout is not valid JSON",
+    };
   }
+  if (!isRecord(parsed) || !isRecord(parsed.typescript))
+    return {
+      success: false,
+      message: "typia transform payload must include a TypeScript map",
+    };
+
+  const typescript: Record<string, string> = Object.create(null);
+  for (const [relativePath, value] of Object.entries(parsed.typescript)) {
+    const normalized = normalizeRelativePath(relativePath);
+    if (normalized === null || typeof value !== "string")
+      return {
+        success: false,
+        message:
+          "typia transform payload must use relative TypeScript paths with string contents",
+      };
+    if (Object.hasOwn(typescript, normalized))
+      return {
+        success: false,
+        message: "typia transform payload contains duplicate TypeScript paths",
+      };
+    typescript[normalized] = value;
+  }
+
+  const rawDiagnostics = parsed.diagnostics ?? [];
+  if (
+    !Array.isArray(rawDiagnostics) ||
+    !rawDiagnostics.every(isTypiaTransformDiagnostic)
+  )
+    return {
+      success: false,
+      message: "typia transform payload contains malformed diagnostics",
+    };
+  return {
+    success: true,
+    value: { diagnostics: rawDiagnostics, typescript },
+  };
+}
+
+function isTypiaTransformDiagnostic(
+  value: unknown,
+): value is ITypiaTransformDiagnostic {
+  if (!isRecord(value)) return false;
+  return (
+    (value.category === "error" || value.category === "warning") &&
+    (typeof value.code === "number" || typeof value.code === "string") &&
+    typeof value.messageText === "string" &&
+    (value.file === undefined ||
+      value.file === null ||
+      typeof value.file === "string") &&
+    isOptionalPositiveInteger(value.line) &&
+    isOptionalPositiveInteger(value.character) &&
+    isOptionalNonNegativeInteger(value.start) &&
+    isOptionalPositiveInteger(value.length)
+  );
+}
+
+function mapTypiaTransformDiagnostic(
+  diagnostic: ITypiaTransformDiagnostic,
+): ICompilerService.IDiagnostic {
+  return {
+    line: diagnostic.line ?? 1,
+    column: diagnostic.character ?? 1,
+    length: diagnostic.length ?? 1,
+    severity: diagnostic.category,
+    message: diagnostic.messageText,
+    code:
+      typeof diagnostic.code === "number"
+        ? `TS${diagnostic.code}`
+        : diagnostic.code,
+  };
+}
+
+function runtimeError(
+  message: string,
+  stage = "typia-transform",
+): ICompilerService.IError {
+  return {
+    type: "error",
+    target: "javascript",
+    value: { name: "CompilerPipelineError", stage, message },
+  };
+}
+
+function normalizeRelativePath(path: string): string | null {
+  const normalized = path.replace(/\\/g, "/");
+  if (
+    normalized.length === 0 ||
+    normalized.startsWith("/") ||
+    /^[A-Za-z]:\//.test(normalized) ||
+    normalized.includes("\0") ||
+    normalized.split("/").includes("..")
+  )
+    return null;
+  return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isOptionalPositiveInteger(value: unknown): boolean {
+  return value === undefined || (Number.isInteger(value) && Number(value) > 0);
+}
+
+function isOptionalNonNegativeInteger(value: unknown): boolean {
+  return value === undefined || (Number.isInteger(value) && Number(value) >= 0);
 }
 
 function joinUnder(root: string, rel: string): string {

--- a/website/src/compiler/workflowPathFilters.test.mjs
+++ b/website/src/compiler/workflowPathFilters.test.mjs
@@ -9,12 +9,44 @@ const readWorkflow = (name) =>
   );
 
 const workflowPaths = (text) => {
-  return new Set(
-    text
-      .split(/\r?\n/)
-      .map((line) => /^\s+-\s+['"]?([^'"]+)['"]?\s*$/.exec(line)?.[1])
-      .filter((path) => path !== undefined),
-  );
+  const lines = text.split(/\r?\n/);
+  const block = (key, start, end) => {
+    const pattern = new RegExp(`^(\\s*)${key}:\\s*$`);
+    const index = lines.findIndex(
+      (line, candidate) =>
+        candidate >= start && candidate < end && pattern.test(line),
+    );
+    assert.notEqual(index, -1, `workflow omits ${key}`);
+    const indent = /^\s*/.exec(lines[index])[0].length;
+    let next = index + 1;
+    while (
+      next < end &&
+      (lines[next].trim().length === 0 ||
+        /^\s*/.exec(lines[next])[0].length > indent)
+    )
+      next += 1;
+    return { start: index + 1, end: next };
+  };
+
+  const on = block("on", 0, lines.length);
+  const pullRequest = block("pull_request", on.start, on.end);
+  const paths = block("paths", pullRequest.start, pullRequest.end);
+  const result = new Set();
+  for (const line of lines.slice(paths.start, paths.end)) {
+    const match = /^\s+-\s+(['"]?)([^'"]+)\1\s*$/.exec(line);
+    if (match) result.add(match[2]);
+  }
+  return result;
+};
+
+const assertOrdered = (text, labels) => {
+  let previous = -1;
+  for (const label of labels) {
+    const current = text.indexOf(label);
+    assert.notEqual(current, -1, `workflow omits ${label}`);
+    assert.ok(current > previous, `${label} is out of order`);
+    previous = current;
+  }
 };
 
 /**
@@ -27,16 +59,25 @@ const workflowPaths = (text) => {
  * 1. Read the website and test pull-request path filters.
  * 2. Assert each consumed workspace, compiler, and tarball input is present.
  * 3. Assert unrelated benchmark and README changes remain excluded.
+ * 4. Verify dependency install, tag selection, compiler tests, and build order.
  */
 test("workflow path filters match consumed inputs", async () => {
+  const synthetic = workflowPaths(
+    `on:\n  pull_request:\n    paths:\n      - 'inside/**'\njobs:\n  test:\n    strategy:\n      matrix:\n        include:\n          - 'outside/**'\n`,
+  );
+  assert.deepEqual(synthetic, new Set(["inside/**"]));
+
   const websiteText = await readWorkflow("website");
   const website = workflowPaths(websiteText);
   for (const path of [
+    ".github/workflows/release.yml",
+    ".github/workflows/website.yml",
     "config/**",
     "examples/**",
     "experiments/tarballs/**",
     "packages/**",
     "website/**",
+    "website/package.json",
     "package.json",
     "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
@@ -45,6 +86,7 @@ test("workflow path filters match consumed inputs", async () => {
 
   const tests = workflowPaths(await readWorkflow("test"));
   for (const path of [
+    ".github/workflows/test.yml",
     "config/**",
     "examples/**",
     "packages/**",
@@ -67,4 +109,19 @@ test("workflow path filters match consumed inputs", async () => {
     /require\('\.\/website\/node_modules\/@ttsc\/wasm\/package\.json'\)\.version/,
   );
   assert.match(websiteText, /git clone --branch "v\$\{TTSC_VERSION\}"/);
+  assertOrdered(websiteText, [
+    "- name: Install Dependencies",
+    "- name: Checkout ttsc sibling",
+    "- name: Packages",
+    "- name: Test Playground Compiler",
+    "- name: Build",
+  ]);
+  assertOrdered(websiteText, [
+    'TTSC_VERSION="$(node -p',
+    'git clone --branch "v${TTSC_VERSION}"',
+  ]);
+  assertOrdered(websiteText, [
+    "pnpm run test:compiler",
+    "go -C compiler test ./cmd/playground",
+  ]);
 });

--- a/website/src/compiler/workflowPathFilters.test.mjs
+++ b/website/src/compiler/workflowPathFilters.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const readWorkflow = (name) =>
+  readFile(
+    new URL(`../../../.github/workflows/${name}.yml`, import.meta.url),
+    "utf8",
+  );
+
+const workflowPaths = (text) => {
+  return new Set(
+    text
+      .split(/\r?\n/)
+      .map((line) => /^\s+-\s+['"]?([^'"]+)['"]?\s*$/.exec(line)?.[1])
+      .filter((path) => path !== undefined),
+  );
+};
+
+/**
+ * Verifies pull-request workflows watch every directly consumed input.
+ *
+ * The website job builds packages, stages tarballs, and installs the complete
+ * workspace, while the test job compiles workspaces that extend shared config.
+ * Omitting those inputs defers failures until after a pull request merges.
+ *
+ * 1. Read the website and test pull-request path filters.
+ * 2. Assert each consumed workspace, compiler, and tarball input is present.
+ * 3. Assert unrelated benchmark and README changes remain excluded.
+ */
+test("workflow path filters match consumed inputs", async () => {
+  const websiteText = await readWorkflow("website");
+  const website = workflowPaths(websiteText);
+  for (const path of [
+    "config/**",
+    "examples/**",
+    "experiments/tarballs/**",
+    "packages/**",
+    "website/**",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+  ])
+    assert.equal(website.has(path), true, `website workflow omits ${path}`);
+
+  const tests = workflowPaths(await readWorkflow("test"));
+  for (const path of [
+    "config/**",
+    "examples/**",
+    "packages/**",
+    "tests/**",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+  ])
+    assert.equal(tests.has(path), true, `test workflow omits ${path}`);
+
+  for (const paths of [website, tests]) {
+    assert.equal(paths.has("benchmark/**"), false);
+    assert.equal(paths.has("README.md"), false);
+  }
+
+  assert.match(websiteText, /pnpm run test:compiler/);
+  assert.match(websiteText, /go -C compiler test \.\/cmd\/playground/);
+  assert.match(
+    websiteText,
+    /require\('\.\/website\/node_modules\/@ttsc\/wasm\/package\.json'\)\.version/,
+  );
+  assert.match(websiteText, /git clone --branch "v\$\{TTSC_VERSION\}"/);
+});


### PR DESCRIPTION
## Intent

Prevent the playground from presenting emitted output after typia's transform has failed, and make the website and test workflows run whenever their consumed workspace or compiler configuration inputs change.

## Scope

- Model and propagate the complete playground plugin response, including transform diagnostics, status, stderr, malformed output, and thrown transport failures.
- Stop the ordinary TypeScript build when the typia transform state is invalid while preserving successful multi-file transforms.
- Add deterministic worker/compiler and Go plugin contract regression coverage for the transform boundary.
- Extend the website workflow filter to cover `pnpm-lock.yaml` and `pnpm-workspace.yaml`.
- Extend the test workflow filter to cover `config/**`.

## Deferred

- No repository Actions permission or workflow active-state changes.
- No unrelated website redesign, transformer behavior change, or repository-wide formatting.
- Solo Self-Review and merge remain separate campaign gates after implementation.

## Verification

Pending implementation. The campaign deliberately cancels exact-SHA GitHub Actions runs after every push; focused compiler/plugin tests, package and workspace builds, tarball staging, and the production website build will run locally before handoff.

Closes #2036
Closes #2059
