### PR TITLE
fix(typia): preserve type and notation contracts

### DIFF
--- a/packages/interface/src/typings/CamelCase.ts
+++ b/packages/interface/src/typings/CamelCase.ts
@@ -53,9 +53,11 @@ type CamelizeObject<T extends object> =
                 : T extends NativeClass
                   ? T
                   : {
-                      [Key in keyof T as CamelizeString<
-                        Key & string
-                      >]: CamelizeMain<T[Key]>;
+                      [Key in keyof T as Key extends string
+                        ? CamelizeString<Key>
+                        : Key extends number
+                          ? Key
+                          : never]: CamelizeMain<T[Key]>;
                     };
 
 type CamelizeArray<T extends readonly unknown[]> = {

--- a/packages/interface/src/typings/CamelCase.ts
+++ b/packages/interface/src/typings/CamelCase.ts
@@ -1,4 +1,5 @@
 import { Equal } from "./internal/Equal";
+import { IsBroadString } from "./internal/IsBroadString";
 import { IsTupleLike } from "./internal/IsTupleLike";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
@@ -64,15 +65,16 @@ type CamelizeArray<T extends readonly unknown[]> = {
   [P in keyof T]: CamelizeMain<T[P]>;
 };
 
-type CamelizeString<Key extends string> = string extends Key
-  ? string
-  : Key extends `_${infer R}`
-    ? `_${CamelizeString<R>}`
-    : Key extends `${infer _F}_${infer _R}`
-      ? CamelizeSnakeString<Key>
-      : Key extends Uppercase<Key>
-        ? Lowercase<Key>
-        : CamelizePascalString<Key>;
+type CamelizeString<Key extends string> =
+  IsBroadString<Key> extends true
+    ? string
+    : Key extends `_${infer R}`
+      ? `_${CamelizeString<R>}`
+      : Key extends `${infer _F}_${infer _R}`
+        ? CamelizeSnakeString<Key>
+        : Key extends Uppercase<Key>
+          ? Lowercase<Key>
+          : CamelizePascalString<Key>;
 type CamelizePascalString<Key extends string> =
   Key extends `${infer F}${infer R}` ? `${Lowercase<F>}${R}` : Key;
 type CamelizeSnakeString<Key extends string> = Key extends `_${infer R}`

--- a/packages/interface/src/typings/CamelCase.ts
+++ b/packages/interface/src/typings/CamelCase.ts
@@ -1,5 +1,5 @@
 import { Equal } from "./internal/Equal";
-import { IsTuple } from "./internal/IsTuple";
+import { IsTupleLike } from "./internal/IsTupleLike";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
 
@@ -13,8 +13,13 @@ import { ValueOf } from "./internal/ValueOf";
  * @author Jeongho Nam - https://github.com/samchon
  * @template T Target type to transform
  */
-export type CamelCase<T> =
-  Equal<T, CamelizeMain<T>> extends true ? T : CamelizeMain<T>;
+export type CamelCase<T> = unknown extends T
+  ? T
+  : object extends T
+    ? T
+    : Equal<T, CamelizeMain<T>> extends true
+      ? T
+      : CamelizeMain<T>;
 
 type CamelizeMain<T> = T extends [never]
   ? never // special trick for (jsonable | null) type
@@ -28,34 +33,34 @@ type CamelizeMain<T> = T extends [never]
 
 type CamelizeObject<T extends object> =
   T extends Array<infer U>
-    ? IsTuple<T> extends true
-      ? CamelizeTuple<T>
-      : CamelizeMain<U>[]
-    : T extends Set<infer U>
-      ? Set<CamelizeMain<U>>
-      : T extends Map<infer K, infer V>
-        ? Map<CamelizeMain<K>, CamelizeMain<V>>
-        : T extends WeakSet<any> | WeakMap<any, any>
-          ? never
-          : T extends NativeClass
-            ? T
-            : {
-                [Key in keyof T as CamelizeString<Key & string>]: CamelizeMain<
-                  T[Key]
-                >;
-              };
+    ? IsTupleLike<T> extends true
+      ? CamelizeArray<T>
+      : Array<CamelizeMain<U>>
+    : T extends ReadonlyArray<infer U>
+      ? IsTupleLike<T> extends true
+        ? CamelizeArray<T>
+        : ReadonlyArray<CamelizeMain<U>>
+      : T extends Set<infer U>
+        ? Set<CamelizeMain<U>>
+        : T extends Map<infer K, infer V>
+          ? Map<CamelizeMain<K>, CamelizeMain<V>>
+          : T extends ReadonlyMap<infer K, infer V>
+            ? ReadonlyMap<CamelizeMain<K>, CamelizeMain<V>>
+            : T extends ReadonlySet<infer U>
+              ? ReadonlySet<CamelizeMain<U>>
+              : T extends WeakSet<any> | WeakMap<any, any>
+                ? never
+                : T extends NativeClass
+                  ? T
+                  : {
+                      [Key in keyof T as CamelizeString<
+                        Key & string
+                      >]: CamelizeMain<T[Key]>;
+                    };
 
-type CamelizeTuple<T extends readonly any[]> = T extends []
-  ? []
-  : T extends [infer F]
-    ? [CamelizeMain<F>]
-    : T extends [infer F, ...infer Rest extends readonly any[]]
-      ? [CamelizeMain<F>, ...CamelizeTuple<Rest>]
-      : T extends [(infer F)?]
-        ? [CamelizeMain<F>?]
-        : T extends [(infer F)?, ...infer Rest extends readonly any[]]
-          ? [CamelizeMain<F>?, ...CamelizeTuple<Rest>]
-          : [];
+type CamelizeArray<T extends readonly unknown[]> = {
+  [P in keyof T]: CamelizeMain<T[P]>;
+};
 
 type CamelizeString<Key extends string> = Key extends `_${infer R}`
   ? `_${CamelizeString<R>}`

--- a/packages/interface/src/typings/CamelCase.ts
+++ b/packages/interface/src/typings/CamelCase.ts
@@ -62,13 +62,15 @@ type CamelizeArray<T extends readonly unknown[]> = {
   [P in keyof T]: CamelizeMain<T[P]>;
 };
 
-type CamelizeString<Key extends string> = Key extends `_${infer R}`
-  ? `_${CamelizeString<R>}`
-  : Key extends `${infer _F}_${infer _R}`
-    ? CamelizeSnakeString<Key>
-    : Key extends Uppercase<Key>
-      ? Lowercase<Key>
-      : CamelizePascalString<Key>;
+type CamelizeString<Key extends string> = string extends Key
+  ? string
+  : Key extends `_${infer R}`
+    ? `_${CamelizeString<R>}`
+    : Key extends `${infer _F}_${infer _R}`
+      ? CamelizeSnakeString<Key>
+      : Key extends Uppercase<Key>
+        ? Lowercase<Key>
+        : CamelizePascalString<Key>;
 type CamelizePascalString<Key extends string> =
   Key extends `${infer F}${infer R}` ? `${Lowercase<F>}${R}` : Key;
 type CamelizeSnakeString<Key extends string> = Key extends `_${infer R}`

--- a/packages/interface/src/typings/CamelCase.ts
+++ b/packages/interface/src/typings/CamelCase.ts
@@ -18,37 +18,47 @@ export type CamelCase<T> = unknown extends T
   ? T
   : object extends T
     ? T
-    : Equal<T, CamelizeMain<T>> extends true
-      ? T
-      : CamelizeMain<T>;
+    : T extends readonly unknown[]
+      ? CamelizeMain<T> // avoid eagerly comparing recursive tuple rest aliases
+      : Equal<T, CamelizeMain<T>> extends true
+        ? T
+        : CamelizeMain<T>;
 
-type CamelizeMain<T> = T extends [never]
+// TupleStack closes recursive tuple rest cycles without limiting other nesting.
+type CamelizeMain<T, TupleStack = never> = T extends [never]
   ? never // special trick for (jsonable | null) type
   : T extends { valueOf(): boolean | bigint | number | string }
     ? ValueOf<T>
     : T extends Function
       ? never
       : T extends object
-        ? CamelizeObject<T>
+        ? CamelizeObject<T, TupleStack>
         : T;
 
-type CamelizeObject<T extends object> =
+type CamelizeObject<T extends object, TupleStack> =
   T extends Array<infer U>
     ? IsTupleLike<T> extends true
-      ? CamelizeArray<T>
-      : Array<CamelizeMain<U>>
+      ? T extends TupleStack
+        ? T
+        : CamelizeArray<T, TupleStack | T>
+      : Array<CamelizeMain<U, TupleStack>>
     : T extends ReadonlyArray<infer U>
       ? IsTupleLike<T> extends true
-        ? CamelizeArray<T>
-        : ReadonlyArray<CamelizeMain<U>>
+        ? T extends TupleStack
+          ? T
+          : CamelizeArray<T, TupleStack | T>
+        : ReadonlyArray<CamelizeMain<U, TupleStack>>
       : T extends Set<infer U>
-        ? Set<CamelizeMain<U>>
+        ? Set<CamelizeMain<U, TupleStack>>
         : T extends Map<infer K, infer V>
-          ? Map<CamelizeMain<K>, CamelizeMain<V>>
+          ? Map<CamelizeMain<K, TupleStack>, CamelizeMain<V, TupleStack>>
           : T extends ReadonlyMap<infer K, infer V>
-            ? ReadonlyMap<CamelizeMain<K>, CamelizeMain<V>>
+            ? ReadonlyMap<
+                CamelizeMain<K, TupleStack>,
+                CamelizeMain<V, TupleStack>
+              >
             : T extends ReadonlySet<infer U>
-              ? ReadonlySet<CamelizeMain<U>>
+              ? ReadonlySet<CamelizeMain<U, TupleStack>>
               : T extends WeakSet<any> | WeakMap<any, any>
                 ? never
                 : T extends NativeClass
@@ -58,11 +68,11 @@ type CamelizeObject<T extends object> =
                         ? CamelizeString<Key>
                         : Key extends number
                           ? Key
-                          : never]: CamelizeMain<T[Key]>;
+                          : never]: CamelizeMain<T[Key], TupleStack>;
                     };
 
-type CamelizeArray<T extends readonly unknown[]> = {
-  [P in keyof T]: CamelizeMain<T[P]>;
+type CamelizeArray<T extends readonly unknown[], TupleStack> = {
+  [P in keyof T]: CamelizeMain<T[P], TupleStack>;
 };
 
 type CamelizeString<Key extends string> =

--- a/packages/interface/src/typings/ClassProperties.ts
+++ b/packages/interface/src/typings/ClassProperties.ts
@@ -1,5 +1,3 @@
-import { OmitNever } from "./OmitNever";
-
 /**
  * Extracts non-function properties from a class type.
  *
@@ -10,6 +8,12 @@ import { OmitNever } from "./OmitNever";
  * @author Jeongho Nam - https://github.com/samchon
  * @template T Target class type
  */
-export type ClassProperties<T extends object> = OmitNever<{
-  [K in keyof T]: T[K] extends Function ? never : T[K];
-}>;
+export type ClassProperties<T extends object> = {
+  [K in keyof T as [T[K]] extends [never]
+    ? never
+    : [Exclude<T[K], undefined>] extends [never]
+      ? K
+      : Exclude<T[K], undefined> extends Function
+        ? never
+        : K]: T[K];
+};

--- a/packages/interface/src/typings/DeepPartial.ts
+++ b/packages/interface/src/typings/DeepPartial.ts
@@ -15,7 +15,8 @@
  * - **Primitives** (`string`, `number`, `boolean`, `bigint`, `symbol`, `null`,
  *   `undefined`): returned as-is
  * - **Functions**: returned as-is
- * - **Arrays**: element type becomes `DeepPartial<U>`
+ * - **Arrays and tuples**: members become deeply partial while mutability and
+ *   tuple positions are preserved
  * - **Objects**: all properties become optional with `DeepPartial` applied
  *
  * @author Michael - https://github.com/8471919

--- a/packages/interface/src/typings/DeepPartial.ts
+++ b/packages/interface/src/typings/DeepPartial.ts
@@ -30,10 +30,10 @@ export type DeepPartial<T> = T extends
   | null
   | undefined
   ? T
-  : T extends (...args: unknown[]) => unknown
+  : T extends Function
     ? T
-    : T extends Array<infer U>
-      ? Array<DeepPartial<U>>
+    : T extends readonly unknown[]
+      ? { [P in keyof T]: DeepPartial<T[P]> }
       : T extends object
         ? { [P in keyof T]?: DeepPartial<T[P]> }
         : T;

--- a/packages/interface/src/typings/KebabCase.ts
+++ b/packages/interface/src/typings/KebabCase.ts
@@ -76,9 +76,11 @@ type KebabageArray<T extends readonly unknown[]> = {
 /* -----------------------------------------------------------
     STRING CONVERTER
 ----------------------------------------------------------- */
-type KebabageString<Key extends string> = Key extends `${infer _}`
-  ? KebabagePrefix<SnakageStringRepeatedly<Key, "">>
-  : Key;
+type KebabageString<Key extends string> = string extends Key
+  ? string
+  : Key extends `${infer _}`
+    ? KebabagePrefix<SnakageStringRepeatedly<Key, "">>
+    : Key;
 type KebabagePrefix<S extends string> = S extends `_${infer Rest}`
   ? `_${KebabagePrefix<Rest>}`
   : KebabageBody<S>;

--- a/packages/interface/src/typings/KebabCase.ts
+++ b/packages/interface/src/typings/KebabCase.ts
@@ -22,41 +22,51 @@ export type KebabCase<T> = unknown extends T
   ? T
   : object extends T
     ? T
-    : Equal<T, KebabageMain<T>> extends true
-      ? T
-      : KebabageMain<T>;
+    : T extends readonly unknown[]
+      ? KebabageMain<T> // avoid eagerly comparing recursive tuple rest aliases
+      : Equal<T, KebabageMain<T>> extends true
+        ? T
+        : KebabageMain<T>;
 
 /* -----------------------------------------------------------
     OBJECT CONVERSION
 ----------------------------------------------------------- */
 
-type KebabageMain<T> = T extends [never]
+// TupleStack closes recursive tuple rest cycles without limiting other nesting.
+type KebabageMain<T, TupleStack = never> = T extends [never]
   ? never // special trick for (jsonable | null) type
   : T extends { valueOf(): boolean | bigint | number | string }
     ? ValueOf<T>
     : T extends Function
       ? never
       : T extends object
-        ? KebabageObject<T>
+        ? KebabageObject<T, TupleStack>
         : T;
 
-type KebabageObject<T extends object> =
+type KebabageObject<T extends object, TupleStack> =
   T extends Array<infer U>
     ? IsTupleLike<T> extends true
-      ? KebabageArray<T>
-      : Array<KebabageMain<U>>
+      ? T extends TupleStack
+        ? T
+        : KebabageArray<T, TupleStack | T>
+      : Array<KebabageMain<U, TupleStack>>
     : T extends ReadonlyArray<infer U>
       ? IsTupleLike<T> extends true
-        ? KebabageArray<T>
-        : ReadonlyArray<KebabageMain<U>>
+        ? T extends TupleStack
+          ? T
+          : KebabageArray<T, TupleStack | T>
+        : ReadonlyArray<KebabageMain<U, TupleStack>>
       : T extends Set<infer U>
-        ? Set<KebabageMain<U>>
+        ? Set<KebabageMain<U, TupleStack>>
         : T extends Map<infer K, infer V>
-          ? Map<KebabageMain<K>, KebabageMain<V>>
+          ? Map<KebabageMain<K, TupleStack>, KebabageMain<V, TupleStack>>
           : T extends ReadonlyMap<infer K, infer V>
-            ? ReadonlyMap<KebabageMain<K>, KebabageMain<V>>
+            ? ReadonlyMap<
+                KebabageMain<K, TupleStack>,
+                KebabageMain<V, TupleStack>
+              >
             : T extends ReadonlySet<infer U>
-              ? ReadonlySet<KebabageMain<U>>
+              ? ReadonlySet<KebabageMain<U, TupleStack>>
               : T extends WeakSet<any> | WeakMap<any, any>
                 ? never
                 : T extends NativeClass
@@ -66,14 +76,14 @@ type KebabageObject<T extends object> =
                         ? KebabageString<Key>
                         : Key extends number
                           ? Key
-                          : never]: KebabageMain<T[Key]>;
+                          : never]: KebabageMain<T[Key], TupleStack>;
                     };
 
 /* -----------------------------------------------------------
     SPECIAL CASES
 ----------------------------------------------------------- */
-type KebabageArray<T extends readonly unknown[]> = {
-  [P in keyof T]: KebabageMain<T[P]>;
+type KebabageArray<T extends readonly unknown[], TupleStack> = {
+  [P in keyof T]: KebabageMain<T[P], TupleStack>;
 };
 
 /* -----------------------------------------------------------

--- a/packages/interface/src/typings/KebabCase.ts
+++ b/packages/interface/src/typings/KebabCase.ts
@@ -1,4 +1,5 @@
 import { Equal } from "./internal/Equal";
+import { IsBroadString } from "./internal/IsBroadString";
 import { IsTupleLike } from "./internal/IsTupleLike";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
@@ -78,11 +79,12 @@ type KebabageArray<T extends readonly unknown[]> = {
 /* -----------------------------------------------------------
     STRING CONVERTER
 ----------------------------------------------------------- */
-type KebabageString<Key extends string> = string extends Key
-  ? string
-  : Key extends `${infer _}`
-    ? KebabagePrefix<SnakageStringRepeatedly<Key, "">>
-    : Key;
+type KebabageString<Key extends string> =
+  IsBroadString<Key> extends true
+    ? string
+    : Key extends `${infer _}`
+      ? KebabagePrefix<SnakageStringRepeatedly<Key, "">>
+      : Key;
 type KebabagePrefix<S extends string> = S extends `_${infer Rest}`
   ? `_${KebabagePrefix<Rest>}`
   : KebabageBody<S>;

--- a/packages/interface/src/typings/KebabCase.ts
+++ b/packages/interface/src/typings/KebabCase.ts
@@ -61,9 +61,11 @@ type KebabageObject<T extends object> =
                 : T extends NativeClass
                   ? T
                   : {
-                      [Key in keyof T as KebabageString<
-                        Key & string
-                      >]: KebabageMain<T[Key]>;
+                      [Key in keyof T as Key extends string
+                        ? KebabageString<Key>
+                        : Key extends number
+                          ? Key
+                          : never]: KebabageMain<T[Key]>;
                     };
 
 /* -----------------------------------------------------------

--- a/packages/interface/src/typings/KebabCase.ts
+++ b/packages/interface/src/typings/KebabCase.ts
@@ -1,4 +1,5 @@
 import { Equal } from "./internal/Equal";
+import { IsTupleLike } from "./internal/IsTupleLike";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
 
@@ -16,8 +17,13 @@ import { ValueOf } from "./internal/ValueOf";
  * @author Jeongho Nam - https://github.com/samchon
  * @template T Target type to transform
  */
-export type KebabCase<T> =
-  Equal<T, KebabageMain<T>> extends true ? T : KebabageMain<T>;
+export type KebabCase<T> = unknown extends T
+  ? T
+  : object extends T
+    ? T
+    : Equal<T, KebabageMain<T>> extends true
+      ? T
+      : KebabageMain<T>;
 
 /* -----------------------------------------------------------
     OBJECT CONVERSION
@@ -35,46 +41,37 @@ type KebabageMain<T> = T extends [never]
 
 type KebabageObject<T extends object> =
   T extends Array<infer U>
-    ? IsTuple<T> extends true
-      ? KebabageTuple<T>
-      : KebabageMain<U>[]
-    : T extends Set<infer U>
-      ? Set<KebabageMain<U>>
-      : T extends Map<infer K, infer V>
-        ? Map<KebabageMain<K>, KebabageMain<V>>
-        : T extends WeakSet<any> | WeakMap<any, any>
-          ? never
-          : T extends NativeClass
-            ? T
-            : {
-                [Key in keyof T as KebabageString<Key & string>]: KebabageMain<
-                  T[Key]
-                >;
-              };
+    ? IsTupleLike<T> extends true
+      ? KebabageArray<T>
+      : Array<KebabageMain<U>>
+    : T extends ReadonlyArray<infer U>
+      ? IsTupleLike<T> extends true
+        ? KebabageArray<T>
+        : ReadonlyArray<KebabageMain<U>>
+      : T extends Set<infer U>
+        ? Set<KebabageMain<U>>
+        : T extends Map<infer K, infer V>
+          ? Map<KebabageMain<K>, KebabageMain<V>>
+          : T extends ReadonlyMap<infer K, infer V>
+            ? ReadonlyMap<KebabageMain<K>, KebabageMain<V>>
+            : T extends ReadonlySet<infer U>
+              ? ReadonlySet<KebabageMain<U>>
+              : T extends WeakSet<any> | WeakMap<any, any>
+                ? never
+                : T extends NativeClass
+                  ? T
+                  : {
+                      [Key in keyof T as KebabageString<
+                        Key & string
+                      >]: KebabageMain<T[Key]>;
+                    };
 
 /* -----------------------------------------------------------
     SPECIAL CASES
 ----------------------------------------------------------- */
-type IsTuple<T extends readonly any[] | { length: number }> = [T] extends [
-  never,
-]
-  ? false
-  : T extends readonly any[]
-    ? number extends T["length"]
-      ? false
-      : true
-    : false;
-type KebabageTuple<T extends readonly any[]> = T extends []
-  ? []
-  : T extends [infer F]
-    ? [KebabageMain<F>]
-    : T extends [infer F, ...infer Rest extends readonly any[]]
-      ? [KebabageMain<F>, ...KebabageTuple<Rest>]
-      : T extends [(infer F)?]
-        ? [KebabageMain<F>?]
-        : T extends [(infer F)?, ...infer Rest extends readonly any[]]
-          ? [KebabageMain<F>?, ...KebabageTuple<Rest>]
-          : [];
+type KebabageArray<T extends readonly unknown[]> = {
+  [P in keyof T]: KebabageMain<T[P]>;
+};
 
 /* -----------------------------------------------------------
     STRING CONVERTER

--- a/packages/interface/src/typings/PascalCase.ts
+++ b/packages/interface/src/typings/PascalCase.ts
@@ -53,9 +53,11 @@ type PascalizeObject<T extends object> =
                 : T extends NativeClass
                   ? T
                   : {
-                      [Key in keyof T as PascalizeString<
-                        Key & string
-                      >]: PascalizeMain<T[Key]>;
+                      [Key in keyof T as Key extends string
+                        ? PascalizeString<Key>
+                        : Key extends number
+                          ? Key
+                          : never]: PascalizeMain<T[Key]>;
                     };
 
 type PascalizeArray<T extends readonly unknown[]> = {

--- a/packages/interface/src/typings/PascalCase.ts
+++ b/packages/interface/src/typings/PascalCase.ts
@@ -1,4 +1,5 @@
 import { Equal } from "./internal/Equal";
+import { IsBroadString } from "./internal/IsBroadString";
 import { IsTupleLike } from "./internal/IsTupleLike";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
@@ -64,13 +65,14 @@ type PascalizeArray<T extends readonly unknown[]> = {
   [P in keyof T]: PascalizeMain<T[P]>;
 };
 
-type PascalizeString<Key extends string> = string extends Key
-  ? string
-  : Key extends `_${infer R}`
-    ? `_${PascalizeString<R>}`
-    : Key extends `${infer _F}_${infer _R}`
-      ? PascalizeSnakeString<Key>
-      : Capitalize<Key>;
+type PascalizeString<Key extends string> =
+  IsBroadString<Key> extends true
+    ? string
+    : Key extends `_${infer R}`
+      ? `_${PascalizeString<R>}`
+      : Key extends `${infer _F}_${infer _R}`
+        ? PascalizeSnakeString<Key>
+        : Capitalize<Key>;
 type PascalizeSnakeString<Key extends string> = Key extends `_${infer R}`
   ? PascalizeSnakeString<R>
   : Key extends `${infer F}${infer M}_${infer R}`

--- a/packages/interface/src/typings/PascalCase.ts
+++ b/packages/interface/src/typings/PascalCase.ts
@@ -18,37 +18,47 @@ export type PascalCase<T> = unknown extends T
   ? T
   : object extends T
     ? T
-    : Equal<T, PascalizeMain<T>> extends true
-      ? T
-      : PascalizeMain<T>;
+    : T extends readonly unknown[]
+      ? PascalizeMain<T> // avoid eagerly comparing recursive tuple rest aliases
+      : Equal<T, PascalizeMain<T>> extends true
+        ? T
+        : PascalizeMain<T>;
 
-type PascalizeMain<T> = T extends [never]
+// TupleStack closes recursive tuple rest cycles without limiting other nesting.
+type PascalizeMain<T, TupleStack = never> = T extends [never]
   ? never // special trick for (jsonable | null) type
   : T extends { valueOf(): boolean | bigint | number | string }
     ? ValueOf<T>
     : T extends Function
       ? never
       : T extends object
-        ? PascalizeObject<T>
+        ? PascalizeObject<T, TupleStack>
         : T;
 
-type PascalizeObject<T extends object> =
+type PascalizeObject<T extends object, TupleStack> =
   T extends Array<infer U>
     ? IsTupleLike<T> extends true
-      ? PascalizeArray<T>
-      : Array<PascalizeMain<U>>
+      ? T extends TupleStack
+        ? T
+        : PascalizeArray<T, TupleStack | T>
+      : Array<PascalizeMain<U, TupleStack>>
     : T extends ReadonlyArray<infer U>
       ? IsTupleLike<T> extends true
-        ? PascalizeArray<T>
-        : ReadonlyArray<PascalizeMain<U>>
+        ? T extends TupleStack
+          ? T
+          : PascalizeArray<T, TupleStack | T>
+        : ReadonlyArray<PascalizeMain<U, TupleStack>>
       : T extends Set<infer U>
-        ? Set<PascalizeMain<U>>
+        ? Set<PascalizeMain<U, TupleStack>>
         : T extends Map<infer K, infer V>
-          ? Map<PascalizeMain<K>, PascalizeMain<V>>
+          ? Map<PascalizeMain<K, TupleStack>, PascalizeMain<V, TupleStack>>
           : T extends ReadonlyMap<infer K, infer V>
-            ? ReadonlyMap<PascalizeMain<K>, PascalizeMain<V>>
+            ? ReadonlyMap<
+                PascalizeMain<K, TupleStack>,
+                PascalizeMain<V, TupleStack>
+              >
             : T extends ReadonlySet<infer U>
-              ? ReadonlySet<PascalizeMain<U>>
+              ? ReadonlySet<PascalizeMain<U, TupleStack>>
               : T extends WeakSet<any> | WeakMap<any, any>
                 ? never
                 : T extends NativeClass
@@ -58,11 +68,11 @@ type PascalizeObject<T extends object> =
                         ? PascalizeString<Key>
                         : Key extends number
                           ? Key
-                          : never]: PascalizeMain<T[Key]>;
+                          : never]: PascalizeMain<T[Key], TupleStack>;
                     };
 
-type PascalizeArray<T extends readonly unknown[]> = {
-  [P in keyof T]: PascalizeMain<T[P]>;
+type PascalizeArray<T extends readonly unknown[], TupleStack> = {
+  [P in keyof T]: PascalizeMain<T[P], TupleStack>;
 };
 
 type PascalizeString<Key extends string> =

--- a/packages/interface/src/typings/PascalCase.ts
+++ b/packages/interface/src/typings/PascalCase.ts
@@ -62,11 +62,13 @@ type PascalizeArray<T extends readonly unknown[]> = {
   [P in keyof T]: PascalizeMain<T[P]>;
 };
 
-type PascalizeString<Key extends string> = Key extends `_${infer R}`
-  ? `_${PascalizeString<R>}`
-  : Key extends `${infer _F}_${infer _R}`
-    ? PascalizeSnakeString<Key>
-    : Capitalize<Key>;
+type PascalizeString<Key extends string> = string extends Key
+  ? string
+  : Key extends `_${infer R}`
+    ? `_${PascalizeString<R>}`
+    : Key extends `${infer _F}_${infer _R}`
+      ? PascalizeSnakeString<Key>
+      : Capitalize<Key>;
 type PascalizeSnakeString<Key extends string> = Key extends `_${infer R}`
   ? PascalizeSnakeString<R>
   : Key extends `${infer F}${infer M}_${infer R}`

--- a/packages/interface/src/typings/PascalCase.ts
+++ b/packages/interface/src/typings/PascalCase.ts
@@ -1,5 +1,5 @@
 import { Equal } from "./internal/Equal";
-import { IsTuple } from "./internal/IsTuple";
+import { IsTupleLike } from "./internal/IsTupleLike";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
 
@@ -13,8 +13,13 @@ import { ValueOf } from "./internal/ValueOf";
  * @author Jeongho Nam - https://github.com/samchon
  * @template T Target type to transform
  */
-export type PascalCase<T> =
-  Equal<T, PascalizeMain<T>> extends true ? T : PascalizeMain<T>;
+export type PascalCase<T> = unknown extends T
+  ? T
+  : object extends T
+    ? T
+    : Equal<T, PascalizeMain<T>> extends true
+      ? T
+      : PascalizeMain<T>;
 
 type PascalizeMain<T> = T extends [never]
   ? never // special trick for (jsonable | null) type
@@ -28,34 +33,34 @@ type PascalizeMain<T> = T extends [never]
 
 type PascalizeObject<T extends object> =
   T extends Array<infer U>
-    ? IsTuple<T> extends true
-      ? PascalizeTuple<T>
-      : PascalizeMain<U>[]
-    : T extends Set<infer U>
-      ? Set<PascalizeMain<U>>
-      : T extends Map<infer K, infer V>
-        ? Map<PascalizeMain<K>, PascalizeMain<V>>
-        : T extends WeakSet<any> | WeakMap<any, any>
-          ? never
-          : T extends NativeClass
-            ? T
-            : {
-                [Key in keyof T as PascalizeString<
-                  Key & string
-                >]: PascalizeMain<T[Key]>;
-              };
+    ? IsTupleLike<T> extends true
+      ? PascalizeArray<T>
+      : Array<PascalizeMain<U>>
+    : T extends ReadonlyArray<infer U>
+      ? IsTupleLike<T> extends true
+        ? PascalizeArray<T>
+        : ReadonlyArray<PascalizeMain<U>>
+      : T extends Set<infer U>
+        ? Set<PascalizeMain<U>>
+        : T extends Map<infer K, infer V>
+          ? Map<PascalizeMain<K>, PascalizeMain<V>>
+          : T extends ReadonlyMap<infer K, infer V>
+            ? ReadonlyMap<PascalizeMain<K>, PascalizeMain<V>>
+            : T extends ReadonlySet<infer U>
+              ? ReadonlySet<PascalizeMain<U>>
+              : T extends WeakSet<any> | WeakMap<any, any>
+                ? never
+                : T extends NativeClass
+                  ? T
+                  : {
+                      [Key in keyof T as PascalizeString<
+                        Key & string
+                      >]: PascalizeMain<T[Key]>;
+                    };
 
-type PascalizeTuple<T extends readonly any[]> = T extends []
-  ? []
-  : T extends [infer F]
-    ? [PascalizeMain<F>]
-    : T extends [infer F, ...infer Rest extends readonly any[]]
-      ? [PascalizeMain<F>, ...PascalizeTuple<Rest>]
-      : T extends [(infer F)?]
-        ? [PascalizeMain<F>?]
-        : T extends [(infer F)?, ...infer Rest extends readonly any[]]
-          ? [PascalizeMain<F>?, ...PascalizeTuple<Rest>]
-          : [];
+type PascalizeArray<T extends readonly unknown[]> = {
+  [P in keyof T]: PascalizeMain<T[P]>;
+};
 
 type PascalizeString<Key extends string> = Key extends `_${infer R}`
   ? `_${PascalizeString<R>}`

--- a/packages/interface/src/typings/Resolved.ts
+++ b/packages/interface/src/typings/Resolved.ts
@@ -19,45 +19,55 @@ export type Resolved<T> = unknown extends T
   ? T
   : object extends T
     ? T
-    : Equal<T, ResolvedMain<T>> extends true
-      ? T
-      : ResolvedMain<T>;
+    : T extends readonly unknown[]
+      ? ResolvedMain<T> // avoid eagerly comparing recursive tuple rest aliases
+      : Equal<T, ResolvedMain<T>> extends true
+        ? T
+        : ResolvedMain<T>;
 
-type ResolvedMain<T> = T extends [never]
+// TupleStack closes recursive tuple rest cycles without limiting other nesting.
+type ResolvedMain<T, TupleStack = never> = T extends [never]
   ? never // (special trick for jsonable | null) type
   : ValueOf<T> extends boolean | number | bigint | string
     ? ValueOf<T>
     : T extends Function
       ? never
       : T extends object
-        ? ResolvedObject<T>
+        ? ResolvedObject<T, TupleStack>
         : ValueOf<T>;
 
-type ResolvedObject<T extends object> =
+type ResolvedObject<T extends object, TupleStack> =
   T extends Array<infer U>
     ? IsTupleLike<T> extends true
-      ? ResolvedArray<T>
-      : Array<ResolvedMain<U>>
+      ? T extends TupleStack
+        ? T
+        : ResolvedArray<T, TupleStack | T>
+      : Array<ResolvedMain<U, TupleStack>>
     : T extends ReadonlyArray<infer U>
       ? IsTupleLike<T> extends true
-        ? ResolvedArray<T>
-        : ReadonlyArray<ResolvedMain<U>>
+        ? T extends TupleStack
+          ? T
+          : ResolvedArray<T, TupleStack | T>
+        : ReadonlyArray<ResolvedMain<U, TupleStack>>
       : T extends Set<infer U>
-        ? Set<ResolvedMain<U>>
+        ? Set<ResolvedMain<U, TupleStack>>
         : T extends Map<infer K, infer V>
-          ? Map<ResolvedMain<K>, ResolvedMain<V>>
+          ? Map<ResolvedMain<K, TupleStack>, ResolvedMain<V, TupleStack>>
           : T extends ReadonlyMap<infer K, infer V>
-            ? ReadonlyMap<ResolvedMain<K>, ResolvedMain<V>>
+            ? ReadonlyMap<
+                ResolvedMain<K, TupleStack>,
+                ResolvedMain<V, TupleStack>
+              >
             : T extends ReadonlySet<infer U>
-              ? ReadonlySet<ResolvedMain<U>>
+              ? ReadonlySet<ResolvedMain<U, TupleStack>>
               : T extends WeakSet<any> | WeakMap<any, any>
                 ? never
                 : T extends NativeClass
                   ? T
                   : {
-                      [P in keyof T]: ResolvedMain<T[P]>;
+                      [P in keyof T]: ResolvedMain<T[P], TupleStack>;
                     };
 
-type ResolvedArray<T extends readonly unknown[]> = {
-  [P in keyof T]: ResolvedMain<T[P]>;
+type ResolvedArray<T extends readonly unknown[], TupleStack> = {
+  [P in keyof T]: ResolvedMain<T[P], TupleStack>;
 };

--- a/packages/interface/src/typings/Resolved.ts
+++ b/packages/interface/src/typings/Resolved.ts
@@ -1,5 +1,5 @@
 import { Equal } from "./internal/Equal";
-import { IsTuple } from "./internal/IsTuple";
+import { IsTupleLike } from "./internal/IsTupleLike";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
 
@@ -15,8 +15,13 @@ import { ValueOf } from "./internal/ValueOf";
  * @author Kyungsu Kang - https://github.com/kakasoo
  * @template T Target type to resolve
  */
-export type Resolved<T> =
-  Equal<T, ResolvedMain<T>> extends true ? T : ResolvedMain<T>;
+export type Resolved<T> = unknown extends T
+  ? T
+  : object extends T
+    ? T
+    : Equal<T, ResolvedMain<T>> extends true
+      ? T
+      : ResolvedMain<T>;
 
 type ResolvedMain<T> = T extends [never]
   ? never // (special trick for jsonable | null) type
@@ -30,29 +35,29 @@ type ResolvedMain<T> = T extends [never]
 
 type ResolvedObject<T extends object> =
   T extends Array<infer U>
-    ? IsTuple<T> extends true
-      ? ResolvedTuple<T>
-      : ResolvedMain<U>[]
-    : T extends Set<infer U>
-      ? Set<ResolvedMain<U>>
-      : T extends Map<infer K, infer V>
-        ? Map<ResolvedMain<K>, ResolvedMain<V>>
-        : T extends WeakSet<any> | WeakMap<any, any>
-          ? never
-          : T extends NativeClass
-            ? T
-            : {
-                [P in keyof T]: ResolvedMain<T[P]>;
-              };
+    ? IsTupleLike<T> extends true
+      ? ResolvedArray<T>
+      : Array<ResolvedMain<U>>
+    : T extends ReadonlyArray<infer U>
+      ? IsTupleLike<T> extends true
+        ? ResolvedArray<T>
+        : ReadonlyArray<ResolvedMain<U>>
+      : T extends Set<infer U>
+        ? Set<ResolvedMain<U>>
+        : T extends Map<infer K, infer V>
+          ? Map<ResolvedMain<K>, ResolvedMain<V>>
+          : T extends ReadonlyMap<infer K, infer V>
+            ? ReadonlyMap<ResolvedMain<K>, ResolvedMain<V>>
+            : T extends ReadonlySet<infer U>
+              ? ReadonlySet<ResolvedMain<U>>
+              : T extends WeakSet<any> | WeakMap<any, any>
+                ? never
+                : T extends NativeClass
+                  ? T
+                  : {
+                      [P in keyof T]: ResolvedMain<T[P]>;
+                    };
 
-type ResolvedTuple<T extends readonly any[]> = T extends []
-  ? []
-  : T extends [infer F]
-    ? [ResolvedMain<F>]
-    : T extends [infer F, ...infer Rest extends readonly any[]]
-      ? [ResolvedMain<F>, ...ResolvedTuple<Rest>]
-      : T extends [(infer F)?]
-        ? [ResolvedMain<F>?]
-        : T extends [(infer F)?, ...infer Rest extends readonly any[]]
-          ? [ResolvedMain<F>?, ...ResolvedTuple<Rest>]
-          : [];
+type ResolvedArray<T extends readonly unknown[]> = {
+  [P in keyof T]: ResolvedMain<T[P]>;
+};

--- a/packages/interface/src/typings/SnakeCase.ts
+++ b/packages/interface/src/typings/SnakeCase.ts
@@ -57,9 +57,11 @@ type SnakageObject<T extends object> =
                 : T extends NativeClass
                   ? T
                   : {
-                      [Key in keyof T as SnakageString<
-                        Key & string
-                      >]: SnakageMain<T[Key]>;
+                      [Key in keyof T as Key extends string
+                        ? SnakageString<Key>
+                        : Key extends number
+                          ? Key
+                          : never]: SnakageMain<T[Key]>;
                     };
 
 /* -----------------------------------------------------------

--- a/packages/interface/src/typings/SnakeCase.ts
+++ b/packages/interface/src/typings/SnakeCase.ts
@@ -18,41 +18,51 @@ export type SnakeCase<T> = unknown extends T
   ? T
   : object extends T
     ? T
-    : Equal<T, SnakageMain<T>> extends true
-      ? T
-      : SnakageMain<T>;
+    : T extends readonly unknown[]
+      ? SnakageMain<T> // avoid eagerly comparing recursive tuple rest aliases
+      : Equal<T, SnakageMain<T>> extends true
+        ? T
+        : SnakageMain<T>;
 
 /* -----------------------------------------------------------
     OBJECT CONVERSION
 ----------------------------------------------------------- */
 
-type SnakageMain<T> = T extends [never]
+// TupleStack closes recursive tuple rest cycles without limiting other nesting.
+type SnakageMain<T, TupleStack = never> = T extends [never]
   ? never // special trick for (jsonable | null) type
   : T extends { valueOf(): boolean | bigint | number | string }
     ? ValueOf<T>
     : T extends Function
       ? never
       : T extends object
-        ? SnakageObject<T>
+        ? SnakageObject<T, TupleStack>
         : T;
 
-type SnakageObject<T extends object> =
+type SnakageObject<T extends object, TupleStack> =
   T extends Array<infer U>
     ? IsTupleLike<T> extends true
-      ? SnakageArray<T>
-      : Array<SnakageMain<U>>
+      ? T extends TupleStack
+        ? T
+        : SnakageArray<T, TupleStack | T>
+      : Array<SnakageMain<U, TupleStack>>
     : T extends ReadonlyArray<infer U>
       ? IsTupleLike<T> extends true
-        ? SnakageArray<T>
-        : ReadonlyArray<SnakageMain<U>>
+        ? T extends TupleStack
+          ? T
+          : SnakageArray<T, TupleStack | T>
+        : ReadonlyArray<SnakageMain<U, TupleStack>>
       : T extends Set<infer U>
-        ? Set<SnakageMain<U>>
+        ? Set<SnakageMain<U, TupleStack>>
         : T extends Map<infer K, infer V>
-          ? Map<SnakageMain<K>, SnakageMain<V>>
+          ? Map<SnakageMain<K, TupleStack>, SnakageMain<V, TupleStack>>
           : T extends ReadonlyMap<infer K, infer V>
-            ? ReadonlyMap<SnakageMain<K>, SnakageMain<V>>
+            ? ReadonlyMap<
+                SnakageMain<K, TupleStack>,
+                SnakageMain<V, TupleStack>
+              >
             : T extends ReadonlySet<infer U>
-              ? ReadonlySet<SnakageMain<U>>
+              ? ReadonlySet<SnakageMain<U, TupleStack>>
               : T extends WeakSet<any> | WeakMap<any, any>
                 ? never
                 : T extends NativeClass
@@ -62,14 +72,14 @@ type SnakageObject<T extends object> =
                         ? SnakageString<Key>
                         : Key extends number
                           ? Key
-                          : never]: SnakageMain<T[Key]>;
+                          : never]: SnakageMain<T[Key], TupleStack>;
                     };
 
 /* -----------------------------------------------------------
     SPECIAL CASES
 ----------------------------------------------------------- */
-type SnakageArray<T extends readonly unknown[]> = {
-  [P in keyof T]: SnakageMain<T[P]>;
+type SnakageArray<T extends readonly unknown[], TupleStack> = {
+  [P in keyof T]: SnakageMain<T[P], TupleStack>;
 };
 
 /* -----------------------------------------------------------

--- a/packages/interface/src/typings/SnakeCase.ts
+++ b/packages/interface/src/typings/SnakeCase.ts
@@ -72,9 +72,11 @@ type SnakageArray<T extends readonly unknown[]> = {
 /* -----------------------------------------------------------
     STRING CONVERTER
 ----------------------------------------------------------- */
-type SnakageString<Key extends string> = Key extends `${infer _}`
-  ? SnakageStringRepeatedly<Key, "">
-  : Key;
+type SnakageString<Key extends string> = string extends Key
+  ? string
+  : Key extends `${infer _}`
+    ? SnakageStringRepeatedly<Key, "">
+    : Key;
 type SnakageStringRepeatedly<
   S extends string,
   Previous extends string,

--- a/packages/interface/src/typings/SnakeCase.ts
+++ b/packages/interface/src/typings/SnakeCase.ts
@@ -1,4 +1,5 @@
 import { Equal } from "./internal/Equal";
+import { IsTupleLike } from "./internal/IsTupleLike";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
 
@@ -12,8 +13,13 @@ import { ValueOf } from "./internal/ValueOf";
  * @author Jeongho Nam - https://github.com/samchon
  * @template T Target type to transform
  */
-export type SnakeCase<T> =
-  Equal<T, SnakageMain<T>> extends true ? T : SnakageMain<T>;
+export type SnakeCase<T> = unknown extends T
+  ? T
+  : object extends T
+    ? T
+    : Equal<T, SnakageMain<T>> extends true
+      ? T
+      : SnakageMain<T>;
 
 /* -----------------------------------------------------------
     OBJECT CONVERSION
@@ -31,46 +37,37 @@ type SnakageMain<T> = T extends [never]
 
 type SnakageObject<T extends object> =
   T extends Array<infer U>
-    ? IsTuple<T> extends true
-      ? SnakageTuple<T>
-      : SnakageMain<U>[]
-    : T extends Set<infer U>
-      ? Set<SnakageMain<U>>
-      : T extends Map<infer K, infer V>
-        ? Map<SnakageMain<K>, SnakageMain<V>>
-        : T extends WeakSet<any> | WeakMap<any, any>
-          ? never
-          : T extends NativeClass
-            ? T
-            : {
-                [Key in keyof T as SnakageString<Key & string>]: SnakageMain<
-                  T[Key]
-                >;
-              };
+    ? IsTupleLike<T> extends true
+      ? SnakageArray<T>
+      : Array<SnakageMain<U>>
+    : T extends ReadonlyArray<infer U>
+      ? IsTupleLike<T> extends true
+        ? SnakageArray<T>
+        : ReadonlyArray<SnakageMain<U>>
+      : T extends Set<infer U>
+        ? Set<SnakageMain<U>>
+        : T extends Map<infer K, infer V>
+          ? Map<SnakageMain<K>, SnakageMain<V>>
+          : T extends ReadonlyMap<infer K, infer V>
+            ? ReadonlyMap<SnakageMain<K>, SnakageMain<V>>
+            : T extends ReadonlySet<infer U>
+              ? ReadonlySet<SnakageMain<U>>
+              : T extends WeakSet<any> | WeakMap<any, any>
+                ? never
+                : T extends NativeClass
+                  ? T
+                  : {
+                      [Key in keyof T as SnakageString<
+                        Key & string
+                      >]: SnakageMain<T[Key]>;
+                    };
 
 /* -----------------------------------------------------------
     SPECIAL CASES
 ----------------------------------------------------------- */
-type IsTuple<T extends readonly any[] | { length: number }> = [T] extends [
-  never,
-]
-  ? false
-  : T extends readonly any[]
-    ? number extends T["length"]
-      ? false
-      : true
-    : false;
-type SnakageTuple<T extends readonly any[]> = T extends []
-  ? []
-  : T extends [infer F]
-    ? [SnakageMain<F>]
-    : T extends [infer F, ...infer Rest extends readonly any[]]
-      ? [SnakageMain<F>, ...SnakageTuple<Rest>]
-      : T extends [(infer F)?]
-        ? [SnakageMain<F>?]
-        : T extends [(infer F)?, ...infer Rest extends readonly any[]]
-          ? [SnakageMain<F>?, ...SnakageTuple<Rest>]
-          : [];
+type SnakageArray<T extends readonly unknown[]> = {
+  [P in keyof T]: SnakageMain<T[P]>;
+};
 
 /* -----------------------------------------------------------
     STRING CONVERTER

--- a/packages/interface/src/typings/SnakeCase.ts
+++ b/packages/interface/src/typings/SnakeCase.ts
@@ -1,4 +1,5 @@
 import { Equal } from "./internal/Equal";
+import { IsBroadString } from "./internal/IsBroadString";
 import { IsTupleLike } from "./internal/IsTupleLike";
 import { NativeClass } from "./internal/NativeClass";
 import { ValueOf } from "./internal/ValueOf";
@@ -74,11 +75,12 @@ type SnakageArray<T extends readonly unknown[]> = {
 /* -----------------------------------------------------------
     STRING CONVERTER
 ----------------------------------------------------------- */
-type SnakageString<Key extends string> = string extends Key
-  ? string
-  : Key extends `${infer _}`
-    ? SnakageStringRepeatedly<Key, "">
-    : Key;
+type SnakageString<Key extends string> =
+  IsBroadString<Key> extends true
+    ? string
+    : Key extends `${infer _}`
+      ? SnakageStringRepeatedly<Key, "">
+      : Key;
 type SnakageStringRepeatedly<
   S extends string,
   Previous extends string,

--- a/packages/interface/src/typings/SpecialFields.ts
+++ b/packages/interface/src/typings/SpecialFields.ts
@@ -9,5 +9,5 @@
  * @template Target Target value type to match
  */
 export type SpecialFields<Instance extends object, Target> = {
-  [P in keyof Instance]: Instance[P] extends Target ? P : never;
+  [P in keyof Instance]-?: Instance[P] extends Target ? P : never;
 }[keyof Instance];

--- a/packages/interface/src/typings/SpecialFields.ts
+++ b/packages/interface/src/typings/SpecialFields.ts
@@ -10,4 +10,4 @@
  */
 export type SpecialFields<Instance extends object, Target> = {
   [P in keyof Instance]: Instance[P] extends Target ? P : never;
-}[keyof Instance & string];
+}[keyof Instance];

--- a/packages/interface/src/typings/internal/IsBroadString.ts
+++ b/packages/interface/src/typings/internal/IsBroadString.ts
@@ -1,0 +1,6 @@
+/** Tests whether a string type contains an unconstrained template segment. */
+export type IsBroadString<T extends string> = string extends T
+  ? true
+  : T extends `${infer _First}${infer Rest}`
+    ? IsBroadString<Rest>
+    : false;

--- a/packages/interface/src/typings/internal/IsTupleLike.ts
+++ b/packages/interface/src/typings/internal/IsTupleLike.ts
@@ -1,0 +1,11 @@
+/**
+ * Tests whether an array type declares tuple positions.
+ *
+ * Unlike a fixed-length check, this recognizes optional and variadic tuples
+ * through their explicit index keys while excluding homogeneous arrays.
+ */
+export type IsTupleLike<T extends readonly unknown[]> = T extends readonly []
+  ? true
+  : Exclude<keyof T, keyof any[]> extends never
+    ? false
+    : true;

--- a/packages/interface/src/typings/internal/IsTupleLike.ts
+++ b/packages/interface/src/typings/internal/IsTupleLike.ts
@@ -2,7 +2,8 @@
  * Tests whether an array type declares tuple positions.
  *
  * Unlike a fixed-length check, this recognizes optional and variadic tuples
- * through their explicit index keys while excluding homogeneous arrays.
+ * through fixed index keys or a required suffix while excluding homogeneous
+ * arrays.
  */
 export type IsTupleLike<T extends readonly unknown[]> = T extends readonly []
   ? true

--- a/packages/interface/src/typings/internal/IsTupleLike.ts
+++ b/packages/interface/src/typings/internal/IsTupleLike.ts
@@ -6,6 +6,6 @@
  */
 export type IsTupleLike<T extends readonly unknown[]> = T extends readonly []
   ? true
-  : Exclude<keyof T, keyof any[]> extends never
+  : Extract<keyof T, `${number}`> extends never
     ? false
     : true;

--- a/packages/interface/src/typings/internal/IsTupleLike.ts
+++ b/packages/interface/src/typings/internal/IsTupleLike.ts
@@ -7,5 +7,7 @@
 export type IsTupleLike<T extends readonly unknown[]> = T extends readonly []
   ? true
   : Extract<keyof T, `${number}`> extends never
-    ? false
+    ? T extends readonly [...unknown[], unknown]
+      ? true
+      : false
     : true;

--- a/packages/typia/native/cmd/ttsc-typia/notation_dynamic_keys_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/notation_dynamic_keys_transform_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestNotationDynamicKeysTransform verifies dynamic key rewriting and collision rejection.
+//
+// Index signatures use the dynamic object-entry branch rather than statically
+// emitted property assignments. That branch must apply the selected rename to
+// every runtime key and reject two source keys that normalize to one destination
+// before either value is silently lost.
+//
+//  1. Transform direct and factory forms of plain/assert/is/validate operations
+//     for camel, Pascal, snake, and kebab notation.
+//  2. Require valid dynamic and nested keys to use each selected convention.
+//  3. Require every operation form to throw on a dynamic destination collision.
+func TestNotationDynamicKeysTransform(t *testing.T) {
+  project := notationDynamicKeysProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("dynamic notation transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  notationDynamicKeysRunRuntimeCases(t, project, out)
+}
+
+func notationDynamicKeysProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "notation-dynamic-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(notationDynamicKeysTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(notationDynamicKeysSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func notationDynamicKeysRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(notationDynamicKeysRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("dynamic notation runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const notationDynamicKeysTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const notationDynamicKeysSource = `import typia from "typia";
+
+type UnderscoreRecord = Record<string, { inner_key: string }>;
+type CamelRecord = Record<string, { innerValue: string }>;
+
+export const camel = {
+  direct: (input: UnderscoreRecord) => typia.notations.camel<UnderscoreRecord>(input),
+  create: typia.notations.createCamel<UnderscoreRecord>(),
+  assert: (input: unknown) => typia.notations.assertCamel<UnderscoreRecord>(input),
+  createAssert: typia.notations.createAssertCamel<UnderscoreRecord>(),
+  is: (input: unknown) => typia.notations.isCamel<UnderscoreRecord>(input),
+  createIs: typia.notations.createIsCamel<UnderscoreRecord>(),
+  validate: (input: unknown) => typia.notations.validateCamel<UnderscoreRecord>(input),
+  createValidate: typia.notations.createValidateCamel<UnderscoreRecord>(),
+};
+export const pascal = {
+  direct: (input: UnderscoreRecord) => typia.notations.pascal<UnderscoreRecord>(input),
+  create: typia.notations.createPascal<UnderscoreRecord>(),
+  assert: (input: unknown) => typia.notations.assertPascal<UnderscoreRecord>(input),
+  createAssert: typia.notations.createAssertPascal<UnderscoreRecord>(),
+  is: (input: unknown) => typia.notations.isPascal<UnderscoreRecord>(input),
+  createIs: typia.notations.createIsPascal<UnderscoreRecord>(),
+  validate: (input: unknown) => typia.notations.validatePascal<UnderscoreRecord>(input),
+  createValidate: typia.notations.createValidatePascal<UnderscoreRecord>(),
+};
+export const snake = {
+  direct: (input: CamelRecord) => typia.notations.snake<CamelRecord>(input),
+  create: typia.notations.createSnake<CamelRecord>(),
+  assert: (input: unknown) => typia.notations.assertSnake<CamelRecord>(input),
+  createAssert: typia.notations.createAssertSnake<CamelRecord>(),
+  is: (input: unknown) => typia.notations.isSnake<CamelRecord>(input),
+  createIs: typia.notations.createIsSnake<CamelRecord>(),
+  validate: (input: unknown) => typia.notations.validateSnake<CamelRecord>(input),
+  createValidate: typia.notations.createValidateSnake<CamelRecord>(),
+};
+export const kebab = {
+  direct: (input: CamelRecord) => typia.notations.kebab<CamelRecord>(input),
+  create: typia.notations.createKebab<CamelRecord>(),
+  assert: (input: unknown) => typia.notations.assertKebab<CamelRecord>(input),
+  createAssert: typia.notations.createAssertKebab<CamelRecord>(),
+  is: (input: unknown) => typia.notations.isKebab<CamelRecord>(input),
+  createIs: typia.notations.createIsKebab<CamelRecord>(),
+  validate: (input: unknown) => typia.notations.validateKebab<CamelRecord>(input),
+  createValidate: typia.notations.createValidateKebab<CamelRecord>(),
+};
+`
+
+const notationDynamicKeysRuntimeRunner = `const mod = require("./main.cjs");
+
+const families = [
+  {
+    name: "camel",
+    api: mod.camel,
+    valid: { user_id: { inner_key: "u" }, account_name: { inner_key: "a" } },
+    expected: [["userId", "innerKey"], ["accountName", "innerKey"]],
+    collision: { user_id: { inner_key: "a" }, userId: { inner_key: "b" } },
+  },
+  {
+    name: "pascal",
+    api: mod.pascal,
+    valid: { user_id: { inner_key: "u" }, account_name: { inner_key: "a" } },
+    expected: [["UserId", "InnerKey"], ["AccountName", "InnerKey"]],
+    collision: { user_id: { inner_key: "a" }, UserId: { inner_key: "b" } },
+  },
+  {
+    name: "snake",
+    api: mod.snake,
+    valid: { userId: { innerValue: "u" }, accountName: { innerValue: "a" } },
+    expected: [["user_id", "inner_value"], ["account_name", "inner_value"]],
+    collision: { userId: { innerValue: "a" }, user_id: { innerValue: "b" } },
+  },
+  {
+    name: "kebab",
+    api: mod.kebab,
+    valid: { userId: { innerValue: "u" }, account_name: { innerValue: "a" } },
+    expected: [["user-id", "inner-value"], ["account-name", "inner-value"]],
+    collision: { userId: { innerValue: "a" }, user_id: { innerValue: "b" } },
+  },
+];
+const variants = ["direct", "create", "assert", "createAssert", "is", "createIs", "validate", "createValidate"];
+
+for (const family of families) {
+  for (const variant of variants) {
+    const raw = family.api[variant](family.valid);
+    const converted = variant === "validate" || variant === "createValidate"
+      ? raw.success === true ? raw.data : null
+      : raw;
+    if (converted === null) {
+      throw new Error(family.name + "." + variant + " rejected valid dynamic input");
+    }
+    for (const [outer, inner] of family.expected) {
+      if (!Object.hasOwn(converted, outer) || !Object.hasOwn(converted[outer], inner)) {
+        throw new Error(family.name + "." + variant + " kept an unconverted key: " + JSON.stringify(converted));
+      }
+    }
+
+    let collision = null;
+    try {
+      family.api[variant](family.collision);
+    } catch (error) {
+      collision = error;
+    }
+    if (collision === null) {
+      throw new Error(family.name + "." + variant + " silently accepted a destination collision");
+    }
+  }
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/notation_dynamic_keys_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/notation_dynamic_keys_transform_test.go
@@ -105,6 +105,10 @@ const notationDynamicKeysSource = `import typia from "typia";
 
 type UnderscoreRecord = Record<string, { inner_key: string }>;
 type CamelRecord = Record<string, { innerValue: string }>;
+interface SnakeLiteral { "__proto__": { innerValue: string }; }
+
+export const snakeLiteral = (input: SnakeLiteral) =>
+  typia.notations.snake<SnakeLiteral>(input);
 
 export const camel = {
   direct: (input: UnderscoreRecord) => typia.notations.camel<UnderscoreRecord>(input),
@@ -150,6 +154,17 @@ export const kebab = {
 
 const notationDynamicKeysRuntimeRunner = `const mod = require("./main.cjs");
 
+const literalMagic = mod.snakeLiteral(
+  Object.fromEntries([["__proto__", { innerValue: "literal" }]]),
+);
+if (
+  Object.getPrototypeOf(literalMagic) !== Object.prototype ||
+  !Object.hasOwn(literalMagic, "__proto__") ||
+  !Object.hasOwn(literalMagic.__proto__, "inner_value")
+) {
+  throw new Error("snake literal __proto__ was not emitted as an own data property");
+}
+
 const families = [
   {
     name: "camel",
@@ -157,6 +172,7 @@ const families = [
     valid: { user_id: { inner_key: "u" }, account_name: { inner_key: "a" } },
     expected: [["userId", "innerKey"], ["accountName", "innerKey"]],
     collision: { user_id: { inner_key: "a" }, userId: { inner_key: "b" } },
+    collisionKeys: ["user_id", "userId", "userId"],
   },
   {
     name: "pascal",
@@ -164,13 +180,19 @@ const families = [
     valid: { user_id: { inner_key: "u" }, account_name: { inner_key: "a" } },
     expected: [["UserId", "InnerKey"], ["AccountName", "InnerKey"]],
     collision: { user_id: { inner_key: "a" }, UserId: { inner_key: "b" } },
+    collisionKeys: ["user_id", "UserId", "UserId"],
   },
   {
     name: "snake",
     api: mod.snake,
-    valid: { userId: { innerValue: "u" }, accountName: { innerValue: "a" } },
-    expected: [["user_id", "inner_value"], ["account_name", "inner_value"]],
+    valid: Object.fromEntries([
+      ["userId", { innerValue: "u" }],
+      ["accountName", { innerValue: "a" }],
+      ["__proto__", { innerValue: "p" }],
+    ]),
+    expected: [["user_id", "inner_value"], ["account_name", "inner_value"], ["__proto__", "inner_value"]],
     collision: { userId: { innerValue: "a" }, user_id: { innerValue: "b" } },
+    collisionKeys: ["userId", "user_id", "user_id"],
   },
   {
     name: "kebab",
@@ -178,6 +200,7 @@ const families = [
     valid: { userId: { innerValue: "u" }, account_name: { innerValue: "a" } },
     expected: [["user-id", "inner-value"], ["account-name", "inner-value"]],
     collision: { userId: { innerValue: "a" }, user_id: { innerValue: "b" } },
+    collisionKeys: ["userId", "user_id", "user-id"],
   },
 ];
 const variants = ["direct", "create", "assert", "createAssert", "is", "createIs", "validate", "createValidate"];
@@ -191,8 +214,15 @@ for (const family of families) {
     if (converted === null) {
       throw new Error(family.name + "." + variant + " rejected valid dynamic input");
     }
+    if (Object.keys(converted).length !== family.expected.length) {
+      throw new Error(family.name + "." + variant + " emitted unexpected keys: " + JSON.stringify(converted));
+    }
     for (const [outer, inner] of family.expected) {
-      if (!Object.hasOwn(converted, outer) || !Object.hasOwn(converted[outer], inner)) {
+      if (
+        !Object.hasOwn(converted, outer) ||
+        Object.keys(converted[outer]).length !== 1 ||
+        !Object.hasOwn(converted[outer], inner)
+      ) {
         throw new Error(family.name + "." + variant + " kept an unconverted key: " + JSON.stringify(converted));
       }
     }
@@ -205,6 +235,11 @@ for (const family of families) {
     }
     if (collision === null) {
       throw new Error(family.name + "." + variant + " silently accepted a destination collision");
+    }
+    for (const key of family.collisionKeys) {
+      if (!String(collision.message).includes(JSON.stringify(key))) {
+        throw new Error(family.name + "." + variant + " collision omitted " + key + ": " + collision.message);
+      }
     }
   }
 }

--- a/packages/typia/native/cmd/ttsc-typia/notation_dynamic_keys_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/notation_dynamic_keys_transform_test.go
@@ -105,6 +105,8 @@ const notationDynamicKeysSource = `import typia from "typia";
 
 type UnderscoreRecord = Record<string, { inner_key: string }>;
 type CamelRecord = Record<string, { innerValue: string }>;
+type NumericRecord = Record<number, { innerValue: string }>;
+type TemplateRecord = Record<` + "`item_${string}`" + `, { inner_key: string }>;
 interface SnakeLiteral { "__proto__": { innerValue: string }; }
 interface CamelMixed {
   user_id: { inner_key: string };
@@ -115,6 +117,10 @@ export const snakeLiteral = (input: SnakeLiteral) =>
   typia.notations.snake<SnakeLiteral>(input);
 export const mixedCamel = (input: CamelMixed) =>
   typia.notations.camel<CamelMixed>(input);
+export const numericSnake = (input: NumericRecord) =>
+  typia.notations.snake<NumericRecord>(input);
+export const templateCamel = (input: TemplateRecord) =>
+  typia.notations.camel<TemplateRecord>(input);
 
 export const camel = {
   direct: (input: UnderscoreRecord) => typia.notations.camel<UnderscoreRecord>(input),
@@ -187,6 +193,16 @@ for (const key of ["user_id", "userId", "userId"]) {
   if (!String(mixedCollision.message).includes(JSON.stringify(key))) {
     throw new Error("camel mixed collision omitted " + key + ": " + mixedCollision.message);
   }
+}
+
+const numeric = mod.numericSnake({ 7: { innerValue: "numeric" } });
+if (!Object.hasOwn(numeric, "7") || !Object.hasOwn(numeric[7], "inner_value")) {
+  throw new Error("snake numeric index key disagreed with its mapped return type");
+}
+
+const template = mod.templateCamel({ item_user_id: { inner_key: "template" } });
+if (!Object.hasOwn(template, "itemUserId") || !Object.hasOwn(template.itemUserId, "innerKey")) {
+  throw new Error("camel template-literal index key was not converted");
 }
 
 const families = [

--- a/packages/typia/native/cmd/ttsc-typia/notation_dynamic_keys_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/notation_dynamic_keys_transform_test.go
@@ -106,9 +106,15 @@ const notationDynamicKeysSource = `import typia from "typia";
 type UnderscoreRecord = Record<string, { inner_key: string }>;
 type CamelRecord = Record<string, { innerValue: string }>;
 interface SnakeLiteral { "__proto__": { innerValue: string }; }
+interface CamelMixed {
+  user_id: { inner_key: string };
+  [key: string]: { inner_key: string };
+}
 
 export const snakeLiteral = (input: SnakeLiteral) =>
   typia.notations.snake<SnakeLiteral>(input);
+export const mixedCamel = (input: CamelMixed) =>
+  typia.notations.camel<CamelMixed>(input);
 
 export const camel = {
   direct: (input: UnderscoreRecord) => typia.notations.camel<UnderscoreRecord>(input),
@@ -163,6 +169,24 @@ if (
   !Object.hasOwn(literalMagic.__proto__, "inner_value")
 ) {
   throw new Error("snake literal __proto__ was not emitted as an own data property");
+}
+
+let mixedCollision = null;
+try {
+  mod.mixedCamel({
+    user_id: { inner_key: "literal" },
+    userId: { inner_key: "dynamic" },
+  });
+} catch (error) {
+  mixedCollision = error;
+}
+if (mixedCollision === null) {
+  throw new Error("camel mixed literal/dynamic destination collision was accepted");
+}
+for (const key of ["user_id", "userId", "userId"]) {
+  if (!String(mixedCollision.message).includes(JSON.stringify(key))) {
+    throw new Error("camel mixed collision omitted " + key + ": " + mixedCollision.message);
+  }
 }
 
 const families = [

--- a/packages/typia/native/cmd/ttsc-typia/notation_kebab_case_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/notation_kebab_case_transform_test.go
@@ -36,7 +36,7 @@ func TestNotationKebabCaseTransform(t *testing.T) {
   if code != 0 {
     t.Fatalf("kebab notation transform failed: code=%d stderr=\n%s", code, errText)
   }
-  for _, key := range []string{`"user-id"`, `"user-name"`, `"_private-value"`, `xmlparser:`, `"inner-value"`} {
+  for _, key := range []string{`"user-id"`, `"user-name"`, `"_private-value"`, `"xmlparser"`, `"inner-value"`} {
     if !strings.Contains(out, key) {
       t.Fatalf("emitted converter should contain kebab key %s:\n%s", key, out)
     }

--- a/packages/typia/native/cmd/ttsc-typia/notation_literal_collision_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/notation_literal_collision_transform_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestNotationLiteralCollisionTransform verifies static destination collisions are rejected.
+//
+// Literal property metadata exposes every source key during code emission. A
+// converter must reject two distinct literals that normalize to one result
+// instead of emitting duplicate assignments whose last value silently wins.
+//
+//  1. Transform direct and factory plain/assert/is/validate calls for all cases.
+//  2. Give each naming family two literal keys with one normalized destination.
+//  3. Execute every operation and require an error naming both source keys and destination.
+func TestNotationLiteralCollisionTransform(t *testing.T) {
+  project := notationLiteralCollisionProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("literal collision transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  notationLiteralCollisionRunRuntimeCases(t, project, out)
+}
+
+func notationLiteralCollisionProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "notation-literal-collision-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(notationDynamicKeysTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(notationLiteralCollisionSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func notationLiteralCollisionRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(notationLiteralCollisionRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("literal collision runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const notationLiteralCollisionSource = `import typia from "typia";
+
+interface CamelCollision { user_id: string; userId: string; }
+interface PascalCollision { user_id: string; UserId: string; }
+interface SnakeCollision { userId: string; user_id: string; }
+interface KebabCollision { userId: string; user_id: string; }
+
+export const camel = {
+  direct: (input: CamelCollision) => typia.notations.camel<CamelCollision>(input),
+  create: typia.notations.createCamel<CamelCollision>(),
+  assert: (input: unknown) => typia.notations.assertCamel<CamelCollision>(input),
+  createAssert: typia.notations.createAssertCamel<CamelCollision>(),
+  is: (input: unknown) => typia.notations.isCamel<CamelCollision>(input),
+  createIs: typia.notations.createIsCamel<CamelCollision>(),
+  validate: (input: unknown) => typia.notations.validateCamel<CamelCollision>(input),
+  createValidate: typia.notations.createValidateCamel<CamelCollision>(),
+};
+export const pascal = {
+  direct: (input: PascalCollision) => typia.notations.pascal<PascalCollision>(input),
+  create: typia.notations.createPascal<PascalCollision>(),
+  assert: (input: unknown) => typia.notations.assertPascal<PascalCollision>(input),
+  createAssert: typia.notations.createAssertPascal<PascalCollision>(),
+  is: (input: unknown) => typia.notations.isPascal<PascalCollision>(input),
+  createIs: typia.notations.createIsPascal<PascalCollision>(),
+  validate: (input: unknown) => typia.notations.validatePascal<PascalCollision>(input),
+  createValidate: typia.notations.createValidatePascal<PascalCollision>(),
+};
+export const snake = {
+  direct: (input: SnakeCollision) => typia.notations.snake<SnakeCollision>(input),
+  create: typia.notations.createSnake<SnakeCollision>(),
+  assert: (input: unknown) => typia.notations.assertSnake<SnakeCollision>(input),
+  createAssert: typia.notations.createAssertSnake<SnakeCollision>(),
+  is: (input: unknown) => typia.notations.isSnake<SnakeCollision>(input),
+  createIs: typia.notations.createIsSnake<SnakeCollision>(),
+  validate: (input: unknown) => typia.notations.validateSnake<SnakeCollision>(input),
+  createValidate: typia.notations.createValidateSnake<SnakeCollision>(),
+};
+export const kebab = {
+  direct: (input: KebabCollision) => typia.notations.kebab<KebabCollision>(input),
+  create: typia.notations.createKebab<KebabCollision>(),
+  assert: (input: unknown) => typia.notations.assertKebab<KebabCollision>(input),
+  createAssert: typia.notations.createAssertKebab<KebabCollision>(),
+  is: (input: unknown) => typia.notations.isKebab<KebabCollision>(input),
+  createIs: typia.notations.createIsKebab<KebabCollision>(),
+  validate: (input: unknown) => typia.notations.validateKebab<KebabCollision>(input),
+  createValidate: typia.notations.createValidateKebab<KebabCollision>(),
+};
+`
+
+const notationLiteralCollisionRuntimeRunner = `const mod = require("./main.cjs");
+
+const families = [
+  { name: "camel", api: mod.camel, input: { user_id: "a", userId: "b" }, expected: ["user_id", "userId", "userId"] },
+  { name: "pascal", api: mod.pascal, input: { user_id: "a", UserId: "b" }, expected: ["user_id", "UserId", "UserId"] },
+  { name: "snake", api: mod.snake, input: { userId: "a", user_id: "b" }, expected: ["userId", "user_id", "user_id"] },
+  { name: "kebab", api: mod.kebab, input: { userId: "a", user_id: "b" }, expected: ["userId", "user_id", "user-id"] },
+];
+const variants = ["direct", "create", "assert", "createAssert", "is", "createIs", "validate", "createValidate"];
+
+for (const family of families) {
+  for (const variant of variants) {
+    let collision = null;
+    try {
+      family.api[variant](family.input);
+    } catch (error) {
+      collision = error;
+    }
+    if (collision === null) {
+      throw new Error(family.name + "." + variant + " silently accepted a literal destination collision");
+    }
+    for (const key of family.expected) {
+      if (!String(collision.message).includes(JSON.stringify(key))) {
+        throw new Error(family.name + "." + variant + " collision omitted " + key + ": " + collision.message);
+      }
+    }
+  }
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -254,7 +254,12 @@ module.exports._notationAssign = (output, sources, source, value, rename) => {
   const destination = rename(source);
   if (Object.hasOwn(output, destination))
     module.exports._notationKeyCollision(sources[destination], source, destination);
-  output[destination] = value;
+  Object.defineProperty(output, destination, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
   sources[destination] = source;
 };
 module.exports._notationKeyCollision = (first, second, destination) => {

--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -67,6 +67,7 @@ func ttscTypiaTestWriteCommonRuntimeStubs(t *testing.T, runtimeDir string) {
     "functional-error-stub.cjs":  ttscTypiaTestFunctionalErrorStub,
     "access-expression-stub.cjs": ttscTypiaTestAccessExpressionStub,
     "string-length-stub.cjs":     ttscTypiaTestStringLengthStub,
+    "notation-stub.cjs":          ttscTypiaTestNotationStub,
   }
   for name, content := range files {
     if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
@@ -84,6 +85,13 @@ func ttscTypiaTestRewriteCommonJS(t *testing.T, js string) string {
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_functionalTypeGuardErrorFactory")`, `require("./functional-error-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_accessExpressionAsString")`, `require("./access-expression-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_stringLength")`, `require("./string-length-stub.cjs")`)
+  for _, helper := range []string{"_notationAssign", "_notationCamel", "_notationKebab", "_notationKeyCollision", "_notationPascal", "_notationSnake"} {
+    runtimeJS = strings.ReplaceAll(
+      runtimeJS,
+      `require("typia/lib/internal/`+helper+`")`,
+      `require("./notation-stub.cjs")`,
+    )
+  }
   for _, needle := range []string{`require("typia")`, `require('typia')`, `from "typia"`, `from 'typia'`, `typia/lib/internal/`} {
     if strings.Contains(runtimeJS, needle) {
       t.Fatalf("runtime module still contains unresolved typia import %q", needle)
@@ -184,5 +192,75 @@ module.exports._accessExpressionAsString = (key) => {
   return reserved.has(key) === false && /^[A-Za-z_$][0-9A-Za-z_$]*$/.test(key)
     ? "." + key
     : "[" + JSON.stringify(key) + "]";
+};
+`
+
+const ttscTypiaTestNotationStub = `const capitalize = (str) =>
+  str.length === 0 ? str : str[0].toUpperCase() + str.substring(1);
+const unsnake = ({ plain, snake }) => (str) => {
+  let prefix = "";
+  while (str.startsWith("_")) {
+    prefix += "_";
+    str = str.substring(1);
+  }
+  const items = str.split("_").filter((item) => item.length !== 0);
+  if (items.length === 0) return prefix;
+  return prefix + (items.length === 1 ? plain(items[0]) : items.map(snake).join(""));
+};
+const snake = (source) => {
+  if (source.length === 0) return source;
+  let prefix = "";
+  while (source.startsWith("_")) {
+    prefix += "_";
+    source = source.substring(1);
+  }
+  const items = source.split("_");
+  if (items.length > 1) return prefix + items.map((item) => item.toLowerCase()).join("_");
+  const indexes = [];
+  for (let i = 0; i < source.length; i++) {
+    const code = source.charCodeAt(i);
+    if (65 <= code && code <= 90) indexes.push(i);
+  }
+  for (let i = indexes.length - 1; i > 0; --i)
+    if (indexes[i] - indexes[i - 1] === 1) indexes.splice(i, 1);
+  if (indexes[0] === 0) indexes.splice(0, 1);
+  if (indexes.length === 0) return prefix + source.toLowerCase();
+  let output = "";
+  for (let i = 0; i < indexes.length; i++) {
+    output += source.substring(i === 0 ? 0 : indexes[i - 1], indexes[i]).toLowerCase() + "_";
+  }
+  return prefix + output + source.substring(indexes[indexes.length - 1]).toLowerCase();
+};
+
+module.exports._notationCamel = unsnake({
+  plain: (str) => str === str.toUpperCase() ? str.toLowerCase() : str[0].toLowerCase() + str.substring(1),
+  snake: (str, index) => index === 0 ? str.toLowerCase() : capitalize(str.toLowerCase()),
+});
+module.exports._notationPascal = unsnake({
+  plain: capitalize,
+  snake: capitalize,
+});
+module.exports._notationSnake = snake;
+module.exports._notationKebab = (source) => {
+  let snaked = snake(source);
+  let prefix = "";
+  while (snaked.startsWith("_")) {
+    prefix += "_";
+    snaked = snaked.substring(1);
+  }
+  return prefix + snaked.replaceAll("_", "-");
+};
+module.exports._notationAssign = (output, sources, source, value, rename) => {
+  const destination = rename(source);
+  if (Object.hasOwn(output, destination))
+    module.exports._notationKeyCollision(sources[destination], source, destination);
+  output[destination] = value;
+  sources[destination] = source;
+};
+module.exports._notationKeyCollision = (first, second, destination) => {
+  throw new Error(
+    "typia.notations cannot rename both " + JSON.stringify(first) +
+    " and " + JSON.stringify(second) + " to " + JSON.stringify(destination) + ".",
+  );
 };
 `

--- a/packages/typia/native/core/programmers/helpers/NotationJoiner.go
+++ b/packages/typia/native/core/programmers/helpers/NotationJoiner.go
@@ -13,10 +13,13 @@ type notationJoinerNamespace struct{}
 var NotationJoiner = notationJoinerNamespace{}
 
 type NotationJoiner_ObjectProps struct {
-  Rename  func(str string) string
-  Input   *shimast.Expression
-  Entries []IExpressionEntry
-  Emit    *shimprinter.EmitContext
+  Rename         func(str string) string
+  DynamicRename  func() *shimast.Node
+  DynamicAssign  func() *shimast.Node
+  ThrowCollision func(first string, second string, destination string) *shimast.Node
+  Input          *shimast.Expression
+  Entries        []IExpressionEntry
+  Emit           *shimprinter.EmitContext
 }
 
 type NotationJoiner_TupleProps struct {
@@ -48,6 +51,15 @@ func (notationJoinerNamespace) Object(props NotationJoiner_ObjectProps) *shimast
       dynamic = append(dynamic, entry)
     }
   }
+  destinations := map[string]string{}
+  for _, entry := range regular {
+    source := *entry.Key.GetSoleLiteral()
+    destination := props.Rename(source)
+    if previous, ok := destinations[destination]; ok && previous != source {
+      return props.ThrowCollision(previous, source, destination)
+    }
+    destinations[destination] = source
+  }
 
   properties := make([]*shimast.Node, 0, len(regular))
   for _, entry := range regular {
@@ -70,6 +82,7 @@ func (notationJoinerNamespace) Object(props NotationJoiner_ObjectProps) *shimast
 
   key := f.NewIdentifier("key")
   output := f.NewIdentifier("output")
+  sources := f.NewIdentifier("sources")
   statements := []*shimast.Node{}
   if len(regular) != 0 {
     statements = append(statements, notationJoiner_regular_skip(regular, props.Emit))
@@ -89,12 +102,18 @@ func (notationJoinerNamespace) Object(props NotationJoiner_ObjectProps) *shimast
       f.NewBlock(
         f.NewNodeList([]*shimast.Node{
           f.NewExpressionStatement(
-            f.NewBinaryExpression(
+            f.NewCallExpression(
+              props.DynamicAssign(),
               nil,
-              f.NewElementAccessExpression(output, nil, key, shimast.NodeFlagsNone),
               nil,
-              f.NewToken(shimast.KindEqualsToken),
-              entry.Expression,
+              f.NewNodeList([]*shimast.Node{
+                output,
+                sources,
+                key,
+                entry.Expression,
+                props.DynamicRename(),
+              }),
+              shimast.NodeFlagsNone,
             ),
           ),
           f.NewContinueStatement(nil),
@@ -105,30 +124,67 @@ func (notationJoinerNamespace) Object(props NotationJoiner_ObjectProps) *shimast
     ))
   }
 
-  return f.NewBlock(
-    f.NewNodeList([]*shimast.Node{
-      nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
-        Name: "output",
-        Value: f.NewAsExpression(
-          literal,
-          nativefactories.TypeFactory.Keyword("any", props.Emit),
-        ),
-      }, props.Emit),
-      f.NewForInOrOfStatement(
-        shimast.KindForOfStatement,
+  sourceStatements := []*shimast.Node{
+    nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
+      Name: "sources",
+      Value: f.NewCallExpression(
+        f.NewIdentifier("Object.create"),
         nil,
-        nativefactories.StatementFactory.Entry(nativefactories.StatementFactory_EntryProps{Key: "key", Value: "value"}, props.Emit),
-        f.NewCallExpression(
-          f.NewIdentifier("Object.entries"),
+        nil,
+        f.NewNodeList([]*shimast.Node{
+          f.NewKeywordExpression(shimast.KindNullKeyword),
+        }),
+        shimast.NodeFlagsNone,
+      ),
+    }, props.Emit),
+  }
+  for _, entry := range regular {
+    source := *entry.Key.GetSoleLiteral()
+    destination := props.Rename(source)
+    sourceStatements = append(sourceStatements, f.NewExpressionStatement(
+      f.NewBinaryExpression(
+        nil,
+        f.NewElementAccessExpression(
+          sources,
           nil,
-          nil,
-          f.NewNodeList([]*shimast.Node{props.Input}),
+          f.NewStringLiteral(destination, shimast.TokenFlagsNone),
           shimast.NodeFlagsNone,
         ),
-        f.NewBlock(f.NewNodeList(statements), false),
+        nil,
+        f.NewToken(shimast.KindEqualsToken),
+        f.NewStringLiteral(source, shimast.TokenFlagsNone),
       ),
-      f.NewReturnStatement(output),
-    }),
+    ))
+  }
+
+  body := []*shimast.Node{
+    nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
+      Name: "output",
+      Value: f.NewAsExpression(
+        literal,
+        nativefactories.TypeFactory.Keyword("any", props.Emit),
+      ),
+    }, props.Emit),
+  }
+  body = append(body, sourceStatements...)
+  body = append(body,
+    f.NewForInOrOfStatement(
+      shimast.KindForOfStatement,
+      nil,
+      nativefactories.StatementFactory.Entry(nativefactories.StatementFactory_EntryProps{Key: "key", Value: "value"}, props.Emit),
+      f.NewCallExpression(
+        f.NewIdentifier("Object.entries"),
+        nil,
+        nil,
+        f.NewNodeList([]*shimast.Node{props.Input}),
+        shimast.NodeFlagsNone,
+      ),
+      f.NewBlock(f.NewNodeList(statements), false),
+    ),
+    f.NewReturnStatement(output),
+  )
+  return f.NewBlock(
+    f.NewNodeList(body),
     false,
   )
 }

--- a/packages/typia/native/core/programmers/helpers/NotationJoiner.go
+++ b/packages/typia/native/core/programmers/helpers/NotationJoiner.go
@@ -66,7 +66,9 @@ func (notationJoinerNamespace) Object(props NotationJoiner_ObjectProps) *shimast
     str := props.Rename(*entry.Key.GetSoleLiteral())
     properties = append(properties, f.NewPropertyAssignment(
       nil,
-      nativefactories.IdentifierFactory.Identifier(str, props.Emit),
+      f.NewComputedPropertyName(
+        f.NewStringLiteral(str, shimast.TokenFlagsNone),
+      ),
       nil,
       nil,
       entry.Expression,

--- a/packages/typia/native/core/programmers/helpers/joiner_branch_coverage_test.go
+++ b/packages/typia/native/core/programmers/helpers/joiner_branch_coverage_test.go
@@ -52,9 +52,11 @@ func TestJoinerBranchCoverage(t *testing.T) {
 		t.Fatal("clone joiner returned nil")
 	}
 	if NotationJoiner.Object(NotationJoiner_ObjectProps{
-		Rename:  func(str string) string { return str },
-		Input:   input,
-		Entries: entries,
+		Rename:        func(str string) string { return str },
+		DynamicRename: func() *shimast.Node { return factory.NewIdentifier("rename") },
+		DynamicAssign: func() *shimast.Node { return factory.NewIdentifier("assign") },
+		Input:         input,
+		Entries:       entries,
 	}) == nil ||
 		NotationJoiner.Tuple(NotationJoiner_TupleProps{Elements: []*shimast.Expression{value}, Rest: input}) == nil ||
 		NotationJoiner.Array(NotationJoiner_ArrayProps{Input: input, Arrow: value}) == nil {

--- a/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
+++ b/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
@@ -1017,7 +1017,26 @@ func notationGeneralProgrammer_configure(props struct {
       },
       Joiner: func(next nativeinternal.FeatureProgrammer_ObjectorJoinerProps) *shimast.Node {
         return nativehelpers.NotationJoiner.Object(nativehelpers.NotationJoiner_ObjectProps{
-          Rename:  props.Rename.Func,
+          Rename: props.Rename.Func,
+          DynamicRename: func() *shimast.Node {
+            return notationGeneralProgrammer_internal(props.Context, "notation"+notationGeneralProgrammer_capitalize(props.Rename.Name))
+          },
+          DynamicAssign: func() *shimast.Node {
+            return notationGeneralProgrammer_internal(props.Context, "notationAssign")
+          },
+          ThrowCollision: func(first string, second string, destination string) *shimast.Node {
+            return f.NewCallExpression(
+              notationGeneralProgrammer_internal(props.Context, "notationKeyCollision"),
+              nil,
+              nil,
+              f.NewNodeList([]*shimast.Node{
+                f.NewStringLiteral(first, shimast.TokenFlagsNone),
+                f.NewStringLiteral(second, shimast.TokenFlagsNone),
+                f.NewStringLiteral(destination, shimast.TokenFlagsNone),
+              }),
+              shimast.NodeFlagsNone,
+            )
+          },
           Input:   next.Input,
           Entries: next.Entries,
           Emit:    props.Context.Emit,

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.7",
+  "version": "13.1.8",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/src/internal/_notationAny.ts
+++ b/packages/typia/src/internal/_notationAny.ts
@@ -1,3 +1,5 @@
+import { _notationAssign } from "./_notationAssign";
+
 export const _notationAny = (rename: (str: string) => string) => {
   const main = (input: any): any => {
     if (typeof input === "object")
@@ -29,9 +31,12 @@ export const _notationAny = (rename: (str: string) => string) => {
       else return object(input);
     return input;
   };
-  const object = (input: Record<string, any>) =>
-    Object.fromEntries(
-      Object.entries(input).map(([key, value]) => [rename(key), main(value)]),
-    );
+  const object = (input: Record<string, any>) => {
+    const output: Record<string, any> = {};
+    const sources: Record<string, string> = Object.create(null);
+    for (const [key, value] of Object.entries(input))
+      _notationAssign(output, sources, key, main(value), rename);
+    return output;
+  };
   return main;
 };

--- a/packages/typia/src/internal/_notationAssign.ts
+++ b/packages/typia/src/internal/_notationAssign.ts
@@ -10,6 +10,11 @@ export const _notationAssign = (
   const destination: string = rename(source);
   if (Object.hasOwn(output, destination))
     _notationKeyCollision(sources[destination]!, source, destination);
-  output[destination] = value;
+  Object.defineProperty(output, destination, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
   sources[destination] = source;
 };

--- a/packages/typia/src/internal/_notationAssign.ts
+++ b/packages/typia/src/internal/_notationAssign.ts
@@ -1,0 +1,15 @@
+import { _notationKeyCollision } from "./_notationKeyCollision";
+
+export const _notationAssign = (
+  output: Record<string, any>,
+  sources: Record<string, string>,
+  source: string,
+  value: any,
+  rename: (str: string) => string,
+): void => {
+  const destination: string = rename(source);
+  if (Object.hasOwn(output, destination))
+    _notationKeyCollision(sources[destination]!, source, destination);
+  output[destination] = value;
+  sources[destination] = source;
+};

--- a/packages/typia/src/internal/_notationKebab.ts
+++ b/packages/typia/src/internal/_notationKebab.ts
@@ -1,0 +1,11 @@
+import { _notationSnake } from "./_notationSnake";
+
+export const _notationKebab = (str: string): string => {
+  let snaked: string = _notationSnake(str);
+  let prefix: string = "";
+  while (snaked.startsWith("_")) {
+    prefix += "_";
+    snaked = snaked.substring(1);
+  }
+  return `${prefix}${snaked.replaceAll("_", "-")}`;
+};

--- a/packages/typia/src/internal/_notationKeyCollision.ts
+++ b/packages/typia/src/internal/_notationKeyCollision.ts
@@ -1,0 +1,9 @@
+export const _notationKeyCollision = (
+  first: string,
+  second: string,
+  destination: string,
+): never => {
+  throw new Error(
+    `typia.notations cannot rename both ${JSON.stringify(first)} and ${JSON.stringify(second)} to ${JSON.stringify(destination)}.`,
+  );
+};

--- a/packages/typia/src/notations.ts
+++ b/packages/typia/src/notations.ts
@@ -23,7 +23,10 @@ import { NoTransformConfigurationError } from "./transformers/NoTransformConfigu
  * Converts property names to camelCase.
  *
  * Transforms all property names in the object (including nested) to camelCase
- * convention. Creates a new object with renamed properties.
+ * convention. Creates a new object with renamed properties. Distinct source
+ * keys that become the same destination key are rejected with an error instead
+ * of silently discarding a value. This collision policy also applies to the
+ * assert, is, validate, and factory variants.
  *
  * Does not validate the input. For validation, use:
  *
@@ -34,6 +37,7 @@ import { NoTransformConfigurationError } from "./transformers/NoTransformConfigu
  * @template T Type of input value
  * @param input Object to convert
  * @returns New object with camelCase property names
+ * @throws {Error} When two source keys become the same destination key
  */
 export function camel<T>(input: T): CamelCase<T>;
 
@@ -137,7 +141,10 @@ export function validateCamel(): never {
  * Converts property names to PascalCase.
  *
  * Transforms all property names in the object (including nested) to PascalCase
- * convention. Creates a new object with renamed properties.
+ * convention. Creates a new object with renamed properties. Distinct source
+ * keys that become the same destination key are rejected with an error instead
+ * of silently discarding a value. This collision policy also applies to the
+ * assert, is, validate, and factory variants.
  *
  * Does not validate the input. For validation, use:
  *
@@ -148,6 +155,7 @@ export function validateCamel(): never {
  * @template T Type of input value
  * @param input Object to convert
  * @returns New object with PascalCase property names
+ * @throws {Error} When two source keys become the same destination key
  */
 export function pascal<T>(input: T): PascalCase<T>;
 
@@ -251,7 +259,10 @@ export function validatePascal(): never {
  * Converts property names to snake_case.
  *
  * Transforms all property names in the object (including nested) to snake_case
- * convention. Creates a new object with renamed properties.
+ * convention. Creates a new object with renamed properties. Distinct source
+ * keys that become the same destination key are rejected with an error instead
+ * of silently discarding a value. This collision policy also applies to the
+ * assert, is, validate, and factory variants.
  *
  * Does not validate the input. For validation, use:
  *
@@ -262,6 +273,7 @@ export function validatePascal(): never {
  * @template T Type of input value
  * @param input Object to convert
  * @returns New object with snake_case property names
+ * @throws {Error} When two source keys become the same destination key
  */
 export function snake<T>(input: T): SnakeCase<T>;
 
@@ -365,7 +377,10 @@ export function validateSnake(): never {
  * Converts property names to kebab-case.
  *
  * Transforms all property names in the object (including nested) to kebab-case
- * convention. Creates a new object with renamed properties.
+ * convention. Creates a new object with renamed properties. Distinct source
+ * keys that become the same destination key are rejected with an error instead
+ * of silently discarding a value. This collision policy also applies to the
+ * assert, is, validate, and factory variants.
  *
  * Does not validate the input. For validation, use:
  *
@@ -376,6 +391,7 @@ export function validateSnake(): never {
  * @template T Type of input value
  * @param input Object to convert
  * @returns New object with kebab-case property names
+ * @throws {Error} When two source keys become the same destination key
  */
 export function kebab<T>(input: T): KebabCase<T>;
 

--- a/tests/test-interface/src/typings/test_class_properties_optional_methods.ts
+++ b/tests/test-interface/src/typings/test_class_properties_optional_methods.ts
@@ -12,7 +12,8 @@ declare const symbolData: unique symbol;
  * non-function data plus accessors.
  *
  * 1. Declare required and optional functions under all property-key kinds.
- * 2. Mix them with optional data, numeric/symbol data, and an accessor.
+ * 2. Mix them with optional data, numeric/symbol data, an accessor, overloads, and
+ *    inherited members.
  * 3. Require the shallow data-only object with modifiers intact.
  */
 export type ClassPropertiesOptionalMethodCases = [
@@ -21,6 +22,7 @@ export type ClassPropertiesOptionalMethodCases = [
       ClassProperties<Example>,
       {
         value: number;
+        inherited: number;
         optional?: string;
         2: boolean;
         [symbolData]: Date;
@@ -30,7 +32,12 @@ export type ClassPropertiesOptionalMethodCases = [
   >,
 ];
 
-class Example {
+class Parent {
+  inherited = 1;
+  inheritedReset?(): void {}
+}
+
+class Example extends Parent {
   value = 1;
   optional?: string;
   callback?: () => void;
@@ -40,6 +47,11 @@ class Example {
   2 = true;
   [symbolMethod]?(): void {}
   [symbolData] = new Date();
+  convert(value: string): number;
+  convert(value: number): string;
+  convert(value: string | number): string | number {
+    return value;
+  }
   get upper(): string {
     return String(this.value);
   }

--- a/tests/test-interface/src/typings/test_class_properties_optional_methods.ts
+++ b/tests/test-interface/src/typings/test_class_properties_optional_methods.ts
@@ -1,0 +1,54 @@
+import { ClassProperties } from "@typia/interface";
+
+declare const symbolMethod: unique symbol;
+declare const symbolData: unique symbol;
+
+/**
+ * Verifies `ClassProperties<T>` removes optional functions at every key kind.
+ *
+ * Reading an optional method adds `undefined`, so a direct `T[K] extends
+ * Function` predicate retains it. Classification must ignore only absence,
+ * remove function-valued string/number/symbol members, and preserve optional
+ * non-function data plus accessors.
+ *
+ * 1. Declare required and optional functions under all property-key kinds.
+ * 2. Mix them with optional data, numeric/symbol data, and an accessor.
+ * 3. Require the shallow data-only object with modifiers intact.
+ */
+export type ClassPropertiesOptionalMethodCases = [
+  Assert<
+    IsEqual<
+      ClassProperties<Example>,
+      {
+        value: number;
+        optional?: string;
+        2: boolean;
+        [symbolData]: Date;
+        readonly upper: string;
+      }
+    >
+  >,
+];
+
+class Example {
+  value = 1;
+  optional?: string;
+  callback?: () => void;
+  reset?(): void {}
+  0(): void {}
+  1?(): void {}
+  2 = true;
+  [symbolMethod]?(): void {}
+  [symbolData] = new Date();
+  get upper(): string {
+    return String(this.value);
+  }
+}
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-interface/src/typings/test_deep_partial_array_shapes.ts
+++ b/tests/test-interface/src/typings/test_deep_partial_array_shapes.ts
@@ -1,0 +1,49 @@
+import { DeepPartial } from "@typia/interface";
+
+/**
+ * Verifies `DeepPartial<T>` preserves mutable, readonly, and tuple array
+ * shapes.
+ *
+ * Treating every mutable tuple as `Array<infer U>` widens its positions, while
+ * a readonly array misses that branch entirely. Deep recursion must be
+ * homomorphic over each array shape so optional and variadic tuple structure is
+ * retained.
+ *
+ * 1. Recurse through mutable and readonly arrays of nested objects.
+ * 2. Preserve mutable and readonly fixed tuples.
+ * 3. Preserve optional and variadic tuple elements while partializing values.
+ */
+export type DeepPartialArrayShapeCases = [
+  Assert<
+    IsEqual<
+      DeepPartial<Array<{ id: number; child: { name: string } }>>,
+      Array<{ id?: number; child?: { name?: string } }>
+    >
+  >,
+  Assert<
+    IsEqual<
+      DeepPartial<readonly { id: number; child: { name: string } }[]>,
+      readonly { id?: number; child?: { name?: string } }[]
+    >
+  >,
+  Assert<
+    IsEqual<
+      DeepPartial<[{ head_id: number }, { tail_id: number }?]>,
+      [{ head_id?: number }, { tail_id?: number }?]
+    >
+  >,
+  Assert<
+    IsEqual<
+      DeepPartial<readonly [{ head_id: number }, ...{ item_id: number }[]]>,
+      readonly [{ head_id?: number }, ...{ item_id?: number }[]]
+    >
+  >,
+];
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-interface/src/typings/test_deep_partial_callables.ts
+++ b/tests/test-interface/src/typings/test_deep_partial_callables.ts
@@ -1,0 +1,40 @@
+import { DeepPartial } from "@typia/interface";
+
+/**
+ * Verifies `DeepPartial<T>` preserves every callable and construct signature.
+ *
+ * A callable predicate accepting `unknown[]` is narrower than parameterized
+ * functions under strict variance, while constructors are callable only with
+ * `new`. Both categories must pass through unchanged instead of becoming an
+ * optional mapped object.
+ *
+ * 1. Apply `DeepPartial` to parameterized, rest, overloaded, and generic calls.
+ * 2. Apply it to concrete and abstract constructor signatures.
+ * 3. Require exact type identity for every signature.
+ */
+export type DeepPartialCallableCases = [
+  Assert<IsEqual<DeepPartial<Parameterized>, Parameterized>>,
+  Assert<IsEqual<DeepPartial<RestCallable>, RestCallable>>,
+  Assert<IsEqual<DeepPartial<Overloaded>, Overloaded>>,
+  Assert<IsEqual<DeepPartial<Generic>, Generic>>,
+  Assert<IsEqual<DeepPartial<Constructor>, Constructor>>,
+  Assert<IsEqual<DeepPartial<AbstractConstructor>, AbstractConstructor>>,
+];
+
+type Parameterized = (value: string, count?: number) => boolean;
+type RestCallable = (head: string, ...tail: number[]) => string;
+interface Overloaded {
+  (value: string): number;
+  (value: number): string;
+}
+type Generic = <T>(value: T) => T;
+type Constructor = new (value: string) => { value: string };
+type AbstractConstructor = abstract new (value: number) => { value: number };
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-interface/src/typings/test_deep_partial_callables.ts
+++ b/tests/test-interface/src/typings/test_deep_partial_callables.ts
@@ -10,7 +10,7 @@ import { DeepPartial } from "@typia/interface";
  *
  * 1. Apply `DeepPartial` to parameterized, rest, overloaded, and generic calls.
  * 2. Apply it to concrete and abstract constructor signatures.
- * 3. Require exact type identity for every signature.
+ * 3. Preserve the same signatures through nested properties and unions.
  */
 export type DeepPartialCallableCases = [
   Assert<IsEqual<DeepPartial<Parameterized>, Parameterized>>,
@@ -19,6 +19,18 @@ export type DeepPartialCallableCases = [
   Assert<IsEqual<DeepPartial<Generic>, Generic>>,
   Assert<IsEqual<DeepPartial<Constructor>, Constructor>>,
   Assert<IsEqual<DeepPartial<AbstractConstructor>, AbstractConstructor>>,
+  Assert<
+    IsEqual<
+      DeepPartial<{ handler: Parameterized; child: { value: string } }>,
+      { handler?: Parameterized; child?: { value?: string } }
+    >
+  >,
+  Assert<
+    IsEqual<
+      DeepPartial<Parameterized | { value: string }>,
+      Parameterized | { value?: string }
+    >
+  >,
 ];
 
 type Parameterized = (value: string, count?: number) => boolean;

--- a/tests/test-interface/src/typings/test_notation_dynamic_key_types.ts
+++ b/tests/test-interface/src/typings/test_notation_dynamic_key_types.ts
@@ -1,0 +1,46 @@
+import { CamelCase, KebabCase, PascalCase, SnakeCase } from "@typia/interface";
+
+/**
+ * Verifies notation aliases describe recursively converted index signatures.
+ *
+ * Runtime index-signature keys are not present as literals in metadata, but the
+ * mapped return type still exposes a broad string key with converted nested
+ * values. Each naming family must agree with that dynamic runtime shape.
+ *
+ * 1. Declare snake-keyed and camel-keyed string records.
+ * 2. Apply each notation alias to its matching source record.
+ * 3. Require broad string keys and the correctly converted nested value type.
+ */
+export type NotationDynamicKeyTypeCases = [
+  Assert<
+    IsEqual<
+      CamelCase<Record<string, { inner_key: string }>>,
+      Record<string, { innerKey: string }>
+    >
+  >,
+  Assert<PascalDynamicActual extends PascalDynamicExpected ? true : false>,
+  Assert<PascalDynamicExpected extends PascalDynamicActual ? true : false>,
+  Assert<
+    IsEqual<
+      SnakeCase<Record<string, { innerKey: string }>>,
+      Record<string, { inner_key: string }>
+    >
+  >,
+  Assert<
+    IsEqual<
+      KebabCase<Record<string, { innerKey: string }>>,
+      Record<string, { "inner-key": string }>
+    >
+  >,
+];
+
+type PascalDynamicActual = PascalCase<Record<string, { inner_key: string }>>;
+type PascalDynamicExpected = Record<string, { InnerKey: string }>;
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-interface/src/typings/test_notation_dynamic_key_types.ts
+++ b/tests/test-interface/src/typings/test_notation_dynamic_key_types.ts
@@ -55,9 +55,27 @@ export type NotationDynamicKeyTypeCases = [
       Record<number, { "inner-value": string }>
     >
   >,
+  Assert<IsEqual<CamelTemplateActual["itemUserId"], { innerKey: string }>>,
+  Assert<IsEqual<PascalTemplateActual["ItemUserId"], { InnerKey: string }>>,
+  Assert<IsEqual<SnakeTemplateActual["item_user_id"], { inner_value: string }>>,
+  Assert<
+    IsEqual<KebabTemplateActual["item-user-id"], { "inner-value": string }>
+  >,
 ];
 
 type PascalDynamicActual = PascalCase<Record<string, { inner_key: string }>>;
+type CamelTemplateActual = CamelCase<
+  Record<`item_${string}`, { inner_key: string }>
+>;
+type PascalTemplateActual = PascalCase<
+  Record<`item_${string}`, { inner_key: string }>
+>;
+type SnakeTemplateActual = SnakeCase<
+  Record<`item${string}`, { innerValue: string }>
+>;
+type KebabTemplateActual = KebabCase<
+  Record<`item${string}`, { innerValue: string }>
+>;
 
 type Assert<T extends true> = T;
 type IsEqual<X, Y> =

--- a/tests/test-interface/src/typings/test_notation_dynamic_key_types.ts
+++ b/tests/test-interface/src/typings/test_notation_dynamic_key_types.ts
@@ -18,8 +18,7 @@ export type NotationDynamicKeyTypeCases = [
       Record<string, { innerKey: string }>
     >
   >,
-  Assert<PascalDynamicActual extends PascalDynamicExpected ? true : false>,
-  Assert<PascalDynamicExpected extends PascalDynamicActual ? true : false>,
+  Assert<IsEqual<PascalDynamicActual, Record<string, { InnerKey: string }>>>,
   Assert<
     IsEqual<
       SnakeCase<Record<string, { innerKey: string }>>,
@@ -35,7 +34,6 @@ export type NotationDynamicKeyTypeCases = [
 ];
 
 type PascalDynamicActual = PascalCase<Record<string, { inner_key: string }>>;
-type PascalDynamicExpected = Record<string, { InnerKey: string }>;
 
 type Assert<T extends true> = T;
 type IsEqual<X, Y> =

--- a/tests/test-interface/src/typings/test_notation_dynamic_key_types.ts
+++ b/tests/test-interface/src/typings/test_notation_dynamic_key_types.ts
@@ -31,6 +31,30 @@ export type NotationDynamicKeyTypeCases = [
       Record<string, { "inner-key": string }>
     >
   >,
+  Assert<
+    IsEqual<
+      CamelCase<{ 0: { inner_key: string } }>,
+      { 0: { innerKey: string } }
+    >
+  >,
+  Assert<
+    IsEqual<
+      PascalCase<Record<number, { inner_key: string }>>,
+      Record<number, { InnerKey: string }>
+    >
+  >,
+  Assert<
+    IsEqual<
+      SnakeCase<Record<number, { innerValue: string }>>,
+      Record<number, { inner_value: string }>
+    >
+  >,
+  Assert<
+    IsEqual<
+      KebabCase<Record<number, { innerValue: string }>>,
+      Record<number, { "inner-value": string }>
+    >
+  >,
 ];
 
 type PascalDynamicActual = PascalCase<Record<string, { inner_key: string }>>;

--- a/tests/test-interface/src/typings/test_notation_readonly_containers.ts
+++ b/tests/test-interface/src/typings/test_notation_readonly_containers.ts
@@ -8,11 +8,35 @@ import { CamelCase, KebabCase, PascalCase, SnakeCase } from "@typia/interface";
  * array/tuple/set/map mutability and optional or rest tuple positions do not
  * change.
  *
- * 1. Convert readonly arrays and optional/rest tuples in every notation.
- * 2. Convert readonly sets and maps in every notation.
+ * 1. Convert one array/tuple/set/map composite in every notation.
+ * 2. Pin optional-only tuples and mutable sets/maps separately.
  * 3. Keep the transformed nested member keys specific to each naming family.
  */
 export type NotationReadonlyContainerCases = [
+  Assert<
+    IsEqual<
+      CamelCase<ReadonlyContainers<SnakeItem>>,
+      ReadonlyContainers<CamelItem>
+    >
+  >,
+  Assert<
+    IsEqual<
+      PascalCase<ReadonlyContainers<SnakeItem>>,
+      ReadonlyContainers<PascalItem>
+    >
+  >,
+  Assert<
+    IsEqual<
+      SnakeCase<ReadonlyContainers<CamelItem>>,
+      ReadonlyContainers<SnakeItem>
+    >
+  >,
+  Assert<
+    IsEqual<
+      KebabCase<ReadonlyContainers<CamelItem>>,
+      ReadonlyContainers<KebabItem>
+    >
+  >,
   Assert<IsEqual<CamelCase<readonly SnakeItem[]>, readonly CamelItem[]>>,
   Assert<IsEqual<PascalCase<readonly [SnakeItem?]>, readonly [PascalItem?]>>,
   Assert<
@@ -46,6 +70,13 @@ interface PascalItem {
 interface KebabItem {
   "item-id": number;
 }
+
+type ReadonlyContainers<T> = readonly [
+  readonly T[],
+  readonly [T, T?, ...T[]],
+  ReadonlySet<T>,
+  ReadonlyMap<T, T>,
+];
 
 type Assert<T extends true> = T;
 type IsEqual<X, Y> =

--- a/tests/test-interface/src/typings/test_notation_readonly_containers.ts
+++ b/tests/test-interface/src/typings/test_notation_readonly_containers.ts
@@ -3,10 +3,10 @@ import { CamelCase, KebabCase, PascalCase, SnakeCase } from "@typia/interface";
 /**
  * Verifies every notation alias preserves readonly container structure.
  *
- * The four aliases share the same mutable-only container decision. This matrix
- * pins one common contract: recursive key conversion changes member shapes,
- * while array/tuple/set/map mutability and optional or rest tuple positions do
- * not change.
+ * The four aliases share the same container decision tree. This matrix pins one
+ * common contract: recursive key conversion changes member shapes, while
+ * array/tuple/set/map mutability and optional or rest tuple positions do not
+ * change.
  *
  * 1. Convert readonly arrays and optional/rest tuples in every notation.
  * 2. Convert readonly sets and maps in every notation.

--- a/tests/test-interface/src/typings/test_notation_readonly_containers.ts
+++ b/tests/test-interface/src/typings/test_notation_readonly_containers.ts
@@ -1,0 +1,56 @@
+import { CamelCase, KebabCase, PascalCase, SnakeCase } from "@typia/interface";
+
+/**
+ * Verifies every notation alias preserves readonly container structure.
+ *
+ * The four aliases share the same mutable-only container decision. This matrix
+ * pins one common contract: recursive key conversion changes member shapes,
+ * while array/tuple/set/map mutability and optional or rest tuple positions do
+ * not change.
+ *
+ * 1. Convert readonly arrays and optional/rest tuples in every notation.
+ * 2. Convert readonly sets and maps in every notation.
+ * 3. Keep the transformed nested member keys specific to each naming family.
+ */
+export type NotationReadonlyContainerCases = [
+  Assert<IsEqual<CamelCase<readonly SnakeItem[]>, readonly CamelItem[]>>,
+  Assert<IsEqual<PascalCase<readonly [SnakeItem?]>, readonly [PascalItem?]>>,
+  Assert<
+    IsEqual<
+      PascalCase<readonly [SnakeItem, SnakeItem?, ...SnakeItem[]]>,
+      readonly [PascalItem, PascalItem?, ...PascalItem[]]
+    >
+  >,
+  Assert<IsEqual<SnakeCase<ReadonlySet<CamelItem>>, ReadonlySet<SnakeItem>>>,
+  Assert<
+    IsEqual<
+      KebabCase<ReadonlyMap<CamelItem, CamelItem>>,
+      ReadonlyMap<KebabItem, KebabItem>
+    >
+  >,
+  Assert<IsEqual<CamelCase<Set<SnakeItem>>, Set<CamelItem>>>,
+  Assert<
+    IsEqual<SnakeCase<Map<CamelItem, CamelItem>>, Map<SnakeItem, SnakeItem>>
+  >,
+];
+
+interface SnakeItem {
+  item_id: number;
+}
+interface CamelItem {
+  itemId: number;
+}
+interface PascalItem {
+  ItemId: number;
+}
+interface KebabItem {
+  "item-id": number;
+}
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-interface/src/typings/test_omit_never_property_keys.ts
+++ b/tests/test-interface/src/typings/test_omit_never_property_keys.ts
@@ -1,0 +1,39 @@
+import { OmitNever } from "@typia/interface";
+
+declare const removed: unique symbol;
+declare const retained: unique symbol;
+
+/**
+ * Verifies `OmitNever<T>` removes impossible keys of every property-key kind.
+ *
+ * `OmitNever` delegates key discovery to `SpecialFields`, so a string-only
+ * discovery union leaves numeric and unique-symbol `never` properties exposed.
+ * Removing those keys must not disturb neighboring data properties.
+ *
+ * 1. Mix string, number, and symbol `never` properties with ordinary data.
+ * 2. Apply `OmitNever` to the object.
+ * 3. Require only the ordinary string, number, and symbol data keys to remain.
+ */
+export type OmitNeverPropertyKeyCases = [
+  Assert<
+    IsEqual<
+      OmitNever<{
+        impossible: never;
+        0: never;
+        [removed]: never;
+        value: string;
+        1: number;
+        [retained]: boolean;
+      }>,
+      { value: string; 1: number; [retained]: boolean }
+    >
+  >,
+];
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-interface/src/typings/test_resolved_readonly_containers.ts
+++ b/tests/test-interface/src/typings/test_resolved_readonly_containers.ts
@@ -1,0 +1,48 @@
+import { Resolved } from "@typia/interface";
+
+/**
+ * Verifies `Resolved<T>` preserves readonly container and tuple contracts.
+ *
+ * Readonly arrays, sets, and maps do not extend their mutable counterparts, so
+ * mutable-only conditionals expose collection methods as object fields. The
+ * result must remain the same container kind while recursively resolving its
+ * members.
+ *
+ * 1. Resolve mutable and readonly arrays plus fixed and variadic tuples.
+ * 2. Resolve mutable and readonly sets and maps.
+ * 3. Confirm nested methods disappear without losing container readonlyness.
+ */
+export type ResolvedReadonlyContainerCases = [
+  Assert<IsEqual<Resolved<Mutable[]>, Plain[]>>,
+  Assert<IsEqual<Resolved<readonly Mutable[]>, readonly Plain[]>>,
+  Assert<IsEqual<Resolved<readonly [Mutable?]>, readonly [Plain?]>>,
+  Assert<
+    IsEqual<
+      Resolved<readonly [Mutable, Mutable?, ...Mutable[]]>,
+      readonly [Plain, Plain?, ...Plain[]]
+    >
+  >,
+  Assert<IsEqual<Resolved<Set<Mutable>>, Set<Plain>>>,
+  Assert<IsEqual<Resolved<ReadonlySet<Mutable>>, ReadonlySet<Plain>>>,
+  Assert<IsEqual<Resolved<Map<Mutable, Mutable>>, Map<Plain, Plain>>>,
+  Assert<
+    IsEqual<Resolved<ReadonlyMap<Mutable, Mutable>>, ReadonlyMap<Plain, Plain>>
+  >,
+];
+
+interface Mutable {
+  value: number;
+  run(): void;
+}
+interface Plain {
+  value: number;
+  run: never;
+}
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-interface/src/typings/test_resolved_readonly_containers.ts
+++ b/tests/test-interface/src/typings/test_resolved_readonly_containers.ts
@@ -4,16 +4,17 @@ import { Resolved } from "@typia/interface";
  * Verifies `Resolved<T>` preserves readonly container and tuple contracts.
  *
  * Readonly arrays, sets, and maps do not extend their mutable counterparts, so
- * mutable-only conditionals expose collection methods as object fields. The
- * result must remain the same container kind while recursively resolving its
- * members.
+ * mutable-only conditionals expose collection methods as object fields, while
+ * tuple checks based on extra keys mistake tagged arrays for tuples. The result
+ * must remain the same container kind while recursively resolving its members.
  *
- * 1. Resolve mutable and readonly arrays plus fixed and variadic tuples.
+ * 1. Resolve mutable, readonly, and branded arrays plus tuple variants.
  * 2. Resolve mutable and readonly sets and maps.
  * 3. Confirm nested methods disappear without losing container readonlyness.
  */
 export type ResolvedReadonlyContainerCases = [
   Assert<IsEqual<Resolved<Mutable[]>, Plain[]>>,
+  Assert<IsEqual<Resolved<BrandedArray>, string[]>>,
   Assert<IsEqual<Resolved<readonly Mutable[]>, readonly Plain[]>>,
   Assert<IsEqual<Resolved<readonly [Mutable?]>, readonly [Plain?]>>,
   Assert<
@@ -38,6 +39,8 @@ interface Plain {
   value: number;
   run: never;
 }
+
+type BrandedArray = string[] & { readonly __brand?: "array" };
 
 type Assert<T extends true> = T;
 type IsEqual<X, Y> =

--- a/tests/test-interface/src/typings/test_special_fields_property_keys.ts
+++ b/tests/test-interface/src/typings/test_special_fields_property_keys.ts
@@ -23,6 +23,7 @@ export type SpecialFieldsPropertyKeyCases = [
           7: number;
           [match]: number;
           other: string;
+          optional?: string;
           8: string;
           [miss]: string;
         },

--- a/tests/test-interface/src/typings/test_special_fields_property_keys.ts
+++ b/tests/test-interface/src/typings/test_special_fields_property_keys.ts
@@ -1,0 +1,42 @@
+import { SpecialFields } from "@typia/interface";
+
+declare const match: unique symbol;
+declare const miss: unique symbol;
+
+/**
+ * Verifies `SpecialFields<Instance, Target>` selects every property-key kind.
+ *
+ * Indexing the mapped result with `keyof Instance & string` discards numeric
+ * and unique-symbol matches even though the mapped predicate selected them. The
+ * final union must be indexed by the complete source key set.
+ *
+ * 1. Declare matching and non-matching string, number, and symbol properties.
+ * 2. Select the number-valued keys.
+ * 3. Require the exact three-kind key union without false positives.
+ */
+export type SpecialFieldsPropertyKeyCases = [
+  Assert<
+    IsEqual<
+      SpecialFields<
+        {
+          text: number;
+          7: number;
+          [match]: number;
+          other: string;
+          8: string;
+          [miss]: string;
+        },
+        number
+      >,
+      "text" | 7 | typeof match
+    >
+  >,
+];
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-interface/src/typings/test_tuple_helper_recursive_boundaries.ts
+++ b/tests/test-interface/src/typings/test_tuple_helper_recursive_boundaries.ts
@@ -1,0 +1,38 @@
+import {
+  CamelCase,
+  KebabCase,
+  PascalCase,
+  Resolved,
+  SnakeCase,
+} from "@typia/interface";
+
+/**
+ * Verifies homomorphic tuple transforms terminate on recursive rest aliases.
+ *
+ * Preserving a variadic tuple by mapping all of its declared positions can
+ * revisit the tuple through its own rest element. The transformed head must
+ * remain available without making TypeScript expand that recursive path
+ * forever.
+ *
+ * 1. Resolve a recursive tuple and inspect its transformed head.
+ * 2. Apply every notation family to a recursive tuple.
+ * 3. Confirm each notation head is renamed while compilation terminates.
+ */
+export type TupleHelperRecursiveBoundaryCases = [
+  Assert<IsEqual<Resolved<RecursiveResolved>[0], string>>,
+  Assert<IsEqual<keyof CamelCase<RecursiveNotation>[0], "firstValue">>,
+  Assert<IsEqual<keyof PascalCase<RecursiveNotation>[0], "FirstValue">>,
+  Assert<IsEqual<keyof SnakeCase<RecursiveNotation>[0], "first_value">>,
+  Assert<IsEqual<keyof KebabCase<RecursiveNotation>[0], "first-value">>,
+];
+
+type RecursiveResolved = [String, ...RecursiveResolved[]];
+type RecursiveNotation = [{ first_value: String }, ...RecursiveNotation[]];
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-interface/src/typings/test_tuple_helper_variadic_boundaries.ts
+++ b/tests/test-interface/src/typings/test_tuple_helper_variadic_boundaries.ts
@@ -1,4 +1,10 @@
-import { CamelCase, PascalCase, Resolved } from "@typia/interface";
+import {
+  CamelCase,
+  KebabCase,
+  PascalCase,
+  Resolved,
+  SnakeCase,
+} from "@typia/interface";
 
 /**
  * Verifies mapped tuple helpers retain variadic positions and member
@@ -8,14 +14,19 @@ import { CamelCase, PascalCase, Resolved } from "@typia/interface";
  * array. Mapping the complete tuple keeps its required head, repeated middle,
  * and required tail while recursively resolving or renaming each position.
  *
- * 1. Resolve a variadic tuple containing boxed primitive members.
- * 2. Camel-case object members in each variadic position.
- * 3. Pascal-case the same shape without widening it to a union array.
+ * 1. Resolve variadic tuples with required head and suffix positions.
+ * 2. Apply every notation family to a suffix-only variadic tuple.
+ * 3. Preserve mutable and readonly shapes without widening to union arrays.
  */
 export type TupleHelperVariadicBoundaryCases = [
   Assert<IsEqual<ResolvedVariadic, ExpectedResolvedVariadic>>,
+  Assert<IsEqual<ResolvedSuffixVariadic, ExpectedResolvedSuffixVariadic>>,
   Assert<IsEqual<CamelCaseVariadic, ExpectedCamelCaseVariadic>>,
   Assert<IsEqual<PascalCaseVariadic, ExpectedPascalCaseVariadic>>,
+  Assert<IsEqual<CamelCaseSuffixVariadic, ExpectedCamelCaseSuffixVariadic>>,
+  Assert<IsEqual<PascalCaseSuffixVariadic, ExpectedPascalCaseSuffixVariadic>>,
+  Assert<IsEqual<SnakeCaseSuffixVariadic, ExpectedSnakeCaseSuffixVariadic>>,
+  Assert<IsEqual<KebabCaseSuffixVariadic, ExpectedKebabCaseSuffixVariadic>>,
 ];
 
 type Assert<T extends true> = T;
@@ -29,6 +40,8 @@ type IsEqual<X, Y> =
 
 type ResolvedVariadic = Resolved<[Date, ...Number[], Boolean]>;
 type ExpectedResolvedVariadic = [Date, ...number[], boolean];
+type ResolvedSuffixVariadic = Resolved<readonly [...Number[], Boolean]>;
+type ExpectedResolvedSuffixVariadic = readonly [...number[], boolean];
 
 type CamelCaseVariadic = CamelCase<
   [{ first_value: String }, ...Array<{ middle_value: Number }>, IBooleanTail]
@@ -51,3 +64,35 @@ type ExpectedPascalCaseVariadic = [
 interface IBooleanTail {
   final_value: Boolean;
 }
+
+type CamelCaseSuffixVariadic = CamelCase<
+  [...Array<{ middle_value: Number }>, IBooleanTail]
+>;
+type ExpectedCamelCaseSuffixVariadic = [
+  ...Array<{ middleValue: number }>,
+  { finalValue: boolean },
+];
+
+type PascalCaseSuffixVariadic = PascalCase<
+  readonly [...Array<{ middle_value: Number }>, IBooleanTail]
+>;
+type ExpectedPascalCaseSuffixVariadic = readonly [
+  ...Array<{ MiddleValue: number }>,
+  { FinalValue: boolean },
+];
+
+type SnakeCaseSuffixVariadic = SnakeCase<
+  [...Array<{ middleValue: Number }>, { finalValue: Boolean }]
+>;
+type ExpectedSnakeCaseSuffixVariadic = [
+  ...Array<{ middle_value: number }>,
+  { final_value: boolean },
+];
+
+type KebabCaseSuffixVariadic = KebabCase<
+  readonly [...Array<{ middleValue: Number }>, { finalValue: Boolean }]
+>;
+type ExpectedKebabCaseSuffixVariadic = readonly [
+  ...Array<{ "middle-value": number }>,
+  { "final-value": boolean },
+];

--- a/tests/test-interface/src/typings/test_tuple_helper_variadic_boundaries.ts
+++ b/tests/test-interface/src/typings/test_tuple_helper_variadic_boundaries.ts
@@ -1,5 +1,17 @@
 import { CamelCase, PascalCase, Resolved } from "@typia/interface";
 
+/**
+ * Verifies mapped tuple helpers retain variadic positions and member
+ * transforms.
+ *
+ * A variadic tuple has a numeric `length`, but it is not a plain homogeneous
+ * array. Mapping the complete tuple keeps its required head, repeated middle,
+ * and required tail while recursively resolving or renaming each position.
+ *
+ * 1. Resolve a variadic tuple containing boxed primitive members.
+ * 2. Camel-case object members in each variadic position.
+ * 3. Pascal-case the same shape without widening it to a union array.
+ */
 export type TupleHelperVariadicBoundaryCases = [
   Assert<IsEqual<ResolvedVariadic, ExpectedResolvedVariadic>>,
   Assert<IsEqual<CamelCaseVariadic, ExpectedCamelCaseVariadic>>,
@@ -16,21 +28,25 @@ type IsEqual<X, Y> =
     : false;
 
 type ResolvedVariadic = Resolved<[Date, ...Number[], Boolean]>;
-type ExpectedResolvedVariadic = Array<Date | number | boolean>;
+type ExpectedResolvedVariadic = [Date, ...number[], boolean];
 
 type CamelCaseVariadic = CamelCase<
   [{ first_value: String }, ...Array<{ middle_value: Number }>, IBooleanTail]
 >;
-type ExpectedCamelCaseVariadic = Array<
-  { firstValue: string } | { middleValue: number } | { finalValue: boolean }
->;
+type ExpectedCamelCaseVariadic = [
+  { firstValue: string },
+  ...Array<{ middleValue: number }>,
+  { finalValue: boolean },
+];
 
 type PascalCaseVariadic = PascalCase<
   [{ first_value: String }, ...Array<{ middle_value: Number }>, IBooleanTail]
 >;
-type ExpectedPascalCaseVariadic = Array<
-  { FirstValue: string } | { MiddleValue: number } | { FinalValue: boolean }
->;
+type ExpectedPascalCaseVariadic = [
+  { FirstValue: string },
+  ...Array<{ MiddleValue: number }>,
+  { FinalValue: boolean },
+];
 
 interface IBooleanTail {
   final_value: Boolean;

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -364,6 +364,8 @@ Assertion wrappers throw on the first mismatch, `is` / `equals` wrappers return 
 
 Four case converters: `camel`, `pascal`, `snake`, `kebab`. Each one walks the object and rewrites property names to that case at type *and* runtime. Same four-variant family as everywhere else (`name`, `assertName`, `isName`, `validateName`, plus `create*` factories).
 
+Every enumerable string key is converted, including keys supplied by an index signature. If declared literal properties or runtime index-signature entries become the same destination key, every direct and factory variant throws an `Error` naming both source keys and the destination instead of discarding one value. The `isName` and `validateName` variants reserve `null` and `IValidation.IFailure` for input type mismatches; a key collision is a conversion error and still throws.
+
 ### `camel`
 
 ```typescript copy filename="signatures"


### PR DESCRIPTION
## Intent

Restore the published type-utility and notation contracts across mapped types, readonly containers, dynamic key rewriting, and property exclusion.

## Scope

- preserve callable, constructor, readonly-array, and tuple semantics in `DeepPartial`;
- keep `Resolved` and all four notation aliases aligned with mutable and readonly runtime containers;
- rename dynamic notation keys and reject normalized destination collisions without silent data loss;
- make `SpecialFields`, `OmitNever`, and `ClassProperties` honor all property-key kinds and optional methods.

## Deferred

None currently. The tests-first consequence trace may narrow a claim only if the issue contract proves broader than TypeScript or runtime semantics.

## Verification

Pending tests-first implementation and package-scoped local verification. Campaign Actions are intentionally cancelled by exact pushed SHA after each push; repository Actions settings remain enabled and unchanged.

Closes #2048
Closes #2053
Closes #2054
Closes #2055
