### PR TITLE
fix(benchmark): restore TypeScript 7 build contract

### DIFF
--- a/.agents/skills/benchmark/performance.md
+++ b/.agents/skills/benchmark/performance.md
@@ -12,7 +12,7 @@ The private `@typia/benchmark` workspace measures throughput in megabytes per se
 | `assert` | `typia.assert` on valid input | the same validator libraries |
 | `validate` | `typia.validate` on valid input | the same validator libraries |
 | `assert-error`, `validate-error` | assertion and validation on invalid input | TypeBox, io-ts, Zod, class-validator |
-| `optimizer` | optimized `is` code generation | TypeBox, Ajv, class-validator |
+| `optimizer` | optimized `is` code generation | TypeBox, class-validator |
 | `stringify` | `typia.json.*Stringify` | fast-json-stringify, `JSON.stringify`, class-transformer |
 | `server-assert`, `server-stringify`, `server-performance` | request and response cost in a real server | Express and Fastify, typia versus pure handling and class-transformer |
 
@@ -26,7 +26,7 @@ Node runs all ten categories. Bun runs the seven non-server categories through `
 - **Canonical structures:** keep every compared library on the same structure and equivalent input. A schema shortcut or omitted case invalidates the row.
 - **Competitors:** add library-specific schemas under `benchmark/src/structures/<library>/` and update the templates for every category in scope.
 
-The runner discovers every comparator directory present under a category. `optimizer/ajv` remains a tracked comparator even though the current optimizer template no longer lists Ajv, and template regeneration does not remove a library directory that is absent from the template. When changing the optimizer comparator set, reconcile the template and existing generated directories explicitly before measuring.
+Template regeneration treats each category's declared libraries as authoritative. `BenchmarkProgrammer.generate()` removes non-internal comparator directories that are absent from the category template while preserving the server categories' `internal` subtrees. When changing a comparator set, inspect every generated addition and deletion before measuring.
 
 Each `benchmark/results/<CPU model>/` directory is one machine's committed Node report: `README.md` plus `images/*.svg`. Bun results live under `benchmark/results/<CPU model>/bun/`. A new machine adds its own directory; do not overwrite another machine's results.
 

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -27,9 +27,9 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "CommonJS",                                /* Specify what module code is generated. */
+    "module": "Node16",                                  /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "Node16",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     "ignoreDeprecations": "6.0",
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -102,7 +102,7 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
     "plugins": [
-      { "transform": "typia/src/transform.ts" },
+      { "transform": "typia/lib/transform" },
     ]
   },
   "include": ["./src"],


### PR DESCRIPTION
## Intent

Restore the benchmark's executable and documented workflow contract: build and regenerate on the pinned TypeScript 7 toolchain, resolve typia through its installation-safe descriptor, and describe the comparator set owned by the authoritative generator.

## Scope

- Replace the removed Node10 resolution spelling with a TypeScript 7-supported module/module-resolution contract while preserving the benchmark runner's CommonJS output.
- Resolve the ttsc plugin through the exported `typia/lib/transform` descriptor rather than an unexported source subpath.
- Lock both configuration boundaries with proof and preserve the generated comparator/workload state merged by #2067.
- Update the optimizer comparator table and generator-authority guidance to match the template and `BenchmarkProgrammer.generate()` behavior merged by #2067.

## Deferred

- No performance measurement, result table, SVG, or archived benchmark claim is produced by this configuration repair.

## Verification

- Reproduced both clean failures on the pinned TypeScript `^7.0.2` / ttsc `^0.18.4` workspace before editing.
- `pnpm --dir benchmark build` passed on the final rebased head and emitted 709 JavaScript files from 709 TypeScript files.
- `pnpm --dir benchmark template` completed its full regenerate-format-build lifecycle with zero content diff in programs, templates, or results.
- A real Node `require()` and `ObjectSimple.generate()` probe confirmed the Node16 config still emits executable CommonJS.
- `typia/lib/transform` resolves through both development and published package exports; the unexported source subpath remains rejected.
- Optimizer directories remain exactly `class-validator`, `typebox`, and `typia`; active guidance has no stale optimizer/Ajv ownership claim.
- Solo Self-Review round 1 completed clean with no findings or remediation.

Campaign exact-SHA gating was applied after every push and PR mutation. Package-scoped local verification is the merge gate; no performance measurement was run.

Closes #2073
Closes #2078
