### PR TITLE
fix(openapi): enforce object safety invariants

### DIFF
--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -237,7 +237,7 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
-    return metadataCommentTagFactory_TagRecord{"array": {{Name: "UniqueItems", Target: "array", Kind: "uniqueItems", Value: true, Validate: "$input.length <= 1 || (new Set($input).size === $input.length)", Exclusive: true, Schema: map[string]any{"uniqueItems": true}}}}
+    return metadataCommentTagFactory_TagRecord{"array": {{Name: "UniqueItems", Target: "array", Kind: "uniqueItems", Value: true, Validate: "$importInternal(\"isUniqueItems\")($input)", Exclusive: true, Schema: map[string]any{"uniqueItems": true}}}}
   },
   "type": metadataCommentTagFactory_parse_type,
   "minimum": func(props struct {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.3",
+  "version": "13.1.4",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/src/internal/_isUniqueItems.ts
+++ b/packages/typia/src/internal/_isUniqueItems.ts
@@ -1,12 +1,4 @@
 export const _isUniqueItems = (elements: any[]): boolean => {
-  // EMPTY OR ONLY ONE
-  if (elements.length < 2) return true;
-
-  // SHALLOW COMPARISON
-  if (["boolean", "bigint", "number", "string"].includes(typeof elements[0]))
-    return new Set(elements).size === elements.length;
-
-  // DEEP COMPARISON
   for (let i = 0; i < elements.length; i++)
     for (let j = i + 1; j < elements.length; j++)
       if (equals(new WeakMap())(elements[i], elements[j])) return false;
@@ -15,145 +7,149 @@ export const _isUniqueItems = (elements: any[]): boolean => {
 
 const equals = (visited: WeakMap<object, WeakMap<object, boolean>>) => {
   const next = (a: any, b: any): boolean => {
-    // SHALLOW EQUAL
     if (a === b) return true;
-    else if (typeof a !== typeof b || typeof a !== "object") return false;
-    // COMPARE CONTAINERS
-    else if (Array.isArray(a))
-      return Array.isArray(b) && a.map((x, i) => next(x, b[i])).every((x) => x);
-    else if (a instanceof Set)
+    if (
+      a === null ||
+      b === null ||
+      typeof a !== "object" ||
+      typeof b !== "object"
+    )
+      return false;
+
+    const previous: boolean | undefined = visited.get(a)?.get(b);
+    if (previous !== undefined) return previous;
+    const pairs: WeakMap<object, boolean> =
+      visited.get(a) ?? new WeakMap<object, boolean>();
+    visited.set(a, pairs);
+    pairs.set(b, true);
+
+    const result: boolean = compare(a, b);
+    pairs.set(b, result);
+    return result;
+  };
+
+  const compare = (a: object, b: object): boolean => {
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) {
+        const aHas: boolean = Object.hasOwn(a, i);
+        if (aHas !== Object.hasOwn(b, i) || (aHas && !next(a[i], b[i])))
+          return false;
+      }
+      return true;
+    }
+    if (Array.isArray(b)) return false;
+
+    if (a instanceof Set) {
+      if (!(b instanceof Set) || a.size !== b.size) return false;
+      const unmatched: any[] = [...b];
+      for (const value of a) {
+        const index: number = unmatched.findIndex((candidate) =>
+          next(value, candidate),
+        );
+        if (index === -1) return false;
+        unmatched.splice(index, 1);
+      }
+      return true;
+    }
+    if (a instanceof Map) {
+      if (!(b instanceof Map) || a.size !== b.size) return false;
+      const unmatched: [any, any][] = [...b];
+      for (const [key, value] of a) {
+        const index: number = unmatched.findIndex(
+          ([candidateKey, candidateValue]) =>
+            next(key, candidateKey) && next(value, candidateValue),
+        );
+        if (index === -1) return false;
+        unmatched.splice(index, 1);
+      }
+      return true;
+    }
+
+    if (a instanceof Boolean)
+      return b instanceof Boolean && a.valueOf() === b.valueOf();
+    if (Object.prototype.toString.call(a) === "[object BigInt]")
       return (
-        b instanceof Set && a.size === b.size && [...a].every((x) => b.has(x))
+        Object.prototype.toString.call(b) === "[object BigInt]" &&
+        a.valueOf() === b.valueOf()
       );
-    else if (a instanceof Map)
+    if (Object.prototype.toString.call(a) === "[object Symbol]")
       return (
-        b instanceof Map &&
-        a.size === b.size &&
-        [...a].every(([k, v]) => b.has(k) && next(v, b.get(k)))
+        Object.prototype.toString.call(b) === "[object Symbol]" &&
+        a.valueOf() === b.valueOf()
       );
-    // ATOMIC CLASSES
-    else if (a instanceof Boolean)
-      return b instanceof Boolean
-        ? a.valueOf() === b.valueOf()
-        : a.valueOf() === b;
-    else if (a instanceof BigInt)
-      return b instanceof BigInt ? a === b : a === BigInt(b);
-    else if (a instanceof Number)
-      return b instanceof Number
-        ? a.valueOf() === b.valueOf()
-        : a.valueOf() === b;
-    else if (a instanceof String)
-      return b instanceof String
-        ? a.valueOf() === b.valueOf()
-        : a.valueOf() === b;
-    else if (a instanceof Date)
+    if (a instanceof Number)
+      return b instanceof Number && a.valueOf() === b.valueOf();
+    if (a instanceof String)
+      return b instanceof String && a.valueOf() === b.valueOf();
+    if (a instanceof Date)
       return b instanceof Date && a.getTime() === b.getTime();
-    // BINARY DATA
-    else if (a instanceof Uint8Array)
+    if (a instanceof RegExp)
       return (
-        b instanceof Uint8Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
+        b instanceof RegExp && a.source === b.source && a.flags === b.flags
       );
-    else if (a instanceof Uint8ClampedArray)
-      return (
-        b instanceof Uint8ClampedArray &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Uint16Array)
-      return (
-        b instanceof Uint16Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Uint32Array)
-      return (
-        b instanceof Uint32Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof BigUint64Array)
-      return (
-        b instanceof BigUint64Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Int8Array)
-      return (
-        b instanceof Int8Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Int16Array)
-      return (
-        b instanceof Int16Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Int32Array)
-      return (
-        b instanceof Int32Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof BigInt64Array)
-      return (
-        b instanceof BigInt64Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Float32Array)
-      return (
-        b instanceof Float32Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Float64Array)
-      return (
-        b instanceof Float64Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof ArrayBuffer) {
-      if (!(b instanceof ArrayBuffer) || a.byteLength !== b.byteLength)
-        return false;
-      const x: Uint8Array = new Uint8Array(a);
-      const y: Uint8Array = new Uint8Array(b);
-      return x.every((v, i) => v === y[i]);
-    } else if (a instanceof SharedArrayBuffer) {
-      if (!(b instanceof SharedArrayBuffer) || a.byteLength !== b.byteLength)
-        return false;
-      const x: Uint8Array = new Uint8Array(a);
-      const y: Uint8Array = new Uint8Array(b);
-      return x.every((v, i) => v === y[i]);
-    } else if (a instanceof DataView) {
-      if (!(b instanceof DataView) || a.byteLength !== b.byteLength)
-        return false;
-      const x: Uint8Array = new Uint8Array(a.buffer);
-      const y: Uint8Array = new Uint8Array(b.buffer);
-      return x.every((v, i) => v === y[i]);
-    } else if (a instanceof File)
+
+    if (typeof File !== "undefined" && a instanceof File)
       return (
         b instanceof File &&
         a.name === b.name &&
         a.size === b.size &&
         a.type === b.type &&
-        next(a.slice(), b.slice())
+        a.lastModified === b.lastModified
       );
-    // JUST PLAIN OBJECTS
-    else if (a !== null && b !== null) {
-      if (visited.has(a) && visited.get(a)!.has(b))
-        return visited.get(a)!.get(b)!;
-      if (!visited.has(a)) visited.set(a, new WeakMap());
-      visited.get(a)!.set(b, true);
-      const res: boolean =
-        Object.keys(a).length === Object.keys(b).length &&
-        Object.keys(a).every((x) => next(a[x], b[x]));
-      visited.get(a)!.set(b, res);
-      return res;
+    if (typeof Blob !== "undefined" && a instanceof Blob)
+      return b instanceof Blob && a.size === b.size && a.type === b.type;
+
+    if (a instanceof DataView) {
+      if (!(b instanceof DataView) || a.byteLength !== b.byteLength)
+        return false;
+      return bytes(a.buffer, a.byteOffset, a.byteLength).every(
+        (value, index) =>
+          value === bytes(b.buffer, b.byteOffset, b.byteLength)[index],
+      );
     }
-    return false;
+    if (ArrayBuffer.isView(a)) {
+      if (
+        !ArrayBuffer.isView(b) ||
+        b instanceof DataView ||
+        Object.getPrototypeOf(a) !== Object.getPrototypeOf(b) ||
+        a.byteLength !== b.byteLength
+      )
+        return false;
+      const x: Uint8Array = bytes(a.buffer, a.byteOffset, a.byteLength);
+      const y: Uint8Array = bytes(b.buffer, b.byteOffset, b.byteLength);
+      return x.every((value, index) => value === y[index]);
+    }
+    if (a instanceof ArrayBuffer)
+      return (
+        b instanceof ArrayBuffer &&
+        a.byteLength === b.byteLength &&
+        bytes(a).every((value, index) => value === bytes(b)[index])
+      );
+    if (
+      typeof SharedArrayBuffer !== "undefined" &&
+      a instanceof SharedArrayBuffer
+    )
+      return (
+        b instanceof SharedArrayBuffer &&
+        a.byteLength === b.byteLength &&
+        bytes(a).every((value, index) => value === bytes(b)[index])
+      );
+
+    const keys: string[] = Object.keys(a);
+    return (
+      keys.length === Object.keys(b).length &&
+      keys.every(
+        (key) =>
+          Object.hasOwn(b, key) && next((a as any)[key], (b as any)[key]),
+      )
+    );
   };
   return next;
 };
+
+const bytes = (
+  buffer: ArrayBufferLike,
+  byteOffset: number = 0,
+  byteLength: number = buffer.byteLength,
+): Uint8Array => new Uint8Array(buffer, byteOffset, byteLength);

--- a/packages/typia/src/internal/_isUniqueItems.ts
+++ b/packages/typia/src/internal/_isUniqueItems.ts
@@ -136,12 +136,18 @@ const equals = (visited: WeakMap<object, WeakMap<object, boolean>>) => {
         bytes(a).every((value, index) => value === bytes(b)[index])
       );
 
-    const keys: string[] = Object.keys(a);
+    const keys: PropertyKey[] = Reflect.ownKeys(a).filter((key) =>
+      Object.prototype.propertyIsEnumerable.call(a, key),
+    );
     return (
-      keys.length === Object.keys(b).length &&
+      keys.length ===
+        Reflect.ownKeys(b).filter((key) =>
+          Object.prototype.propertyIsEnumerable.call(b, key),
+        ).length &&
       keys.every(
         (key) =>
-          Object.hasOwn(b, key) && next((a as any)[key], (b as any)[key]),
+          Object.prototype.propertyIsEnumerable.call(b, key) &&
+          next((a as any)[key], (b as any)[key]),
       )
     );
   };

--- a/packages/typia/src/internal/_randomArray.ts
+++ b/packages/typia/src/internal/_randomArray.ts
@@ -36,7 +36,8 @@ export const _randomArray = <T>(
         "Unable to generate enough unique items; the element domain may be too small.",
       );
     const candidate: T = props.element(elements.length, count);
-    if (_isUniqueItems([...elements, candidate])) elements.push(candidate);
+    if (elements.every((element) => _isUniqueItems([element, candidate])))
+      elements.push(candidate);
   }
   return elements;
 };

--- a/packages/typia/src/internal/_randomArray.ts
+++ b/packages/typia/src/internal/_randomArray.ts
@@ -1,5 +1,6 @@
 import type { OpenApi } from "@typia/interface";
 
+import { _isUniqueItems } from "./_isUniqueItems";
 import { _randomInteger } from "./_randomInteger";
 
 const DEFAULT_MIN_ITEMS = 1;
@@ -27,8 +28,15 @@ export const _randomArray = <T>(
   });
   if (props.uniqueItems !== true)
     return new Array(count).fill(null).map((_, i) => props.element(i, count));
-  const elements: Set<any> = new Set();
-  while (elements.size !== count)
-    elements.add(props.element(elements.size, count));
-  return Array.from(elements);
+  const elements: T[] = [];
+  const maximumAttempts: number = count * 100 + 1000;
+  for (let attempts = 0; elements.length !== count; attempts++) {
+    if (attempts === maximumAttempts)
+      throw new Error(
+        "Unable to generate enough unique items; the element domain may be too small.",
+      );
+    const candidate: T = props.element(elements.length, count);
+    if (_isUniqueItems([...elements, candidate])) elements.push(candidate);
+  }
+  return elements;
 };

--- a/packages/utils/src/converters/LlmSchemaConverter.ts
+++ b/packages/utils/src/converters/LlmSchemaConverter.ts
@@ -78,7 +78,7 @@ export namespace LlmSchemaConverter {
     });
     if (entity.success === false) return entity;
 
-    const $defs: Record<string, ILlmSchema> = ObjectDictionary.create();
+    const $defs: Record<string, ILlmSchema> = {};
     const result: IResult<ILlmSchema, IJsonSchemaTransformError> = transform({
       ...props,
       config,
@@ -514,7 +514,7 @@ export namespace LlmSchemaConverter {
         const key: string =
           schema.$ref.split("#/$defs/")[1] ?? schema.$ref.split("/").at(-1)!;
         if (ObjectDictionary.get(props.components.schemas, key) === undefined) {
-          props.components.schemas ??= ObjectDictionary.create();
+          props.components.schemas ??= {};
           ObjectDictionary.set(props.components.schemas, key, {});
           ObjectDictionary.set(
             props.components.schemas,

--- a/packages/utils/src/converters/LlmSchemaConverter.ts
+++ b/packages/utils/src/converters/LlmSchemaConverter.ts
@@ -7,6 +7,7 @@ import {
 } from "@typia/interface";
 
 import { JsonDescriptor } from "../utils/internal/JsonDescriptor";
+import { ObjectDictionary } from "../utils/internal/ObjectDictionary";
 import { OpenApiSchemaSanitizer } from "../utils/internal/OpenApiSchemaSanitizer";
 import { LlmTypeChecker } from "../validators/LlmTypeChecker";
 import { OpenApiTypeChecker } from "../validators/OpenApiTypeChecker";
@@ -77,7 +78,7 @@ export namespace LlmSchemaConverter {
     });
     if (entity.success === false) return entity;
 
-    const $defs: Record<string, ILlmSchema> = {};
+    const $defs: Record<string, ILlmSchema> = ObjectDictionary.create();
     const result: IResult<ILlmSchema, IJsonSchemaTransformError> = transform({
       ...props,
       config,
@@ -178,7 +179,7 @@ export namespace LlmSchemaConverter {
           const key: string =
             next.$ref.split("#/components/schemas/")[1] ??
             next.$ref.split("/").at(-1)!;
-          if (props.components.schemas?.[key] === undefined)
+          if (ObjectDictionary.get(props.components.schemas, key) === undefined)
             reasons.push({
               schema: next,
               accessor: accessor,
@@ -234,8 +235,10 @@ export namespace LlmSchemaConverter {
         const key: string =
           input.$ref.split("#/components/schemas/")[1] ??
           input.$ref.split("/").at(-1)!;
-        const target: OpenApi.IJsonSchema | undefined =
-          props.components.schemas?.[key];
+        const target: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+          props.components.schemas,
+          key,
+        );
         if (target === undefined) return;
         else {
           // KEEP THE REFERENCE TYPE
@@ -245,9 +248,9 @@ export namespace LlmSchemaConverter {
               $ref: `#/$defs/${key}`,
             });
           };
-          if (props.$defs[key] !== undefined) return out();
+          if (ObjectDictionary.has(props.$defs, key)) return out();
 
-          props.$defs[key] = {};
+          ObjectDictionary.set(props.$defs, key, {});
           const converted: IResult<ILlmSchema, IJsonSchemaTransformError> =
             transform({
               config: props.config,
@@ -258,7 +261,7 @@ export namespace LlmSchemaConverter {
               accessor: `${props.refAccessor ?? "$def"}[${JSON.stringify(key)}]`,
             });
           if (converted.success === false) return; // UNREACHABLE
-          props.$defs[key] = converted.value;
+          ObjectDictionary.set(props.$defs, key, converted.value);
           return out();
         }
       } else if (OpenApiTypeChecker.isObject(input)) {
@@ -510,10 +513,14 @@ export namespace LlmSchemaConverter {
       else if (LlmTypeChecker.isReference(schema)) {
         const key: string =
           schema.$ref.split("#/$defs/")[1] ?? schema.$ref.split("/").at(-1)!;
-        if (props.components.schemas?.[key] === undefined) {
-          props.components.schemas ??= {};
-          props.components.schemas[key] = {};
-          props.components.schemas[key] = next(props.$defs[key] ?? {});
+        if (ObjectDictionary.get(props.components.schemas, key) === undefined) {
+          props.components.schemas ??= ObjectDictionary.create();
+          ObjectDictionary.set(props.components.schemas, key, {});
+          ObjectDictionary.set(
+            props.components.schemas,
+            key,
+            next(ObjectDictionary.get(props.$defs, key) ?? {}),
+          );
         }
         union.push({
           ...schema,

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -1,5 +1,6 @@
 import { OpenApi, OpenApiV3 } from "@typia/interface";
 
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { OpenApiDiscriminatorConverter } from "./OpenApiDiscriminatorConverter";
 
@@ -204,8 +205,11 @@ export namespace OpenApiV3Downgrader {
       collection.downgraded.schemas = {};
       for (const [key, value] of Object.entries(input.schemas))
         if (value !== undefined)
-          collection.downgraded.schemas[key] =
-            downgradeSchema(collection)(value);
+          ObjectDictionary.set(
+            collection.downgraded.schemas,
+            key,
+            downgradeSchema(collection)(value),
+          );
     }
     return collection;
   };
@@ -363,36 +367,47 @@ export namespace OpenApiV3Downgrader {
       const key: string = schema.$ref.split("/").pop()!;
       if (key.endsWith(".Nullable")) return;
 
-      const found: OpenApi.IJsonSchema | undefined =
-        collection.original.schemas?.[key];
+      const found: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+        collection.original.schemas,
+        key,
+      );
       if (found === undefined) return;
       else if (isNullable(visited)(collection.original)(found) === true) return;
       else if (
-        collection.downgraded.schemas?.[`${key}.Nullable`] === undefined
+        ObjectDictionary.get(
+          collection.downgraded.schemas,
+          `${key}.Nullable`,
+        ) === undefined
       ) {
         collection.downgraded.schemas ??= {};
-        collection.downgraded.schemas[`${key}.Nullable`] = {};
-        collection.downgraded.schemas[`${key}.Nullable`] = downgradeSchema(
-          collection,
-        )(
-          OpenApiTypeChecker.isOneOf(found)
-            ? {
-                ...found,
-                oneOf: [...found.oneOf, { type: "null" }],
-              }
-            : {
-                oneOf: [found, { type: "null" }],
-                title: found.title,
-                description: found.description,
-                example: found.example,
-                examples: found.examples,
-                ...Object.fromEntries(
-                  Object.entries(found).filter(
-                    ([key, value]) =>
-                      key.startsWith("x-") && value !== undefined,
+        ObjectDictionary.set(
+          collection.downgraded.schemas,
+          `${key}.Nullable`,
+          {},
+        );
+        ObjectDictionary.set(
+          collection.downgraded.schemas,
+          `${key}.Nullable`,
+          downgradeSchema(collection)(
+            OpenApiTypeChecker.isOneOf(found)
+              ? {
+                  ...found,
+                  oneOf: [...found.oneOf, { type: "null" }],
+                }
+              : {
+                  oneOf: [found, { type: "null" }],
+                  title: found.title,
+                  description: found.description,
+                  example: found.example,
+                  examples: found.examples,
+                  ...Object.fromEntries(
+                    Object.entries(found).filter(
+                      ([key, value]) =>
+                        key.startsWith("x-") && value !== undefined,
+                    ),
                   ),
-                ),
-              },
+                },
+          ),
         );
       }
       schema.$ref += ".Nullable";
@@ -414,7 +429,10 @@ export namespace OpenApiV3Downgrader {
         if (visited.has(schema.$ref)) return false;
         visited.add(schema.$ref);
         const key: string = schema.$ref.split("/").pop()!;
-        const next: OpenApi.IJsonSchema | undefined = components.schemas?.[key];
+        const next: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+          components.schemas,
+          key,
+        );
         return next ? isNullable(visited)(components)(next) : false;
       }
       return (

--- a/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Upgrader.ts
@@ -1,5 +1,6 @@
 import { IJsonSchemaAttribute, OpenApi, OpenApiV3 } from "@typia/interface";
 
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { OpenApiV3TypeChecker } from "../../validators/OpenApiV3TypeChecker";
 import { OpenApiDiscriminatorConverter } from "./OpenApiDiscriminatorConverter";
@@ -567,7 +568,10 @@ export namespace OpenApiV3Upgrader {
 
       if (OpenApiV3TypeChecker.isReference(input))
         return retrieveObject(components)(
-          components.schemas?.[input.$ref.split("/").pop() ?? ""] ?? {},
+          ObjectDictionary.get(
+            components.schemas,
+            input.$ref.split("/").pop() ?? "",
+          ) ?? {},
           visited,
         );
       return null;

--- a/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Downgrader.ts
@@ -1,5 +1,6 @@
 import { OpenApi, OpenApiV3_1 } from "@typia/interface";
 
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { OpenApiDiscriminatorConverter } from "./OpenApiDiscriminatorConverter";
 
@@ -224,8 +225,11 @@ export namespace OpenApiV3_1Downgrader {
       collection.downgraded.schemas = {};
       for (const [key, value] of Object.entries(input.schemas))
         if (value !== undefined)
-          collection.downgraded.schemas[key] =
-            downgradeSchema(collection)(value);
+          ObjectDictionary.set(
+            collection.downgraded.schemas,
+            key,
+            downgradeSchema(collection)(value),
+          );
     }
     return collection;
   };

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -611,6 +611,7 @@ export namespace OpenApiV3_1Upgrader {
               ...{
                 items: undefined!,
                 prefixItems: schema.prefixItems.map(convertSchema(components)),
+                minItems: schema.minItems ?? 0,
                 additionalItems:
                   typeof schema.items === "object" && schema.items !== null
                     ? convertSchema(components)(schema.items)

--- a/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3_1Upgrader.ts
@@ -1,5 +1,6 @@
 import { IJsonSchemaAttribute, OpenApi, OpenApiV3_1 } from "@typia/interface";
 
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { OpenApiV3_1TypeChecker } from "../../validators/OpenApiV3_1TypeChecker";
 import { OpenApiDiscriminatorConverter } from "./OpenApiDiscriminatorConverter";
@@ -611,10 +612,9 @@ export namespace OpenApiV3_1Upgrader {
                 items: undefined!,
                 prefixItems: schema.prefixItems.map(convertSchema(components)),
                 additionalItems:
-                  typeof schema.additionalItems === "object" &&
-                  schema.additionalItems !== null
-                    ? convertSchema(components)(schema.additionalItems)
-                    : schema.additionalItems,
+                  typeof schema.items === "object" && schema.items !== null
+                    ? convertSchema(components)(schema.items)
+                    : (schema.items ?? true),
               },
             });
           else if (schema.items === undefined)
@@ -783,13 +783,18 @@ export namespace OpenApiV3_1Upgrader {
 
       if (OpenApiV3_1TypeChecker.isReference(input))
         return retrieveObject(components)(
-          components.schemas?.[input.$ref.split("/").pop() ?? ""] ?? {},
+          ObjectDictionary.get(
+            components.schemas,
+            input.$ref.split("/").pop() ?? "",
+          ) ?? {},
           visited,
         );
       else if (OpenApiV3_1TypeChecker.isRecursiveReference(input))
         return retrieveObject(components)(
-          components.schemas?.[input.$recursiveRef.split("/").pop() ?? ""] ??
-            {},
+          ObjectDictionary.get(
+            components.schemas,
+            input.$recursiveRef.split("/").pop() ?? "",
+          ) ?? {},
           visited,
         );
       return null;

--- a/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
@@ -1,5 +1,6 @@
 import { OpenApi, SwaggerV2 } from "@typia/interface";
 
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { SwaggerV2TypeChecker } from "../../validators/SwaggerV2TypeChecker";
 
@@ -539,8 +540,11 @@ export namespace SwaggerV2Downgrader {
     if (input.schemas) {
       for (const [key, value] of Object.entries(input.schemas))
         if (value !== undefined)
-          collection.downgraded[key.split("/").pop()!] =
-            downgradeSchema(collection)(value);
+          ObjectDictionary.set(
+            collection.downgraded,
+            key.split("/").pop()!,
+            downgradeSchema(collection)(value),
+          );
     }
     return collection;
   };
@@ -777,33 +781,42 @@ export namespace SwaggerV2Downgrader {
       const key: string = schema.$ref.split("/").pop()!;
       if (key.endsWith(".Nullable")) return;
 
-      const found: OpenApi.IJsonSchema | undefined =
-        collection.original.schemas?.[key];
+      const found: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+        collection.original.schemas,
+        key,
+      );
       if (found === undefined) return;
       else if (isNullable(visited)(collection.original)(found) === true) return;
-      else if (collection.downgraded[`${key}.Nullable`] === undefined) {
-        collection.downgraded[`${key}.Nullable`] = {};
-        collection.downgraded[`${key}.Nullable`] = downgradeSchema(collection)(
-          OpenApiTypeChecker.isOneOf(found)
-            ? {
-                ...found,
-                oneOf: [...found.oneOf, { type: "null" }],
-              }
-            : {
-                title: found.title,
-                description: found.description,
-                example: found.example,
-                examples: found.examples
-                  ? Object.values(found.examples)
-                  : undefined,
-                ...Object.fromEntries(
-                  Object.entries(found).filter(
-                    ([key, value]) =>
-                      key.startsWith("x-") && value !== undefined,
+      else if (
+        ObjectDictionary.get(collection.downgraded, `${key}.Nullable`) ===
+        undefined
+      ) {
+        ObjectDictionary.set(collection.downgraded, `${key}.Nullable`, {});
+        ObjectDictionary.set(
+          collection.downgraded,
+          `${key}.Nullable`,
+          downgradeSchema(collection)(
+            OpenApiTypeChecker.isOneOf(found)
+              ? {
+                  ...found,
+                  oneOf: [...found.oneOf, { type: "null" }],
+                }
+              : {
+                  title: found.title,
+                  description: found.description,
+                  example: found.example,
+                  examples: found.examples
+                    ? Object.values(found.examples)
+                    : undefined,
+                  ...Object.fromEntries(
+                    Object.entries(found).filter(
+                      ([key, value]) =>
+                        key.startsWith("x-") && value !== undefined,
+                    ),
                   ),
-                ),
-                oneOf: [found, { type: "null" }],
-              },
+                  oneOf: [found, { type: "null" }],
+                },
+          ),
         );
       }
       schema.$ref += ".Nullable";
@@ -862,7 +875,10 @@ export namespace SwaggerV2Downgrader {
         if (visited.has(schema.$ref)) return false;
         visited.add(schema.$ref);
         const key: string = schema.$ref.split("/").pop()!;
-        const next: OpenApi.IJsonSchema | undefined = components.schemas?.[key];
+        const next: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+          components.schemas,
+          key,
+        );
         return next ? isNullable(visited)(components)(next) : false;
       }
       return (

--- a/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Upgrader.ts
@@ -1,5 +1,6 @@
 import { IJsonSchemaAttribute, OpenApi, SwaggerV2 } from "@typia/interface";
 
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { SwaggerV2TypeChecker } from "../../validators/SwaggerV2TypeChecker";
 import { OpenApiExclusiveEmender } from "./OpenApiExclusiveEmender";
@@ -872,7 +873,10 @@ export namespace SwaggerV2Upgrader {
 
       if (SwaggerV2TypeChecker.isReference(input))
         return retrieveObject(definitions)(
-          definitions?.[input.$ref.split("/").pop() ?? ""] ?? {},
+          ObjectDictionary.get(
+            definitions,
+            input.$ref.split("/").pop() ?? "",
+          ) ?? {},
           visited,
         );
       return null;

--- a/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
+++ b/packages/utils/src/http/internal/HttpMigrateRouteComposer.ts
@@ -2,6 +2,7 @@ import { IHttpMigrateRoute, OpenApi } from "@typia/interface";
 
 import { NamingConvention } from "../../utils/NamingConvention";
 import { EndpointUtil } from "../../utils/internal/EndpointUtil";
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiSchemaSanitizer } from "../../utils/internal/OpenApiSchemaSanitizer";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 
@@ -725,9 +726,11 @@ export namespace HttpMigrateRouteComposer {
     schema: OpenApi.IJsonSchema;
   }): OpenApi.IJsonSchema.IReference => {
     props.document.components.schemas ??= {};
-    props.document.components.schemas[props.name] = sanitizeSchema(
-      props.document,
-    )(props.schema);
+    ObjectDictionary.set(
+      props.document.components.schemas,
+      props.name,
+      sanitizeSchema(props.document)(props.schema),
+    );
     return {
       $ref: `#/components/schemas/${props.name}`,
     } satisfies OpenApi.IJsonSchema.IReference;
@@ -749,14 +752,14 @@ export namespace HttpMigrateRouteComposer {
       const visited: Set<string> = new Set();
       while (OpenApiTypeChecker.isReference(schema)) {
         const key: string = schema.$ref.replace("#/components/schemas/", "");
-        if (
-          key === schema.$ref ||
-          visited.has(key) ||
-          document.components.schemas?.[key] === undefined
-        )
+        const found: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+          document.components.schemas,
+          key,
+        );
+        if (key === schema.$ref || visited.has(key) || found === undefined)
           break;
         visited.add(key);
-        schema = document.components.schemas[key]!;
+        schema = found;
       }
       return schema;
     };
@@ -779,12 +782,17 @@ export namespace HttpMigrateRouteComposer {
           ? schema.$ref.replace("#/components/schemas/", "")
           : null;
         if (key === null || visited.has(key)) return schema;
-        const found: OpenApi.IJsonSchema | undefined =
-          document.components.schemas?.[key];
+        const found: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+          document.components.schemas,
+          key,
+        );
         if (found !== undefined) {
           visited.add(key);
-          document.components.schemas![key] =
-            sanitizeSchemaRecursively(document)(visited)(found);
+          ObjectDictionary.set(
+            document.components.schemas!,
+            key,
+            sanitizeSchemaRecursively(document)(visited)(found),
+          );
         }
         return schema;
       }

--- a/packages/utils/src/utils/internal/JsonDescriptor.ts
+++ b/packages/utils/src/utils/internal/JsonDescriptor.ts
@@ -2,6 +2,7 @@ import { OpenApi } from "@typia/interface";
 
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 import { NamingConvention } from "../NamingConvention";
+import { ObjectDictionary } from "./ObjectDictionary";
 
 export namespace JsonDescriptor {
   export const cascade = (props: {
@@ -19,7 +20,8 @@ export namespace JsonDescriptor {
       .map((_, i, array) => array.slice(0, i + 1).join("."))
       .map((key) => ({
         key,
-        description: props.components.schemas?.[key]?.description,
+        description: ObjectDictionary.get(props.components.schemas, key)
+          ?.description,
       }))
       .reverse()
       .filter(

--- a/packages/utils/src/utils/internal/ObjectDictionary.ts
+++ b/packages/utils/src/utils/internal/ObjectDictionary.ts
@@ -1,11 +1,14 @@
 export namespace ObjectDictionary {
-  export const create = <T>(): Record<string, T> => Object.create(null);
-
-  export const has = (record: object | undefined, key: PropertyKey): boolean =>
-    record !== undefined && Object.prototype.hasOwnProperty.call(record, key);
+  export const has = (
+    record: object | null | undefined,
+    key: PropertyKey,
+  ): boolean =>
+    record !== undefined &&
+    record !== null &&
+    Object.prototype.hasOwnProperty.call(record, key);
 
   export const get = <T>(
-    record: Record<string, T> | undefined,
+    record: Record<string, T> | null | undefined,
     key: string,
   ): T | undefined => (has(record, key) ? record![key] : undefined);
 

--- a/packages/utils/src/utils/internal/ObjectDictionary.ts
+++ b/packages/utils/src/utils/internal/ObjectDictionary.ts
@@ -1,0 +1,24 @@
+export namespace ObjectDictionary {
+  export const create = <T>(): Record<string, T> => Object.create(null);
+
+  export const has = (record: object | undefined, key: PropertyKey): boolean =>
+    record !== undefined && Object.prototype.hasOwnProperty.call(record, key);
+
+  export const get = <T>(
+    record: Record<string, T> | undefined,
+    key: string,
+  ): T | undefined => (has(record, key) ? record![key] : undefined);
+
+  export const set = <T>(
+    record: Record<string, T>,
+    key: string,
+    value: T,
+  ): void => {
+    Object.defineProperty(record, key, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value,
+    });
+  };
+}

--- a/packages/utils/src/utils/internal/OpenApiTypeCheckerBase.ts
+++ b/packages/utils/src/utils/internal/OpenApiTypeCheckerBase.ts
@@ -2,6 +2,7 @@ import { IJsonSchemaTransformError, IResult, OpenApi } from "@typia/interface";
 
 import { MapUtil } from "../MapUtil";
 import { JsonDescriptor } from "./JsonDescriptor";
+import { ObjectDictionary } from "./ObjectDictionary";
 import { OpenApiSchemaSanitizer } from "./OpenApiSchemaSanitizer";
 
 /** @internal */
@@ -202,8 +203,10 @@ export namespace OpenApiTypeCheckerBase {
         const key: string = schema.$ref.split(props.prefix).pop()!;
         if (already.has(key) === true) return;
         already.add(key);
-        const found: OpenApi.IJsonSchema | undefined =
-          props.components.schemas?.[key];
+        const found: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+          props.components.schemas,
+          key,
+        );
         if (found !== undefined)
           next(found, `${refAccessor}[${JSON.stringify(key)}]`);
       } else if (isOneOf(schema))
@@ -256,8 +259,10 @@ export namespace OpenApiTypeCheckerBase {
   }): OpenApi.IJsonSchema | null => {
     if (isReference(props.schema) === false) return props.schema;
     const key: string = props.schema.$ref.split(props.prefix).pop()!;
-    const found: OpenApi.IJsonSchema | undefined =
-      props.components.schemas?.[key];
+    const found: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+      props.components.schemas,
+      key,
+    );
     if (found === undefined) {
       props.reasons.push({
         schema: props.schema,
@@ -296,8 +301,10 @@ export namespace OpenApiTypeCheckerBase {
       const key: string =
         props.schema.$ref.split(props.prefix)[1] ??
         props.schema.$ref.split("/").at(-1)!;
-      const target: OpenApi.IJsonSchema | undefined =
-        props.components.schemas?.[key];
+      const target: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+        props.components.schemas,
+        key,
+      );
       if (target === undefined) {
         props.reasons.push({
           schema: props.schema,
@@ -678,7 +685,10 @@ export namespace OpenApiTypeCheckerBase {
     )
       return false;
     return Object.entries(p.y.properties ?? {}).every(([key, b]) => {
-      const a: OpenApi.IJsonSchema | undefined = p.x.properties?.[key];
+      const a: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+        p.x.properties,
+        key,
+      );
       if (a === undefined) return false;
       else if (
         p.x.required?.includes(key) === true &&
@@ -774,7 +784,7 @@ export namespace OpenApiTypeCheckerBase {
     const found: OpenApi.IJsonSchema | undefined = escapeReferenceOfFlatSchema({
       prefix: props.prefix,
       components: props.components,
-      schema: props.components.schemas?.[key] ?? {},
+      schema: ObjectDictionary.get(props.components.schemas, key) ?? {},
     });
     if (found === undefined)
       throw new Error(

--- a/packages/utils/src/utils/internal/coerceLlmArguments.ts
+++ b/packages/utils/src/utils/internal/coerceLlmArguments.ts
@@ -1,6 +1,7 @@
 import { IJsonParseResult, ILlmSchema } from "@typia/interface";
 
 import { LlmTypeChecker } from "../../validators/LlmTypeChecker";
+import { ObjectDictionary } from "./ObjectDictionary";
 import { parseLenientJson } from "./parseLenientJson";
 
 /**
@@ -31,12 +32,8 @@ function coerceValue(
 ): unknown {
   // Resolve reference
   if (LlmTypeChecker.isReference(schema)) {
-    const key: string = schema.$ref.replace("#/$defs/", "");
-    const resolved: ILlmSchema | undefined = $defs?.[key];
-    if (resolved !== undefined) {
-      return coerceValue(value, resolved, $defs);
-    }
-    return value;
+    const resolved: ILlmSchema = resolveSchema(schema, $defs);
+    return resolved === schema ? value : coerceValue(value, resolved, $defs);
   }
 
   // Handle anyOf
@@ -162,9 +159,12 @@ function coerceObject(
 
   // Coerce known properties
   for (const [key, propSchema] of Object.entries(schema.properties)) {
-    if (key in value) {
-      result[key] = coerceValue(value[key], propSchema, $defs);
-    }
+    if (ObjectDictionary.has(value, key))
+      ObjectDictionary.set(
+        result,
+        key,
+        coerceValue(value[key], propSchema, $defs),
+      );
   }
 
   // Preserve additional properties - let validation handle rejection
@@ -174,11 +174,14 @@ function coerceObject(
       : undefined;
 
   for (const key of Object.keys(value)) {
-    if (!(key in schema.properties)) {
-      result[key] = additionalSchema
-        ? coerceValue(value[key], additionalSchema, $defs)
-        : coerceLoose(value[key]);
-    }
+    if (!ObjectDictionary.has(schema.properties, key))
+      ObjectDictionary.set(
+        result,
+        key,
+        additionalSchema
+          ? coerceValue(value[key], additionalSchema, $defs)
+          : coerceLoose(value[key]),
+      );
   }
 
   return result;
@@ -208,12 +211,15 @@ function resolveSchema(
   schema: ILlmSchema,
   $defs: Record<string, ILlmSchema> | undefined,
 ): ILlmSchema {
-  if (LlmTypeChecker.isReference(schema)) {
+  const origin: ILlmSchema = schema;
+  const visited: Set<string> = new Set();
+  while (LlmTypeChecker.isReference(schema)) {
     const key: string = schema.$ref.replace("#/$defs/", "");
-    const resolved: ILlmSchema | undefined = $defs?.[key];
-    if (resolved !== undefined) {
-      return resolveSchema(resolved, $defs);
-    }
+    if (visited.has(key)) return origin;
+    visited.add(key);
+    const resolved: ILlmSchema | undefined = ObjectDictionary.get($defs, key);
+    if (resolved === undefined) return origin;
+    schema = resolved;
   }
   return schema;
 }
@@ -228,10 +234,10 @@ function matchesSchemaType(
   $defs: Record<string, ILlmSchema> | undefined,
 ): boolean {
   if (LlmTypeChecker.isReference(schema)) {
-    const key: string = schema.$ref.replace("#/$defs/", "");
-    const resolved: ILlmSchema | undefined = $defs?.[key];
-    if (resolved) return matchesSchemaType(value, resolved, $defs);
-    return false;
+    const resolved: ILlmSchema = resolveSchema(schema, $defs);
+    return resolved === schema
+      ? false
+      : matchesSchemaType(value, resolved, $defs);
   }
   if (LlmTypeChecker.isNull(schema)) return value === null;
   if (LlmTypeChecker.isBoolean(schema)) return typeof value === "boolean";
@@ -319,7 +325,10 @@ function findMatchingObjectInAnyOf(
   for (const s of objectSchemas) {
     const resolved: ILlmSchema = resolveSchema(s, $defs);
     if (!LlmTypeChecker.isObject(resolved)) continue;
-    const propSchema: ILlmSchema | undefined = resolved.properties?.[key];
+    const propSchema: ILlmSchema | undefined = ObjectDictionary.get(
+      resolved.properties,
+      key,
+    );
     if (propSchema === undefined) continue;
     const resolvedProp: ILlmSchema = resolveSchema(propSchema, $defs);
     if (

--- a/packages/utils/src/utils/internal/parseLenientJson.ts
+++ b/packages/utils/src/utils/internal/parseLenientJson.ts
@@ -1,5 +1,7 @@
 import { DeepPartial, IJsonParseResult } from "@typia/interface";
 
+import { ObjectDictionary } from "./ObjectDictionary";
+
 /**
  * Parse lenient JSON that may be incomplete or malformed.
  *
@@ -603,7 +605,7 @@ class LenientJsonParser {
       }
 
       const value: unknown = this.parseValue(path + "." + key);
-      result[key] = value;
+      ObjectDictionary.set(result, key, value);
 
       this.skipWhitespace();
 

--- a/packages/utils/src/validators/LlmTypeChecker.ts
+++ b/packages/utils/src/validators/LlmTypeChecker.ts
@@ -1,6 +1,7 @@
 import { ILlmSchema } from "@typia/interface";
 
 import { MapUtil } from "../utils/MapUtil";
+import { ObjectDictionary } from "../utils/internal/ObjectDictionary";
 import { OpenApiTypeCheckerBase } from "../utils/internal/OpenApiTypeCheckerBase";
 
 /**
@@ -151,7 +152,10 @@ export namespace LlmTypeChecker {
         const key: string = schema.$ref.split("#/$defs/").pop()!;
         if (already.has(key) === true) return;
         already.add(key);
-        const found: ILlmSchema | undefined = props.$defs?.[key];
+        const found: ILlmSchema | undefined = ObjectDictionary.get(
+          props.$defs,
+          key,
+        );
         if (found !== undefined) next(found, `${refAccessor}[${key}]`);
       } else if (LlmTypeChecker.isAnyOf(schema))
         schema.anyOf.forEach((s, i) => next(s, `${accessor}.anyOf[${i}]`));
@@ -330,7 +334,10 @@ export namespace LlmTypeChecker {
     )
       return false;
     return Object.entries(p.y.properties ?? {}).every(([key, b]) => {
-      const a: ILlmSchema | undefined = p.x.properties?.[key];
+      const a: ILlmSchema | undefined = ObjectDictionary.get(
+        p.x.properties,
+        key,
+      );
       if (a === undefined) return false;
       else if (
         (p.x.required?.includes(key) ?? false) === true &&
@@ -397,6 +404,9 @@ export namespace LlmTypeChecker {
     schema: ILlmSchema,
   ): Exclude<ILlmSchema, ILlmSchema.IReference> =>
     isReference(schema)
-      ? escapeReference($defs, $defs![schema.$ref.replace("#/$defs/", "")]!)
+      ? escapeReference(
+          $defs,
+          ObjectDictionary.get($defs, schema.$ref.replace("#/$defs/", ""))!,
+        )
       : schema;
 }

--- a/packages/utils/src/validators/LlmTypeChecker.ts
+++ b/packages/utils/src/validators/LlmTypeChecker.ts
@@ -402,11 +402,16 @@ export namespace LlmTypeChecker {
   const escapeReference = (
     $defs: Record<string, ILlmSchema> | undefined,
     schema: ILlmSchema,
-  ): Exclude<ILlmSchema, ILlmSchema.IReference> =>
-    isReference(schema)
-      ? escapeReference(
-          $defs,
-          ObjectDictionary.get($defs, schema.$ref.replace("#/$defs/", ""))!,
-        )
-      : schema;
+  ): ILlmSchema => {
+    const visited: Set<string> = new Set();
+    while (isReference(schema)) {
+      const key: string = schema.$ref.replace("#/$defs/", "");
+      if (visited.has(key)) return schema;
+      visited.add(key);
+      const resolved: ILlmSchema | undefined = ObjectDictionary.get($defs, key);
+      if (resolved === undefined) return schema;
+      schema = resolved;
+    }
+    return schema;
+  };
 }

--- a/packages/utils/src/validators/functional/_isUniqueItems.ts
+++ b/packages/utils/src/validators/functional/_isUniqueItems.ts
@@ -1,12 +1,4 @@
 export const _isUniqueItems = (elements: any[]): boolean => {
-  // EMPTY OR ONLY ONE
-  if (elements.length < 2) return true;
-
-  // SHALLOW COMPARISON
-  if (["boolean", "bigint", "number", "string"].includes(typeof elements[0]))
-    return new Set(elements).size === elements.length;
-
-  // DEEP COMPARISON
   for (let i = 0; i < elements.length; i++)
     for (let j = i + 1; j < elements.length; j++)
       if (equals(new WeakMap())(elements[i], elements[j])) return false;
@@ -15,145 +7,149 @@ export const _isUniqueItems = (elements: any[]): boolean => {
 
 const equals = (visited: WeakMap<object, WeakMap<object, boolean>>) => {
   const next = (a: any, b: any): boolean => {
-    // SHALLOW EQUAL
     if (a === b) return true;
-    else if (typeof a !== typeof b || typeof a !== "object") return false;
-    // COMPARE CONTAINERS
-    else if (Array.isArray(a))
-      return Array.isArray(b) && a.map((x, i) => next(x, b[i])).every((x) => x);
-    else if (a instanceof Set)
+    if (
+      a === null ||
+      b === null ||
+      typeof a !== "object" ||
+      typeof b !== "object"
+    )
+      return false;
+
+    const previous: boolean | undefined = visited.get(a)?.get(b);
+    if (previous !== undefined) return previous;
+    const pairs: WeakMap<object, boolean> =
+      visited.get(a) ?? new WeakMap<object, boolean>();
+    visited.set(a, pairs);
+    pairs.set(b, true);
+
+    const result: boolean = compare(a, b);
+    pairs.set(b, result);
+    return result;
+  };
+
+  const compare = (a: object, b: object): boolean => {
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) {
+        const aHas: boolean = Object.hasOwn(a, i);
+        if (aHas !== Object.hasOwn(b, i) || (aHas && !next(a[i], b[i])))
+          return false;
+      }
+      return true;
+    }
+    if (Array.isArray(b)) return false;
+
+    if (a instanceof Set) {
+      if (!(b instanceof Set) || a.size !== b.size) return false;
+      const unmatched: any[] = [...b];
+      for (const value of a) {
+        const index: number = unmatched.findIndex((candidate) =>
+          next(value, candidate),
+        );
+        if (index === -1) return false;
+        unmatched.splice(index, 1);
+      }
+      return true;
+    }
+    if (a instanceof Map) {
+      if (!(b instanceof Map) || a.size !== b.size) return false;
+      const unmatched: [any, any][] = [...b];
+      for (const [key, value] of a) {
+        const index: number = unmatched.findIndex(
+          ([candidateKey, candidateValue]) =>
+            next(key, candidateKey) && next(value, candidateValue),
+        );
+        if (index === -1) return false;
+        unmatched.splice(index, 1);
+      }
+      return true;
+    }
+
+    if (a instanceof Boolean)
+      return b instanceof Boolean && a.valueOf() === b.valueOf();
+    if (Object.prototype.toString.call(a) === "[object BigInt]")
       return (
-        b instanceof Set && a.size === b.size && [...a].every((x) => b.has(x))
+        Object.prototype.toString.call(b) === "[object BigInt]" &&
+        a.valueOf() === b.valueOf()
       );
-    else if (a instanceof Map)
+    if (Object.prototype.toString.call(a) === "[object Symbol]")
       return (
-        b instanceof Map &&
-        a.size === b.size &&
-        [...a].every(([k, v]) => b.has(k) && next(v, b.get(k)))
+        Object.prototype.toString.call(b) === "[object Symbol]" &&
+        a.valueOf() === b.valueOf()
       );
-    // ATOMIC CLASSES
-    else if (a instanceof Boolean)
-      return b instanceof Boolean
-        ? a.valueOf() === b.valueOf()
-        : a.valueOf() === b;
-    else if (a instanceof BigInt)
-      return b instanceof BigInt ? a === b : a === BigInt(b);
-    else if (a instanceof Number)
-      return b instanceof Number
-        ? a.valueOf() === b.valueOf()
-        : a.valueOf() === b;
-    else if (a instanceof String)
-      return b instanceof String
-        ? a.valueOf() === b.valueOf()
-        : a.valueOf() === b;
-    else if (a instanceof Date)
+    if (a instanceof Number)
+      return b instanceof Number && a.valueOf() === b.valueOf();
+    if (a instanceof String)
+      return b instanceof String && a.valueOf() === b.valueOf();
+    if (a instanceof Date)
       return b instanceof Date && a.getTime() === b.getTime();
-    // BINARY DATA
-    else if (a instanceof Uint8Array)
+    if (a instanceof RegExp)
       return (
-        b instanceof Uint8Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
+        b instanceof RegExp && a.source === b.source && a.flags === b.flags
       );
-    else if (a instanceof Uint8ClampedArray)
-      return (
-        b instanceof Uint8ClampedArray &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Uint16Array)
-      return (
-        b instanceof Uint16Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Uint32Array)
-      return (
-        b instanceof Uint32Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof BigUint64Array)
-      return (
-        b instanceof BigUint64Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Int8Array)
-      return (
-        b instanceof Int8Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Int16Array)
-      return (
-        b instanceof Int16Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Int32Array)
-      return (
-        b instanceof Int32Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof BigInt64Array)
-      return (
-        b instanceof BigInt64Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Float32Array)
-      return (
-        b instanceof Float32Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof Float64Array)
-      return (
-        b instanceof Float64Array &&
-        a.length === b.length &&
-        a.every((x, i) => x === b[i])
-      );
-    else if (a instanceof ArrayBuffer) {
-      if (!(b instanceof ArrayBuffer) || a.byteLength !== b.byteLength)
-        return false;
-      const x: Uint8Array = new Uint8Array(a);
-      const y: Uint8Array = new Uint8Array(b);
-      return x.every((v, i) => v === y[i]);
-    } else if (a instanceof SharedArrayBuffer) {
-      if (!(b instanceof SharedArrayBuffer) || a.byteLength !== b.byteLength)
-        return false;
-      const x: Uint8Array = new Uint8Array(a);
-      const y: Uint8Array = new Uint8Array(b);
-      return x.every((v, i) => v === y[i]);
-    } else if (a instanceof DataView) {
-      if (!(b instanceof DataView) || a.byteLength !== b.byteLength)
-        return false;
-      const x: Uint8Array = new Uint8Array(a.buffer);
-      const y: Uint8Array = new Uint8Array(b.buffer);
-      return x.every((v, i) => v === y[i]);
-    } else if (a instanceof File)
+
+    if (typeof File !== "undefined" && a instanceof File)
       return (
         b instanceof File &&
         a.name === b.name &&
         a.size === b.size &&
         a.type === b.type &&
-        next(a.slice(), b.slice())
+        a.lastModified === b.lastModified
       );
-    // JUST PLAIN OBJECTS
-    else if (a !== null && b !== null) {
-      if (visited.has(a) && visited.get(a)!.has(b))
-        return visited.get(a)!.get(b)!;
-      if (!visited.has(a)) visited.set(a, new WeakMap());
-      visited.get(a)!.set(b, true);
-      const res: boolean =
-        Object.keys(a).length === Object.keys(b).length &&
-        Object.keys(a).every((x) => next(a[x], b[x]));
-      visited.get(a)!.set(b, res);
-      return res;
+    if (typeof Blob !== "undefined" && a instanceof Blob)
+      return b instanceof Blob && a.size === b.size && a.type === b.type;
+
+    if (a instanceof DataView) {
+      if (!(b instanceof DataView) || a.byteLength !== b.byteLength)
+        return false;
+      return bytes(a.buffer, a.byteOffset, a.byteLength).every(
+        (value, index) =>
+          value === bytes(b.buffer, b.byteOffset, b.byteLength)[index],
+      );
     }
-    return false;
+    if (ArrayBuffer.isView(a)) {
+      if (
+        !ArrayBuffer.isView(b) ||
+        b instanceof DataView ||
+        Object.getPrototypeOf(a) !== Object.getPrototypeOf(b) ||
+        a.byteLength !== b.byteLength
+      )
+        return false;
+      const x: Uint8Array = bytes(a.buffer, a.byteOffset, a.byteLength);
+      const y: Uint8Array = bytes(b.buffer, b.byteOffset, b.byteLength);
+      return x.every((value, index) => value === y[index]);
+    }
+    if (a instanceof ArrayBuffer)
+      return (
+        b instanceof ArrayBuffer &&
+        a.byteLength === b.byteLength &&
+        bytes(a).every((value, index) => value === bytes(b)[index])
+      );
+    if (
+      typeof SharedArrayBuffer !== "undefined" &&
+      a instanceof SharedArrayBuffer
+    )
+      return (
+        b instanceof SharedArrayBuffer &&
+        a.byteLength === b.byteLength &&
+        bytes(a).every((value, index) => value === bytes(b)[index])
+      );
+
+    const keys: string[] = Object.keys(a);
+    return (
+      keys.length === Object.keys(b).length &&
+      keys.every(
+        (key) =>
+          Object.hasOwn(b, key) && next((a as any)[key], (b as any)[key]),
+      )
+    );
   };
   return next;
 };
+
+const bytes = (
+  buffer: ArrayBufferLike,
+  byteOffset: number = 0,
+  byteLength: number = buffer.byteLength,
+): Uint8Array => new Uint8Array(buffer, byteOffset, byteLength);

--- a/packages/utils/src/validators/functional/_isUniqueItems.ts
+++ b/packages/utils/src/validators/functional/_isUniqueItems.ts
@@ -136,12 +136,18 @@ const equals = (visited: WeakMap<object, WeakMap<object, boolean>>) => {
         bytes(a).every((value, index) => value === bytes(b)[index])
       );
 
-    const keys: string[] = Object.keys(a);
+    const keys: PropertyKey[] = Reflect.ownKeys(a).filter((key) =>
+      Object.prototype.propertyIsEnumerable.call(a, key),
+    );
     return (
-      keys.length === Object.keys(b).length &&
+      keys.length ===
+        Reflect.ownKeys(b).filter((key) =>
+          Object.prototype.propertyIsEnumerable.call(b, key),
+        ).length &&
       keys.every(
         (key) =>
-          Object.hasOwn(b, key) && next((a as any)[key], (b as any)[key]),
+          Object.prototype.propertyIsEnumerable.call(b, key) &&
+          next((a as any)[key], (b as any)[key]),
       )
     );
   };

--- a/packages/utils/src/validators/internal/OpenApiIntegerValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiIntegerValidator.ts
@@ -6,7 +6,11 @@ export namespace OpenApiIntegerValidator {
   export const validate = (
     ctx: IOpenApiValidatorContext<OpenApi.IJsonSchema.IInteger>,
   ): boolean => {
-    if (typeof ctx.value !== "number" || Math.floor(ctx.value) !== ctx.value)
+    if (
+      typeof ctx.value !== "number" ||
+      Number.isFinite(ctx.value) === false ||
+      Math.floor(ctx.value) !== ctx.value
+    )
       return ctx.report(ctx);
     return [
       ctx.schema.minimum !== undefined

--- a/packages/utils/src/validators/internal/OpenApiNumberValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiNumberValidator.ts
@@ -6,7 +6,8 @@ export namespace OpenApiNumberValidator {
   export const validate = (
     ctx: IOpenApiValidatorContext<OpenApi.IJsonSchema.INumber>,
   ): boolean => {
-    if (typeof ctx.value !== "number") return ctx.report(ctx);
+    if (typeof ctx.value !== "number" || Number.isFinite(ctx.value) === false)
+      return ctx.report(ctx);
     return [
       ctx.schema.minimum !== undefined
         ? ctx.value >= ctx.schema.minimum ||

--- a/packages/utils/src/validators/internal/OpenApiObjectValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiObjectValidator.ts
@@ -13,7 +13,7 @@ export namespace OpenApiObjectValidator {
       typeof ctx.value !== "object" ||
       ctx.value === null ||
       Array.isArray(ctx.value) ||
-      isPlainObject(ctx.value) === false
+      isJsonObject(ctx.value) === false
     )
       return ctx.report(ctx);
     return [
@@ -59,10 +59,9 @@ export namespace OpenApiObjectValidator {
     ].every((v) => v);
   };
 
-  const isPlainObject = (value: object): boolean => {
+  const isJsonObject = (value: object): boolean => {
     try {
-      const prototype: object | null = Object.getPrototypeOf(value);
-      return prototype === null || Object.getPrototypeOf(prototype) === null;
+      return Object.prototype.toString.call(value) === "[object Object]";
     } catch {
       return false;
     }

--- a/packages/utils/src/validators/internal/OpenApiObjectValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiObjectValidator.ts
@@ -1,6 +1,7 @@
 import { OpenApi } from "@typia/interface";
 
 import { NamingConvention } from "../../utils/NamingConvention";
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { IOpenApiValidatorContext } from "./IOpenApiValidatorContext";
 import { OpenApiStationValidator } from "./OpenApiStationValidator";
 
@@ -8,14 +9,19 @@ export namespace OpenApiObjectValidator {
   export const validate = (
     ctx: IOpenApiValidatorContext<OpenApi.IJsonSchema.IObject>,
   ): boolean => {
-    if (typeof ctx.value !== "object" || ctx.value === null)
+    if (
+      typeof ctx.value !== "object" ||
+      ctx.value === null ||
+      Array.isArray(ctx.value) ||
+      isPlainObject(ctx.value) === false
+    )
       return ctx.report(ctx);
     return [
       ...Object.entries(ctx.schema.properties ?? {}).map(([key, value]) =>
         OpenApiStationValidator.validate({
           ...ctx,
           schema: value,
-          value: (ctx.value as Record<string, any>)[key],
+          value: ObjectDictionary.get(ctx.value as Record<string, any>, key),
           path:
             ctx.path +
             (NamingConvention.variable(key)
@@ -51,6 +57,15 @@ export namespace OpenApiObjectValidator {
         ? [validateEquals(ctx)]
         : []),
     ].every((v) => v);
+  };
+
+  const isPlainObject = (value: object): boolean => {
+    try {
+      const prototype: object | null = Object.getPrototypeOf(value);
+      return prototype === null || Object.getPrototypeOf(prototype) === null;
+    } catch {
+      return false;
+    }
   };
 
   const validateEquals = (

--- a/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
@@ -1,6 +1,7 @@
 import { OpenApi } from "@typia/interface";
 
 import { MapUtil } from "../../utils";
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../OpenApiTypeChecker";
 import { IOpenApiValidatorContext } from "./IOpenApiValidatorContext";
 import { OpenApiStationValidator } from "./OpenApiStationValidator";
@@ -8,37 +9,53 @@ import { OpenApiStationValidator } from "./OpenApiStationValidator";
 export namespace OpenApiOneOfValidator {
   export const validate = (
     ctx: IOpenApiValidatorContext<OpenApi.IJsonSchema.IOneOf>,
+    references: ReadonlySet<string> = new Set(),
   ): boolean => {
     const discriminator: IDiscriminator = getDiscriminator(ctx);
     for (const item of discriminator.branches)
       if (item.predicator(ctx.value))
-        return OpenApiStationValidator.validate({
-          ...ctx,
-          schema: item.schema,
-        });
+        return OpenApiStationValidator.validate(
+          {
+            ...ctx,
+            schema: item.schema,
+          },
+          undefined,
+          references,
+        );
     if (discriminator.branches.length !== 0)
-      return validate({
-        ...ctx,
-        schema: {
-          oneOf: discriminator.remainders,
+      return validate(
+        {
+          ...ctx,
+          schema: {
+            oneOf: discriminator.remainders,
+          },
         },
-      });
+        references,
+      );
     const matched: OpenApi.IJsonSchema | undefined =
       discriminator.remainders.find(
         (schema) =>
-          OpenApiStationValidator.validate({
-            ...ctx,
-            schema,
-            exceptionable: false,
-            equals: false,
-          }) === true,
+          OpenApiStationValidator.validate(
+            {
+              ...ctx,
+              schema,
+              exceptionable: false,
+              equals: false,
+            },
+            undefined,
+            references,
+          ) === true,
       );
     if (matched === undefined) return ctx.report(ctx);
     return ctx.equals === true
-      ? OpenApiStationValidator.validate({
-          ...ctx,
-          schema: matched,
-        })
+      ? OpenApiStationValidator.validate(
+          {
+            ...ctx,
+            schema: matched,
+          },
+          undefined,
+          references,
+        )
       : true;
   };
 
@@ -246,11 +263,12 @@ export namespace OpenApiOneOfValidator {
             ? (value) =>
                 typeof value === "object" &&
                 value !== null &&
-                (value as any)[top] === target.const
+                ObjectDictionary.get(value as Record<string, unknown>, top) ===
+                  target.const
             : (value) =>
                 typeof value === "object" &&
                 value !== null &&
-                (value as any)[top] !== undefined,
+                ObjectDictionary.has(value, top),
         } satisfies IDiscriminatorBranch;
       })
       .filter((b) => b !== null);
@@ -273,7 +291,7 @@ const getFlattened = (props: {
     return {
       ...getFlattened({
         components: props.components,
-        schema: props.components.schemas?.[key] ?? {},
+        schema: ObjectDictionary.get(props.components.schemas, key) ?? {},
         visited: props.visited,
       }),
       schema: props.schema,

--- a/packages/utils/src/validators/internal/OpenApiStationValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiStationValidator.ts
@@ -1,5 +1,6 @@
 import { OpenApi } from "@typia/interface";
 
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../OpenApiTypeChecker";
 import { IOpenApiValidatorContext } from "./IOpenApiValidatorContext";
 import { OpenApiArrayValidator } from "./OpenApiArrayValidator";
@@ -17,6 +18,7 @@ export namespace OpenApiStationValidator {
   export const validate = (
     ctx: Omit<IOpenApiValidatorContext<OpenApi.IJsonSchema>, "expected">,
     expected?: string,
+    references: ReadonlySet<string> = new Set(),
   ): boolean => {
     // THE TYPE NAME
     expected ??= (() => {
@@ -44,22 +46,43 @@ export namespace OpenApiStationValidator {
       );
     // NESTED
     else if (OpenApiTypeChecker.isReference(ctx.schema)) {
-      const schema: OpenApi.IJsonSchema | undefined =
-        ctx.components.schemas?.[ctx.schema.$ref.split("/").pop() ?? ""];
-      if (schema === undefined) return true;
+      let schema: OpenApi.IJsonSchema = ctx.schema;
+      const visited: Set<string> = new Set(references);
+      while (OpenApiTypeChecker.isReference(schema)) {
+        const key: string = schema.$ref.split("/").pop() ?? "";
+        if (visited.has(key))
+          return ctx.report({
+            ...ctx,
+            expected,
+            description: `Circular schema reference ${JSON.stringify(key)} cannot be resolved.`,
+          });
+        visited.add(key);
+        const found: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+          ctx.components.schemas,
+          key,
+        );
+        if (found === undefined)
+          return ctx.report({
+            ...ctx,
+            expected,
+            description: `Unable to resolve schema reference ${JSON.stringify(key)}.`,
+          });
+        schema = found;
+      }
       return OpenApiStationValidator.validate(
-        {
-          ...ctx,
-          schema,
-        },
+        { ...ctx, schema },
         expected,
+        visited,
       );
     } else if (OpenApiTypeChecker.isOneOf(ctx.schema))
-      return OpenApiOneOfValidator.validate({
-        ...ctx,
-        schema: ctx.schema,
-        expected,
-      });
+      return OpenApiOneOfValidator.validate(
+        {
+          ...ctx,
+          schema: ctx.schema,
+          expected,
+        },
+        references,
+      );
     // ATOMICS
     else if (OpenApiTypeChecker.isConstant(ctx.schema))
       return OpenApiConstantValidator.validate({

--- a/packages/utils/src/validators/internal/OpenApiTupleValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiTupleValidator.ts
@@ -35,7 +35,6 @@ export namespace OpenApiTupleValidator {
       return ctx.report(ctx);
 
     return Array.from({ length }, (_, index) => {
-      const value: unknown = array[index];
       const schema: OpenApi.IJsonSchema | undefined =
         index < ctx.schema.prefixItems.length
           ? ctx.schema.prefixItems[index]
@@ -43,6 +42,13 @@ export namespace OpenApiTupleValidator {
               ctx.schema.additionalItems !== null
             ? ctx.schema.additionalItems
             : undefined;
+      const value: unknown = array[index];
+      if (Object.hasOwn(array, index) === false || value === undefined)
+        return ctx.report({
+          ...ctx,
+          value,
+          path: `${ctx.path}[${index}]`,
+        });
       return schema === undefined
         ? true
         : OpenApiStationValidator.validate({

--- a/packages/utils/src/validators/internal/OpenApiTupleValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiTupleValidator.ts
@@ -12,10 +12,12 @@ export namespace OpenApiTupleValidator {
 
     const array: unknown[] = ctx.value;
     const length: number = array.length;
-    if (ctx.schema.minItems !== undefined && length < ctx.schema.minItems)
+    const minimum: number =
+      ctx.schema.minItems ?? ctx.schema.prefixItems.length;
+    if (length < minimum)
       return ctx.report({
         ...ctx,
-        expected: `Array<> & MinItems<${ctx.schema.minItems}>`,
+        expected: `Array<> & MinItems<${minimum}>`,
       });
     if (ctx.schema.maxItems !== undefined && length > ctx.schema.maxItems)
       return ctx.report({

--- a/packages/utils/src/validators/internal/OpenApiTupleValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiTupleValidator.ts
@@ -1,5 +1,6 @@
 import { OpenApi } from "@typia/interface";
 
+import { _isUniqueItems } from "../functional/_isUniqueItems";
 import { IOpenApiValidatorContext } from "./IOpenApiValidatorContext";
 import { OpenApiStationValidator } from "./OpenApiStationValidator";
 
@@ -8,48 +9,49 @@ export namespace OpenApiTupleValidator {
     ctx: IOpenApiValidatorContext<OpenApi.IJsonSchema.ITuple>,
   ): boolean => {
     if (!Array.isArray(ctx.value)) return ctx.report(ctx);
-    else if (!!ctx.schema.additionalItems === false) {
-      if (ctx.value.length !== ctx.schema.prefixItems.length)
-        return ctx.report(ctx);
-      return ctx.value
-        .map((v, i) =>
-          OpenApiStationValidator.validate({
-            ...ctx,
-            schema: ctx.schema.prefixItems[i]!,
-            value: v,
-            path: `${ctx.path}[${i}]`,
-          }),
-        )
-        .every((v) => v);
-    }
 
-    if (ctx.value.length < ctx.schema.prefixItems.length)
+    const array: unknown[] = ctx.value;
+    const length: number = array.length;
+    if (ctx.schema.minItems !== undefined && length < ctx.schema.minItems)
+      return ctx.report({
+        ...ctx,
+        expected: `Array<> & MinItems<${ctx.schema.minItems}>`,
+      });
+    if (ctx.schema.maxItems !== undefined && length > ctx.schema.maxItems)
+      return ctx.report({
+        ...ctx,
+        expected: `Array<> & MaxItems<${ctx.schema.maxItems}>`,
+      });
+    if (ctx.schema.uniqueItems === true && !_isUniqueItems(array))
+      return ctx.report({
+        ...ctx,
+        expected: "Array<> & UniqueItems",
+      });
+    if (
+      length > ctx.schema.prefixItems.length &&
+      (ctx.schema.additionalItems === false ||
+        ctx.schema.additionalItems === undefined)
+    )
       return ctx.report(ctx);
-    const next =
-      typeof ctx.schema.additionalItems === "object" &&
-      ctx.schema.additionalItems !== null
-        ? (v: unknown, i: number) =>
-            OpenApiStationValidator.validate({
-              ...ctx,
-              schema: ctx.schema.additionalItems as OpenApi.IJsonSchema,
-              value: v,
-              path: `${ctx.path}[${i}]`,
-            })
-        : () => true;
-    return (
-      ctx.value.length >= ctx.schema.prefixItems.length &&
-      ctx.value
-        .map((v, i) =>
-          i < ctx.schema.prefixItems.length
-            ? OpenApiStationValidator.validate({
-                ...ctx,
-                schema: ctx.schema.prefixItems[i]!,
-                value: v,
-                path: `${ctx.path}[${i}]`,
-              })
-            : next(v, i),
-        )
-        .every((v) => v)
-    );
+
+    return Array.from({ length }, (_, index) => {
+      const value: unknown = array[index];
+      const schema: OpenApi.IJsonSchema | undefined =
+        index < ctx.schema.prefixItems.length
+          ? ctx.schema.prefixItems[index]
+          : typeof ctx.schema.additionalItems === "object" &&
+              ctx.schema.additionalItems !== null
+            ? ctx.schema.additionalItems
+            : undefined;
+      return schema === undefined
+        ? true
+        : OpenApiStationValidator.validate({
+            ...ctx,
+            schema,
+            value,
+            path: `${ctx.path}[${index}]`,
+            required: true,
+          });
+    }).every((value) => value);
   };
 }

--- a/tests/test-mcp/src/features/test_mcp_tool_output_validation.ts
+++ b/tests/test-mcp/src/features/test_mcp_tool_output_validation.ts
@@ -178,7 +178,7 @@ const invalidCases: ReadonlyArray<
 > = [
   ["undefined", "$input"],
   ["null", "$input"],
-  ["array", "$input.value"],
+  ["array", "$input"],
   ["primitive", "$input"],
   ["missing", "$input.value"],
   ["extra", "$input.extra"],

--- a/tests/test-typia-schema/src/features/random/test_random_unique_items_structural.ts
+++ b/tests/test-typia-schema/src/features/random/test_random_unique_items_structural.ts
@@ -1,0 +1,46 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { tags } from "typia";
+
+type IUniqueBooleans = Array<{ value: boolean }> &
+  tags.MinItems<2> &
+  tags.MaxItems<2> &
+  tags.UniqueItems;
+
+/**
+ * Verifies random UniqueItems generation shares validator equality and stops.
+ *
+ * The generator previously used Set reference identity, so two structurally
+ * equal objects were accepted even though validation rejected them, while a
+ * finite primitive domain could loop forever. A deterministic generator makes
+ * both outcomes observable without timing guesses.
+ *
+ * 1. Alternate a two-value object domain and require a valid two-element result.
+ * 2. Collapse the domain to one structural value while requesting two.
+ * 3. Require a deterministic exhaustion error instead of an invalid result or
+ *    non-termination.
+ */
+export const test_random_unique_items_structural = (): void => {
+  let next = false;
+  const possible: IUniqueBooleans = typia.random<IUniqueBooleans>({
+    boolean: () => (next = !next),
+  });
+  TestValidator.equals("possible length", possible.length, 2);
+  TestValidator.equals(
+    "possible validates",
+    typia.is<IUniqueBooleans>(possible),
+    true,
+  );
+
+  let error: unknown;
+  try {
+    typia.random<IUniqueBooleans>({
+      boolean: () => false,
+    });
+  } catch (exp) {
+    error = exp;
+  }
+  TestValidator.predicate("finite domain throws", () => error instanceof Error);
+  TestValidator.predicate("diagnostic identifies uniqueness exhaustion", () =>
+    (error as Error).message.includes("unique items"),
+  );
+};

--- a/tests/test-typia-schema/src/features/validate/test_validate_unique_items_structural.ts
+++ b/tests/test-typia-schema/src/features/validate/test_validate_unique_items_structural.ts
@@ -59,6 +59,17 @@ export const test_validate_unique_items_structural = (): void => {
     [duplicateObject, nullPrototype],
     false,
   );
+  const symbol: unique symbol = Symbol("key");
+  assertUnique(
+    "enumerable symbol structural duplicate",
+    [{ [symbol]: 1 }, { [symbol]: 1 }],
+    false,
+  );
+  assertUnique(
+    "enumerable symbol distinction",
+    [{ [symbol]: 1 }, { [symbol]: 2 }],
+    true,
+  );
 
   assertUnique(
     "deep sets",

--- a/tests/test-typia-schema/src/features/validate/test_validate_unique_items_structural.ts
+++ b/tests/test-typia-schema/src/features/validate/test_validate_unique_items_structural.ts
@@ -1,0 +1,211 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { tags } from "typia";
+import { _isUniqueItems } from "typia/lib/internal/_isUniqueItems";
+
+interface ITaggedPayload {
+  values: Array<{ id: number }> & tags.UniqueItems;
+}
+
+interface IJsDocPayload {
+  /** @uniqueItems */
+  values: Array<{ id: number }>;
+}
+
+/**
+ * Verifies every UniqueItems entry point uses structural equality.
+ *
+ * The runtime helper previously selected shallow comparison from only the first
+ * element, omitted array lengths and object key membership, and the JSDoc tag
+ * emitted a separate Set-based predicate. This matrix locks one
+ * order-independent relation across mixed values, containers, cycles, tagged
+ * arrays, and JSDoc arrays.
+ *
+ * 1. Exercise positive and negative structural pairs for JSON and native
+ *    containers, including visible DataView bytes and cycles.
+ * 2. Repeat the duplicate-object oracle with both the type tag and JSDoc tag.
+ * 3. Require mixed-array ordering and null-prototype objects not to change the
+ *    result.
+ */
+export const test_validate_unique_items_structural = (): void => {
+  const duplicateObject = { id: 1 };
+  const structurallyDuplicate = { id: 1 };
+  const nullPrototype = Object.assign(Object.create(null), { id: 1 });
+
+  assertUnique("empty", [], true);
+  assertUnique("one item", [duplicateObject], true);
+  assertUnique("strict primitive duplicate", [1, 1], false);
+  assertUnique("strict primitive distinction", [1, "1"], true);
+  assertUnique("strict NaN distinction", [Number.NaN, Number.NaN], true);
+  assertUnique("strict signed zero duplicate", [0, -0], false);
+  assertUnique(
+    "mixed duplicate after primitive",
+    [0, duplicateObject, structurallyDuplicate],
+    false,
+  );
+  assertUnique(
+    "mixed duplicate before primitive",
+    [duplicateObject, structurallyDuplicate, 0],
+    false,
+  );
+  assertUnique("different array lengths forward", [[1], [1, 2]], true);
+  assertUnique("different array lengths reverse", [[1, 2], [1]], true);
+  assertUnique(
+    "different own keys",
+    [{ x: undefined }, { y: undefined }],
+    true,
+  );
+  assertUnique(
+    "null prototype structural duplicate",
+    [duplicateObject, nullPrototype],
+    false,
+  );
+
+  assertUnique(
+    "deep sets",
+    [new Set([{ id: 1 }]), new Set([{ id: 1 }])],
+    false,
+  );
+  assertUnique(
+    "set order does not matter",
+    [new Set([{ id: 1 }, 2]), new Set([2, { id: 1 }])],
+    false,
+  );
+  assertUnique(
+    "different sets",
+    [new Set([{ id: 1 }]), new Set([{ id: 2 }])],
+    true,
+  );
+  assertUnique(
+    "deep maps",
+    [
+      new Map([[{ id: 1 }, { value: 2 }]]),
+      new Map([[{ id: 1 }, { value: 2 }]]),
+    ],
+    false,
+  );
+  assertUnique(
+    "map order does not matter",
+    [
+      new Map<any, any>([
+        [{ id: 1 }, { value: 2 }],
+        ["other", 3],
+      ]),
+      new Map<any, any>([
+        ["other", 3],
+        [{ id: 1 }, { value: 2 }],
+      ]),
+    ],
+    false,
+  );
+  assertUnique(
+    "different maps",
+    [new Map([[{ id: 1 }, 2]]), new Map([[{ id: 1 }, 3]])],
+    true,
+  );
+
+  assertUnique("boxed booleans", [new Boolean(true), new Boolean(true)], false);
+  assertUnique("boxed bigints", [Object(1n), Object(1n)], false);
+  assertUnique("boxed numbers", [new Number(1), new Number(1)], false);
+  assertUnique("boxed strings", [new String("x"), new String("x")], false);
+  assertUnique(
+    "boxed registered symbols",
+    [Object(Symbol.for("typia.unique")), Object(Symbol.for("typia.unique"))],
+    false,
+  );
+  assertUnique("dates", [new Date(1), new Date(1)], false);
+  assertUnique("different dates", [new Date(1), new Date(2)], true);
+  assertUnique("regular expressions", [/x/gi, /x/gi], false);
+  assertUnique("regular expression flags", [/x/g, /x/i], true);
+
+  const firstBytes = new Uint8Array([9, 1, 2, 9]);
+  const secondBytes = new Uint8Array([8, 1, 2, 8]);
+  assertUnique(
+    "visible DataView bytes",
+    [
+      new DataView(firstBytes.buffer, 1, 2),
+      new DataView(secondBytes.buffer, 1, 2),
+    ],
+    false,
+  );
+  assertUnique(
+    "different DataView bytes",
+    [
+      new DataView(new Uint8Array([1]).buffer),
+      new DataView(new Uint8Array([2]).buffer),
+    ],
+    true,
+  );
+  assertUnique(
+    "typed-array visible bytes",
+    [new Uint8Array([9, 1, 2, 9]).subarray(1, 3), new Uint8Array([1, 2])],
+    false,
+  );
+  assertUnique(
+    "typed-array classes differ",
+    [new Uint8Array([0, 0]), new Uint16Array([0])],
+    true,
+  );
+  assertUnique(
+    "array buffers",
+    [new Uint8Array([1, 2]).buffer, new Uint8Array([1, 2]).buffer],
+    false,
+  );
+  if (typeof SharedArrayBuffer !== "undefined")
+    assertUnique(
+      "shared array buffers",
+      [
+        Object.assign(new SharedArrayBuffer(2), {}),
+        Object.assign(new SharedArrayBuffer(2), {}),
+      ],
+      false,
+    );
+  if (typeof Blob !== "undefined") {
+    assertUnique("blobs", [new Blob(["x"]), new Blob(["x"])], false);
+    assertUnique(
+      "different blob metadata",
+      [new Blob(["x"], { type: "text/plain" }), new Blob(["x"])],
+      true,
+    );
+  }
+  if (typeof File !== "undefined") {
+    assertUnique(
+      "files",
+      [
+        new File(["x"], "x.txt", { type: "text/plain", lastModified: 1 }),
+        new File(["x"], "x.txt", { type: "text/plain", lastModified: 1 }),
+      ],
+      false,
+    );
+    assertUnique(
+      "different file metadata",
+      [new File(["x"], "x.txt"), new File(["x"], "y.txt")],
+      true,
+    );
+  }
+
+  const left: { id: number; self?: unknown } = { id: 1 };
+  const right: { id: number; self?: unknown } = { id: 1 };
+  left.self = left;
+  right.self = right;
+  assertUnique("cycles", [left, right], false);
+  right.id = 2;
+  assertUnique("different cycles", [left, right], true);
+
+  const input = { values: [duplicateObject, structurallyDuplicate] };
+  TestValidator.equals(
+    "type tag rejects duplicate objects",
+    typia.is<ITaggedPayload>(input),
+    false,
+  );
+  TestValidator.equals(
+    "JSDoc tag rejects duplicate objects",
+    typia.is<IJsDocPayload>(input),
+    false,
+  );
+};
+
+const assertUnique = (
+  label: string,
+  input: unknown[],
+  expected: boolean,
+): void => TestValidator.equals(label, _isUniqueItems(input), expected);

--- a/tests/test-utils-automated/src/internal/_test_validate.ts
+++ b/tests/test-utils-automated/src/internal/_test_validate.ts
@@ -128,6 +128,8 @@ const normalizePath = (props: {
       if (selected === undefined) return path;
       schema = resolve(props.components, selected);
     }
+    if (OpenApiTypeChecker.isObject(schema) && isJsonObject(value) === false)
+      return path;
     if (OpenApiTypeChecker.isObject(schema) && typeof segment.key === "string")
       schema =
         schema.properties?.[segment.key] ??
@@ -312,8 +314,7 @@ const compatibleWith = (props: {
   if (OpenApiTypeChecker.isString(schema)) return typeof value === "string";
   if (OpenApiTypeChecker.isArray(schema) || OpenApiTypeChecker.isTuple(schema))
     return Array.isArray(value);
-  if (OpenApiTypeChecker.isObject(schema))
-    return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (OpenApiTypeChecker.isObject(schema)) return isJsonObject(value);
   if (OpenApiTypeChecker.isOneOf(schema))
     return schema.oneOf.some((child) =>
       compatibleWith({
@@ -338,6 +339,16 @@ const resolve = (
     schema = components.schemas?.[key] ?? {};
   }
   return schema;
+};
+
+const isJsonObject = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return false;
+  try {
+    return Object.prototype.toString.call(value) === "[object Object]";
+  } catch {
+    return false;
+  }
 };
 
 const parsePath = (path: string): IPathSegment[] => {

--- a/tests/test-utils/src/features/llm/parse/test_llm_json_prototype_safe_objects.ts
+++ b/tests/test-utils/src/features/llm/parse/test_llm_json_prototype_safe_objects.ts
@@ -1,0 +1,110 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmJson } from "@typia/utils";
+
+/**
+ * Verifies LLM JSON parsing and coercion treat object keys as own data.
+ *
+ * The lenient parser assigned into ordinary objects, allowing `__proto__` to
+ * replace the result prototype, while coercion used inherited membership and
+ * copied attacker-controlled prototype values into required arguments. Both
+ * native and lenient parse paths must preserve reserved names as data.
+ *
+ * 1. Parse nested reserved keys through native and trailing-comma fallbacks.
+ * 2. Require own properties without prototype mutation at every level.
+ * 3. Coerce an object with an inherited required field and prove validation still
+ *    reports it missing.
+ */
+export const test_llm_json_prototype_safe_objects = (): void => {
+  for (const [label, input] of [
+    ["native", '{"__proto__":{"admin":true},"nested":[{"constructor":1}]}'],
+    ["lenient", '{"__proto__":{"admin":true},"nested":[{"constructor":1}],}'],
+  ] as const) {
+    const parsed = LlmJson.parse<Record<string, unknown>>(input);
+    TestValidator.equals(`${label} parse succeeds`, parsed.success, true);
+    if (!parsed.success) continue;
+    TestValidator.predicate(`${label} owns __proto__`, () =>
+      Object.hasOwn(parsed.data, "__proto__"),
+    );
+    TestValidator.equals(
+      `${label} prototype not polluted`,
+      (parsed.data as any).admin,
+      undefined,
+    );
+    const child = (parsed.data.nested as Record<string, unknown>[])[0]!;
+    TestValidator.predicate(`${label} owns constructor`, () =>
+      Object.hasOwn(child, "constructor"),
+    );
+    TestValidator.equals(
+      `${label} constructor value`,
+      (child as Record<string, unknown>)["constructor"],
+      1,
+    );
+  }
+
+  const parameters: ILlmSchema.IParameters = {
+    type: "object",
+    properties: {
+      admin: { type: "boolean" },
+    },
+    required: ["admin"],
+    additionalProperties: false,
+    $defs: {},
+  };
+  const inherited = Object.create({ admin: "true" });
+  const coerced = LlmJson.coerce<Record<string, unknown>>(
+    inherited,
+    parameters,
+  );
+  TestValidator.equals(
+    "inherited value is not copied",
+    Object.hasOwn(coerced, "admin"),
+    false,
+  );
+  TestValidator.equals(
+    "inherited value cannot satisfy validation",
+    LlmJson.validate(parameters)(coerced).success,
+    false,
+  );
+
+  const reservedParameters: ILlmSchema.IParameters = {
+    type: "object",
+    properties: Object.fromEntries([["__proto__", { type: "boolean" }]]),
+    required: ["__proto__"],
+    additionalProperties: false,
+    $defs: {},
+  };
+  const reservedValue = Object.fromEntries([["__proto__", "true"]]);
+  const reserved = LlmJson.coerce<Record<string, unknown>>(
+    reservedValue,
+    reservedParameters,
+  );
+  TestValidator.predicate("reserved argument stays own", () =>
+    Object.hasOwn(reserved, "__proto__"),
+  );
+  TestValidator.equals(
+    "reserved argument coerces",
+    reserved["__proto__"],
+    true,
+  );
+
+  const cyclicParameters: ILlmSchema.IParameters = {
+    type: "object",
+    properties: { loop: { $ref: "#/$defs/A" } },
+    required: ["loop"],
+    additionalProperties: false,
+    $defs: {
+      A: { $ref: "#/$defs/B" },
+      B: { $ref: "#/$defs/A" },
+    },
+  };
+  const cyclic = LlmJson.coerce<Record<string, unknown>>(
+    { loop: "unchanged" },
+    cyclicParameters,
+  );
+  TestValidator.equals(
+    "cyclic aliases terminate without coercion",
+    cyclic.loop,
+    "unchanged",
+  );
+};

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_reserved_references.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_reserved_references.ts
@@ -1,0 +1,120 @@
+import { TestValidator } from "@nestia/e2e";
+import {
+  IJsonSchemaTransformError,
+  ILlmSchema,
+  IResult,
+  OpenApi,
+  SwaggerV2,
+} from "@typia/interface";
+import { LlmSchemaConverter, OpenApiConverter } from "@typia/utils";
+
+/**
+ * Verifies reserved schema names remain own definitions in both directions.
+ *
+ * Ordinary-object lookup made inherited names such as `constructor` and
+ * `toString` appear already converted, while assigning `__proto__` could mutate
+ * a definition store instead of creating a definition. Missing inherited
+ * references must be errors, not implicit schemas.
+ *
+ * 1. Convert reserved, nested, and recursive component names into LLM $defs.
+ * 2. Invert those $defs into an ordinary components object without prototype
+ *    mutation.
+ * 3. Require an inherited-only component name to produce a conversion error.
+ */
+export const test_llm_schema_reserved_references = (): void => {
+  const schemas = Object.fromEntries([
+    ["toString", { type: "string" }],
+    [
+      "constructor",
+      {
+        type: "object",
+        properties: { child: { $ref: "#/components/schemas/__proto__" } },
+        required: ["child"],
+      },
+    ],
+    [
+      "__proto__",
+      {
+        type: "object",
+        properties: { next: { $ref: "#/components/schemas/__proto__" } },
+      },
+    ],
+  ]) as Record<string, OpenApi.IJsonSchema>;
+  const $defs: Record<string, ILlmSchema> = {};
+  const converted = LlmSchemaConverter.schema({
+    components: { schemas },
+    $defs,
+    schema: {
+      type: "object",
+      properties: Object.fromEntries([
+        ["text", { $ref: "#/components/schemas/toString" }],
+        ["record", { $ref: "#/components/schemas/constructor" }],
+      ]),
+      required: ["text", "record"],
+    },
+  });
+  TestValidator.equals("reserved conversion succeeds", converted.success, true);
+  for (const key of ["toString", "constructor", "__proto__"])
+    TestValidator.predicate(`$defs owns ${key}`, () =>
+      Object.hasOwn($defs, key),
+    );
+  TestValidator.equals(
+    "$defs prototype is not polluted",
+    ($defs as any).next,
+    undefined,
+  );
+
+  const components: OpenApi.IComponents = { schemas: {} };
+  const inverted = LlmSchemaConverter.invert({
+    components,
+    $defs,
+    schema: converted.success ? converted.value : {},
+  });
+  TestValidator.predicate("inverted object retained", () => "type" in inverted);
+  for (const key of ["toString", "constructor", "__proto__"])
+    TestValidator.predicate(`components owns ${key}`, () =>
+      Object.hasOwn(components.schemas!, key),
+    );
+  TestValidator.equals(
+    "components prototype is not polluted",
+    (components.schemas as any).next,
+    undefined,
+  );
+
+  const inheritedSchemas = Object.create({
+    toString: { type: "string" },
+  }) as Record<string, OpenApi.IJsonSchema>;
+  const missing: IResult<ILlmSchema, IJsonSchemaTransformError> =
+    LlmSchemaConverter.schema({
+      components: { schemas: inheritedSchemas },
+      $defs: {},
+      schema: { $ref: "#/components/schemas/toString" },
+    });
+  TestValidator.equals(
+    "inherited-only component is missing",
+    missing.success,
+    false,
+  );
+
+  const downgraded = [
+    OpenApiConverter.downgradeComponents({ schemas }, "2.0"),
+    OpenApiConverter.downgradeComponents({ schemas }, "3.0").schemas!,
+    OpenApiConverter.downgradeComponents({ schemas }, "3.1").schemas!,
+  ];
+  for (const [index, definitions] of downgraded.entries())
+    for (const key of ["toString", "constructor", "__proto__"])
+      TestValidator.predicate(`downgrade ${index} owns ${key}`, () =>
+        Object.hasOwn(definitions, key),
+      );
+
+  const upgraded = OpenApiConverter.upgradeDocument({
+    swagger: "2.0",
+    definitions: Object.fromEntries([
+      ["__proto__", { type: "string" }],
+      ["entry", { $ref: "#/definitions/__proto__" }],
+    ]),
+  } satisfies SwaggerV2.IDocument);
+  TestValidator.predicate("Swagger definition stays own", () =>
+    Object.hasOwn(upgraded.components.schemas!, "__proto__"),
+  );
+};

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_reserved_references.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_reserved_references.ts
@@ -6,7 +6,11 @@ import {
   OpenApi,
   SwaggerV2,
 } from "@typia/interface";
-import { LlmSchemaConverter, OpenApiConverter } from "@typia/utils";
+import {
+  LlmSchemaConverter,
+  LlmTypeChecker,
+  OpenApiConverter,
+} from "@typia/utils";
 
 /**
  * Verifies reserved schema names remain own definitions in both directions.
@@ -93,6 +97,63 @@ export const test_llm_schema_reserved_references = (): void => {
   TestValidator.equals(
     "inherited-only component is missing",
     missing.success,
+    false,
+  );
+
+  const parameters = LlmSchemaConverter.parameters({
+    components: { schemas },
+    schema: {
+      type: "object",
+      properties: {
+        value: { $ref: "#/components/schemas/__proto__" },
+      },
+      required: ["value"],
+    },
+  });
+  TestValidator.equals(
+    "parameters conversion succeeds",
+    parameters.success,
+    true,
+  );
+  if (parameters.success)
+    TestValidator.equals(
+      "public $defs keeps ordinary prototype",
+      Object.getPrototypeOf(parameters.value.$defs),
+      Object.prototype,
+    );
+
+  const createdComponents: OpenApi.IComponents = {};
+  LlmSchemaConverter.invert({
+    components: createdComponents,
+    $defs: Object.fromEntries([["__proto__", { type: "string" }]]),
+    schema: { $ref: "#/$defs/__proto__" },
+  });
+  TestValidator.equals(
+    "public components keeps ordinary prototype",
+    Object.getPrototypeOf(createdComponents.schemas!),
+    Object.prototype,
+  );
+
+  const cyclicDefinitions: Record<string, ILlmSchema> = {
+    A: { $ref: "#/$defs/B" },
+    B: { $ref: "#/$defs/A" },
+  };
+  TestValidator.equals(
+    "cyclic LLM coverage terminates",
+    LlmTypeChecker.covers({
+      $defs: cyclicDefinitions,
+      x: { $ref: "#/$defs/A" },
+      y: { type: "string" },
+    }),
+    false,
+  );
+  TestValidator.equals(
+    "inherited LLM definition is unresolved",
+    LlmTypeChecker.covers({
+      $defs: Object.create({ toString: { type: "string" } }),
+      x: { $ref: "#/$defs/toString" },
+      y: { type: "string" },
+    }),
     false,
   );
 

--- a/tests/test-utils/src/features/migrate/test_http_migrate_prototype_safe_components.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_prototype_safe_components.ts
@@ -1,0 +1,94 @@
+import { TestValidator } from "@nestia/e2e";
+import {
+  IHttpMigrateApplication,
+  IHttpMigrateRoute,
+  OpenApi,
+} from "@typia/interface";
+import { HttpMigration } from "@typia/utils";
+
+/**
+ * Verifies HTTP migration resolves only own component schemas.
+ *
+ * Component maps can arrive from programmatic callers rather than JSON, so an
+ * inherited schema name must never be treated as a route parameter object.
+ * Reserved own names remain valid schema data.
+ *
+ * 1. Resolve an own `toString` query-object component.
+ * 2. Ignore an inherited-only component with the same object shape.
+ * 3. Require route composition to preserve own component membership.
+ */
+export const test_http_migrate_prototype_safe_components = (): void => {
+  const schemas = Object.assign(
+    Object.create({
+      inherited: {
+        type: "object",
+        properties: { polluted: { type: "string" } },
+      },
+    }),
+    Object.fromEntries([
+      [
+        "toString",
+        {
+          type: "object",
+          properties: { keyword: { type: "string" } },
+        },
+      ],
+    ]),
+  ) as Record<string, OpenApi.IJsonSchema>;
+  const document: OpenApi.IDocument = {
+    openapi: "3.2.0",
+    "x-typia-emended-v12": true,
+    components: { schemas },
+    paths: {
+      "/own": {
+        get: {
+          parameters: [
+            {
+              name: "query",
+              in: "query",
+              schema: { $ref: "#/components/schemas/toString" },
+            },
+          ],
+        },
+      },
+      "/inherited": {
+        get: {
+          parameters: [
+            {
+              name: "query",
+              in: "query",
+              schema: { $ref: "#/components/schemas/inherited" },
+            },
+          ],
+        },
+      },
+    },
+  };
+  const app: IHttpMigrateApplication = HttpMigration.application(document);
+  const own: IHttpMigrateRoute = app.routes.find(
+    (route) => route.path === "/own",
+  )!;
+  const inherited: IHttpMigrateRoute = app.routes.find(
+    (route) => route.path === "/inherited",
+  )!;
+
+  TestValidator.equals(
+    "own reserved component resolves",
+    (own.query!.schema as OpenApi.IJsonSchema.IReference).$ref,
+    "#/components/schemas/toString",
+  );
+  TestValidator.predicate(
+    "inherited component is not resolved",
+    () =>
+      (inherited.query!.schema as OpenApi.IJsonSchema.IReference).$ref !==
+      "#/components/schemas/inherited",
+  );
+  TestValidator.predicate("reserved component remains own", () =>
+    Object.hasOwn(app.document().components.schemas!, "toString"),
+  );
+  TestValidator.equals(
+    "inherited component remains absent",
+    Object.hasOwn(app.document().components.schemas!, "inherited"),
+    false,
+  );
+};

--- a/tests/test-utils/src/features/openapi/test_json_schema_upgrade_v31_tuple_items.ts
+++ b/tests/test-utils/src/features/openapi/test_json_schema_upgrade_v31_tuple_items.ts
@@ -42,6 +42,7 @@ export const test_json_schema_upgrade_v31_tuple_items = (): void => {
     items: false,
   } as unknown as OpenApiV3_1.IJsonSchema);
   assertTupleRest("false rest", falseRest, false);
+  expectValidation("false rest permits omitted prefix", falseRest, [], true);
   expectValidation("false rest accepts prefix", falseRest, ["x"], true);
   expectValidation("false rest rejects extra", falseRest, ["x", 1], false);
 

--- a/tests/test-utils/src/features/openapi/test_json_schema_upgrade_v31_tuple_items.ts
+++ b/tests/test-utils/src/features/openapi/test_json_schema_upgrade_v31_tuple_items.ts
@@ -1,0 +1,85 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3_1 } from "@typia/interface";
+import { OpenApiConverter, OpenApiValidator } from "@typia/utils";
+
+/**
+ * Verifies OpenAPI 3.1 prefixItems keeps the standard items rest schema.
+ *
+ * JSON Schema 2020-12 assigns tuple rest behavior to `items`; the deprecated
+ * `additionalItems` keyword has no effect beside `prefixItems`. The upgrader
+ * previously dropped `items` and consulted the deprecated keyword, changing
+ * valid tuple languages.
+ *
+ * 1. Upgrade schema, false, and omitted `items` rest forms beside prefixItems.
+ * 2. Require the emended additionalItems form to preserve each meaning.
+ * 3. Validate positive and negative boundary values after conversion.
+ */
+export const test_json_schema_upgrade_v31_tuple_items = (): void => {
+  const schemaRest = upgrade({
+    type: "array",
+    prefixItems: [{ type: "string" }],
+    items: { type: "number" },
+    additionalItems: false,
+    minItems: 1,
+  } as OpenApiV3_1.IJsonSchema);
+  assertTupleRest("schema rest", schemaRest, { type: "number" });
+  expectValidation(
+    "schema rest accepts numbers",
+    schemaRest,
+    ["x", 1, 2],
+    true,
+  );
+  expectValidation(
+    "schema rest rejects strings",
+    schemaRest,
+    ["x", "y"],
+    false,
+  );
+
+  const falseRest = upgrade({
+    type: "array",
+    prefixItems: [{ type: "string" }],
+    items: false,
+  } as unknown as OpenApiV3_1.IJsonSchema);
+  assertTupleRest("false rest", falseRest, false);
+  expectValidation("false rest accepts prefix", falseRest, ["x"], true);
+  expectValidation("false rest rejects extra", falseRest, ["x", 1], false);
+
+  const openRest = upgrade({
+    type: "array",
+    prefixItems: [{ type: "string" }],
+  } as OpenApiV3_1.IJsonSchema);
+  assertTupleRest("omitted items is open", openRest, true);
+  expectValidation(
+    "open rest accepts extra",
+    openRest,
+    ["x", { anything: true }],
+    true,
+  );
+};
+
+const upgrade = (schema: OpenApiV3_1.IJsonSchema): OpenApi.IJsonSchema =>
+  OpenApiConverter.upgradeSchema({ components: {}, schema });
+
+const assertTupleRest = (
+  label: string,
+  schema: OpenApi.IJsonSchema,
+  expected: boolean | OpenApi.IJsonSchema,
+): void => {
+  if (!("prefixItems" in schema))
+    throw new Error(`${label} did not produce a tuple.`);
+  TestValidator.equals(label, schema.additionalItems, expected);
+};
+
+const expectValidation = (
+  label: string,
+  schema: OpenApi.IJsonSchema,
+  value: unknown,
+  success: boolean,
+): void =>
+  TestValidator.equals(
+    label,
+    OpenApiValidator.validate({ components: {}, schema, value, required: true })
+      .success,
+    success,
+  );

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_intrinsic_object_tuple_invariants.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_intrinsic_object_tuple_invariants.ts
@@ -1,0 +1,197 @@
+import { TestValidator } from "@nestia/e2e";
+import { IValidation, OpenApi } from "@typia/interface";
+import { OpenApiValidator } from "@typia/utils";
+
+/**
+ * Verifies OpenAPI validation enforces intrinsic JSON and tuple invariants.
+ *
+ * Object validation previously admitted every non-null JavaScript object,
+ * numeric validation admitted non-finite values, and tuple validation ignored
+ * bounds, uniqueness, optional prefixes, and element requiredness. These
+ * expectations come from the JSON data model and JSON Schema 2020-12 rather
+ * than the prior implementation.
+ *
+ * 1. Check plain/null-prototype objects against arrays and native instances.
+ * 2. Reject non-finite numbers and unresolved inherited references.
+ * 3. Exercise tuple min/max/unique, optional prefixes, required present elements,
+ *    typed rest items, false rest items, and empty tuples.
+ */
+export const test_openapi_validator_intrinsic_object_tuple_invariants =
+  (): void => {
+    const objectSchema: OpenApi.IJsonSchema.IObject = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    };
+    expectSuccess("plain object", objectSchema, { name: "typia" });
+    expectSuccess(
+      "null-prototype object",
+      objectSchema,
+      Object.assign(Object.create(null), { name: "typia" }),
+    );
+    const emptyObjectSchema: OpenApi.IJsonSchema.IObject = { type: "object" };
+    for (const [label, value] of [
+      ["array", []],
+      ["date", new Date(0)],
+      ["map", new Map()],
+      ["set", new Set()],
+      ["class", new (class Payload {})()],
+    ] as const)
+      expectFailure(`${label} is not a JSON object`, emptyObjectSchema, value);
+    expectFailure(
+      "inherited object property is absent",
+      objectSchema,
+      Object.create({ name: "inherited" }),
+    );
+
+    for (const value of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ]) {
+      expectFailure("non-finite number", { type: "number" }, value);
+      expectFailure("non-finite integer", { type: "integer" }, value);
+    }
+    expectSuccess("finite number boundary", { type: "number" }, 0);
+    expectSuccess("finite integer boundary", { type: "integer" }, 0);
+    expectSuccess(
+      "number bound boundary",
+      { type: "number", minimum: 0, maximum: 1 },
+      1,
+    );
+    expectFailure(
+      "number bound violation",
+      { type: "number", minimum: 0, maximum: 1 },
+      2,
+    );
+
+    const inheritedSchemas = Object.create({
+      toString: { type: "string" },
+    }) as Record<string, OpenApi.IJsonSchema>;
+    expectFailure(
+      "inherited reference is unresolved",
+      { $ref: "#/components/schemas/toString" },
+      "not actually resolved",
+      { schemas: inheritedSchemas },
+    );
+    expectSuccess(
+      "reserved own reference resolves",
+      { $ref: "#/components/schemas/toString" },
+      "resolved",
+      { schemas: Object.fromEntries([["toString", { type: "string" }]]) },
+    );
+    expectFailure(
+      "cyclic reference chain fails deterministically",
+      { $ref: "#/components/schemas/Loop" },
+      "value",
+      {
+        schemas: {
+          Loop: { $ref: "#/components/schemas/Alias" },
+          Alias: { $ref: "#/components/schemas/Loop" },
+        },
+      },
+    );
+    expectFailure(
+      "cyclic union reference fails deterministically",
+      { $ref: "#/components/schemas/UnionLoop" },
+      "value",
+      {
+        schemas: {
+          UnionLoop: {
+            oneOf: [{ $ref: "#/components/schemas/UnionLoop" }],
+          },
+        },
+      },
+    );
+
+    const optionalTuple: OpenApi.IJsonSchema.ITuple = {
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "number" }],
+      additionalItems: false,
+      minItems: 1,
+      maxItems: 2,
+    };
+    expectSuccess("optional trailing prefix", optionalTuple, ["first"]);
+    expectFailure("tuple minimum", optionalTuple, []);
+    expectFailure("tuple maximum", optionalTuple, ["first", 2, 3]);
+    expectFailure(
+      "present tuple element is required",
+      optionalTuple,
+      ["first", undefined],
+      {},
+      false,
+    );
+    expectFailure(
+      "tuple holes are not present JSON values",
+      optionalTuple,
+      Object.assign(new Array(2), { 0: "first" }),
+      {},
+      false,
+    );
+
+    const uniqueTuple: OpenApi.IJsonSchema.ITuple = {
+      type: "array",
+      prefixItems: [{ type: "number" }, { type: "number" }],
+      additionalItems: false,
+      minItems: 2,
+      uniqueItems: true,
+    };
+    expectFailure("tuple uniqueness", uniqueTuple, [1, 1]);
+    expectFailure(
+      "structural array duplicates",
+      {
+        type: "array",
+        items: {},
+        uniqueItems: true,
+      },
+      [0, { id: 1 }, { id: 1 }],
+    );
+    expectSuccess("tuple unique values", uniqueTuple, [1, 2]);
+
+    const restTuple: OpenApi.IJsonSchema.ITuple = {
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      additionalItems: { type: "number" },
+      minItems: 1,
+    };
+    expectSuccess("typed tuple rest", restTuple, ["first", 1, 2]);
+    expectFailure("invalid tuple rest", restTuple, ["first", "second"]);
+    expectSuccess(
+      "empty fixed tuple",
+      { type: "array", prefixItems: [], additionalItems: false, maxItems: 0 },
+      [],
+    );
+  };
+
+const expectSuccess = (
+  label: string,
+  schema: OpenApi.IJsonSchema,
+  value: unknown,
+  components: OpenApi.IComponents = {},
+  required: boolean = true,
+): void =>
+  TestValidator.equals(
+    label,
+    validate(schema, value, components, required).success,
+    true,
+  );
+const expectFailure = (
+  label: string,
+  schema: OpenApi.IJsonSchema,
+  value: unknown,
+  components: OpenApi.IComponents = {},
+  required: boolean = true,
+): void =>
+  TestValidator.equals(
+    label,
+    validate(schema, value, components, required).success,
+    false,
+  );
+
+const validate = (
+  schema: OpenApi.IJsonSchema,
+  value: unknown,
+  components: OpenApi.IComponents,
+  required: boolean,
+): IValidation<unknown> =>
+  OpenApiValidator.validate({ components, schema, value, required });

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_intrinsic_object_tuple_invariants.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_intrinsic_object_tuple_invariants.ts
@@ -103,6 +103,12 @@ export const test_openapi_validator_intrinsic_object_tuple_invariants =
         },
       },
     );
+    expectFailure(
+      "null component dictionary is unresolved",
+      { $ref: "#/components/schemas/Missing" },
+      "value",
+      { schemas: null } as unknown as OpenApi.IComponents,
+    );
 
     const optionalTuple: OpenApi.IJsonSchema.ITuple = {
       type: "array",
@@ -125,6 +131,30 @@ export const test_openapi_validator_intrinsic_object_tuple_invariants =
       "tuple holes are not present JSON values",
       optionalTuple,
       Object.assign(new Array(2), { 0: "first" }),
+      {},
+      false,
+    );
+    expectFailure(
+      "unknown tuple prefix still requires a JSON value",
+      {
+        type: "array",
+        prefixItems: [{}],
+        additionalItems: false,
+        minItems: 1,
+      },
+      [undefined],
+      {},
+      false,
+    );
+    expectFailure(
+      "open tuple rest still requires a JSON value",
+      {
+        type: "array",
+        prefixItems: [],
+        additionalItems: true,
+        minItems: 1,
+      },
+      [undefined],
       {},
       false,
     );

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_intrinsic_object_tuple_invariants.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_intrinsic_object_tuple_invariants.ts
@@ -29,13 +29,16 @@ export const test_openapi_validator_intrinsic_object_tuple_invariants =
       objectSchema,
       Object.assign(Object.create(null), { name: "typia" }),
     );
+    class Payload {
+      public name = "typia";
+    }
+    expectSuccess("serializable class object", objectSchema, new Payload());
     const emptyObjectSchema: OpenApi.IJsonSchema.IObject = { type: "object" };
     for (const [label, value] of [
       ["array", []],
       ["date", new Date(0)],
       ["map", new Map()],
       ["set", new Set()],
-      ["class", new (class Payload {})()],
     ] as const)
       expectFailure(`${label} is not a JSON object`, emptyObjectSchema, value);
     expectFailure(

--- a/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
@@ -150,7 +150,7 @@ const invalidCases: ReadonlyArray<
 > = [
   ["undefined", "$input"],
   ["null", "$input"],
-  ["array", "$input.value"],
+  ["array", "$input"],
   ["primitive", "$input"],
   ["missing", "$input.value"],
   ["extra", "$input.extra"],


### PR DESCRIPTION
## Overview

Reserve one cohesive implementation batch for OpenAPI object safety:

- make `UniqueItems` validation and random generation use one deterministic deep structural equality relation;
- treat parsed JSON objects and schema/component maps as prototype-safe data dictionaries;
- enforce intrinsic object, numeric, tuple, reference, and OpenAPI 3.1 conversion invariants across OpenAPI and LLM consumers.

Closes #2032
Closes #2042
Closes #2043

## Scope

The implementation will remain within the shared typia/runtime and `@typia/utils` OpenAPI/LLM owners, with focused regression coverage for positive, negative, boundary, and oracle-derived cases. Fixture-specific workarounds, unrelated scalar semantics, and repository-wide formatting are excluded.

## Coordination

PR #2060 currently has an adjacent OpenAPI 3.1 upgrader change and PR #2062 has adjacent Swagger conversion work. This branch will refresh from current `master` before merge and resolve any converter overlap semantically, retaining both contracts.

## Verification

Pending. This draft is an implementation-free campaign claim; tests-first focused suites, affected package builds, broader applicable local verification, and repeated solo Self-Review rounds will be recorded before merge.

Repository Actions are deliberately cancelled by exact campaign commit SHA after every push and pull-request event. No workflow or repository Actions setting is disabled; local verification is the campaign gate.
