### PR TITLE
docs(agents): fill the available runtime pool

### DIFF
--- a/.agents/skills/discussion/SKILL.md
+++ b/.agents/skills/discussion/SKILL.md
@@ -9,7 +9,7 @@ Discussion explores a topic without changing code or turning the exchange into a
 
 ## Team
 
-Form the largest practical team, up to six agents. Give every agent a self-contained brief with the topic, constraints, known evidence, output expectations, and the exact repository instructions and skills to read. Do not give a preferred conclusion or divide the topic into assigned slices.
+Form the largest practical team, up to nine agents so the lead and participants fit the ten-agent session limit. Give every agent a self-contained brief with the topic, constraints, known evidence, output expectations, and the exact repository instructions and skills to read. Do not give a preferred conclusion or divide the topic into assigned slices.
 
 ## Knowledge Base
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -32,7 +32,7 @@ Self-Review does not authorize creating, pushing, updating, or merging a pull re
 
 Use Review Cycle only when the user explicitly asks for a team or multi-agent review.
 
-1. Form the largest practical team, up to six review agents. Give every agent the same complete surface and require an independent complete round. Different analytical lenses are welcome; divided coverage is forbidden.
+1. Form the largest practical team, up to nine review agents so the lead and reviewers fit the ten-agent session limit. Give every agent the same complete surface and require an independent complete round. Different analytical lenses are welcome; divided coverage is forbidden.
 2. Agents submit independent findings to the lead. They do not negotiate a consensus or use discussion transcripts.
 3. The lead independently reproduces and validates every proposal against the repository. Apply only technically sound, in-scope improvements; rewrite, combine, partially accept, or reject proposals as the evidence warrants.
 4. If the lead applies any improvement, replace the team and begin another complete cycle. Stop only after a full cycle yields no accepted improvement.
@@ -49,7 +49,7 @@ The lead validates every proposal and applies the Team Review Cycle stop rule. E
 
 Use issue discovery only as part of the issue-campaign skill.
 
-1. Form the largest practical review team, up to six agents, and apply the briefing rules below. Give every agent the entire campaign scope and require the issue-campaign, project, development, and review skills in its brief.
+1. Form the largest practical review team, up to nine agents so the lead and reviewers fit the ten-agent session limit, and apply the briefing rules below. Give every agent the entire campaign scope and require the issue-campaign, project, development, and review skills in its brief.
 2. Every agent independently audits source, tests, documentation, CI, packaging, generated artifacts, platform behavior, upstream or downstream provenance, and open and closed issue or pull-request history. Audit the current implementation and history against the repository development skill's **Forbidden** section; a verified violation remains a meaningful candidate even when existing tests pass. Never divide the repository by package, file, concern, agent, or round.
 3. Each agent submits its own evidence-backed candidates without discussion or a shared list.
 4. The lead reopens the evidence, reproduces the behavior, checks ownership, provenance, and any claimed **Forbidden** classification, and compares existing issues and pull requests. Reject, rewrite, combine, partially accept, or return a proposal as the evidence requires.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Follow the literal request; it is the contract, not a hint at what the user "rea
 - **Evidence precedes correction.** Treat issue reports, review proposals, and claims that something is wrong or missing as hypotheses. Verify the real code path, tests, generated artifacts, upstream ownership, and history before accepting the premise or changing behavior.
 - **Trace the consequence surface.** A named file or failing case is the starting point, not the investigation boundary. Follow the same cause through downstream consumers, side effects, state transitions, platforms, and boundary cases, then address the whole verified class of failure within the requested goal.
 - **Default over ask.** On an ambiguous detail, pick the sensible default and say what you chose; reserve questions for forks only the user can settle.
+- **Fill the available agent pool when parallel work is independent.** Use up to ten concurrent agents in total, including the lead, when the runtime provides that capacity; keep at most nine child agents active so the lead retains one coordination slot.
 
 ## Skills
 


### PR DESCRIPTION
## Intent

Align repository agent orchestration with the runtime's ten-agent capacity so independent campaign work and complete review rounds can use every available slot.

## Scope

- Define the global pool as ten concurrent agents including the lead.
- Raise team review, issue discovery, and discussion participation to nine child agents so one lead slot remains available.
- Preserve whole-surface independent review and all existing campaign evidence requirements.

## Verification

- `git diff --check`
- Readback of every changed orchestration limit and the lead/child arithmetic.

This administrative contract update was explicitly requested while the issue campaign was active. It does not change product code, package outputs, workflows, or campaign issue behavior.
