### PR TITLE
fix(typia): backtrack tagged union and template branches

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/any_array_type_tags_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/any_array_type_tags_transform_test.go
@@ -141,13 +141,35 @@ export const validateConcrete = typia.createValidate<
   string[] & tags.MinItems<2> & ContainsStatus
 >();
 
-// Union branch: a tagged any-element array beside another array variant.
-// The union explorer discriminates by element checks, which an any element
-// satisfies trivially, so these tags are knowingly NOT enforced yet (the
-// residual gap documented on issue #1933).
+// Union branch: a tagged any-element array beside another array variant. The
+// wrapper predicate participates in complete-branch selection (#2040).
 export const validateUnion = typia.createValidate<
   { list: (unknown[] & tags.MinItems<2>) | string[] }
 >();
+export const validateUnionReversed = typia.createValidate<
+  { list: string[] | (unknown[] & tags.MinItems<2>) }
+>();
+export const isUnion = typia.createIs<
+  { list: (unknown[] & tags.MinItems<2>) | string[] }
+>();
+export const assertUnion = typia.createAssert<
+  { list: (unknown[] & tags.MinItems<2>) | string[] }
+>();
+export const equalsUnion = typia.createEquals<
+  { list: (unknown[] & tags.MinItems<2>) | string[] }
+>();
+export const validateTupleUnion = typia.createValidate<
+  { list: (unknown[] & tags.MinItems<2>) | [number] }
+>();
+export const validateTaggedAlternatives = typia.createValidate<
+  { list: (unknown[] & tags.MinItems<2>) | (string[] & tags.MaxItems<1>) }
+>();
+export const stringifyUnion = typia.json.createValidateStringify<
+  { list: (unknown[] & tags.MinItems<2>) | string[] }
+>();
+export const schemaUnion = typia.json.schemas<[
+  (unknown[] & tags.MinItems<2>) | string[],
+]>();
 `
 
 const anyArrayTypeTagsRuntimeRunner = `const mod = require("./main.cjs");
@@ -194,11 +216,43 @@ expectFailure("concrete too short", mod.validateConcrete(["SUCCESS"]), "MinItems
 expectFailure("concrete no status", mod.validateConcrete(["a", "b"]), "ContainsStatus");
 expectSuccess("concrete valid", mod.validateConcrete(["a", "SUCCESS"]));
 
-// 4. Union with a tagged any-element branch: pins the documented residual
-//    gap — the whole bucket keeps the historical wholesale acceptance, so
-//    even [1] (matching neither branch on paper) passes. When union branch
-//    backtracking lands, flip the last expectation to a failure.
+// 4. Complete branches backtrack across wrapper predicates and element types.
 expectSuccess("union via tagged any", mod.validateUnion({ list: [1, 2] }));
 expectSuccess("union via string branch", mod.validateUnion({ list: ["solo"] }));
-expectSuccess("union residual gap", mod.validateUnion({ list: [1] }));
+expectFailure("union no valid branch", mod.validateUnion({ list: [1] }), "MinItems<2>");
+expectSuccess("reversed union via tagged any", mod.validateUnionReversed({ list: [1, 2] }));
+expectSuccess("reversed union via string branch", mod.validateUnionReversed({ list: ["solo"] }));
+expectFailure("reversed union no valid branch", mod.validateUnionReversed({ list: [1] }), "MinItems<2>");
+if (mod.isUnion({ list: [1] }) !== false || mod.isUnion({ list: [1, 2] }) !== true) {
+  throw new Error("is did not honor the complete tagged union branches");
+}
+if (mod.equalsUnion({ list: [1] }) !== false || mod.equalsUnion({ list: ["solo"] }) !== true) {
+  throw new Error("equals did not honor the complete tagged union branches");
+}
+let asserted = false;
+try {
+  mod.assertUnion({ list: [1] });
+} catch (error) {
+  asserted = String(error && error.message).includes("MinItems<2>");
+}
+if (asserted !== true) {
+  throw new Error("assert did not attribute the failed wrapper tag");
+}
+
+expectSuccess("tuple branch", mod.validateTupleUnion({ list: [1] }));
+expectSuccess("tuple union tagged any", mod.validateTupleUnion({ list: [1, 2] }));
+expectSuccess("tagged alternative string", mod.validateTaggedAlternatives({ list: ["solo"] }));
+expectSuccess("tagged alternative any", mod.validateTaggedAlternatives({ list: [1, 2] }));
+expectSuccess("tagged alternative empty", mod.validateTaggedAlternatives({ list: [] }));
+expectFailure("tagged alternatives reject", mod.validateTaggedAlternatives({ list: [1] }), "MinItems<2>");
+
+const stringified = mod.stringifyUnion({ list: ["solo"] });
+if (stringified.success !== true || JSON.parse(stringified.data).list[0] !== "solo") {
+  throw new Error("validated stringify rejected a later valid branch: " + JSON.stringify(stringified));
+}
+expectFailure("validated stringify no valid branch", mod.stringifyUnion({ list: [1] }), "MinItems<2>");
+const unionSchema = JSON.stringify(mod.schemaUnion);
+if (unionSchema.includes('"minItems":2') === false) {
+  throw new Error("array union schema lost MinItems: " + unionSchema);
+}
 `

--- a/packages/typia/native/cmd/ttsc-typia/template_interpolation_type_tags_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/template_interpolation_type_tags_transform_test.go
@@ -100,8 +100,10 @@ func templateInterpolationTypeTagsRunRuntimeCases(t *testing.T, project string, 
   // common stub set covers; stub them before the shared rewrite asserts that no
   // `typia/lib/internal/*` import survives.
   extraStubs := map[string]string{
-    "is-type-int32-stub.cjs": "module.exports._isTypeInt32 = (value) => Number.isInteger(value) && -2147483648 <= value && value <= 2147483647;\n",
-    "random-number-stub.cjs": templateInterpolationTypeTagsRandomNumberStub,
+    "is-type-int32-stub.cjs":         "module.exports._isTypeInt32 = (value) => Number.isInteger(value) && -2147483648 <= value && value <= 2147483647;\n",
+    "random-number-stub.cjs":         templateInterpolationTypeTagsRandomNumberStub,
+    "random-string-stub.cjs":         "module.exports._randomString = () => 'prefix';\n",
+    "json-stringify-string-stub.cjs": "module.exports._jsonStringifyString = (value) => JSON.stringify(value);\n",
   }
   for name, content := range extraStubs {
     if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
@@ -110,6 +112,8 @@ func templateInterpolationTypeTagsRunRuntimeCases(t *testing.T, project string, 
   }
   runtimeJS := strings.ReplaceAll(js, `require("typia/lib/internal/_isTypeInt32")`, `require("./is-type-int32-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_randomNumber")`, `require("./random-number-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_randomString")`, `require("./random-string-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyString")`, `require("./json-stringify-string-stub.cjs")`)
   runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
   if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
     t.Fatalf("write runtime module: %v", err)
@@ -153,8 +157,13 @@ type StrNum = ` + "`${string & tags.MaxLength<2>}-${number}`" + `;
 type NumStr = ` + "`${number & tags.Maximum<9>}-${string & tags.MinLength<2>}`" + `;
 type Dec = ` + "`${number & tags.Maximum<1.2>}.${number}`" + `;
 type BigDot = ` + "`${bigint}.${number & tags.Minimum<5>}`" + `;
+type Triple = ` + "`${string & tags.MaxLength<2>}${string & tags.MinLength<2>}${number & tags.Minimum<10>}`" + `;
+type AmbiguousUnion = Adjacent | NonAdj;
 interface DynKey {
   [key: ` + "`slot${number & tags.Minimum<0> & tags.Maximum<9>}`" + `]: string;
+}
+interface AmbiguousDynKey {
+  [key: ` + "`${string}${number & tags.Minimum<10>}`" + `]: string;
 }
 
 export const isPercent = typia.createIs<Percent>();
@@ -168,14 +177,22 @@ export const isMultiline = typia.createIs<Multiline>();
 export const isBigRange = typia.createIs<BigRange>();
 export const isBigExcl = typia.createIs<BigExcl>();
 export const isAdjacent = typia.createIs<Adjacent>();
+export const validateAdjacent = typia.createValidate<Adjacent>();
+export const assertAdjacent = typia.createAssert<Adjacent>();
 export const isInfix = typia.createIs<Infix>();
 export const isNonAdj = typia.createIs<NonAdj>();
 export const isStrNum = typia.createIs<StrNum>();
 export const isNumStr = typia.createIs<NumStr>();
 export const isDec = typia.createIs<Dec>();
 export const isBigDot = typia.createIs<BigDot>();
+export const isTriple = typia.createIs<Triple>();
+export const isAmbiguousUnion = typia.createIs<AmbiguousUnion>();
 export const equalsDynKey = typia.createEquals<DynKey>();
+export const equalsAmbiguousDynKey = typia.createEquals<AmbiguousDynKey>();
 export const randomPercent = typia.createRandom<Percent>();
+export const randomAdjacent = typia.createRandom<Adjacent>();
+export const stringifyAdjacent = typia.json.createValidateStringify<{ value: Adjacent }>();
+export const schemaAdjacent = typia.json.schemas<[Adjacent]>();
 `
 
 const templateInterpolationTypeTagsRuntimeRunner = `const mod = require("./main.cjs");
@@ -248,11 +265,13 @@ expect("bigint excluded value", mod.isBigExcl("#5"), false);
 expect("bigint allowed value", mod.isBigExcl("#3"), true);
 expect("bigint exclude negative", mod.isBigExcl("#-1"), false);
 
-// Adjacent variable-width placeholders fall back (tag unenforced) rather than a
-// greedy-split false negative: "abc123" is a valid string-then-number(>=10)
-// split (string="abc", number=123). If the number tag were wrongly enforced on
-// the greedy split, the number group would be "3" and this would be false.
-expect("adjacent placeholders fall back", mod.isAdjacent("abc123"), true);
+// Adjacent variable-width placeholders accept a non-greedy split when it is the
+// split that satisfies the number tag.
+expect("adjacent placeholders backtrack", mod.isAdjacent("abc123"), true);
+expect("adjacent placeholders edge split", mod.isAdjacent("123"), true);
+expect("adjacent placeholders no valid split", mod.isAdjacent("abc9"), false);
+expect("adjacent placeholders structural failure", mod.isAdjacent("abc"), false);
+expect("adjacent placeholders long invalid input", mod.isAdjacent("x".repeat(2048) + "9"), false);
 
 // A sole string fenced by literals is enforced: the ^/$ anchors pin "a" and the
 // final "b", so the split string="XbY" (length 3) is unique and exceeds
@@ -260,15 +279,13 @@ expect("adjacent placeholders fall back", mod.isAdjacent("abc123"), true);
 expect("sole string fenced by literals, too long", mod.isInfix("aXbYb"), false);
 expect("sole string fenced by literals, in range", mod.isInfix("aXb"), true);
 
-// A string with a placeholder sibling falls back (greedy ([\s\S]*) could overrun
-// the fence), so its tag is unenforced rather than a false negative: "aXbXcd" is
-// a valid string-X-string(>=3) split (second="bXcd") and stays true.
-expect("string with sibling falls back", mod.isNonAdj("aXbXcd"), true);
+// A repeated literal fence tries each split until the tagged suffix is valid.
+expect("string sibling backtracks", mod.isNonAdj("aXbXcd"), true);
+expect("string sibling no valid split", mod.isNonAdj("aXbc"), false);
 
-// string-first across a separator the number's exponent can absorb: the string
-// falls back (greedy could capture "xy-1e"), so "xy-1e-9" is no longer a false
-// negative (string="xy" length 2 <= 2 is a valid split).
-expect("strnum string-first falls back", mod.isStrNum("xy-1e-9"), true);
+// A separator that can also occur in an exponent is tried at each position.
+expect("strnum string-first backtracks", mod.isStrNum("xy-1e-9"), true);
+expect("strnum no valid bounded prefix", mod.isStrNum("toolong-1"), false);
 
 // number-first: "-" is not number-extendable, so both placeholders are pinned
 // and enforced — number=50 > 9 fails, string="a" length 1 < 2 fails.
@@ -276,15 +293,35 @@ expect("numstr ok", mod.isNumStr("5-ab"), true);
 expect("numstr number violated", mod.isNumStr("50-ab"), false);
 expect("numstr string violated", mod.isNumStr("5-a"), false);
 
-// number-"."-number: "." is a decimal extension, so the split slides ("1.9.0"
-// splits as 1.9|0 or 1|9.0); the placeholder falls back, so the valid first="1"
-// (<= 1.2) split is no longer a false negative.
-expect("dec decimal-separator falls back", mod.isDec("1.9.0"), true);
+// A decimal point can be part of either number; any fully valid split passes.
+expect("dec decimal-separator backtracks", mod.isDec("1.9.0"), true);
+expect("dec no valid bounded first number", mod.isDec("2.0.3"), false);
 
-// An untagged bigint lowers to the decimal NUMBER span, so it absorbs the ".";
-// the number after it falls back, so "1.9.4" (valid as bigint=1 | number=9.4 >=
-// 5) is not a false negative.
-expect("bigint-dot-number falls back", mod.isBigDot("1.9.4"), true);
+// A bigint/number mix keeps the bigint side integral while trying dot fences.
+expect("bigint-dot-number backtracks", mod.isBigDot("1.9.4"), true);
+expect("bigint-dot-number no valid suffix", mod.isBigDot("1.4.0"), false);
+expect("three adjacent placeholders backtrack", mod.isTriple("abcd12"), true);
+expect("three adjacent placeholders no valid split", mod.isTriple("abcd9"), false);
+expect("ambiguous union adjacent branch", mod.isAmbiguousUnion("prefix123"), true);
+expect("ambiguous union fenced branch", mod.isAmbiguousUnion("aXbXcd"), true);
+expect("ambiguous union no valid branch", mod.isAmbiguousUnion("prefix9"), false);
+
+const adjacentFailure = mod.validateAdjacent("abc9");
+if (
+  adjacentFailure.success !== false ||
+  adjacentFailure.errors.every((error) => error.expected.includes("Minimum<10>") === false)
+) {
+  throw new Error("ambiguous validate error should name Minimum<10>: " + JSON.stringify(adjacentFailure));
+}
+let adjacentAsserted = false;
+try {
+  mod.assertAdjacent("abc9");
+} catch (error) {
+  adjacentAsserted = String(error && error.message).includes("Minimum<10>");
+}
+if (adjacentAsserted !== true) {
+  throw new Error("ambiguous assert error should name Minimum<10>");
+}
 
 // A dynamic index key typed as a tagged-interpolation template (the
 // check_dynamic_key path): a key whose number violates the tag no longer
@@ -293,6 +330,8 @@ expect("dynkey in range", mod.equalsDynKey({ slot5: "x" }), true);
 expect("dynkey both ends", mod.equalsDynKey({ slot0: "x", slot9: "y" }), true);
 expect("dynkey out of range", mod.equalsDynKey({ slot50: "x" }), false);
 expect("dynkey non-number", mod.equalsDynKey({ slotABC: "x" }), false);
+expect("ambiguous dynkey valid split", mod.equalsAmbiguousDynKey({ slot123: "x" }), true);
+expect("ambiguous dynkey invalid split", mod.equalsAmbiguousDynKey({ slot9: "x" }), false);
 
 // validate must name the violated placeholder tag, not just the template.
 const tooBig = mod.validatePercent("150%");
@@ -318,5 +357,29 @@ for (let i = 0; i < 100; ++i) {
   if (mod.isPercent(value) !== true) {
     throw new Error("random percent did not round-trip: " + JSON.stringify(value));
   }
+}
+for (let i = 0; i < 25; ++i) {
+  const value = mod.randomAdjacent(generator);
+  if (mod.isAdjacent(value) !== true) {
+    throw new Error("random adjacent template did not round-trip: " + JSON.stringify(value));
+  }
+}
+const stringifiedAdjacent = mod.stringifyAdjacent({ value: "prefix123" });
+if (
+  stringifiedAdjacent.success !== true ||
+  JSON.parse(stringifiedAdjacent.data).value !== "prefix123"
+) {
+  throw new Error("validated stringify rejected an existentially valid split");
+}
+const invalidStringifiedAdjacent = mod.stringifyAdjacent({ value: "prefix9" });
+if (
+  invalidStringifiedAdjacent.success !== false ||
+  invalidStringifiedAdjacent.errors.every((error) => error.expected.includes("Minimum<10>") === false)
+) {
+  throw new Error("validated stringify did not preserve the ambiguous placeholder tag diagnostic");
+}
+const adjacentSchema = JSON.stringify(mod.schemaAdjacent);
+if (adjacentSchema.includes("Minimum<10>")) {
+  throw new Error("template interpolation tags must remain intentionally absent from JSON Schema");
 }
 `

--- a/packages/typia/native/core/programmers/helpers/UnionExplorer.go
+++ b/packages/typia/native/core/programmers/helpers/UnionExplorer.go
@@ -79,11 +79,12 @@ type UnionExplorer_ObjectProps struct {
 }
 
 type UnionExplorer_ArrayLikeConfig struct {
-  Checker func(props UnionExplorer_ArrayLikeCheckerProps) *shimast.Node
-  Decoder func(props UnionExplorer_ArrayLikeDecoderProps) *shimast.Node
-  Empty   *shimast.Node
-  Success *shimast.Expression
-  Failure func(props UnionExplorer_ArrayLikeFailureProps) *shimast.Node
+  Checker   func(props UnionExplorer_ArrayLikeCheckerProps) *shimast.Node
+  Candidate func(props UnionExplorer_ArrayLikeCandidateProps) *shimast.Node
+  Decoder   func(props UnionExplorer_ArrayLikeDecoderProps) *shimast.Node
+  Empty     *shimast.Node
+  Success   *shimast.Expression
+  Failure   func(props UnionExplorer_ArrayLikeFailureProps) *shimast.Node
 }
 
 type UnionExplorer_ArrayLikeCheckerProps struct {
@@ -94,6 +95,12 @@ type UnionExplorer_ArrayLikeCheckerProps struct {
 }
 
 type UnionExplorer_ArrayLikeDecoderProps struct {
+  Input      *shimast.Expression
+  Definition any
+  Explore    any
+}
+
+type UnionExplorer_ArrayLikeCandidateProps struct {
   Input      *shimast.Expression
   Definition any
   Explore    any
@@ -622,46 +629,69 @@ func unionExplorer_check_union_array_like(props unionExplorer_check_union_array_
       inputType = nativefactories.TypeFactory.Keyword("any", props.Emit)
       postfix = "\"[0]\""
     }
-    return f.NewAsExpression(
-      f.NewArrayLiteralExpression(
+    entries := []*shimast.Node{
+      f.NewArrowFunction(
+        nil,
+        nil,
         f.NewNodeList([]*shimast.Node{
-          f.NewArrowFunction(
+          nativefactories.IdentifierFactory.Parameter("top", inputType, nil, props.Emit),
+        }),
+        nativefactories.TypeFactory.Keyword("any", props.Emit),
+        nil,
+        f.NewToken(shimast.KindEqualsGreaterThanToken),
+        props.Config.Checker(UnionExplorer_ArrayLikeCheckerProps{
+          Input:      f.NewIdentifier("top"),
+          Definition: props.Accessor.Element(meta),
+          Explore:    unionExplorer_with_postfix(props.Explore, false, postfix),
+          Container:  array,
+        }),
+      ),
+      f.NewArrowFunction(
+        nil,
+        nil,
+        f.NewNodeList([]*shimast.Node{
+          nativefactories.IdentifierFactory.Parameter(
+            "entire",
+            f.NewTypeReferenceNode(f.NewIdentifier("any[]"), nil),
             nil,
-            nil,
-            f.NewNodeList([]*shimast.Node{
-              nativefactories.IdentifierFactory.Parameter("top", inputType, nil, props.Emit),
-            }),
-            nativefactories.TypeFactory.Keyword("any", props.Emit),
-            nil,
-            f.NewToken(shimast.KindEqualsGreaterThanToken),
-            props.Config.Checker(UnionExplorer_ArrayLikeCheckerProps{
-              Input:      f.NewIdentifier("top"),
-              Definition: props.Accessor.Element(meta),
-              Explore:    unionExplorer_with_postfix(props.Explore, false, postfix),
-              Container:  array,
-            }),
-          ),
-          f.NewArrowFunction(
-            nil,
-            nil,
-            f.NewNodeList([]*shimast.Node{
-              nativefactories.IdentifierFactory.Parameter(
-                "entire",
-                f.NewTypeReferenceNode(f.NewIdentifier("any[]"), nil),
-                nil,
-                props.Emit,
-              ),
-            }),
-            nativefactories.TypeFactory.Keyword("any", props.Emit),
-            nil,
-            f.NewToken(shimast.KindEqualsGreaterThanToken),
-            props.Config.Decoder(UnionExplorer_ArrayLikeDecoderProps{
-              Input:      f.NewIdentifier("entire"),
-              Definition: meta,
-              Explore:    unionExplorer_with_tracable(props.Explore, true),
-            }),
+            props.Emit,
           ),
         }),
+        nativefactories.TypeFactory.Keyword("any", props.Emit),
+        nil,
+        f.NewToken(shimast.KindEqualsGreaterThanToken),
+        props.Config.Decoder(UnionExplorer_ArrayLikeDecoderProps{
+          Input:      f.NewIdentifier("entire"),
+          Definition: meta,
+          Explore:    unionExplorer_with_tracable(props.Explore, true),
+        }),
+      ),
+    }
+    if props.Config.Candidate != nil {
+      entries = append(entries, f.NewArrowFunction(
+        nil,
+        nil,
+        f.NewNodeList([]*shimast.Node{
+          nativefactories.IdentifierFactory.Parameter(
+            "entire",
+            f.NewTypeReferenceNode(f.NewIdentifier("any[]"), nil),
+            nil,
+            props.Emit,
+          ),
+        }),
+        nativefactories.TypeFactory.Keyword("boolean", props.Emit),
+        nil,
+        f.NewToken(shimast.KindEqualsGreaterThanToken),
+        props.Config.Candidate(UnionExplorer_ArrayLikeCandidateProps{
+          Input:      f.NewIdentifier("entire"),
+          Definition: meta,
+          Explore:    unionExplorer_with_tracable(props.Explore, false),
+        }),
+      ))
+    }
+    return f.NewAsExpression(
+      f.NewArrayLiteralExpression(
+        f.NewNodeList(entries),
         true,
       ),
       f.NewTypeReferenceNode(f.NewIdentifier("const"), nil),
@@ -709,12 +739,17 @@ func unionExplorer_check_union_array_like(props unionExplorer_check_union_array_
         "pred",
         f.NewIdentifier("tuplePredicators"),
         f.NewIfStatement(
-          f.NewCallExpression(
-            f.NewIdentifier("pred[0]"),
-            nil,
-            nil,
-            f.NewNodeList([]*shimast.Node{array}),
-            shimast.NodeFlagsNone,
+          unionExplorer_array_candidate_condition(
+            f.NewCallExpression(
+              f.NewIdentifier("pred[0]"),
+              nil,
+              nil,
+              f.NewNodeList([]*shimast.Node{array}),
+              shimast.NodeFlagsNone,
+            ),
+            props.Config.Candidate != nil,
+            array,
+            props.Emit,
           ),
           f.NewReturnStatement(
             f.NewCallExpression(
@@ -741,12 +776,12 @@ func unionExplorer_check_union_array_like(props unionExplorer_check_union_array_
     for _, x := range arrayList {
       arrayPredicates = append(arrayPredicates, predicate(x))
     }
-    statements = append(statements,
-      nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
-        Name:  "top",
-        Value: props.Accessor.Front(props.Input),
-      }, props.Emit),
-      f.NewIfStatement(
+    statements = append(statements, nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
+      Name:  "top",
+      Value: props.Accessor.Front(props.Input),
+    }, props.Emit))
+    if props.Config.Candidate == nil {
+      statements = append(statements, f.NewIfStatement(
         f.NewBinaryExpression(
           nil,
           nativefactories.ExpressionFactory.Number(0, props.Emit),
@@ -756,7 +791,9 @@ func unionExplorer_check_union_array_like(props unionExplorer_check_union_array_
         ),
         unionExplorer_return_or_statement(props.Config.Empty, props.Emit),
         nil,
-      ),
+      ))
+    }
+    statements = append(statements,
       nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
         Name: "arrayPredicators",
         Value: f.NewArrayLiteralExpression(
@@ -780,19 +817,37 @@ func unionExplorer_check_union_array_like(props unionExplorer_check_union_array_
               nil,
               nil,
               f.NewToken(shimast.KindEqualsGreaterThanToken),
-              f.NewCallExpression(
-                f.NewIdentifier("pred[0]"),
-                nil,
-                nil,
-                f.NewNodeList([]*shimast.Node{top}),
-                shimast.NodeFlagsNone,
-              ),
+              func() *shimast.Node {
+                element := f.NewCallExpression(
+                  f.NewIdentifier("pred[0]"),
+                  nil,
+                  nil,
+                  f.NewNodeList([]*shimast.Node{top}),
+                  shimast.NodeFlagsNone,
+                )
+                if props.Config.Candidate == nil {
+                  return element
+                }
+                return f.NewBinaryExpression(
+                  nil,
+                  f.NewBinaryExpression(
+                    nil,
+                    nativefactories.ExpressionFactory.Number(0, props.Emit),
+                    nil,
+                    f.NewToken(shimast.KindEqualsEqualsEqualsToken),
+                    props.Accessor.Size(props.Input),
+                  ),
+                  nil,
+                  f.NewToken(shimast.KindBarBarToken),
+                  element,
+                )
+              }(),
             ),
           }),
           shimast.NodeFlagsNone,
         ),
       }, props.Emit),
-      unionExplorer_array_if(iterate, array, top, props.Config.Success, props.Emit),
+      unionExplorer_array_if(iterate, array, top, props.Config.Success, props.Config.Candidate != nil, props.Emit),
     )
   }
   names := make([]string, 0, len(targets))
@@ -819,8 +874,75 @@ func unionExplorer_check_union_array_like(props unionExplorer_check_union_array_
   )
 }
 
-func unionExplorer_array_if(iterate func(init string, from *shimast.Expression, ifStatement *shimast.Node) *shimast.Node, array *shimast.Node, top *shimast.Node, success *shimast.Expression, emit ...*shimprinter.EmitContext) *shimast.Node {
+func unionExplorer_array_if(iterate func(init string, from *shimast.Expression, ifStatement *shimast.Node) *shimast.Node, array *shimast.Node, top *shimast.Node, success *shimast.Expression, candidate bool, emit ...*shimprinter.EmitContext) *shimast.Node {
   f := nativecontext.EmitFactoryOf(unionExplorer_factory, emit...)
+  if candidate {
+    elementCondition := f.NewCallExpression(
+      nativefactories.IdentifierFactory.Access(nil, array, "every"),
+      nil,
+      nil,
+      f.NewNodeList([]*shimast.Node{
+        f.NewArrowFunction(
+          nil,
+          nil,
+          f.NewNodeList([]*shimast.Node{
+            nativefactories.IdentifierFactory.Parameter("value", nativefactories.TypeFactory.Keyword("any", emit...), nil, emit...),
+          }),
+          nil,
+          nil,
+          f.NewToken(shimast.KindEqualsGreaterThanToken),
+          f.NewBinaryExpression(
+            nil,
+            success,
+            nil,
+            f.NewToken(shimast.KindEqualsEqualsEqualsToken),
+            f.NewCallExpression(
+              f.NewIdentifier("pred[0]"),
+              nil,
+              nil,
+              f.NewNodeList([]*shimast.Node{f.NewIdentifier("value")}),
+              shimast.NodeFlagsNone,
+            ),
+          ),
+        ),
+      }),
+      shimast.NodeFlagsNone,
+    )
+    return f.NewBlock(f.NewNodeList([]*shimast.Node{
+      iterate(
+        "pred",
+        f.NewIdentifier("passed"),
+        f.NewIfStatement(
+          unionExplorer_array_candidate_condition(elementCondition, true, array, emit...),
+          f.NewReturnStatement(f.NewCallExpression(
+            f.NewIdentifier("pred[1]"),
+            nil,
+            nil,
+            f.NewNodeList([]*shimast.Node{array}),
+            shimast.NodeFlagsNone,
+          )),
+          nil,
+        ),
+      ),
+      f.NewIfStatement(
+        f.NewBinaryExpression(
+          nil,
+          nativefactories.ExpressionFactory.Number(0, emit...),
+          nil,
+          f.NewToken(shimast.KindLessThanToken),
+          f.NewIdentifier("passed.length"),
+        ),
+        f.NewReturnStatement(f.NewCallExpression(
+          f.NewIdentifier("passed[0][1]"),
+          nil,
+          nil,
+          f.NewNodeList([]*shimast.Node{array}),
+          shimast.NodeFlagsNone,
+        )),
+        nil,
+      ),
+    }), true)
+  }
   return f.NewIfStatement(
     f.NewBinaryExpression(
       nil,
@@ -907,6 +1029,26 @@ func unionExplorer_array_if(iterate func(init string, from *shimast.Expression, 
       ),
       nil,
     ),
+  )
+}
+
+func unionExplorer_array_candidate_condition(element *shimast.Node, candidate bool, array *shimast.Node, emit ...*shimprinter.EmitContext) *shimast.Node {
+  if candidate == false {
+    return element
+  }
+  f := nativecontext.EmitFactoryOf(unionExplorer_factory, emit...)
+  return f.NewBinaryExpression(
+    nil,
+    f.NewCallExpression(
+      f.NewIdentifier("pred[2]"),
+      nil,
+      nil,
+      f.NewNodeList([]*shimast.Node{array}),
+      shimast.NodeFlagsNone,
+    ),
+    nil,
+    f.NewToken(shimast.KindAmpersandAmpersandToken),
+    element,
   )
 }
 

--- a/packages/typia/native/core/programmers/helpers/union_explorer_coverage_test.go
+++ b/packages/typia/native/core/programmers/helpers/union_explorer_coverage_test.go
@@ -91,7 +91,7 @@ func TestUnionExplorerCoverage(t *testing.T) {
 	if unionExplorer_array_if(func(init string, from *shimast.Expression, ifStatement *shimast.Node) *shimast.Node {
 		iterated = init == "pred" && from != nil && ifStatement != nil
 		return ifStatement
-	}, input, input, factory.NewKeywordExpression(shimast.KindTrueKeyword)) == nil || !iterated {
+	}, input, input, factory.NewKeywordExpression(shimast.KindTrueKeyword), false) == nil || !iterated {
 		t.Fatal("array disambiguation helper did not invoke iterator")
 	}
 	if unionExplorer_return_or_statement(input) == nil ||

--- a/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
+++ b/packages/typia/native/core/programmers/internal/CheckerProgrammer.go
@@ -826,21 +826,27 @@ func (checkerProgrammerNamespace) Decode(props CheckerProgrammer_DecodeProps) *s
         body = checkerProgrammer_explore_tuples(checkerProgrammer_exploreTuplesProps{Config: props.Config, Context: props.Context, Functor: props.Functor, Tuples: props.Metadata.Tuples, Input: props.Input, Explore: explore})
       }
     } else if checkerProgrammer_array_any(props.Metadata.Arrays) {
-      // Any-element arrays need no element exploration, but a sole array's
-      // validating wrapper tags (MinItems, custom predicates, ...) still
-      // constrain the container and survive on the entry conditions. Unions
-      // mixing a tag-constrained any-element array with other array-like
-      // variants keep the historical wholesale acceptance: the union
-      // explorer discriminates by element checks, which an any element
-      // satisfies trivially, so honoring those tags needs branch
-      // backtracking (tracked on #1933).
-      body = nil
+      // A sole any-element array only needs its wrapper predicates. In a
+      // union, however, those predicates participate in branch selection:
+      // a failed tagged-any candidate must backtrack to a concrete array or
+      // tuple candidate instead of accepting or rejecting the whole bucket.
       if len(props.Metadata.Arrays) == 1 && len(props.Metadata.Tuples) == 0 {
+        body = nil
         conditions = nativeiterate.Check_array_length(nativeiterate.Check_array_lengthProps{
           Context: props.Context,
           Array:   props.Metadata.Arrays[0],
           Input:   props.Input,
         }).Conditions
+      } else if checkerProgrammer_has_array_type_tags(props.Metadata.Arrays) {
+        explore := props.Explore
+        explore.From = "array"
+        if len(props.Metadata.Tuples) == 0 {
+          body = checkerProgrammer_explore_arrays(checkerProgrammer_exploreArraysProps{Config: props.Config, Context: props.Context, Functor: props.Functor, Arrays: props.Metadata.Arrays, Input: props.Input, Explore: explore})
+        } else {
+          body = checkerProgrammer_explore_arrays_and_tuples(checkerProgrammer_exploreArraysAndTuplesProps{Config: props.Config, Context: props.Context, Functor: props.Functor, Definitions: checkerProgrammer_array_tuple_definitions(props.Metadata.Arrays, props.Metadata.Tuples), Input: props.Input, Explore: explore})
+        }
+      } else {
+        body = nil
       }
     } else if len(props.Metadata.Tuples) == 0 {
       explore := props.Explore
@@ -1540,14 +1546,18 @@ func checkerProgrammer_explore_arrays(props checkerProgrammer_exploreArraysProps
       for _, value := range next.Definitions {
         arrays = append(arrays, value.(*nativemetadata.MetadataArray))
       }
+      config := checkerProgrammer_array_like_config(props.Context, props.Config, props.Functor,
+        func(v nativehelpers.UnionExplorer_ArrayLikeCheckerProps) *shimast.Node {
+          return CheckerProgrammer.Decode(CheckerProgrammer_DecodeProps{Context: props.Context, Config: props.Config, Functor: props.Functor, Metadata: v.Definition.(*nativemetadata.MetadataSchema), Input: v.Input, Explore: featureProgrammer_as_explore(v.Explore)})
+        },
+        func(v nativehelpers.UnionExplorer_ArrayLikeDecoderProps) *shimast.Node {
+          return checkerProgrammer_decode_array(checkerProgrammer_decodeArrayProps{Context: props.Context, Config: props.Config, Functor: props.Functor, Array: v.Definition.(*nativemetadata.MetadataArray), Input: v.Input, Explore: featureProgrammer_as_explore(v.Explore)})
+        })
+      if checkerProgrammer_has_array_type_tags(arrays) {
+        config.Candidate = checkerProgrammer_array_tag_candidate(props.Context)
+      }
       return nativehelpers.UnionExplorer.Array(nativehelpers.UnionExplorer_ArrayProps{
-        Config: checkerProgrammer_array_like_config(props.Context, props.Config, props.Functor,
-          func(v nativehelpers.UnionExplorer_ArrayLikeCheckerProps) *shimast.Node {
-            return CheckerProgrammer.Decode(CheckerProgrammer_DecodeProps{Context: props.Context, Config: props.Config, Functor: props.Functor, Metadata: v.Definition.(*nativemetadata.MetadataSchema), Input: v.Input, Explore: featureProgrammer_as_explore(v.Explore)})
-          },
-          func(v nativehelpers.UnionExplorer_ArrayLikeDecoderProps) *shimast.Node {
-            return checkerProgrammer_decode_array(checkerProgrammer_decodeArrayProps{Context: props.Context, Config: props.Config, Functor: props.Functor, Array: v.Definition.(*nativemetadata.MetadataArray), Input: v.Input, Explore: featureProgrammer_as_explore(v.Explore)})
-          }),
+        Config:     config,
         Parameters: next.Parameters,
         Arrays:     arrays,
         Input:      next.Input,
@@ -1562,37 +1572,41 @@ func checkerProgrammer_explore_arrays_and_tuples(props checkerProgrammer_explore
   return checkerProgrammer_explore_array_like_union_types(checkerProgrammer_exploreArrayLikeUnionTypesProps{
     Config: props.Config, Functor: props.Functor, Definitions: props.Definitions, Input: props.Input, Explore: props.Explore, Emit: props.Context.Emit,
     Factory: func(next checkerProgrammer_exploreArrayLikeUnionTypesFactoryProps) *shimast.Node {
+      config := checkerProgrammer_array_like_config(props.Context, props.Config, props.Functor,
+        func(v nativehelpers.UnionExplorer_ArrayLikeCheckerProps) *shimast.Node {
+          if tuple, ok := v.Definition.(*nativemetadata.MetadataTuple); ok {
+            return checkerProgrammer_decode_tuple(checkerProgrammer_decodeTupleProps{Config: props.Config, Context: props.Context, Functor: props.Functor, Input: v.Input, Tuple: tuple, Explore: featureProgrammer_as_explore(v.Explore)})
+          }
+          expected := []string{}
+          for _, elem := range props.Definitions {
+            switch x := elem.(type) {
+            case *nativemetadata.MetadataArray:
+              expected = append(expected, x.GetDisplayName())
+            case *nativemetadata.MetadataTuple:
+              expected = append(expected, x.Type.GetDisplayName())
+            }
+          }
+          return props.Config.Atomist(CheckerProgrammer_AtomistProps{
+            Explore: featureProgrammer_as_explore(v.Explore),
+            Entry: nativehelpers.ICheckEntry{
+              Expected:   strings.Join(expected, " | "),
+              Expression: CheckerProgrammer.Decode(CheckerProgrammer_DecodeProps{Functor: props.Functor, Context: props.Context, Config: props.Config, Metadata: v.Definition.(*nativemetadata.MetadataSchema), Input: v.Input, Explore: featureProgrammer_as_explore(v.Explore)}),
+              Conditions: [][]nativehelpers.ICheckEntry_ICondition{},
+            },
+            Input: v.Container,
+          })
+        },
+        func(v nativehelpers.UnionExplorer_ArrayLikeDecoderProps) *shimast.Node {
+          if tuple, ok := v.Definition.(*nativemetadata.MetadataTuple); ok {
+            return checkerProgrammer_decode_tuple(checkerProgrammer_decodeTupleProps{Context: props.Context, Config: props.Config, Functor: props.Functor, Input: v.Input, Tuple: tuple, Explore: featureProgrammer_as_explore(v.Explore)})
+          }
+          return checkerProgrammer_decode_array(checkerProgrammer_decodeArrayProps{Context: props.Context, Config: props.Config, Functor: props.Functor, Input: v.Input, Array: v.Definition.(*nativemetadata.MetadataArray), Explore: featureProgrammer_as_explore(v.Explore)})
+        })
+      if checkerProgrammer_definitions_have_array_type_tags(next.Definitions) {
+        config.Candidate = checkerProgrammer_array_tag_candidate(props.Context)
+      }
       return nativehelpers.UnionExplorer.Array_or_tuple(nativehelpers.UnionExplorer_ArrayOrTupleProps{
-        Config: checkerProgrammer_array_like_config(props.Context, props.Config, props.Functor,
-          func(v nativehelpers.UnionExplorer_ArrayLikeCheckerProps) *shimast.Node {
-            if tuple, ok := v.Definition.(*nativemetadata.MetadataTuple); ok {
-              return checkerProgrammer_decode_tuple(checkerProgrammer_decodeTupleProps{Config: props.Config, Context: props.Context, Functor: props.Functor, Input: v.Input, Tuple: tuple, Explore: featureProgrammer_as_explore(v.Explore)})
-            }
-            expected := []string{}
-            for _, elem := range props.Definitions {
-              switch x := elem.(type) {
-              case *nativemetadata.MetadataArray:
-                expected = append(expected, x.GetDisplayName())
-              case *nativemetadata.MetadataTuple:
-                expected = append(expected, x.Type.GetDisplayName())
-              }
-            }
-            return props.Config.Atomist(CheckerProgrammer_AtomistProps{
-              Explore: featureProgrammer_as_explore(v.Explore),
-              Entry: nativehelpers.ICheckEntry{
-                Expected:   strings.Join(expected, " | "),
-                Expression: CheckerProgrammer.Decode(CheckerProgrammer_DecodeProps{Functor: props.Functor, Context: props.Context, Config: props.Config, Metadata: v.Definition.(*nativemetadata.MetadataSchema), Input: v.Input, Explore: featureProgrammer_as_explore(v.Explore)}),
-                Conditions: [][]nativehelpers.ICheckEntry_ICondition{},
-              },
-              Input: v.Container,
-            })
-          },
-          func(v nativehelpers.UnionExplorer_ArrayLikeDecoderProps) *shimast.Node {
-            if tuple, ok := v.Definition.(*nativemetadata.MetadataTuple); ok {
-              return checkerProgrammer_decode_tuple(checkerProgrammer_decodeTupleProps{Context: props.Context, Config: props.Config, Functor: props.Functor, Input: v.Input, Tuple: tuple, Explore: featureProgrammer_as_explore(v.Explore)})
-            }
-            return checkerProgrammer_decode_array(checkerProgrammer_decodeArrayProps{Context: props.Context, Config: props.Config, Functor: props.Functor, Input: v.Input, Array: v.Definition.(*nativemetadata.MetadataArray), Explore: featureProgrammer_as_explore(v.Explore)})
-          }),
+        Config:      config,
         Parameters:  next.Parameters,
         Definitions: next.Definitions,
         Input:       next.Input,
@@ -1785,7 +1799,7 @@ func checkerProgrammer_check_object_reference(props checkerProgrammer_decodeObje
   }
   return checkerProgrammer_and(
     decoded,
-    checkerProgrammer_object_type_tags_condition(tags, props.Context.Emit),
+    checkerProgrammer_entry_condition(tags, props.Context.Emit),
     props.Context.Emit,
   )
 }
@@ -1819,7 +1833,7 @@ func checkerProgrammer_decode_object_reference(props checkerProgrammer_decodeObj
   )
 }
 
-func checkerProgrammer_object_type_tags_condition(entry nativehelpers.ICheckEntry, emit *shimprinter.EmitContext) *shimast.Node {
+func checkerProgrammer_entry_condition(entry nativehelpers.ICheckEntry, emit *shimprinter.EmitContext) *shimast.Node {
   f := nativecontext.EmitFactoryOf(checkerProgrammer_factory, emit)
   expressions := []*shimast.Node{}
   if entry.Expression != nil {
@@ -1850,6 +1864,44 @@ func checkerProgrammer_has_object_type_tags(objects []*nativemetadata.MetadataOb
     }
   }
   return false
+}
+
+func checkerProgrammer_has_array_type_tags(arrays []*nativemetadata.MetadataArray) bool {
+  for _, array := range arrays {
+    for _, row := range array.Tags {
+      for _, tag := range row {
+        if tag.Validate != "" {
+          return true
+        }
+      }
+    }
+  }
+  return false
+}
+
+func checkerProgrammer_definitions_have_array_type_tags(definitions []any) bool {
+  arrays := []*nativemetadata.MetadataArray{}
+  for _, definition := range definitions {
+    if array, ok := definition.(*nativemetadata.MetadataArray); ok {
+      arrays = append(arrays, array)
+    }
+  }
+  return checkerProgrammer_has_array_type_tags(arrays)
+}
+
+func checkerProgrammer_array_tag_candidate(context nativecontext.ITypiaContext) func(nativehelpers.UnionExplorer_ArrayLikeCandidateProps) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(checkerProgrammer_factory, context.Emit)
+  return func(props nativehelpers.UnionExplorer_ArrayLikeCandidateProps) *shimast.Node {
+    array, ok := props.Definition.(*nativemetadata.MetadataArray)
+    if ok == false {
+      return f.NewKeywordExpression(shimast.KindTrueKeyword)
+    }
+    return checkerProgrammer_entry_condition(nativeiterate.Check_array_length(nativeiterate.Check_array_lengthProps{
+      Context: context,
+      Array:   array,
+      Input:   props.Input,
+    }), context.Emit)
+  }
 }
 
 func checkerProgrammer_array_like_config(context nativecontext.ITypiaContext, config CheckerProgrammer_IConfig, functor *nativehelpers.FunctionProgrammer, checker func(v nativehelpers.UnionExplorer_ArrayLikeCheckerProps) *shimast.Node, decoder func(v nativehelpers.UnionExplorer_ArrayLikeDecoderProps) *shimast.Node) nativehelpers.UnionExplorer_ArrayLikeConfig {

--- a/packages/typia/native/core/programmers/iterate/check_template.go
+++ b/packages/typia/native/core/programmers/iterate/check_template.go
@@ -1,6 +1,7 @@
 package iterate
 
 import (
+  "fmt"
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
@@ -32,8 +33,10 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
   internal := make([]*shimast.Node, 0, len(props.Templates))
   var solePattern string
   var soleCaptures []templateCapture
+  var soleBacktracking *nativehelpers.ICheckEntry_ICondition
   for _, tpl := range props.Templates {
     pattern, captures := template_runtime_pattern(tpl.Row)
+    backtracking := template_requires_backtracking(tpl.Row)
     expression := f.NewCallExpression(
       f.NewIdentifier("RegExp(/"+pattern+"/).test"),
       nil,
@@ -46,6 +49,16 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
     // them — both the whole-string matrix and the per-placeholder
     // interpolation matrix — into the member expression instead.
     if len(props.Templates) > 1 {
+      if backtracking {
+        expression = f.NewBinaryExpression(
+          nil,
+          expression,
+          nil,
+          f.NewToken(shimast.KindAmpersandAmpersandToken),
+          check_template_backtracking(props, tpl),
+        )
+        captures = nil
+      }
       if tags := check_template_inline_all_tags(props, tpl, pattern, captures); tags != nil {
         expression = f.NewBinaryExpression(
           nil,
@@ -57,7 +70,15 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
       }
     } else {
       solePattern = pattern
-      soleCaptures = captures
+      if backtracking {
+        soleCaptures = nil
+        soleBacktracking = &nativehelpers.ICheckEntry_ICondition{
+          Expected:   check_template_backtracking_expected(tpl),
+          Expression: check_template_backtracking(props, tpl),
+        }
+      } else {
+        soleCaptures = captures
+      }
     }
     internal = append(internal, expression)
   }
@@ -74,7 +95,7 @@ func Check_template(props Check_templateProps) nativehelpers.ICheckEntry {
     Expected:   strings.Join(names, " | "),
   }
   if len(props.Templates) == 1 {
-    entry.Conditions = check_template_all_conditions(props, props.Templates[0], solePattern, soleCaptures)
+    entry.Conditions = check_template_all_conditions(props, props.Templates[0], solePattern, soleCaptures, soleBacktracking)
   }
   return entry
 }
@@ -114,10 +135,10 @@ func check_template_type_tags(props Check_templateProps, tpl *nativemetadata.Met
 // must hold simultaneously, so all matrices collapse into a single AND row:
 // single-row matrices keep one ICondition per tag (so validate still names the
 // exact tag), while a multi-row (union) matrix collapses to one OR'd ICondition.
-func check_template_all_conditions(props Check_templateProps, tpl *nativemetadata.MetadataTemplate, pattern string, captures []templateCapture) [][]nativehelpers.ICheckEntry_ICondition {
+func check_template_all_conditions(props Check_templateProps, tpl *nativemetadata.MetadataTemplate, pattern string, captures []templateCapture, backtracking *nativehelpers.ICheckEntry_ICondition) [][]nativehelpers.ICheckEntry_ICondition {
   wholeString := check_template_type_tags(props, tpl)
   groups := check_template_placeholder_groups(props, tpl, pattern, captures)
-  if len(groups) == 0 {
+  if len(groups) == 0 && backtracking == nil {
     return wholeString
   }
   // groups is non-empty here, and every group contributes at least one
@@ -126,6 +147,9 @@ func check_template_all_conditions(props Check_templateProps, tpl *nativemetadat
   check_template_append_matrix(&row, wholeString, props.Emit)
   for _, group := range groups {
     check_template_append_matrix(&row, group, props.Emit)
+  }
+  if backtracking != nil {
+    row = append(row, *backtracking)
   }
   return [][]nativehelpers.ICheckEntry_ICondition{row}
 }
@@ -182,22 +206,31 @@ func check_template_placeholder_groups(props Check_templateProps, tpl *nativemet
 // this placeholder only because template_fully_constrained holds, i.e. each row
 // carries a validate-able tag, so no produced row is empty.
 func check_template_capture_conditions(props Check_templateProps, base string, pattern string, capture templateCapture) [][]nativehelpers.ICheckEntry_ICondition {
+  return check_template_value_conditions(
+    props,
+    base,
+    capture.Atomic,
+    capture.Kind,
+    check_template_capture_input(pattern, capture, props.Input, props.Emit),
+  )
+}
+
+func check_template_value_conditions(props Check_templateProps, base string, atomic *nativemetadata.MetadataAtomic, kind string, input *shimast.Expression) [][]nativehelpers.ICheckEntry_ICondition {
   output := [][]nativehelpers.ICheckEntry_ICondition{}
-  for _, row := range capture.Atomic.Tags {
+  for _, row := range atomic.Tags {
     conditions := []nativehelpers.ICheckEntry_ICondition{}
-    if capture.Kind != "string" {
-      // number and bigint share the numeric transpiler; the bigint validate
-      // scripts already compare via `BigInt(...)`, and check_template_capture_input
-      // hands them a `BigInt(...)`-parsed value. The exclude literals use
-      // capture.Kind so a bigint placeholder emits bigint literals.
+    if kind != "string" {
+      // Number and bigint share the numeric transpiler. Coercion stays here so
+      // both direct RegExp captures and backtracking slices use the same tag
+      // predicates, while bigint exclude checks still emit bigint literals.
       for _, tag := range check_number_filter_validate(row) {
         conditions = append(conditions, nativehelpers.ICheckEntry_ICondition{
           Expected:   base + " & " + tag.Name,
-          Expression: check_number_transpile(props.Context, tag.Validate)(check_template_capture_input(pattern, capture, props.Input, props.Emit)),
+          Expression: check_number_transpile(props.Context, tag.Validate)(check_template_coerce_input(kind, input, props.Emit)),
         })
       }
       for _, tag := range row {
-        if condition := check_exclude_condition(capture.Kind, tag, check_template_capture_input(pattern, capture, props.Input, props.Emit), props.Emit); condition != nil {
+        if condition := check_exclude_condition(kind, tag, check_template_coerce_input(kind, input, props.Emit), props.Emit); condition != nil {
           conditions = append(conditions, *condition)
         }
       }
@@ -205,11 +238,11 @@ func check_template_capture_conditions(props Check_templateProps, base string, p
       for _, tag := range check_string_filter_validate(row) {
         conditions = append(conditions, nativehelpers.ICheckEntry_ICondition{
           Expected:   base + " & " + tag.Name,
-          Expression: check_string_transpile(props.Context, tag.Validate)(check_template_capture_input(pattern, capture, props.Input, props.Emit)),
+          Expression: check_string_transpile(props.Context, tag.Validate)(input),
         })
       }
       for _, tag := range row {
-        if condition := check_exclude_condition("string", tag, check_template_capture_input(pattern, capture, props.Input, props.Emit), props.Emit); condition != nil {
+        if condition := check_exclude_condition("string", tag, input, props.Emit); condition != nil {
           conditions = append(conditions, *condition)
         }
       }
@@ -219,13 +252,33 @@ func check_template_capture_conditions(props Check_templateProps, base string, p
   return output
 }
 
-// check_template_capture_input builds the expression that re-extracts a
-// placeholder's captured substring: `RegExp(/pattern/).exec(input)[index]`,
-// coerced through `Number(...)` for a numeric placeholder or `BigInt(...)` for a
-// bigint one (a string placeholder uses the raw substring). The surrounding
-// `.test()` (entry expression for a sole template, member expression for a
-// union) guarantees the match is non-null, and the bigint capture pattern admits
-// only integers, so the conversion never throws.
+func check_template_coerce_input(kind string, input *shimast.Expression, emit *shimprinter.EmitContext) *shimast.Expression {
+  f := nativecontext.EmitFactoryOf(check_template_factory, emit)
+  coerce := ""
+  switch kind {
+  case "number":
+    coerce = "Number"
+  case "bigint":
+    coerce = "BigInt"
+  }
+  if coerce == "" {
+    return input
+  }
+  return f.NewCallExpression(
+    f.NewIdentifier(coerce),
+    nil,
+    nil,
+    f.NewNodeList([]*shimast.Node{input}),
+    shimast.NodeFlagsNone,
+  )
+}
+
+// check_template_capture_input re-extracts a placeholder's raw captured
+// substring: `RegExp(/pattern/).exec(input)[index]`. The surrounding `.test()`
+// (entry expression for a sole template, member expression for a union)
+// guarantees the match is non-null. Numeric coercion belongs to
+// check_template_value_conditions so direct captures and backtracking slices
+// share the same path.
 func check_template_capture_input(pattern string, capture templateCapture, input *shimast.Expression, emit *shimprinter.EmitContext) *shimast.Expression {
   f := nativecontext.EmitFactoryOf(check_template_factory, emit)
   element := f.NewElementAccessExpression(
@@ -240,23 +293,282 @@ func check_template_capture_input(pattern string, capture templateCapture, input
     nativefactories.ExpressionFactory.Number(capture.Index, emit),
     shimast.NodeFlagsNone,
   )
-  coerce := ""
-  switch capture.Kind {
-  case "number":
-    coerce = "Number"
-  case "bigint":
-    coerce = "BigInt"
-  }
-  if coerce != "" {
-    return f.NewCallExpression(
-      f.NewIdentifier(coerce),
-      nil,
-      nil,
-      f.NewNodeList([]*shimast.Node{element}),
-      shimast.NodeFlagsNone,
+  return element
+}
+
+// check_template_backtracking accepts a template when at least one complete
+// assignment of substrings to placeholders satisfies both their structural
+// patterns and every runtime-checkable tag. One memoized visitor per template
+// row enumerates UTF-16 offsets, matching JavaScript string slicing and RegExp
+// semantics without repeating the same suffix search or committing to
+// RegExp.exec's single greedy capture.
+func check_template_backtracking(props Check_templateProps, tpl *nativemetadata.MetadataTemplate) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(check_template_factory, props.Emit)
+  statements := make([]*shimast.Node, 0, (len(tpl.Row)+1)*2+1)
+  for index := 0; index <= len(tpl.Row); index++ {
+    memoName := fmt.Sprintf("_templateMemo%d", index)
+    visitName := fmt.Sprintf("_templateVisit%d", index)
+    offsetName := fmt.Sprintf("_templateStart%d", index)
+    cachedName := fmt.Sprintf("_templateCached%d", index)
+    resultName := fmt.Sprintf("_templateResult%d", index)
+    offset := f.NewIdentifier(offsetName)
+    memo := f.NewIdentifier(memoName)
+
+    statements = append(statements,
+      nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
+        Name:  memoName,
+        Value: f.NewNewExpression(f.NewIdentifier("Map"), nil, f.NewNodeList(nil)),
+      }, props.Emit),
+      nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
+        Name: visitName,
+        Value: f.NewArrowFunction(
+          nil,
+          nil,
+          f.NewNodeList([]*shimast.Node{
+            nativefactories.IdentifierFactory.Parameter(offsetName, nativefactories.TypeFactory.Keyword("number", props.Emit), nil, props.Emit),
+          }),
+          nativefactories.TypeFactory.Keyword("boolean", props.Emit),
+          nil,
+          f.NewToken(shimast.KindEqualsGreaterThanToken),
+          f.NewBlock(f.NewNodeList([]*shimast.Node{
+            nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
+              Name: cachedName,
+              Value: f.NewCallExpression(
+                nativefactories.IdentifierFactory.Access(props.Emit, memo, "get"),
+                nil,
+                nil,
+                f.NewNodeList([]*shimast.Node{offset}),
+                shimast.NodeFlagsNone,
+              ),
+            }, props.Emit),
+            f.NewIfStatement(
+              f.NewBinaryExpression(
+                nil,
+                f.NewIdentifier(cachedName),
+                nil,
+                f.NewToken(shimast.KindExclamationEqualsEqualsToken),
+                f.NewIdentifier("undefined"),
+              ),
+              f.NewReturnStatement(f.NewIdentifier(cachedName)),
+              nil,
+            ),
+            nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
+              Name:  resultName,
+              Type:  nativefactories.TypeFactory.Keyword("boolean", props.Emit),
+              Value: check_template_backtracking_step(props, tpl, index, offset),
+            }, props.Emit),
+            f.NewExpressionStatement(f.NewCallExpression(
+              nativefactories.IdentifierFactory.Access(props.Emit, memo, "set"),
+              nil,
+              nil,
+              f.NewNodeList([]*shimast.Node{offset, f.NewIdentifier(resultName)}),
+              shimast.NodeFlagsNone,
+            )),
+            f.NewReturnStatement(f.NewIdentifier(resultName)),
+          }), true),
+        ),
+      }, props.Emit),
     )
   }
-  return element
+  statements = append(statements, f.NewReturnStatement(check_template_backtracking_call(
+    0,
+    nativefactories.ExpressionFactory.Number(0, props.Emit),
+    props.Emit,
+  )))
+  return f.NewCallExpression(
+    f.NewParenthesizedExpression(f.NewArrowFunction(
+      nil,
+      nil,
+      f.NewNodeList(nil),
+      nativefactories.TypeFactory.Keyword("boolean", props.Emit),
+      nil,
+      f.NewToken(shimast.KindEqualsGreaterThanToken),
+      f.NewBlock(f.NewNodeList(statements), true),
+    )),
+    nil,
+    nil,
+    nil,
+    shimast.NodeFlagsNone,
+  )
+}
+
+func check_template_backtracking_step(props Check_templateProps, tpl *nativemetadata.MetadataTemplate, index int, offset *shimast.Expression) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(check_template_factory, props.Emit)
+  if index == len(tpl.Row) {
+    return f.NewBinaryExpression(
+      nil,
+      offset,
+      nil,
+      f.NewToken(shimast.KindEqualsEqualsEqualsToken),
+      nativefactories.IdentifierFactory.Access(props.Emit, props.Input, "length"),
+    )
+  }
+  meta := tpl.Row[index]
+  if literal, ok := template_literal_value(meta); ok {
+    value := f.NewStringLiteral(literal, shimast.TokenFlagsNone)
+    starts := f.NewCallExpression(
+      nativefactories.IdentifierFactory.Access(props.Emit, props.Input, "startsWith"),
+      nil,
+      nil,
+      f.NewNodeList([]*shimast.Node{value, offset}),
+      shimast.NodeFlagsNone,
+    )
+    nextOffset := f.NewBinaryExpression(
+      nil,
+      offset,
+      nil,
+      f.NewToken(shimast.KindPlusToken),
+      nativefactories.IdentifierFactory.Access(props.Emit, value, "length"),
+    )
+    return f.NewBinaryExpression(
+      nil,
+      starts,
+      nil,
+      f.NewToken(shimast.KindAmpersandAmpersandToken),
+      check_template_backtracking_call(index+1, nextOffset, props.Emit),
+    )
+  }
+
+  endName := fmt.Sprintf("_templateEnd%d", index)
+  end := f.NewIdentifier(endName)
+  slice := f.NewCallExpression(
+    nativefactories.IdentifierFactory.Access(props.Emit, props.Input, "slice"),
+    nil,
+    nil,
+    f.NewNodeList([]*shimast.Node{offset, end}),
+    shimast.NodeFlagsNone,
+  )
+  conditions := []*shimast.Node{
+    f.NewCallExpression(
+      f.NewIdentifier("RegExp(/"+template_backtracking_pattern(meta)+"/).test"),
+      nil,
+      nil,
+      f.NewNodeList([]*shimast.Node{slice}),
+      shimast.NodeFlagsNone,
+    ),
+  }
+  if atomic, kind, ok := template_constrained_capture(meta); ok {
+    conditions = append(conditions, check_template_condition_matrix(check_template_value_conditions(
+      props,
+      tpl.GetBaseName(),
+      atomic,
+      kind,
+      slice,
+    ), props.Emit))
+  }
+  conditions = append(conditions, check_template_backtracking_call(index+1, end, props.Emit))
+
+  length := f.NewBinaryExpression(
+    nil,
+    f.NewBinaryExpression(
+      nil,
+      nativefactories.IdentifierFactory.Access(props.Emit, props.Input, "length"),
+      nil,
+      f.NewToken(shimast.KindMinusToken),
+      offset,
+    ),
+    nil,
+    f.NewToken(shimast.KindPlusToken),
+    nativefactories.ExpressionFactory.Number(1, props.Emit),
+  )
+  positionName := fmt.Sprintf("_templateOffset%d", index)
+  candidates := f.NewCallExpression(
+    f.NewIdentifier("Array.from"),
+    nil,
+    nil,
+    f.NewNodeList([]*shimast.Node{
+      f.NewObjectLiteralExpression(f.NewNodeList([]*shimast.Node{
+        f.NewPropertyAssignment(nil, f.NewIdentifier("length"), nil, nil, length),
+      }), false),
+      f.NewArrowFunction(
+        nil,
+        nil,
+        f.NewNodeList([]*shimast.Node{
+          nativefactories.IdentifierFactory.Parameter(fmt.Sprintf("_templateUnused%d", index), nil, nil, props.Emit),
+          nativefactories.IdentifierFactory.Parameter(positionName, nativefactories.TypeFactory.Keyword("number", props.Emit), nil, props.Emit),
+        }),
+        nil,
+        nil,
+        f.NewToken(shimast.KindEqualsGreaterThanToken),
+        f.NewBinaryExpression(
+          nil,
+          offset,
+          nil,
+          f.NewToken(shimast.KindPlusToken),
+          f.NewIdentifier(positionName),
+        ),
+      ),
+    }),
+    shimast.NodeFlagsNone,
+  )
+  return f.NewCallExpression(
+    nativefactories.IdentifierFactory.Access(props.Emit, candidates, "some"),
+    nil,
+    nil,
+    f.NewNodeList([]*shimast.Node{
+      f.NewArrowFunction(
+        nil,
+        nil,
+        f.NewNodeList([]*shimast.Node{
+          nativefactories.IdentifierFactory.Parameter(endName, nativefactories.TypeFactory.Keyword("number", props.Emit), nil, props.Emit),
+        }),
+        nil,
+        nil,
+        f.NewToken(shimast.KindEqualsGreaterThanToken),
+        check_template_reduce(conditions, shimast.KindAmpersandAmpersandToken, props.Emit),
+      ),
+    }),
+    shimast.NodeFlagsNone,
+  )
+}
+
+func check_template_backtracking_call(index int, offset *shimast.Expression, emit *shimprinter.EmitContext) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(check_template_factory, emit)
+  return f.NewCallExpression(
+    f.NewIdentifier(fmt.Sprintf("_templateVisit%d", index)),
+    nil,
+    nil,
+    f.NewNodeList([]*shimast.Node{offset}),
+    shimast.NodeFlagsNone,
+  )
+}
+
+func check_template_condition_matrix(matrix [][]nativehelpers.ICheckEntry_ICondition, emit *shimprinter.EmitContext) *shimast.Node {
+  rows := make([]*shimast.Node, 0, len(matrix))
+  for _, row := range matrix {
+    columns := make([]*shimast.Node, 0, len(row))
+    for _, condition := range row {
+      columns = append(columns, condition.Expression)
+    }
+    rows = append(rows, check_template_reduce(columns, shimast.KindAmpersandAmpersandToken, emit))
+  }
+  return check_template_reduce(rows, shimast.KindBarBarToken, emit)
+}
+
+func check_template_backtracking_expected(tpl *nativemetadata.MetadataTemplate) string {
+  names := []string{}
+  seen := map[string]bool{}
+  for _, meta := range tpl.Row {
+    atomic, _, ok := template_constrained_capture(meta)
+    if ok == false {
+      continue
+    }
+    for _, row := range atomic.Tags {
+      for _, tag := range row {
+        if tag.Validate == "" && (tag.Kind != "exclude" || len(check_exclude_values(tag)) == 0) {
+          continue
+        }
+        if seen[tag.Name] == false {
+          seen[tag.Name] = true
+          names = append(names, tag.Name)
+        }
+      }
+    }
+  }
+  if len(names) == 0 {
+    return tpl.GetBaseName()
+  }
+  return tpl.GetBaseName() + " & (" + strings.Join(names, " & ") + ")"
 }
 
 // check_template_inline_all_tags folds a union member template's whole-string

--- a/packages/typia/native/core/programmers/iterate/template_interpolation_tags_test.go
+++ b/packages/typia/native/core/programmers/iterate/template_interpolation_tags_test.go
@@ -141,10 +141,10 @@ func TestTemplateConstrainedCapture(t *testing.T) {
 //
 //  1. A leading literal plus a constrained number captures at index 1.
 //  2. `${n}-${n}` keeps both numbers ("-" is not number-extendable) at 1 and 2;
-//     a string with a sibling absorbs the separator and falls back entirely.
+//     a string with a sibling absorbs the separator and has no direct capture.
 //  3. A sole constrained string lowers to `([\s\S]*)`, anchored.
 //  4. A constrained bigint lowers to the integer-only `([+-]?\d+)`, anchored.
-//  5. A constrained placeholder adjacent to a variable-width neighbor falls back.
+//  5. An ambiguous placeholder has no direct capture; backtracking owns it.
 //  6. A template with no constrained placeholder yields no captures and the
 //     historical pattern.
 func TestTemplateRuntimePattern(t *testing.T) {
@@ -169,10 +169,10 @@ func TestTemplateRuntimePattern(t *testing.T) {
   }
 
   // A string with a sibling absorbs the "-" (greedy `[\s\S]*`), unpinning both
-  // itself and the number, so the whole template falls back to no captures.
+  // itself and the number, so the direct-capture path stays empty.
   _, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{str, iterateLiteral("-"), numberB})
   if len(captures) != 0 {
-    t.Fatalf("string-with-sibling template must fall back, got %#v", captures)
+    t.Fatalf("string-with-sibling template must not capture directly, got %#v", captures)
   }
 
   // A constrained string captures every character (newlines included) via
@@ -197,15 +197,15 @@ func TestTemplateRuntimePattern(t *testing.T) {
 
   // A constrained placeholder adjacent to a variable-width neighbor (here an
   // unconstrained string before the number, with no literal between) is
-  // ambiguous under greedy matching, so it falls back to structural-only
-  // matching with no capture — rather than risking a false negative.
+  // ambiguous under greedy matching, so it has no direct capture; the checker
+  // routes the template to existential backtracking instead.
   _, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{iterateAtomic("string"), number})
   if len(captures) != 0 {
     t.Fatalf("number adjacent to a variable-width neighbor must not be captured, got %#v", captures)
   }
   _, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{str, numberB})
   if len(captures) != 0 {
-    t.Fatalf("two adjacent constrained placeholders must both fall back, got %#v", captures)
+    t.Fatalf("two adjacent constrained placeholders must not capture directly, got %#v", captures)
   }
 
   pattern, captures = template_runtime_pattern([]*nativemetadata.MetadataSchema{iterateLiteral("plain"), iterateAtomic("string")})
@@ -217,11 +217,43 @@ func TestTemplateRuntimePattern(t *testing.T) {
   }
 }
 
+// TestTemplateRequiresBacktracking separates unique captures from ambiguous
+// boundary searches and keeps each searched placeholder's standalone pattern
+// faithful to its runtime base type.
+func TestTemplateRequiresBacktracking(t *testing.T) {
+  number := iterateTemplateAtomic("number", [][]nativemetadata.IMetadataTypeTag{{{Name: "Minimum<10>", Validate: "10 <= $input"}}})
+  str := iterateTemplateAtomic("string", [][]nativemetadata.IMetadataTypeTag{{{Name: "MinLength<3>", Validate: "$input.length >= 3"}}})
+
+  cases := []struct {
+    name string
+    row  []*nativemetadata.MetadataSchema
+    want bool
+  }{
+    {"unique suffix", []*nativemetadata.MetadataSchema{iterateLiteral("v"), number}, false},
+    {"adjacent placeholders", []*nativemetadata.MetadataSchema{iterateAtomic("string"), number}, true},
+    {"safe numeric fence", []*nativemetadata.MetadataSchema{number, iterateLiteral("-"), number}, false},
+    {"decimal fence", []*nativemetadata.MetadataSchema{number, iterateLiteral("."), iterateAtomic("number")}, true},
+    {"repeated string fence", []*nativemetadata.MetadataSchema{iterateAtomic("string"), iterateLiteral("X"), str}, true},
+  }
+  for _, tc := range cases {
+    if got := template_requires_backtracking(tc.row); got != tc.want {
+      t.Fatalf("template_requires_backtracking(%s) = %v, want %v", tc.name, got, tc.want)
+    }
+  }
+
+  if got := template_backtracking_pattern(str); got != "^[\\s\\S]*$" {
+    t.Fatalf("constrained string backtracking pattern = %q", got)
+  }
+  if got := template_backtracking_pattern(iterateAtomic("bigint")); got != "^[+-]?\\d+$" {
+    t.Fatalf("bigint backtracking pattern = %q", got)
+  }
+}
+
 // TestTemplateClearBoundary gates capture on boundaries the greedy regex pins.
 //
 // A placeholder is captured only when, on each side, the template edge or a
 // literal whose first character its relevant variable neighbor cannot absorb
-// pins it; otherwise the split can slide and it falls back.
+// pins it; otherwise the split can slide and requires backtracking.
 //
 //  1. A single literal segment is a boundary; an atomic, a multi-value constant,
 //     and nil are not.

--- a/packages/typia/native/core/programmers/iterate/template_runtime_pattern.go
+++ b/packages/typia/native/core/programmers/iterate/template_runtime_pattern.go
@@ -84,10 +84,47 @@ func template_runtime_pattern(row []*nativemetadata.MetadataSchema) (string, []t
   return nativeutils.PatternUtil.Fix(strings.Join(parts, "")), captures
 }
 
+// template_requires_backtracking reports whether a constrained placeholder has
+// an ambiguous boundary. Such a template cannot validate tags from the single
+// greedy capture selected by RegExp.exec; the checker must instead search the
+// possible placeholder boundaries and accept when any complete split satisfies
+// every structural and tag predicate.
+func template_requires_backtracking(row []*nativemetadata.MetadataSchema) bool {
+  for i, meta := range row {
+    if _, _, ok := template_constrained_capture(meta); ok && template_clear_boundary(row, i) == false {
+      return true
+    }
+  }
+  return false
+}
+
+// template_backtracking_pattern is the whole-substring structural predicate
+// used for one placeholder during existential boundary search. Constrained
+// string and bigint placeholders retain the runtime capture semantics from
+// template_runtime_pattern: strings include newlines and bigints are integers.
+func template_backtracking_pattern(meta *nativemetadata.MetadataSchema) string {
+  sub := metadata_to_pattern(struct {
+    top      bool
+    metadata *nativemetadata.MetadataSchema
+  }{
+    top:      false,
+    metadata: meta,
+  })
+  if meta != nil && meta.Bucket() == 1 && len(meta.Atomics) == 1 && meta.Atomics[0].Type == "bigint" {
+    sub = "[+-]?\\d+"
+  } else if _, kind, ok := template_constrained_capture(meta); ok {
+    switch kind {
+    case "string":
+      sub = "[\\s\\S]*"
+    }
+  }
+  return nativeutils.PatternUtil.Fix(sub)
+}
+
 // template_clear_boundary reports whether the placeholder at row[i] is delimited
 // strongly enough that the greedy structural regex assigns it a unique — hence
-// correct — substring. An ambiguous placeholder falls back to structural-only
-// matching (tag unenforced, as before) rather than risking a false negative.
+// correct — substring. Ambiguous placeholders skip direct capture and are
+// validated by the existential matcher in check_template_backtracking.
 //
 // Two adjacent variable-width placeholders slide their shared boundary iff the
 // left one can extend over the first character of the literal between them: a
@@ -100,9 +137,9 @@ func template_runtime_pattern(row []*nativemetadata.MetadataSchema) (string, []t
 //   - `${n}-${n}` (#1965): "-" is not in a number's right-extension set, so both
 //     numbers are pinned and enforced.
 //   - `${number}.${number}` / IP grids: "." extends a number (decimal), so the
-//     split slides ("5.9.1.1.1" splits as 5.9|… or 5|9.1|…) — fall back.
+//     split slides ("5.9.1.1.1" splits as 5.9|… or 5|9.1|…) — backtrack.
 //   - `${string}-${number}` / `${string}X${string}`: a string absorbs any
-//     character, so a string with any sibling falls back.
+//     character, so a string with any sibling needs backtracking.
 //   - `a${string}b` / `prefix${string}suffix` / `${number}%` / `CODE-${string}`:
 //     sole placeholder, the `^`/`$` anchors pin both ends — enforced.
 func template_clear_boundary(row []*nativemetadata.MetadataSchema, i int) bool {
@@ -141,7 +178,7 @@ func template_boundary_safe(row []*nativemetadata.MetadataSchema, i int, dir int
 
 // template_variable_kind returns the base type a variable placeholder matches:
 // "number", "bigint", or "string". Anything else (boolean, unions, constants)
-// is treated as "string" — conservatively absorbing, so its neighbor falls back.
+// is treated as "string" — conservatively absorbing, so its neighbor backtracks.
 func template_variable_kind(meta *nativemetadata.MetadataSchema) string {
   if meta != nil && meta.Bucket() == 1 && len(meta.Atomics) == 1 {
     switch meta.Atomics[0].Type {
@@ -171,14 +208,22 @@ func template_right_extends(kind string, ch rune) bool {
 
 // template_literal_first returns the first character of a literal segment's text.
 func template_literal_first(meta *nativemetadata.MetadataSchema) (rune, bool) {
-  if meta == nil || len(meta.Constants) == 0 || len(meta.Constants[0].Values) == 0 {
+  value, ok := template_literal_value(meta)
+  if ok == false {
     return 0, false
   }
-  runes := []rune(fmt.Sprint(meta.Constants[0].Values[0].Value))
+  runes := []rune(value)
   if len(runes) == 0 {
     return 0, false
   }
   return runes[0], true
+}
+
+func template_literal_value(meta *nativemetadata.MetadataSchema) (string, bool) {
+  if template_is_literal(meta) == false || len(meta.Constants) == 0 || len(meta.Constants[0].Values) == 0 {
+    return "", false
+  }
+  return fmt.Sprint(meta.Constants[0].Values[0].Value), true
 }
 
 // template_is_literal reports whether a row element is a single fixed literal

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.6",
+  "version": "13.1.7",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/website/src/content/docs/validators/tags.mdx
+++ b/website/src/content/docs/validators/tags.mdx
@@ -1,6 +1,7 @@
 ---
 title: Guide Documents > Runtime Validators > Special Tags
 ---
+
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
 import { Tabs } from "nextra/components";
@@ -35,18 +36,20 @@ typia.assert<User>(input);
 
 Compiled output — note that each constraint becomes inline code:
 
-<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>
     <LocalSource
       path="examples/src/validators/is-type-tag.ts"
       filename="examples/src/validators/is-type-tag.ts"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
   <Tabs.Tab>
     <LocalSource
       path="examples/bin/validators/is-type-tag.js"
       filename="examples/bin/validators/is-type-tag.js"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
 </Tabs>
 
@@ -65,13 +68,13 @@ Type tags compose with `|` and `&` exactly like regular TypeScript types:
 ```typescript copy
 type N = number & (tags.Type<"uint32"> | tags.Type<"double">);
 ```
+
 - the `number` value can be a `uint32` **or** a `double` — the validator accepts either
 
 ```typescript copy
-type ID =
-  | (number & tags.Type<"int32">)
-  | (bigint  & tags.Type<"uint64">);
+type ID = (number & tags.Type<"int32">) | (bigint & tags.Type<"uint64">);
 ```
+
 - the value is either:
   - a `number` that is `int32`, **or**
   - a `bigint` that is `uint64`
@@ -79,8 +82,9 @@ type ID =
 ```typescript copy
 type Mixed =
   | (number & (tags.Type<"int32"> | tags.Type<"float">))
-  | (bigint  & tags.Type<"uint64">);
+  | (bigint & tags.Type<"uint64">);
 ```
+
 - the value is either:
   - a `number` that is `int32` **or** `float`, **or**
   - a `bigint` that is `uint64`
@@ -88,6 +92,16 @@ type Mixed =
 Note the parentheses on the third example — `number & (Type<"int32"> | Type<"float">)` is the `number` branch; `bigint & Type<"uint64">` is the `bigint` branch. The grouping matters: changing the parentheses changes the meaning, so when in doubt, match the structure of the bulleted breakdown above.
 
 If you intersect a tag with the wrong base type (e.g. `tags.MaxLength<100>` on a `number`), the TypeScript compiler will reject it.
+
+### On array union branches
+
+Array tags constrain their own union branch, including when that branch has `any` or `unknown` elements:
+
+```typescript copy
+type Batch = (unknown[] & tags.MinItems<2>) | string[];
+```
+
+The validator accepts `[1, 2]` through the tagged `unknown[]` branch and `["single"]` through the `string[]` branch, but rejects `[1]` because it satisfies neither complete branch. Branch selection checks the array's wrapper tags together with its element type, so a failed `MinItems`, `MaxItems`, `UniqueItems`, or custom array predicate does not bypass the constraint or prevent a later array or tuple branch from matching.
 
 ### Inside template literals
 
@@ -97,9 +111,12 @@ A tag intersected into a template-literal interpolation constrains that placehol
 type Percent = `${number & tags.Minimum<0> & tags.Maximum<100>}%`;
 type Serial = `SN-${bigint & tags.Minimum<0n>}`;
 type Hex = `0x${string & tags.Pattern<"^[0-9a-fA-F]+$">}`;
+type Suffix = `${string}${number & tags.Minimum<10>}`;
 ```
 
-The validator matches the template's structural pattern, then re-parses each constrained placeholder — `Number(...)` for a `number`, `BigInt(...)` for a `bigint`, the raw substring for a `string` — and runs that placeholder's own tag checks against it. So `"150%"` matches `` `${number}%` `` structurally but fails `Maximum<100>`, and `"0x1.5"` fails the hex `Pattern`. A `bigint` placeholder captures an integer only, so `"SN-1.5"` is rejected up front and `BigInt(...)` never throws. `is` / `assert` / `validate` agree, and `random` generates a constrained value that round-trips.
+The validator matches the template's structural pattern, then re-parses each constrained placeholder — `Number(...)` for a `number`, `BigInt(...)` for a `bigint`, the raw substring for a `string` — and runs that placeholder's own tag checks against it. So `"150%"` matches `` `${number}%` `` structurally but fails `Maximum<100>`, and `"0x1.5"` fails the hex `Pattern`. A `bigint` placeholder accepts an integer only, so `"SN-1.5"` is rejected before `BigInt(...)` can throw.
+
+When adjacent placeholders or repeated separators make the boundary ambiguous, the validator tries the possible splits and accepts the string if at least one complete split satisfies every placeholder. For `Suffix`, `"prefix123"` passes because the suffix can be parsed as `123`, while `"prefix9"` fails because no numeric suffix reaches `Minimum<10>`. This existential matching also applies to dynamic template keys and unions; `is`, `assert`, `validate`, validated serializers, and generated random values use the same runtime contract.
 
 > `json.schema` / `llm.schema` keep the template's structural `pattern` only: a numeric sub-range like `[0, 100]` cannot be expressed inside a JSON Schema string `pattern`, so a placeholder's tags are intentionally dropped from the emitted schema (the runtime validator still enforces them). Whole-string template tags — e.g. `` tags.MaxLength<30> & `prefix${string}postfix` `` — stay on the schema as before.
 
@@ -146,63 +163,65 @@ For `url`, DNS host labels may contain interior hyphen runs such as `example--ex
 
 #### `Array<T>`
 
-| Tag | Notes |
-|-----|-------|
-| `tags.MinItems<N>` | `arr.length >= N` |
-| `tags.MaxItems<N>` | `arr.length <= N` |
+| Tag                | Notes                          |
+| ------------------ | ------------------------------ |
+| `tags.MinItems<N>` | `arr.length >= N`              |
+| `tags.MaxItems<N>` | `arr.length <= N`              |
 | `tags.UniqueItems` | All elements pairwise distinct |
 
 #### Other useful tags
 
-| Tag | What it does |
-|-----|--------------|
-| `tags.Default<V>` | Records a default value in JSON Schema output |
-| `tags.Example<V>` / `tags.Examples<Record>` | Records example(s) in JSON Schema output |
-| `tags.Constant<V, {title, description}>` | Single-value literal with metadata |
-| `tags.JsonSchemaPlugin<{...}>` | Inject arbitrary `x-…` JSON Schema fields |
-| `tags.Sequence<N>` | Protobuf field number ([protobuf docs](/docs/protobuf/message)) |
+| Tag                                         | What it does                                                    |
+| ------------------------------------------- | --------------------------------------------------------------- |
+| `tags.Default<V>`                           | Records a default value in JSON Schema output                   |
+| `tags.Example<V>` / `tags.Examples<Record>` | Records example(s) in JSON Schema output                        |
+| `tags.Constant<V, {title, description}>`    | Single-value literal with metadata                              |
+| `tags.JsonSchemaPlugin<{...}>`              | Inject arbitrary `x-…` JSON Schema fields                       |
+| `tags.Sequence<N>`                          | Protobuf field number ([protobuf docs](/docs/protobuf/message)) |
 
 ## Comment tags
 
 If you'd rather write JSDoc, the same constraints exist as `@`-prefixed tags:
 
-| Comment tag | Equivalent type tag |
-|-------------|---------------------|
-| `@type int8` | `tags.Type<"int8">` |
-| `@type uint8` | `tags.Type<"uint8">` |
-| `@type int16` | `tags.Type<"int16">` |
-| `@type uint16` | `tags.Type<"uint16">` |
-| `@type int32` | `tags.Type<"int32">` |
-| `@type uint32` | `tags.Type<"uint32">` |
-| `@type int64` | `tags.Type<"int64">` |
-| `@type uint64` | `tags.Type<"uint64">` |
-| `@type float` | `tags.Type<"float">` |
-| `@type double` | `tags.Type<"double">` |
-| `@minimum 0` | `tags.Minimum<0>` |
-| `@maximum 100` | `tags.Maximum<100>` |
-| `@exclusiveMinimum 0` | `tags.ExclusiveMinimum<0>` |
+| Comment tag             | Equivalent type tag          |
+| ----------------------- | ---------------------------- |
+| `@type int8`            | `tags.Type<"int8">`          |
+| `@type uint8`           | `tags.Type<"uint8">`         |
+| `@type int16`           | `tags.Type<"int16">`         |
+| `@type uint16`          | `tags.Type<"uint16">`        |
+| `@type int32`           | `tags.Type<"int32">`         |
+| `@type uint32`          | `tags.Type<"uint32">`        |
+| `@type int64`           | `tags.Type<"int64">`         |
+| `@type uint64`          | `tags.Type<"uint64">`        |
+| `@type float`           | `tags.Type<"float">`         |
+| `@type double`          | `tags.Type<"double">`        |
+| `@minimum 0`            | `tags.Minimum<0>`            |
+| `@maximum 100`          | `tags.Maximum<100>`          |
+| `@exclusiveMinimum 0`   | `tags.ExclusiveMinimum<0>`   |
 | `@exclusiveMaximum 100` | `tags.ExclusiveMaximum<100>` |
-| `@multipleOf 0.5` | `tags.MultipleOf<0.5>` |
-| `@minLength 3` | `tags.MinLength<3>` |
-| `@maxLength 100` | `tags.MaxLength<100>` |
-| `@pattern ^[a-z]+$` | `tags.Pattern<"^[a-z]+$">` |
-| `@format uuid` | `tags.Format<"uuid">` |
-| `@minItems 1` | `tags.MinItems<1>` |
-| `@maxItems 10` | `tags.MaxItems<10>` |
-| `@uniqueItems` | `tags.UniqueItems` |
+| `@multipleOf 0.5`       | `tags.MultipleOf<0.5>`       |
+| `@minLength 3`          | `tags.MinLength<3>`          |
+| `@maxLength 100`        | `tags.MaxLength<100>`        |
+| `@pattern ^[a-z]+$`     | `tags.Pattern<"^[a-z]+$">`   |
+| `@format uuid`          | `tags.Format<"uuid">`        |
+| `@minItems 1`           | `tags.MinItems<1>`           |
+| `@maxItems 10`          | `tags.MaxItems<10>`          |
+| `@uniqueItems`          | `tags.UniqueItems`           |
 
-<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>
     <LocalSource
       path="examples/src/validators/is-comment-tag.ts"
       filename="examples/src/validators/is-comment-tag.ts"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
   <Tabs.Tab>
     <LocalSource
       path="examples/bin/validators/is-comment-tag.js"
       filename="examples/bin/validators/is-comment-tag.js"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
 </Tabs>
 
@@ -247,52 +266,60 @@ You can also set `exclusive: true | string[]` to mark a tag as mutually exclusiv
 
 Example tag definitions from the standard library — refer to these as templates:
 
-<Tabs items={[
+<Tabs
+  items={[
     <code>TagBase.ts</code>,
     <code>Minimum.ts</code>,
     <code>Type.ts</code>,
     <code>Pattern.ts</code>,
-]}>
+  ]}
+>
   <Tabs.Tab>
     <LocalSource
       path="packages/interface/src/tags/TagBase.ts"
       filename="@typia/interface"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
   <Tabs.Tab>
     <LocalSource
       path="packages/interface/src/tags/Minimum.ts"
       filename="@typia/interface"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
   <Tabs.Tab>
     <LocalSource
       path="packages/interface/src/tags/Type.ts"
       filename="@typia/interface"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
   <Tabs.Tab>
     <LocalSource
       path="packages/interface/src/tags/Pattern.ts"
       filename="@typia/interface"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
 </Tabs>
 
 End-to-end example with three custom tags (`Postfix`, `Dollar`, `IsEven`):
 
-<Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
+<Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>
     <LocalSource
       path="examples/src/validators/is-custom-tags.ts"
       filename="examples/src/validators/is-custom-tags.ts"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
   <Tabs.Tab>
     <LocalSource
       path="examples/bin/validators/is-custom-tags.js"
       filename="examples/bin/validators/is-custom-tags.js"
-      showLineNumbers />
+      showLineNumbers
+    />
   </Tabs.Tab>
 </Tabs>
 


### PR DESCRIPTION
Closes #2040.
Closes #2041.

## Campaign scope

This batch fixes two tagged branch-matching failures discovered by the July 2026 issue campaign.

- preserve wrapper tag predicates when an any/unknown-element array participates in an array or tuple union
- find a valid tagged interpolation split when a template-literal boundary is ambiguous instead of dropping placeholder tags
- cover positive, negative, boundary, union-order, validation-diagnostic, and generated-value consequences
- document runtime behavior and the intentionally lossy schema boundary

## Verification

- focused command and internal native regressions pass
- full public and `typia_native_internal` Go suites pass
- typia/package/root builds, package tarball, package matrix, and website production build pass
- five complete Self-Review rounds ended clean
- the sole later package-matrix failure was reproduced unchanged on exact base `e30b0ccf6c`, proving it is an existing master baseline issue
- exact-SHA workflow cancellation gate is quiet for head `8c50c0589f`

Repository-wide formatting, Actions permissions, and workflow activation state are unchanged.