### PR TITLE
fix(typia): restore native mechanics contracts

### DIFF
--- a/examples/src/functional/assertFunction.ts
+++ b/examples/src/functional/assertFunction.ts
@@ -1,7 +1,13 @@
 import typia from "typia";
 
-const func = typia.functional.assertFunction<(x: number, y: number) => number>(
-  (x: number, y: number): number => x + y,
-);
-func(3, 4);
-func(4, 5);
+interface Receiver {
+  offset: number;
+}
+
+function add(this: Receiver, x: number, y: number): number {
+  return this.offset + x + y;
+}
+
+const func = typia.functional.assertFunction(add);
+func.call({ offset: 10 }, 3, 4);
+func.call({ offset: 20 }, 4, 5);

--- a/examples/src/functional/isFunction.ts
+++ b/examples/src/functional/isFunction.ts
@@ -1,7 +1,13 @@
 import typia from "typia";
 
-const func = typia.functional.isFunction<(x: number, y: number) => number>(
-  (x: number, y: number): number => x + y,
-);
-func(3, 4);
-func(4, 5);
+interface Receiver {
+  offset: number;
+}
+
+function add(this: Receiver, x: number, y: number): number {
+  return this.offset + x + y;
+}
+
+const func = typia.functional.isFunction(add);
+func.call({ offset: 10 }, 3, 4);
+func.call({ offset: 20 }, 4, 5);

--- a/examples/src/functional/validateFunction.ts
+++ b/examples/src/functional/validateFunction.ts
@@ -1,7 +1,13 @@
 import typia from "typia";
 
-const func = typia.functional.validateFunction<
-  (x: number, y: number) => number
->((x: number, y: number): number => x + y);
-func(3, 4);
-func(4, 5);
+interface Receiver {
+  offset: number;
+}
+
+function add(this: Receiver, x: number, y: number): number {
+  return this.offset + x + y;
+}
+
+const func = typia.functional.validateFunction(add);
+func.call({ offset: 10 }, 3, 4);
+func.call({ offset: 20 }, 4, 5);

--- a/packages/typia/native/cmd/ttsc-typia/assert_guard_factory_contract_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/assert_guard_factory_contract_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestAssertGuardFactoryContract verifies factory typing and runtime shape.
+//
+// An assertion-guard factory returns the guard itself. Its successful invocation
+// returns void while narrowing the input; it never returns another callable
+// assertion guard.
+//
+//  1. Compile normal and equals factories with explicit and inferred types.
+//  2. Prove successful invocations narrow and have a void return type.
+//  3. Exercise custom errors and the equals-only surplus-property boundary.
+func TestAssertGuardFactoryContract(t *testing.T) {
+  project := compareEqualCoverProject(t, "assert-guard-factory-", assertGuardFactorySource)
+  ttscTypiaTestAssertGuardFactoryType(t, project)
+  ttscTypiaTestTypecheck(t, project)
+  js := compareEqualCoverTransform(t, project)
+  if strings.Contains(js, "createAssertGuard<") {
+    t.Fatalf("assert guard factory call was not transformed:\n%s", js)
+  }
+
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(ttscTypiaTestRewriteCommonJS(t, js)), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(assertGuardFactoryRuntime), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  if output, err := cmd.CombinedOutput(); err != nil {
+    t.Fatalf("assert guard factory runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+func ttscTypiaTestAssertGuardFactoryType(t *testing.T, project string) {
+  t.Helper()
+  program, diagnostics, err := driver.LoadProgram(project, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatalf("load assertion guard fixture: %v", err)
+  }
+  if len(diagnostics) != 0 {
+    t.Fatalf("assertion guard fixture diagnostics: %+v", diagnostics)
+  }
+  defer program.Close()
+
+  source := program.SourceFile(filepath.Join(project, "src", "main.ts"))
+  if source == nil {
+    t.Fatal("assertion guard fixture source was not loaded")
+  }
+  found := 0
+  for _, statement := range source.Statements.Nodes {
+    if statement.Kind != shimast.KindVariableStatement {
+      continue
+    }
+    for _, declaration := range statement.AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes {
+      name := declaration.Name().Text()
+      if name != "inferred" && name != "inferredEquals" {
+        continue
+      }
+      found++
+      typeName := program.Checker.TypeToString(program.Checker.GetTypeAtLocation(declaration))
+      if strings.Contains(typeName, "=> AssertionGuard") {
+        t.Fatalf("%s returns a nested assertion guard: %s", name, typeName)
+      }
+      if typeName != "AssertionGuard<User>" && !strings.Contains(typeName, "asserts input is User") {
+        t.Fatalf("%s is not an assertion guard: %s", name, typeName)
+      }
+    }
+  }
+  if found != 2 {
+    t.Fatalf("expected two inferred assertion guards, found %d", found)
+  }
+}
+
+const assertGuardFactorySource = `import typia, { AssertionGuard, TypeGuardError } from "typia";
+
+interface User {
+  id: number;
+}
+
+const custom = (props: TypeGuardError.IProps): Error =>
+  Object.assign(new Error("custom guard"), props);
+
+export const guard: AssertionGuard<User> = typia.createAssertGuard<User>(custom);
+export const equalsGuard: AssertionGuard<User> = typia.createAssertGuardEquals<User>(custom);
+export const inferred = typia.createAssertGuard<User>();
+export const inferredEquals = typia.createAssertGuardEquals<User>();
+
+let input: unknown = { id: 1 };
+const returned = guard(input);
+input.id satisfies number;
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
+type Assert<T extends true> = T;
+export type FactoryCases = [
+  Assert<Equal<typeof inferred, AssertionGuard<User>>>,
+  Assert<Equal<typeof inferredEquals, AssertionGuard<User>>>,
+  Assert<Equal<typeof returned, void>>,
+];
+
+// @ts-expect-error invoking an assertion guard returns void, not another guard.
+const nested: AssertionGuard<User> = guard(input);
+void nested;
+`
+
+const assertGuardFactoryRuntime = `const mod = require("./main.cjs");
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) throw new Error(label + ": expected " + expected + ", got " + actual);
+};
+
+expect("normal success returns void", mod.guard({ id: 1 }), undefined);
+expect("equals success returns void", mod.equalsGuard({ id: 1 }), undefined);
+expect("normal permits surplus", mod.guard({ id: 1, extra: true }), undefined);
+
+for (const [label, guard, value] of [
+  ["normal invalid", mod.guard, { id: "bad" }],
+  ["equals invalid", mod.equalsGuard, { id: "bad" }],
+  ["equals surplus", mod.equalsGuard, { id: 1, extra: true }],
+]) {
+  let error;
+  try {
+    guard(value);
+  } catch (exp) {
+    error = exp;
+  }
+  expect(label + " uses custom error", error && error.message, "custom guard");
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/compare_less_nan_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/compare_less_nan_transform_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCompareLessNaNTransform verifies NaN-last total ordering.
+//
+// Relational comparison treats NaN as equal to every value because both `<`
+// and `>` return false. The compare contract instead needs a total scalar order
+// so its documented two-direction sort comparator never collapses distinct
+// numeric or Date values.
+//
+//  1. Transform direct and factory comparators over scalars and containers.
+//  2. Exercise NaN, infinities, signed zero, and invalid Date boundaries.
+//  3. Verify antisymmetry and sort composition across nested sibling paths.
+func TestCompareLessNaNTransform(t *testing.T) {
+  project := compareEqualCoverProject(t, "compare-less-nan-", compareLessNaNSource)
+  js := compareEqualCoverTransform(t, project)
+  if !strings.Contains(js, "Number") && !strings.Contains(js, "!==") {
+    t.Fatalf("NaN-aware output is missing a numeric discriminator:\n%s", js)
+  }
+
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(ttscTypiaTestRewriteCommonJS(t, js)), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(compareLessNaNRuntime), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  if output, err := cmd.CombinedOutput(); err != nil {
+    t.Fatalf("NaN ordering runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const compareLessNaNSource = `import typia from "typia";
+
+export const lessNumber = typia.compare.createLess<number>();
+export const lessNumberDirect = (x: number, y: number) => typia.compare.less<number>(x, y);
+export const lessDate = typia.compare.createLess<Date>();
+export const lessArray = typia.compare.createLess<number[]>();
+export const lessTuple = typia.compare.createLess<[number, Date]>();
+export const lessNested = typia.compare.createLess<{ value: number }>();
+export const lessMixed = typia.compare.createLess<number | string>();
+`
+
+const compareLessNaNRuntime = `const mod = require("./main.cjs");
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) throw new Error(label + ": expected " + expected + ", got " + actual);
+};
+const assertPair = (label, less, ordinary, nan) => {
+  expect(label + " ordinary < NaN", less(ordinary, nan), true);
+  expect(label + " NaN !< ordinary", less(nan, ordinary), false);
+  expect(label + " NaN !< NaN", less(nan, nan), false);
+};
+
+for (const less of [mod.lessNumber, mod.lessNumberDirect]) {
+  assertPair("number", less, 1, Number.NaN);
+  expect("-Infinity < finite", less(-Infinity, 0), true);
+  expect("finite < Infinity", less(0, Infinity), true);
+  expect("signed zero equivalent left", less(-0, 0), false);
+  expect("signed zero equivalent right", less(0, -0), false);
+}
+
+assertPair("date", mod.lessDate, new Date(0), new Date(Number.NaN));
+assertPair("array", mod.lessArray, [1], [Number.NaN]);
+assertPair("tuple head", mod.lessTuple, [1, new Date(0)], [Number.NaN, new Date(0)]);
+assertPair("tuple date", mod.lessTuple, [1, new Date(0)], [1, new Date(Number.NaN)]);
+assertPair("nested", mod.lessNested, { value: 1 }, { value: Number.NaN });
+assertPair("mixed numeric arm", mod.lessMixed, 1, Number.NaN);
+expect("mixed type rank before numeric rule", mod.lessMixed(Number.NaN, "a"), true);
+
+const values = [Number.NaN, Infinity, -1, -Infinity, 0, Number.NaN];
+const comparator = (x, y) => mod.lessNumber(x, y) ? -1 : mod.lessNumber(y, x) ? 1 : 0;
+const sorted = values.slice().sort(comparator);
+expect("sort first", sorted[0], -Infinity);
+expect("sort second", sorted[1], -1);
+expect("sort third", sorted[2], 0);
+expect("sort fourth", sorted[3], Infinity);
+expect("sort NaN tail 1", Number.isNaN(sorted[4]), true);
+expect("sort NaN tail 2", Number.isNaN(sorted[5]), true);
+`

--- a/packages/typia/native/cmd/ttsc-typia/functional_receiver_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/functional_receiver_transform_test.go
@@ -16,7 +16,7 @@ import (
 // silently discard that contract.
 //
 //  1. Transform all assert, is/equals, and validate parameter/return variants.
-//  2. Exercise sync and async targets through `.call`, binding, and extraction.
+//  2. Exercise sync, async, bound, and receiver-free targets.
 //  3. Preserve validation failures, thrown errors, and receiver-dependent data.
 func TestFunctionalReceiverTransform(t *testing.T) {
   project := compareEqualCoverProject(t, "functional-receiver-", functionalReceiverSource)
@@ -115,6 +115,12 @@ export const asynchronous = {
 
 const boundReceiver: Receiver = { base: 20, calls: 0 };
 export const boundAssert = typia.functional.assertFunction(syncTarget).bind(boundReceiver);
+export const customAssert = typia.functional.assertParameters(
+  syncTarget,
+  (props) => Object.assign(new Error("custom receiver"), props),
+);
+export const receiverFree = typia.functional.isFunction((input: Input): Output => ({ total: input.value }));
+export const receiverFreeResult = receiverFree({ value: 2 });
 export const throwing = typia.functional.assertParameters(function (this: Receiver, input: Input): Output {
   throw new Error(String(this.base + input.value));
 });
@@ -177,6 +183,7 @@ const checkResult = (label, name, result) => {
   const bound = mod.boundAssert.call(ignored, { value: 2 });
   expect("bound wrapper keeps bound receiver", bound.total, 22);
   expect("bound wrapper ignores call receiver", ignored.calls, 0);
+  expect("receiver-free arrow remains directly callable", mod.receiverFreeResult.total, 2);
 
   const receiver = { base: 40, calls: 0 };
   let thrown;
@@ -196,11 +203,28 @@ const checkResult = (label, name, result) => {
     } catch (exp) {
       error = exp;
     }
-    if (assertNames.has(name)) expect("assert invalid throws", Boolean(error), true);
-    else if (validateNames.has(name)) expect("validate invalid fails", result.success, false);
-    else expect("is invalid returns null", result, null);
+    if (assertNames.has(name)) {
+      expect("assert invalid throws", Boolean(error), true);
+      expect("assert invalid path", error.path, "$input.parameters[0].value");
+    } else if (validateNames.has(name)) {
+      expect("validate invalid fails", result.success, false);
+      expect("validate invalid path", result.errors[0].path, "$input.parameters[0].value");
+    } else {
+      expect("is invalid returns null", result, null);
+    }
     expect(name + " invalid does not invoke target", receiver.calls, 0);
   }
+
+  const customReceiver = { base: 40, calls: 0 };
+  let customError;
+  try {
+    mod.customAssert.call(customReceiver, { value: "bad" });
+  } catch (error) {
+    customError = error;
+  }
+  expect("custom error factory message", customError && customError.message, "custom receiver");
+  expect("custom error factory path", customError && customError.path, "$input.parameters[0].value");
+  expect("custom error does not invoke target", customReceiver.calls, 0);
 })().catch((error) => {
   console.error(error);
   process.exitCode = 1;

--- a/packages/typia/native/cmd/ttsc-typia/functional_receiver_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/functional_receiver_transform_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestFunctionalReceiverTransform verifies dynamic receiver preservation.
+//
+// Functional wrappers advertise the target function's receiver contract, so
+// the emitted wrapper must be an ordinary function and must invoke the captured
+// target with the wrapper's call-site `this`. Arrow wrappers and bare calls
+// silently discard that contract.
+//
+//  1. Transform all assert, is/equals, and validate parameter/return variants.
+//  2. Exercise sync and async targets through `.call`, binding, and extraction.
+//  3. Preserve validation failures, thrown errors, and receiver-dependent data.
+func TestFunctionalReceiverTransform(t *testing.T) {
+  project := compareEqualCoverProject(t, "functional-receiver-", functionalReceiverSource)
+  ttscTypiaTestTypecheck(t, project)
+  js := compareEqualCoverTransform(t, project)
+  if !strings.Contains(js, "Reflect.apply") {
+    t.Fatalf("functional output does not forward the dynamic receiver:\n%s", js)
+  }
+
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(ttscTypiaTestRewriteCommonJS(t, js)), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(functionalReceiverRuntime), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  if output, err := cmd.CombinedOutput(); err != nil {
+    t.Fatalf("functional receiver runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const functionalReceiverSource = `import typia from "typia";
+
+export interface Receiver {
+  base: number;
+  calls: number;
+}
+export interface Input {
+  value: number;
+}
+export interface Output {
+  total: number;
+}
+
+export function syncTarget(this: Receiver, input: Input): Output {
+  this.calls += 1;
+  return { total: this.base + input.value };
+}
+export async function asyncTarget(this: Receiver, input: Input): Promise<Output> {
+  this.calls += 1;
+  return { total: this.base + input.value };
+}
+
+export const sync = {
+  assertFunction: typia.functional.assertFunction(syncTarget),
+  assertParameters: typia.functional.assertParameters(syncTarget),
+  assertReturn: typia.functional.assertReturn(syncTarget),
+  assertEqualsFunction: typia.functional.assertEqualsFunction(syncTarget),
+  assertEqualsParameters: typia.functional.assertEqualsParameters(syncTarget),
+  assertEqualsReturn: typia.functional.assertEqualsReturn(syncTarget),
+  isFunction: typia.functional.isFunction(syncTarget),
+  isParameters: typia.functional.isParameters(syncTarget),
+  isReturn: typia.functional.isReturn(syncTarget),
+  equalsFunction: typia.functional.equalsFunction(syncTarget),
+  equalsParameters: typia.functional.equalsParameters(syncTarget),
+  equalsReturn: typia.functional.equalsReturn(syncTarget),
+  validateFunction: typia.functional.validateFunction(syncTarget),
+  validateParameters: typia.functional.validateParameters(syncTarget),
+  validateReturn: typia.functional.validateReturn(syncTarget),
+  validateEqualsFunction: typia.functional.validateEqualsFunction(syncTarget),
+  validateEqualsParameters: typia.functional.validateEqualsParameters(syncTarget),
+  validateEqualsReturn: typia.functional.validateEqualsReturn(syncTarget),
+};
+
+export const asynchronous = {
+  assertFunction: typia.functional.assertFunction(asyncTarget),
+  assertParameters: typia.functional.assertParameters(asyncTarget),
+  assertReturn: typia.functional.assertReturn(asyncTarget),
+  assertEqualsFunction: typia.functional.assertEqualsFunction(asyncTarget),
+  assertEqualsParameters: typia.functional.assertEqualsParameters(asyncTarget),
+  assertEqualsReturn: typia.functional.assertEqualsReturn(asyncTarget),
+  isFunction: typia.functional.isFunction(asyncTarget),
+  isParameters: typia.functional.isParameters(asyncTarget),
+  isReturn: typia.functional.isReturn(asyncTarget),
+  equalsFunction: typia.functional.equalsFunction(asyncTarget),
+  equalsParameters: typia.functional.equalsParameters(asyncTarget),
+  equalsReturn: typia.functional.equalsReturn(asyncTarget),
+  validateFunction: typia.functional.validateFunction(asyncTarget),
+  validateParameters: typia.functional.validateParameters(asyncTarget),
+  validateReturn: typia.functional.validateReturn(asyncTarget),
+  validateEqualsFunction: typia.functional.validateEqualsFunction(asyncTarget),
+  validateEqualsParameters: typia.functional.validateEqualsParameters(asyncTarget),
+  validateEqualsReturn: typia.functional.validateEqualsReturn(asyncTarget),
+};
+
+const boundReceiver: Receiver = { base: 20, calls: 0 };
+export const boundAssert = typia.functional.assertFunction(syncTarget).bind(boundReceiver);
+export const throwing = typia.functional.assertParameters(function (this: Receiver, input: Input): Output {
+  throw new Error(String(this.base + input.value));
+});
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
+type Assert<T extends true> = T;
+export type ReceiverCases = [
+  Assert<Equal<ThisParameterType<typeof sync.assertFunction>, Receiver>>,
+  Assert<Equal<ThisParameterType<typeof sync.isFunction>, Receiver>>,
+  Assert<Equal<ThisParameterType<typeof sync.equalsParameters>, Receiver>>,
+  Assert<Equal<ThisParameterType<typeof sync.validateReturn>, Receiver>>,
+  Assert<Equal<ThisParameterType<typeof sync.validateEqualsFunction>, Receiver>>,
+  Assert<Equal<ThisParameterType<typeof asynchronous.assertReturn>, Receiver>>,
+  Assert<Equal<ThisParameterType<typeof asynchronous.isParameters>, Receiver>>,
+  Assert<Equal<ThisParameterType<typeof asynchronous.validateFunction>, Receiver>>,
+];
+`
+
+const functionalReceiverRuntime = `const mod = require("./main.cjs");
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) throw new Error(label + ": expected " + expected + ", got " + actual);
+};
+const assertNames = new Set([
+  "assertFunction", "assertParameters", "assertReturn",
+  "assertEqualsFunction", "assertEqualsParameters", "assertEqualsReturn",
+]);
+const validateNames = new Set([
+  "validateFunction", "validateParameters", "validateReturn",
+  "validateEqualsFunction", "validateEqualsParameters", "validateEqualsReturn",
+]);
+const checkResult = (label, name, result) => {
+  if (validateNames.has(name)) {
+    expect(label + " success", result.success, true);
+    expect(label + " total", result.data.total, 42);
+  } else {
+    expect(label + " non-null", result === null, false);
+    expect(label + " total", result.total, 42);
+  }
+};
+
+(async () => {
+  for (const [name, wrapped] of Object.entries(mod.sync)) {
+    const receiver = { base: 40, calls: 0 };
+    const result = wrapped.call(receiver, { value: 2 });
+    checkResult("sync " + name, name, result);
+    expect("sync " + name + " receiver calls", receiver.calls, 1);
+  }
+  for (const [name, wrapped] of Object.entries(mod.asynchronous)) {
+    const receiver = { base: 40, calls: 0 };
+    const result = await wrapped.call(receiver, { value: 2 });
+    checkResult("async " + name, name, result);
+    expect("async " + name + " receiver calls", receiver.calls, 1);
+  }
+
+  const ignored = { base: 100, calls: 0 };
+  const bound = mod.boundAssert.call(ignored, { value: 2 });
+  expect("bound wrapper keeps bound receiver", bound.total, 22);
+  expect("bound wrapper ignores call receiver", ignored.calls, 0);
+
+  const receiver = { base: 40, calls: 0 };
+  let thrown;
+  try {
+    mod.throwing.call(receiver, { value: 2 });
+  } catch (error) {
+    thrown = error;
+  }
+  expect("thrown target error", thrown && thrown.message, "42");
+
+  for (const name of ["assertFunction", "isFunction", "validateFunction"]) {
+    const receiver = { base: 40, calls: 0 };
+    let result;
+    let error;
+    try {
+      result = mod.sync[name].call(receiver, { value: "bad" });
+    } catch (exp) {
+      error = exp;
+    }
+    if (assertNames.has(name)) expect("assert invalid throws", Boolean(error), true);
+    else if (validateNames.has(name)) expect("validate invalid fails", result.success, false);
+    else expect("is invalid returns null", result, null);
+    expect(name + " invalid does not invoke target", receiver.calls, 0);
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+`

--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -3,11 +3,25 @@ package main
 import (
   "bytes"
   "os"
+  "os/exec"
   "path/filepath"
   "runtime"
   "strings"
   "testing"
 )
+
+func ttscTypiaTestTypecheck(t *testing.T, project string) {
+  t.Helper()
+  pnpm, err := exec.LookPath("pnpm")
+  if err != nil {
+    t.Skip("pnpm executable not found")
+  }
+  cmd := exec.Command(pnpm, "exec", "ttsc", "--noEmit", "-p", "tsconfig.json")
+  cmd.Dir = project
+  if output, err := cmd.CombinedOutput(); err != nil {
+    t.Fatalf("fixture typecheck failed: %v\n%s", err, output)
+  }
+}
 
 func ttscTypiaTestRepoRoot(t *testing.T) string {
   t.Helper()
@@ -50,6 +64,7 @@ func ttscTypiaTestWriteCommonRuntimeStubs(t *testing.T, runtimeDir string) {
     "validate-report-stub.cjs":   ttscTypiaTestValidateReportStub,
     "standard-schema-stub.cjs":   ttscTypiaTestStandardSchemaStub,
     "assert-guard-stub.cjs":      ttscTypiaTestAssertGuardStub,
+    "functional-error-stub.cjs":  ttscTypiaTestFunctionalErrorStub,
     "access-expression-stub.cjs": ttscTypiaTestAccessExpressionStub,
   }
   for name, content := range files {
@@ -65,6 +80,7 @@ func ttscTypiaTestRewriteCommonJS(t *testing.T, js string) string {
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_validateReport")`, `require("./validate-report-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_createStandardSchema")`, `require("./standard-schema-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_assertGuard")`, `require("./assert-guard-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_functionalTypeGuardErrorFactory")`, `require("./functional-error-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_accessExpressionAsString")`, `require("./access-expression-stub.cjs")`)
   for _, needle := range []string{`require("typia")`, `require('typia')`, `from "typia"`, `from 'typia'`, `typia/lib/internal/`} {
     if strings.Contains(runtimeJS, needle) {
@@ -110,6 +126,10 @@ const ttscTypiaTestAssertGuardStub = `module.exports._assertGuard = (exceptionab
   }
   return false;
 };
+`
+
+const ttscTypiaTestFunctionalErrorStub = `module.exports._functionalTypeGuardErrorFactory = (props) =>
+  Object.assign(new Error(props.expected), props);
 `
 
 const ttscTypiaTestAccessExpressionStub = `const reserved = new Set([

--- a/packages/typia/native/core/factories/ProtobufFactory.go
+++ b/packages/typia/native/core/factories/ProtobufFactory.go
@@ -44,7 +44,14 @@ func (protobufFactoryNamespace) Metadata(props ProtobufFactory_IProps) *schemame
       Errors: protobufFactory_errors(result.Errors),
     }))
   }
+  protobufFactory_emplaceObjects(props.Components.Objects())
   return result.Data
+}
+
+func protobufFactory_emplaceObjects(objects []*schemametadata.MetadataObjectType) {
+  for _, object := range objects {
+    ProtobufFactory.EmplaceObject(object)
+  }
 }
 
 func (protobufFactoryNamespace) EmplaceObject(object *schemametadata.MetadataObjectType) {
@@ -335,10 +342,6 @@ func protobufFactory_validate() MetadataFactory_Validator {
       }
       visited[obj.Type] = true
       protobufFactory_validateObject(obj.Type, &errors)
-      func() {
-        defer func() { _ = recover() }()
-        ProtobufFactory.EmplaceObject(obj.Type)
-      }()
     }
     noSupport := func(msg string) { insert("does not support " + msg) }
     if props.Metadata.Any {

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -129,15 +129,13 @@ func metadata_explore_symbol_name(node *nativeast.Node, name string) string {
   return name
 }
 
-func metadata_get_type_arguments(checker *nativechecker.Checker, typ *nativechecker.Type) (output []*nativechecker.Type) {
+func metadata_get_type_arguments(checker *nativechecker.Checker, typ *nativechecker.Type) []*nativechecker.Type {
   if checker == nil || typ == nil {
     return nil
   }
-  defer func() {
-    if recover() != nil {
-      output = nil
-    }
-  }()
+  if typ.Flags()&nativechecker.TypeFlagsObject == 0 || typ.ObjectFlags()&nativechecker.ObjectFlagsReference == 0 {
+    return nil
+  }
   return checker.GetTypeArguments(typ)
 }
 

--- a/packages/typia/native/core/factories/internal/metadata/type_arguments_precondition_test.go
+++ b/packages/typia/native/core/factories/internal/metadata/type_arguments_precondition_test.go
@@ -1,0 +1,70 @@
+package metadata
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestMetadataTypeArgumentsPrecondition verifies reference-only extraction.
+//
+// The checker accepts GetTypeArguments only for object-reference types. The
+// helper should identify that capability explicitly, return no arguments for a
+// primitive, and preserve generic arguments for a real reference.
+//
+//  1. Load primitive and generic reference declarations through the checker.
+//  2. Verify the primitive follows the unsupported-input fallback.
+//  3. Verify the reference returns its sole string argument.
+func TestMetadataTypeArgumentsPrecondition(t *testing.T) {
+  dir := t.TempDir()
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}`), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+    t.Fatalf("mkdir src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "src", "main.ts"), []byte(`
+interface Box<T> { value: T; }
+let primitive!: number;
+let reference!: Box<string>;
+`), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  program, diagnostics, err := driver.LoadProgram(dir, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatalf("load program: %v", err)
+  }
+  if len(diagnostics) != 0 {
+    t.Fatalf("fixture diagnostics: %+v", diagnostics)
+  }
+  defer program.Close()
+
+  source := program.SourceFile(filepath.Join(dir, "src", "main.ts"))
+  if source == nil || source.Statements == nil || len(source.Statements.Nodes) != 3 {
+    t.Fatal("fixture declarations were not loaded")
+  }
+  variableType := func(index int) *shimchecker.Type {
+    declaration := source.Statements.Nodes[index].AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes[0]
+    return program.Checker.GetTypeAtLocation(declaration)
+  }
+  if args := metadata_get_type_arguments(program.Checker, variableType(1)); len(args) != 0 {
+    t.Fatalf("primitive type returned %d type arguments", len(args))
+  }
+  args := metadata_get_type_arguments(program.Checker, variableType(2))
+  if len(args) != 1 || program.Checker.TypeToString(args[0]) != "string" {
+    t.Fatalf("generic reference arguments mismatch: %#v", args)
+  }
+}

--- a/packages/typia/native/core/factories/protobuf_recovery_ownership_test.go
+++ b/packages/typia/native/core/factories/protobuf_recovery_ownership_test.go
@@ -1,6 +1,7 @@
 package factories
 
 import (
+  "slices"
   "testing"
 
   schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
@@ -12,10 +13,25 @@ import (
 // inside the Protobuf emplacer must not be converted into a successful semantic
 // result by a blanket recover.
 //
-//  1. Build a sole static object that passes the outer shape preconditions.
-//  2. Give its property an impossible empty semantic schema.
+//  1. Verify unsupported metadata remains an ordinary diagnostic.
+//  2. Build a static object with an impossible empty semantic schema.
 //  3. Require the panic to escape the post-validation emplacement pass.
 func TestProtobufEmplacerRecoveryOwnership(t *testing.T) {
+  unsupported := schemametadata.MetadataSchema_initialize()
+  unsupported.Any = true
+  errors := protobufFactory_validate()(struct {
+    Metadata *schemametadata.MetadataSchema
+    Explore  MetadataFactory_IExplore
+    Top      *schemametadata.MetadataSchema
+  }{
+    Metadata: unsupported,
+    Explore:  MetadataFactory_IExplore{Top: true},
+    Top:      unsupported,
+  })
+  if !slices.Contains(errors, "does not support any type") {
+    t.Fatalf("unsupported any fallback mismatch: %v", errors)
+  }
+
   key := MetadataFactory.SoleLiteral("value")
   dynamicKey := schemametadata.MetadataSchema_initialize()
   dynamicKey.Atomics = append(dynamicKey.Atomics, schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "string"}))

--- a/packages/typia/native/core/factories/protobuf_recovery_ownership_test.go
+++ b/packages/typia/native/core/factories/protobuf_recovery_ownership_test.go
@@ -1,0 +1,48 @@
+package factories
+
+import (
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestProtobufEmplacerRecoveryOwnership verifies unexpected panics stay visible.
+//
+// Unsupported metadata is diagnosed before emission, but an invariant failure
+// inside the Protobuf emplacer must not be converted into a successful semantic
+// result by a blanket recover.
+//
+//  1. Build a sole static object that passes the outer shape preconditions.
+//  2. Give its property an impossible empty semantic schema.
+//  3. Require the panic to escape the post-validation emplacement pass.
+func TestProtobufEmplacerRecoveryOwnership(t *testing.T) {
+  key := MetadataFactory.SoleLiteral("value")
+  dynamicKey := schemametadata.MetadataSchema_initialize()
+  dynamicKey.Atomics = append(dynamicKey.Atomics, schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "string"}))
+  dynamic := schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{
+    Name: "BrokenMap",
+    Properties: []*schemametadata.MetadataProperty{
+      schemametadata.MetadataProperty_create(schemametadata.MetadataProperty{
+        Key:   dynamicKey,
+        Value: schemametadata.MetadataSchema_initialize(),
+      }),
+    },
+  })
+  value := schemametadata.MetadataSchema_initialize()
+  value.Objects = append(value.Objects, schemametadata.MetadataObject_create(schemametadata.MetadataObject{Type: dynamic}))
+  object := schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{
+    Name: "Broken",
+    Properties: []*schemametadata.MetadataProperty{
+      schemametadata.MetadataProperty_create(schemametadata.MetadataProperty{
+        Key:   key,
+        Value: value,
+      }),
+    },
+  })
+  defer func() {
+    if recover() == nil {
+      t.Fatal("unexpected Protobuf emplacer panic was swallowed")
+    }
+  }()
+  protobufFactory_emplaceObjects([]*schemametadata.MetadataObjectType{object})
+}

--- a/packages/typia/native/core/programmers/compare/CompareLessProgrammer.go
+++ b/packages/typia/native/core/programmers/compare/CompareLessProgrammer.go
@@ -219,9 +219,11 @@ func (g *compareLessProgrammerGenerator) core(metadata *schemametadata.MetadataS
 }
 
 // primitive renders the scalar three-way comparator (works for number, string,
-// boolean and bigint via the relational operators).
+// boolean and bigint via the relational operators). Self-inequality detects NaN
+// without coercing other scalar types and places it after every ordinary number.
 func (g *compareLessProgrammerGenerator) primitive(x string, y string) string {
-  return fmt.Sprintf("(%s < %s ? -1 : %s > %s ? 1 : 0)", g.wrap(x), g.wrap(y), g.wrap(x), g.wrap(y))
+  return fmt.Sprintf("(%s !== %s ? (%s !== %s ? 0 : 1) : %s !== %s ? -1 : %s < %s ? -1 : %s > %s ? 1 : 0)",
+    g.wrap(x), g.wrap(x), g.wrap(y), g.wrap(y), g.wrap(y), g.wrap(y), g.wrap(x), g.wrap(y), g.wrap(x), g.wrap(y))
 }
 
 func (g *compareLessProgrammerGenerator) native(name string, x string, y string) string {

--- a/packages/typia/native/core/programmers/functional/FunctionalAssertFunctionProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/FunctionalAssertFunctionProgrammer.go
@@ -66,13 +66,11 @@ func (functionalAssertFunctionProgrammerNamespace) Write(props FunctionalAssertF
   }
   body = append(body, f.NewReturnStatement(r.Value))
   statements = append(statements, f.NewReturnStatement(
-    f.NewArrowFunction(
-      functionalIsProgrammer_asyncModifiers(r.Async, props.Context.Emit),
-      nil,
-      functionalIsProgrammer_parameters(props.Declaration, props.Context.Emit),
+    functionalIsProgrammer_function(
+      props.Context,
+      props.Declaration,
+      r.Async,
       functionalAssertProgrammer_returnType(props.Declaration),
-      nil,
-      f.NewToken(shimast.KindEqualsGreaterThanToken),
       f.NewBlock(f.NewNodeList(body), true),
     ),
   ))

--- a/packages/typia/native/core/programmers/functional/FunctionalAssertParametersProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/FunctionalAssertParametersProgrammer.go
@@ -66,21 +66,13 @@ func (functionalAssertParametersProgrammerNamespace) Write(props FunctionalAsser
   for _, exp := range result.Expressions {
     body = append(body, f.NewExpressionStatement(exp))
   }
-  body = append(body, f.NewReturnStatement(f.NewCallExpression(
-    props.Expression,
-    nil,
-    nil,
-    f.NewNodeList(functionalIsProgrammer_parameterIdentifiers(props.Declaration, props.Context.Emit)),
-    shimast.NodeFlagsNone,
-  )))
+  body = append(body, f.NewReturnStatement(functionalIsProgrammer_call(props.Context, props.Expression, props.Declaration)))
   statements = append(statements, f.NewReturnStatement(
-    f.NewArrowFunction(
-      functionalIsProgrammer_asyncModifiers(output.Async, props.Context.Emit),
-      nil,
-      functionalIsProgrammer_parameters(props.Declaration, props.Context.Emit),
+    functionalIsProgrammer_function(
+      props.Context,
+      props.Declaration,
+      output.Async,
       functionalAssertProgrammer_returnType(props.Declaration),
-      nil,
-      f.NewToken(shimast.KindEqualsGreaterThanToken),
       f.NewBlock(f.NewNodeList(body), true),
     ),
   ))

--- a/packages/typia/native/core/programmers/functional/FunctionalAssertReturnProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/FunctionalAssertReturnProgrammer.go
@@ -62,14 +62,12 @@ func (functionAssertReturnProgrammerNamespace) Write(props FunctionAssertReturnP
   statements := []*shimast.Node{wrapper.Variable}
   statements = append(statements, result.Functions...)
   statements = append(statements, f.NewReturnStatement(
-    f.NewArrowFunction(
-      functionalIsProgrammer_asyncModifiers(result.Async, props.Context.Emit),
-      nil,
-      functionalIsProgrammer_parameters(props.Declaration, props.Context.Emit),
+    functionalIsProgrammer_function(
+      props.Context,
+      props.Declaration,
+      result.Async,
       functionalAssertProgrammer_returnType(props.Declaration),
-      nil,
-      f.NewToken(shimast.KindEqualsGreaterThanToken),
-      result.Value,
+      f.NewBlock(f.NewNodeList([]*shimast.Node{f.NewReturnStatement(result.Value)}), true),
     ),
   ))
   return nativefactories.ExpressionFactory.SelfCall(
@@ -84,13 +82,7 @@ func (functionAssertReturnProgrammerNamespace) Decompose(props FunctionAssertRet
     Checker:     props.Context.Checker,
     Declaration: props.Declaration,
   })
-  caller := f.NewCallExpression(
-    props.Expression,
-    nil,
-    nil,
-    f.NewNodeList(functionalIsProgrammer_parameterIdentifiers(props.Declaration, props.Context.Emit)),
-    shimast.NodeFlagsNone,
-  )
+  caller := functionalIsProgrammer_call(props.Context, props.Expression, props.Declaration)
   value := caller
   if output.Async {
     value = f.NewAwaitExpression(caller)

--- a/packages/typia/native/core/programmers/functional/FunctionalIsFunctionProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/FunctionalIsFunctionProgrammer.go
@@ -43,10 +43,10 @@ func (functionalIsFunctionProgrammerNamespace) Write(props FunctionalIsFunctionP
   body := append([]*shimast.Node{}, p.Statements...)
   body = append(body, r.Statements...)
   statements = append(statements, f.NewReturnStatement(
-    f.NewArrowFunction(
-      functionalIsProgrammer_asyncModifiers(r.Async, props.Context.Emit),
-      nil,
-      functionalIsProgrammer_parameters(props.Declaration, props.Context.Emit),
+    functionalIsProgrammer_function(
+      props.Context,
+      props.Declaration,
+      r.Async,
       FunctionalIsFunctionProgrammer.GetReturnTypeNode(struct {
         Context     nativecontext.ITypiaContext
         Declaration *shimast.Node
@@ -56,8 +56,6 @@ func (functionalIsFunctionProgrammerNamespace) Write(props FunctionalIsFunctionP
         Declaration: props.Declaration,
         Async:       r.Async,
       }),
-      nil,
-      f.NewToken(shimast.KindEqualsGreaterThanToken),
       f.NewBlock(f.NewNodeList(body), true),
     ),
   ))

--- a/packages/typia/native/core/programmers/functional/FunctionalIsParametersProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/FunctionalIsParametersProgrammer.go
@@ -54,10 +54,10 @@ func (functionalIsParametersProgrammerNamespace) Write(props FunctionalIsParamet
   })
   statements := append([]*shimast.Node{}, result.Functions...)
   statements = append(statements, f.NewReturnStatement(
-    f.NewArrowFunction(
-      functionalIsProgrammer_asyncModifiers(output.Async, props.Context.Emit),
-      nil,
-      functionalIsProgrammer_parameters(props.Declaration, props.Context.Emit),
+    functionalIsProgrammer_function(
+      props.Context,
+      props.Declaration,
+      output.Async,
       FunctionalIsFunctionProgrammer.GetReturnTypeNode(struct {
         Context     nativecontext.ITypiaContext
         Declaration *shimast.Node
@@ -67,17 +67,9 @@ func (functionalIsParametersProgrammerNamespace) Write(props FunctionalIsParamet
         Declaration: props.Declaration,
         Async:       output.Async,
       }),
-      nil,
-      f.NewToken(shimast.KindEqualsGreaterThanToken),
       f.NewBlock(f.NewNodeList(append(
         append([]*shimast.Node{}, result.Statements...),
-        f.NewReturnStatement(f.NewCallExpression(
-          props.Expression,
-          nil,
-          nil,
-          f.NewNodeList(functionalIsProgrammer_parameterIdentifiers(props.Declaration, props.Context.Emit)),
-          shimast.NodeFlagsNone,
-        )),
+        f.NewReturnStatement(functionalIsProgrammer_call(props.Context, props.Expression, props.Declaration)),
       )), true),
     ),
   ))
@@ -139,9 +131,52 @@ func functionalIsProgrammer_parameters(declaration *shimast.Node, emit ...*shimp
 
 func functionalIsProgrammer_parameterNodes(declaration *shimast.Node) []*shimast.Node {
   if params := functionalIsProgrammer_parameters(declaration); params != nil {
-    return params.Nodes
+    output := make([]*shimast.Node, 0, len(params.Nodes))
+    for _, param := range params.Nodes {
+      // TypeScript's explicit `this` parameter declares a receiver type but is
+      // erased at runtime. It is neither validated nor forwarded as an argument.
+      if functionalIsProgrammer_parameterName(param) != "this" {
+        output = append(output, param)
+      }
+    }
+    return output
   }
   return nil
+}
+
+func functionalIsProgrammer_function(
+  context nativecontext.ITypiaContext,
+  declaration *shimast.Node,
+  async bool,
+  returnType *shimast.Node,
+  body *shimast.Node,
+) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(functionalIsProgrammer_factory, context.Emit)
+  return f.NewFunctionExpression(
+    functionalIsProgrammer_asyncModifiers(async, context.Emit),
+    nil,
+    nil,
+    nil,
+    functionalIsProgrammer_parameters(declaration, context.Emit),
+    returnType,
+    nil,
+    body,
+  )
+}
+
+func functionalIsProgrammer_call(context nativecontext.ITypiaContext, expression *shimast.Node, declaration *shimast.Node) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(functionalIsProgrammer_factory, context.Emit)
+  return f.NewCallExpression(
+    nativefactories.IdentifierFactory.Access(context.Emit, f.NewIdentifier("Reflect"), "apply"),
+    nil,
+    nil,
+    f.NewNodeList([]*shimast.Node{
+      expression,
+      f.NewKeywordExpression(shimast.KindThisKeyword),
+      f.NewArrayLiteralExpression(f.NewNodeList(functionalIsProgrammer_parameterIdentifiers(declaration, context.Emit)), false),
+    }),
+    shimast.NodeFlagsNone,
+  )
 }
 
 func functionalIsProgrammer_parameterIdentifiers(declaration *shimast.Node, emit ...*shimprinter.EmitContext) []*shimast.Node {

--- a/packages/typia/native/core/programmers/functional/FunctionalIsReturnProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/FunctionalIsReturnProgrammer.go
@@ -50,10 +50,10 @@ func (functionalIsReturnProgrammerNamespace) Write(props FunctionalIsReturnProgr
   })
   statements := append([]*shimast.Node{}, result.Functions...)
   statements = append(statements, f.NewReturnStatement(
-    f.NewArrowFunction(
-      functionalIsProgrammer_asyncModifiers(result.Async, props.Context.Emit),
-      nil,
-      functionalIsProgrammer_parameters(props.Declaration, props.Context.Emit),
+    functionalIsProgrammer_function(
+      props.Context,
+      props.Declaration,
+      result.Async,
       FunctionalIsFunctionProgrammer.GetReturnTypeNode(struct {
         Context     nativecontext.ITypiaContext
         Declaration *shimast.Node
@@ -63,8 +63,6 @@ func (functionalIsReturnProgrammerNamespace) Write(props FunctionalIsReturnProgr
         Declaration: props.Declaration,
         Async:       result.Async,
       }),
-      nil,
-      f.NewToken(shimast.KindEqualsGreaterThanToken),
       f.NewBlock(f.NewNodeList(result.Statements), true),
     ),
   ))
@@ -80,13 +78,7 @@ func (functionalIsReturnProgrammerNamespace) Decompose(props FunctionalIsReturnP
     Checker:     props.Context.Checker,
     Declaration: props.Declaration,
   })
-  caller := f.NewCallExpression(
-    props.Expression,
-    nil,
-    nil,
-    f.NewNodeList(functionalIsProgrammer_parameterIdentifiers(props.Declaration, props.Context.Emit)),
-    shimast.NodeFlagsNone,
-  )
+  caller := functionalIsProgrammer_call(props.Context, props.Expression, props.Declaration)
   name := functionalIsProgrammer_escapeDuplicate(functionalIsProgrammer_parameterNames(props.Declaration), "result")
   value := caller
   if output.Async {

--- a/packages/typia/native/core/programmers/functional/FunctionalValidateFunctionProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/FunctionalValidateFunctionProgrammer.go
@@ -45,10 +45,10 @@ func (functionalValidateFunctionProgrammerNamespace) Write(props FunctionalValid
   body := append([]*shimast.Node{}, p.Statements...)
   body = append(body, r.Statements...)
   statements = append(statements, f.NewReturnStatement(
-    f.NewArrowFunction(
-      functionalIsProgrammer_asyncModifiers(r.Async, props.Context.Emit),
-      nil,
-      functionalIsProgrammer_parameters(props.Declaration, props.Context.Emit),
+    functionalIsProgrammer_function(
+      props.Context,
+      props.Declaration,
+      r.Async,
       FunctionalValidateFunctionProgrammer.GetReturnTypeNode(struct {
         Context     nativecontext.ITypiaContext
         Declaration *shimast.Node
@@ -58,8 +58,6 @@ func (functionalValidateFunctionProgrammerNamespace) Write(props FunctionalValid
         Declaration: props.Declaration,
         Async:       r.Async,
       }),
-      nil,
-      f.NewToken(shimast.KindEqualsGreaterThanToken),
       f.NewBlock(f.NewNodeList(body), true),
     ),
   ))

--- a/packages/typia/native/core/programmers/functional/FunctionalValidateParametersProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/FunctionalValidateParametersProgrammer.go
@@ -49,13 +49,7 @@ func (functionalValidateParametersProgrammerNamespace) Write(props FunctionalVal
     Declaration: props.Declaration,
   })
   f := nativecontext.EmitFactoryOf(functionalValidateProgrammer_factory, props.Context.Emit)
-  caller := f.NewCallExpression(
-    props.Expression,
-    nil,
-    nil,
-    f.NewNodeList(functionalIsProgrammer_parameterIdentifiers(props.Declaration, props.Context.Emit)),
-    shimast.NodeFlagsNone,
-  )
+  caller := functionalIsProgrammer_call(props.Context, props.Expression, props.Declaration)
   data := caller
   if output.Async {
     data = f.NewAwaitExpression(caller)
@@ -68,10 +62,10 @@ func (functionalValidateParametersProgrammerNamespace) Write(props FunctionalVal
     f.NewPropertyAssignment(nil, nativefactories.IdentifierFactory.Identifier("errors", props.Context.Emit), nil, nil, f.NewArrayLiteralExpression(f.NewNodeList(nil), false)),
   }), true)))
   statements = append(statements, f.NewReturnStatement(
-    f.NewArrowFunction(
-      functionalIsProgrammer_asyncModifiers(output.Async, props.Context.Emit),
-      nil,
-      functionalIsProgrammer_parameters(props.Declaration, props.Context.Emit),
+    functionalIsProgrammer_function(
+      props.Context,
+      props.Declaration,
+      output.Async,
       FunctionalValidateFunctionProgrammer.GetReturnTypeNode(struct {
         Context     nativecontext.ITypiaContext
         Declaration *shimast.Node
@@ -81,8 +75,6 @@ func (functionalValidateParametersProgrammerNamespace) Write(props FunctionalVal
         Declaration: props.Declaration,
         Async:       output.Async,
       }),
-      nil,
-      f.NewToken(shimast.KindEqualsGreaterThanToken),
       f.NewBlock(f.NewNodeList(body), true),
     ),
   ))

--- a/packages/typia/native/core/programmers/functional/FunctionalValidateReturnProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/FunctionalValidateReturnProgrammer.go
@@ -50,10 +50,10 @@ func (functionalValidateReturnProgrammerNamespace) Write(props FunctionalValidat
   f := nativecontext.EmitFactoryOf(functionalValidateProgrammer_factory, props.Context.Emit)
   statements := append([]*shimast.Node{}, result.Functions...)
   statements = append(statements, f.NewReturnStatement(
-    f.NewArrowFunction(
-      functionalIsProgrammer_asyncModifiers(result.Async, props.Context.Emit),
-      nil,
-      functionalIsProgrammer_parameters(props.Declaration, props.Context.Emit),
+    functionalIsProgrammer_function(
+      props.Context,
+      props.Declaration,
+      result.Async,
       FunctionalValidateFunctionProgrammer.GetReturnTypeNode(struct {
         Context     nativecontext.ITypiaContext
         Declaration *shimast.Node
@@ -63,8 +63,6 @@ func (functionalValidateReturnProgrammerNamespace) Write(props FunctionalValidat
         Declaration: props.Declaration,
         Async:       result.Async,
       }),
-      nil,
-      f.NewToken(shimast.KindEqualsGreaterThanToken),
       f.NewBlock(f.NewNodeList(result.Statements), true),
     ),
   ))
@@ -80,13 +78,7 @@ func (functionalValidateReturnProgrammerNamespace) Decompose(props FunctionalVal
     Checker:     props.Context.Checker,
     Declaration: props.Declaration,
   })
-  caller := f.NewCallExpression(
-    props.Expression,
-    nil,
-    nil,
-    f.NewNodeList(functionalIsProgrammer_parameterIdentifiers(props.Declaration, props.Context.Emit)),
-    shimast.NodeFlagsNone,
-  )
+  caller := functionalIsProgrammer_call(props.Context, props.Expression, props.Declaration)
   value := caller
   if output.Async {
     value = f.NewAwaitExpression(caller)

--- a/packages/typia/native/core/programmers/plain/PlainClassifyProgrammer.go
+++ b/packages/typia/native/core/programmers/plain/PlainClassifyProgrammer.go
@@ -1573,14 +1573,9 @@ func plainClassifyProgrammer_seed_type(checker *shimchecker.Checker, sig *shimch
 // the tuple is rejected (nil = field-copy) when it is empty or any element after
 // index 0 is REQUIRED — then `[] extends Rest` fails and ClassifiableSeed is
 // `never`. GetTypeArguments / TargetTupleType require an object reference; the
-// IsTupleType caller guarantees that, but a recover degrades a surprise panic to
-// field-copy (the same safe fallback as a failed seed analysis).
-func plainClassifyProgrammer_tuple_seed(checker *shimchecker.Checker, restParamT *shimchecker.Type) (seed *shimchecker.Type) {
-  defer func() {
-    if recover() != nil {
-      seed = nil
-    }
-  }()
+// IsTupleType caller guarantees that capability. Any failure after that
+// precondition is an internal invariant violation and remains observable.
+func plainClassifyProgrammer_tuple_seed(checker *shimchecker.Checker, restParamT *shimchecker.Type) *shimchecker.Type {
   args := checker.GetTypeArguments(restParamT)
   if len(args) == 0 {
     return nil // `[]` -> ClassifiableSeed is never -> field-copy

--- a/packages/typia/native/core/programmers/plain/plain_tuple_seed_recovery_ownership_test.go
+++ b/packages/typia/native/core/programmers/plain/plain_tuple_seed_recovery_ownership_test.go
@@ -1,0 +1,25 @@
+package plain
+
+import (
+  "testing"
+
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
+)
+
+// TestPlainTupleSeedRecoveryOwnership verifies impossible checker state panics.
+//
+// The caller proves tuple ownership before extracting a tuple seed. A missing
+// checker is therefore an invariant violation, not an ordinary field-copy
+// fallback, and must remain observable.
+//
+//  1. Supply a tuple-seed type with no owning checker.
+//  2. Invoke the ownership-only tuple seed helper.
+//  3. Require the checker invariant panic to escape.
+func TestPlainTupleSeedRecoveryOwnership(t *testing.T) {
+  defer func() {
+    if recover() == nil {
+      t.Fatal("unexpected tuple seed panic was swallowed")
+    }
+  }()
+  _ = plainClassifyProgrammer_tuple_seed(nil, &shimchecker.Type{})
+}

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.2",
+  "version": "13.1.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/src/functional.ts
+++ b/packages/typia/src/functional.ts
@@ -3,6 +3,24 @@ import { IValidation } from "@typia/interface";
 import { TypeGuardError } from "./TypeGuardError";
 import { NoTransformConfigurationError } from "./transformers/NoTransformConfigurationError";
 
+type FunctionalIs<T extends (...args: any[]) => any> = T extends (
+  this: infer This,
+  ...args: infer Arguments
+) => infer Output
+  ? Output extends Promise<infer R>
+    ? (this: This, ...args: Arguments) => Promise<R | null>
+    : (this: This, ...args: Arguments) => Output | null
+  : never;
+
+type FunctionalValidate<T extends (...args: any[]) => any> = T extends (
+  this: infer This,
+  ...args: infer Arguments
+) => infer Output
+  ? Output extends Promise<infer R>
+    ? (this: This, ...args: Arguments) => Promise<IValidation<R>>
+    : (this: This, ...args: Arguments) => IValidation<Output>
+  : never;
+
 /* ===========================================================
   FUNCTIONAL
     - ASSERT
@@ -232,11 +250,7 @@ export function assertEqualsReturn(): never {
  */
 export function isFunction<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<R | null>
-    : (...args: Arguments) => Output | null
-  : never;
+): FunctionalIs<T>;
 
 /** @internal */
 export function isFunction(): never {
@@ -263,11 +277,7 @@ export function isFunction(): never {
  */
 export function isParameters<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<R | null>
-    : (...args: Arguments) => Output | null
-  : never;
+): FunctionalIs<T>;
 
 /** @internal */
 export function isParameters(): never {
@@ -294,11 +304,7 @@ export function isParameters(): never {
  */
 export function isReturn<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<R | null>
-    : (...args: Arguments) => Output | null
-  : never;
+): FunctionalIs<T>;
 
 /** @internal */
 export function isReturn(): never {
@@ -325,11 +331,7 @@ export function isReturn(): never {
  */
 export function equalsFunction<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<R | null>
-    : (...args: Arguments) => Output | null
-  : never;
+): FunctionalIs<T>;
 
 /** @internal */
 export function equalsFunction(): never {
@@ -356,11 +358,7 @@ export function equalsFunction(): never {
  */
 export function equalsParameters<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<R | null>
-    : (...args: Arguments) => Output | null
-  : never;
+): FunctionalIs<T>;
 
 /** @internal */
 export function equalsParameters(): never {
@@ -387,11 +385,7 @@ export function equalsParameters(): never {
  */
 export function equalsReturn<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<R | null>
-    : (...args: Arguments) => Output | null
-  : never;
+): FunctionalIs<T>;
 
 /** @internal */
 export function equalsReturn(): never {
@@ -425,11 +419,7 @@ export function equalsReturn(): never {
  */
 export function validateFunction<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<IValidation<R>>
-    : (...args: Arguments) => IValidation<Output>
-  : never;
+): FunctionalValidate<T>;
 
 /** @internal */
 export function validateFunction(): never {
@@ -457,11 +447,7 @@ export function validateFunction(): never {
  */
 export function validateParameters<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<IValidation<R>>
-    : (...args: Arguments) => IValidation<Output>
-  : never;
+): FunctionalValidate<T>;
 
 /** @internal */
 export function validateParameters(): never {
@@ -489,11 +475,7 @@ export function validateParameters(): never {
  */
 export function validateReturn<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<IValidation<R>>
-    : (...args: Arguments) => IValidation<Output>
-  : never;
+): FunctionalValidate<T>;
 
 /** @internal */
 export function validateReturn(): never {
@@ -524,11 +506,7 @@ export function validateReturn(): never {
  */
 export function validateEqualsFunction<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<IValidation<R>>
-    : (...args: Arguments) => IValidation<Output>
-  : never;
+): FunctionalValidate<T>;
 
 /** @internal */
 export function validateEqualsFunction(): never {
@@ -556,11 +534,7 @@ export function validateEqualsFunction(): never {
  */
 export function validateEqualsParameters<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<IValidation<R>>
-    : (...args: Arguments) => IValidation<Output>
-  : never;
+): FunctionalValidate<T>;
 
 /** @internal */
 export function validateEqualsParameters(): never {
@@ -588,11 +562,7 @@ export function validateEqualsParameters(): never {
  */
 export function validateEqualsReturn<T extends (...args: any[]) => any>(
   func: T,
-): T extends (...args: infer Arguments) => infer Output
-  ? Output extends Promise<infer R>
-    ? (...args: Arguments) => Promise<IValidation<R>>
-    : (...args: Arguments) => IValidation<Output>
-  : never;
+): FunctionalValidate<T>;
 
 /** @internal */
 export function validateEqualsReturn(): never {

--- a/packages/typia/src/module.ts
+++ b/packages/typia/src/module.ts
@@ -637,10 +637,10 @@ export function createAssertGuard(
  */
 export function createAssertGuard<T>(
   errorFactory?: undefined | ((props: TypeGuardError.IProps) => Error),
-): (input: unknown) => AssertionGuard<T>;
+): AssertionGuard<T>;
 
 /** @internal */
-export function createAssertGuard<T>(): (input: unknown) => AssertionGuard<T> {
+export function createAssertGuard<T>(): AssertionGuard<T> {
   NoTransformConfigurationError("createAssertGuard");
 }
 
@@ -809,12 +809,10 @@ export function createAssertGuardEquals(
  */
 export function createAssertGuardEquals<T>(
   errorFactory?: undefined | ((props: TypeGuardError.IProps) => Error),
-): (input: unknown) => AssertionGuard<T>;
+): AssertionGuard<T>;
 
 /** @internal */
-export function createAssertGuardEquals<T>(): (
-  input: unknown,
-) => AssertionGuard<T> {
+export function createAssertGuardEquals<T>(): AssertionGuard<T> {
   NoTransformConfigurationError("createAssertGuardEquals");
 }
 

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -291,7 +291,7 @@ namespace compare {
 }
 ```
 
-Lexicographic ordering: walks the properties of `T` in declaration order and decides on the first differing scalar leaf (`number` / `boolean` / `string` / `bigint`), with `undefined < null < value`. Arrays compare element-by-element, the shorter prefix preceding. `NaN` follows every ordinary number and equals itself for ordering purposes; an invalid `Date` follows valid dates by the same rule. `less` and `equals` compose into an `Array.prototype.sort` comparator:
+Lexicographic ordering: walks the properties of `T` in declaration order and decides on the first differing scalar leaf (`number` / `boolean` / `string` / `bigint`), with `undefined < null < value`. Arrays compare element-by-element, the shorter prefix preceding. `NaN` follows every ordinary number, and two `NaN` operands are equivalent only for ordering; an invalid `Date` follows valid dates by the same rule. Two directional `less` checks compose into an `Array.prototype.sort` comparator:
 
 ```typescript copy
 const cmp = (a: IPoint, b: IPoint): number =>

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -9,7 +9,7 @@ import LocalSource from '../../components/LocalSource';
 
 # Miscellaneous
 
-Small modules that share the typia transform but don't fit anywhere else: `plain` (clone / prune), `compare` (structural equality / ordering), `notations` (case conversion), `http` (form data / query / headers / route parameters), and `reflect` (type metadata introspection and literal unions).
+Small modules that share the typia transform but don't fit anywhere else: `plain` (clone / prune), `compare` (structural equality / ordering), `functional` (validated function wrappers), `notations` (case conversion), `http` (form data / query / headers / route parameters), and `reflect` (type metadata introspection and literal unions).
 
 ## `plain`
 
@@ -291,7 +291,7 @@ namespace compare {
 }
 ```
 
-Lexicographic ordering: walks the properties of `T` in declaration order and decides on the first differing scalar leaf (`number` / `boolean` / `string` / `bigint`), with `undefined < null < value`. Arrays compare element-by-element, the shorter prefix preceding. `less` and `equals` compose into an `Array.prototype.sort` comparator:
+Lexicographic ordering: walks the properties of `T` in declaration order and decides on the first differing scalar leaf (`number` / `boolean` / `string` / `bigint`), with `undefined < null < value`. Arrays compare element-by-element, the shorter prefix preceding. `NaN` follows every ordinary number and equals itself for ordering purposes; an invalid `Date` follows valid dates by the same rule. `less` and `equals` compose into an `Array.prototype.sort` comparator:
 
 ```typescript copy
 const cmp = (a: IPoint, b: IPoint): number =>
@@ -312,6 +312,50 @@ Types with no sound total order (`any`, `Function`, `Set`, `Map`, `WeakSet`, `We
     <LocalSource
       path="examples/bin/compare/less.js"
       filename="examples/bin/compare/less.js"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+## `functional`
+
+The `functional` module wraps an existing function with parameter and return-value validation while preserving its call contract. Every wrapper forwards the call-site receiver, so a target with an explicit TypeScript `this` parameter still works through method calls, `.call`, `.apply`, and `.bind`.
+
+```typescript copy filename="signatures"
+namespace functional {
+  function assertFunction<T extends (...args: any[]) => any>(func: T): T;
+  function isFunction<This, Args extends any[], Output>(func: (this: This, ...args: Args) => Output): (this: This, ...args: Args) => Output | null;
+  function validateFunction<This, Args extends any[], Output>(func: (this: This, ...args: Args) => Output): (this: This, ...args: Args) => IValidation<Output>;
+}
+```
+
+The `Function` variants validate both parameters and the return value. Choose `Parameters` or `Return` to validate only that boundary, and choose the `Equals` variants when extra object properties must also be rejected.
+
+```typescript copy
+interface Counter {
+  base: number;
+}
+
+function add(this: Counter, value: number): number {
+  return this.base + value;
+}
+
+const checked = typia.functional.assertFunction(add);
+checked.call({ base: 10 }, 2); // 12
+```
+
+Assertion wrappers throw on the first mismatch, `is` / `equals` wrappers return `null`, and validation wrappers return `IValidation`. Async targets retain both their receiver and their `Promise` result shape.
+
+<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/functional/assertFunction.ts"
+      filename="examples/src/functional/assertFunction.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/bin/functional/assertFunction.js"
+      filename="examples/bin/functional/assertFunction.js"
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>


### PR DESCRIPTION
## Intent

Restore four shared native contracts together: assertion-guard factory typing, semantic panic ownership, total comparator ordering, and functional receiver forwarding.

## Changes

- Make `createAssertGuard` and `createAssertGuardEquals` return `AssertionGuard<T>` directly.
- Replace blanket panic recovery with explicit ownership checks in metadata, Protobuf, and plain tuple paths.
- Give `compare.less` a NaN-last order, including invalid `Date` projections, across direct and factory comparators.
- Preserve dynamic `this` through all `typia.functional.*` wrappers with `Reflect.apply`, while excluding TypeScript's erased `this` parameter from runtime arguments and validation.
- Preserve receiver types in the public functional helpers and document receiver/NaN behavior with runnable examples.
- Ship the native changes as `typia` 13.1.3 after rebasing onto the 13.1.2 predecessor.

## Verification

- Focused guard, recovery, comparison, functional, and plain-native regression suites: pass.
- `go test ./... -count=1` in `packages/typia/native`: pass.
- `go vet ./...` in `packages/typia/native`: pass.
- `go test ./... -count=1` in `packages/typia/test`: pass.
- `pnpm --filter typia build`: pass as 13.1.3.
- `pnpm --filter @typia/examples build`: pass.
- `git diff --check`: pass.
- Four solo Self-Review rounds completed; rounds 1-3 were remediated and round 4 was clean.

The repository-wide `pnpm run test:packages` produced no failure output but exceeded the 15-minute local limit while `test-typia-automated` was still running. The narrower native, transform/runtime, package build, and example build gates above completed successfully.

Campaign Actions were cancelled only for the exact pushed SHA after every push. On final HEAD `ece7583c6a8bdd7cede48e08509a2ff399441d03`, five workflow runs were cancelled and spell-check completed successfully before cancellation.

Closes #1264
Closes #1889
Closes #1950
Closes #2052