### PR TITLE
fix(typia): reject truncated Protobuf payloads

### DIFF
--- a/packages/typia/native/core/programmers/protobuf/ProtobufDecodeProgrammer.go
+++ b/packages/typia/native/core/programmers/protobuf/ProtobufDecodeProgrammer.go
@@ -174,34 +174,25 @@ func protobufDecodeProgrammer_write_object_function(props struct {
   Object  *schemametadata.MetadataObjectType
 }) *shimast.Node {
   f := nativecontext.EmitFactoryOf(protobufDecodeProgrammer_factory, props.Context.Emit)
-  lengthAssign := f.NewExpressionStatement(
-    protobufDecodeProgrammer_assignment(
-      f.NewIdentifier("length"),
-      shimast.KindEqualsToken,
-      nativefactories.ExpressionFactory.Conditional(
-        protobufDecodeProgrammer_lessThan(f.NewIdentifier("length"), nativefactories.ExpressionFactory.Number(0, props.Context.Emit), props.Context.Emit),
-        protobufDecodeProgrammer_callReader("size", nil, props.Context.Emit),
-        protobufDecodeProgrammer_add(protobufDecodeProgrammer_callReader("index", nil, props.Context.Emit), f.NewIdentifier("length"), props.Context.Emit),
-        props.Context.Emit,
-      ),
-      props.Context.Emit,
-    ),
-  )
-  body := []*shimast.Node{lengthAssign}
-  body = append(body, protobufDecodeProgrammer_write_object_function_body(protobufDecodeProgrammer_objectBodyProps{
+  body := protobufDecodeProgrammer_write_object_function_body(protobufDecodeProgrammer_objectBodyProps{
     Context:   props.Context,
-    Condition: protobufDecodeProgrammer_lessThan(protobufDecodeProgrammer_callReader("index", nil, props.Context.Emit), f.NewIdentifier("length"), props.Context.Emit),
+    Condition: protobufDecodeProgrammer_lessThan(protobufDecodeProgrammer_callReader("index", nil, props.Context.Emit), protobufDecodeProgrammer_callReader("size", nil, props.Context.Emit), props.Context.Emit),
     Tag:       "tag",
     Output:    "output",
     Object:    props.Object,
-  })...)
+  })
+  body = append(body, f.NewIfStatement(
+    protobufDecodeProgrammer_lessThan(nativefactories.ExpressionFactory.Number(-1, props.Context.Emit), f.NewIdentifier("previous"), props.Context.Emit),
+    f.NewExpressionStatement(protobufDecodeProgrammer_callReader("close", []*shimast.Node{f.NewIdentifier("previous")}, props.Context.Emit)),
+    nil,
+  ))
   body = append(body, f.NewReturnStatement(f.NewIdentifier("output")))
   return f.NewArrowFunction(
     nil,
     nil,
     f.NewNodeList([]*shimast.Node{
       nativefactories.IdentifierFactory.Parameter("reader", nil, nil, props.Context.Emit),
-      nativefactories.IdentifierFactory.Parameter("length", nativefactories.TypeFactory.Keyword("number", props.Context.Emit), nativefactories.ExpressionFactory.Number(-1, props.Context.Emit), props.Context.Emit),
+      nativefactories.IdentifierFactory.Parameter("previous", nativefactories.TypeFactory.Keyword("number", props.Context.Emit), nativefactories.ExpressionFactory.Number(-1, props.Context.Emit), props.Context.Emit),
     }),
     nativefactories.TypeFactory.Keyword("any", props.Context.Emit),
     nil,
@@ -460,12 +451,13 @@ func protobufDecodeProgrammer_decode_array(props protobufDecodeProgrammer_decode
       f.NewBlock(f.NewNodeList([]*shimast.Node{
         nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
           Name:  "piece",
-          Value: protobufDecodeProgrammer_add(protobufDecodeProgrammer_callReader("uint32", nil, emit), protobufDecodeProgrammer_callReader("index", nil, emit), emit),
+          Value: protobufDecodeProgrammer_callReader("fork", nil, emit),
         }, emit),
         f.NewWhileStatement(
-          protobufDecodeProgrammer_lessThan(protobufDecodeProgrammer_callReader("index", nil, emit), f.NewIdentifier("piece"), emit),
+          protobufDecodeProgrammer_lessThan(protobufDecodeProgrammer_callReader("index", nil, emit), protobufDecodeProgrammer_callReader("size", nil, emit), emit),
           f.NewExpressionStatement(protobufDecodeProgrammer_arrayPush(props.Accessor, decoder, emit)),
         ),
+        f.NewExpressionStatement(protobufDecodeProgrammer_callReader("close", []*shimast.Node{f.NewIdentifier("piece")}, emit)),
       }), true),
       f.NewExpressionStatement(protobufDecodeProgrammer_arrayPush(props.Accessor, decoder, emit)),
     ))
@@ -486,7 +478,7 @@ func protobufDecodeProgrammer_decode_regular_object(props struct {
   }
   args := []*shimast.Node{f.NewIdentifier("reader")}
   if props.Top == false {
-    args = append(args, protobufDecodeProgrammer_callReader("uint32", nil, emit))
+    args = append(args, protobufDecodeProgrammer_callReader("fork", nil, emit))
   }
   return f.NewCallExpression(
     f.NewIdentifier(fmt.Sprintf("%so%d", protobufDecodeProgrammer_PREFIX, index)),
@@ -507,11 +499,11 @@ func protobufDecodeProgrammer_decode_map(props protobufDecodeProgrammer_decodeMa
   }
   statements = append(statements, nativefactories.StatementFactory.Constant(nativefactories.StatementFactory_ConstantProps{
     Name:  "piece",
-    Value: protobufDecodeProgrammer_add(protobufDecodeProgrammer_callReader("uint32", nil, props.Context.Emit), protobufDecodeProgrammer_callReader("index", nil, props.Context.Emit), props.Context.Emit),
+    Value: protobufDecodeProgrammer_callReader("fork", nil, props.Context.Emit),
   }, props.Context.Emit))
   statements = append(statements, protobufDecodeProgrammer_write_object_function_body(protobufDecodeProgrammer_objectBodyProps{
     Context:   props.Context,
-    Condition: protobufDecodeProgrammer_lessThan(protobufDecodeProgrammer_callReader("index", nil, props.Context.Emit), f.NewIdentifier("piece"), props.Context.Emit),
+    Condition: protobufDecodeProgrammer_lessThan(protobufDecodeProgrammer_callReader("index", nil, props.Context.Emit), protobufDecodeProgrammer_callReader("size", nil, props.Context.Emit), props.Context.Emit),
     Tag:       "kind",
     Output:    "entry",
     Object: protobufDecodeProgrammer_createObjectType([]struct {
@@ -522,6 +514,7 @@ func protobufDecodeProgrammer_decode_map(props protobufDecodeProgrammer_decodeMa
       {Key: "value", Value: props.Value},
     }),
   })...)
+  statements = append(statements, f.NewExpressionStatement(protobufDecodeProgrammer_callReader("close", []*shimast.Node{f.NewIdentifier("piece")}, props.Context.Emit)))
   if props.Required == false {
     statements = append(statements, f.NewExpressionStatement(
       protobufDecodeProgrammer_assignment(props.Accessor, shimast.KindQuestionQuestionEqualsToken, props.Initializer, props.Context.Emit),
@@ -676,11 +669,6 @@ func protobufDecodeProgrammer_assignment(left *shimast.Node, operator shimast.Ki
 func protobufDecodeProgrammer_lessThan(left *shimast.Node, right *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {
   f := nativecontext.EmitFactoryOf(protobufDecodeProgrammer_factory, emit)
   return f.NewBinaryExpression(nil, left, nil, f.NewToken(shimast.KindLessThanToken), right)
-}
-
-func protobufDecodeProgrammer_add(left *shimast.Node, right *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {
-  f := nativecontext.EmitFactoryOf(protobufDecodeProgrammer_factory, emit)
-  return f.NewBinaryExpression(nil, left, nil, f.NewToken(shimast.KindPlusToken), right)
 }
 
 func protobufDecodeProgrammer_unsigned_right_shift(left *shimast.Node, right *shimast.Node, emit *shimprinter.EmitContext) *shimast.Node {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.9",
+  "version": "13.1.10",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/src/internal/_ProtobufReader.ts
+++ b/packages/typia/src/internal/_ProtobufReader.ts
@@ -12,10 +12,14 @@ export class _ProtobufReader {
   /** DataView for buffer. */
   private view: DataView;
 
+  /** Current length-delimited boundary. */
+  private end: number;
+
   public constructor(buf: Uint8Array) {
     this.buf = buf;
     this.ptr = 0;
     this.view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    this.end = buf.length;
   }
 
   public index(): number {
@@ -23,7 +27,7 @@ export class _ProtobufReader {
   }
 
   public size(): number {
-    return this.buf.length;
+    return this.end;
   }
 
   public uint32(): number {
@@ -57,58 +61,73 @@ export class _ProtobufReader {
   }
 
   public float(): number {
-    const value: number = this.view.getFloat32(this.ptr, true);
-    this.ptr += 4;
-    return value;
+    return this.view.getFloat32(this.take(4), true);
   }
 
   public double(): number {
-    const value: number = this.view.getFloat64(this.ptr, true);
-    this.ptr += 8;
-    return value;
+    return this.view.getFloat64(this.take(8), true);
   }
 
   public bytes(): Uint8Array {
-    const length: number = this.uint32();
-    const from: number = this.ptr;
-    this.ptr += length;
-    return this.buf.subarray(from, from + length);
+    return this.atomic(() => {
+      const length: number = this.uint32();
+      const from: number = this.take(length);
+      return this.buf.subarray(from, from + length);
+    });
   }
 
   public string(): string {
     return utf8.get().decode(this.bytes());
   }
 
+  public fork(): number {
+    return this.atomic(() => {
+      const previous: number = this.end;
+      const length: number = this.uint32();
+      this.validate(length);
+      this.end = this.ptr + length;
+      return previous;
+    });
+  }
+
+  public close(previous: number): void {
+    if (this.ptr !== this.end)
+      throw new Error("Error on typia.protobuf.decode(): buffer overflow.");
+    this.end = previous;
+  }
+
   public skip(length: number): void {
-    if (length === 0) while (this.u8() & 0x80);
-    else {
-      if (this.index() + length > this.size())
-        throw new Error("Error on typia.protobuf.decode(): buffer overflow.");
-      this.ptr += length;
-    }
+    this.atomic(() => {
+      if (length === 0) while (this.u8() & 0x80);
+      else this.take(length);
+    });
   }
 
   public skipType(wireType: ProtobufWire): void {
-    switch (wireType) {
-      case ProtobufWire.VARIANT:
-        this.skip(0);
-        break;
-      case ProtobufWire.I64:
-        this.skip(8);
-        break;
-      case ProtobufWire.LEN:
-        this.skip(this.uint32());
-        break;
-      case ProtobufWire.START_GROUP:
-        while ((wireType = this.uint32() & 0x07) !== ProtobufWire.END_GROUP)
-          this.skipType(wireType);
-        break;
-      case ProtobufWire.I32:
-        this.skip(4);
-        break;
-      default:
-        throw new Error(`Invalid wire type ${wireType} at offset ${this.ptr}.`);
-    }
+    this.atomic(() => {
+      switch (wireType) {
+        case ProtobufWire.VARIANT:
+          this.skip(0);
+          break;
+        case ProtobufWire.I64:
+          this.skip(8);
+          break;
+        case ProtobufWire.LEN:
+          this.skip(this.uint32());
+          break;
+        case ProtobufWire.START_GROUP:
+          while ((wireType = this.uint32() & 0x07) !== ProtobufWire.END_GROUP)
+            this.skipType(wireType);
+          break;
+        case ProtobufWire.I32:
+          this.skip(4);
+          break;
+        default:
+          throw new Error(
+            `Invalid wire type ${wireType} at offset ${this.ptr}.`,
+          );
+      }
+    });
   }
 
   private varint32(): number {
@@ -176,11 +195,39 @@ export class _ProtobufReader {
   }
 
   private u8(): number {
-    return this.view.getUint8(this.ptr++);
+    return this.view.getUint8(this.take(1));
   }
 
   private u8n(): bigint {
     return BigInt(this.u8());
+  }
+
+  private take(length: number): number {
+    this.validate(length);
+    const from: number = this.ptr;
+    this.ptr += length;
+    return from;
+  }
+
+  private atomic<T>(closure: () => T): T {
+    const index: number = this.ptr;
+    const end: number = this.end;
+    try {
+      return closure();
+    } catch (error) {
+      this.ptr = index;
+      this.end = end;
+      throw error;
+    }
+  }
+
+  private validate(length: number): void {
+    if (
+      Number.isSafeInteger(length) === false ||
+      length < 0 ||
+      length > this.size() - this.ptr
+    )
+      throw new Error("Error on typia.protobuf.decode(): buffer overflow.");
   }
 }
 

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_truncated_length_delimited.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_truncated_length_delimited.ts
@@ -1,0 +1,167 @@
+import typia from "typia";
+
+/**
+ * Verifies generated Protobuf decoders reject truncated sized wire records.
+ *
+ * Decoder validation runs after wire parsing, so `is` and `validate` variants
+ * must not turn a partial string or byte view into a successful product value.
+ * Nested, packed, map, and unknown-field paths must share the reader boundary.
+ *
+ * 1. Exercise every direct and factory decoder with truncated strings and bytes.
+ * 2. Cover optional, repeated, map, nested, packed, unknown, and fixed-width data.
+ * 3. Pair every one-byte-short case with zero-length or exact-end valid input.
+ */
+export const test_protobuf_decode_truncated_length_delimited = (): void => {
+  const decoders: Array<readonly [string, (input: Uint8Array) => unknown]> = [
+    ["decode", (input) => typia.protobuf.decode<IProduct>(input)],
+    ["createDecode", typia.protobuf.createDecode<IProduct>()],
+    ["assertDecode", (input) => typia.protobuf.assertDecode<IProduct>(input)],
+    ["createAssertDecode", typia.protobuf.createAssertDecode<IProduct>()],
+    ["isDecode", (input) => typia.protobuf.isDecode<IProduct>(input)],
+    ["createIsDecode", typia.protobuf.createIsDecode<IProduct>()],
+    [
+      "validateDecode",
+      (input) => typia.protobuf.validateDecode<IProduct>(input),
+    ],
+    ["createValidateDecode", typia.protobuf.createValidateDecode<IProduct>()],
+  ];
+  for (const [label, decode] of decoders) {
+    assertOverflow(`${label} string`, () =>
+      decode(Uint8Array.of(0x0a, 3, 0x61, 0x62)),
+    );
+    assertOverflow(`${label} bytes`, () =>
+      decode(Uint8Array.of(0x12, 3, 1, 2)),
+    );
+  }
+
+  const zero: typia.Resolved<IString> = typia.protobuf.decode<IString>(
+    Uint8Array.of(0x0a, 0),
+  );
+  if (zero.value !== "") throw new Error("zero-length string did not decode.");
+  const exact: typia.Resolved<IString> = typia.protobuf.decode<IString>(
+    Uint8Array.of(0x0a, 2, 0x61, 0x62),
+  );
+  if (exact.value !== "ab") throw new Error("exact-end string did not decode.");
+
+  const framed: Uint8Array = Uint8Array.of(0xff, 0x0a, 1, 0x61, 0xff);
+  if (typia.protobuf.decode<IString>(framed.subarray(1, 4)).value !== "a")
+    throw new Error("a sliced-buffer payload did not respect its exact end.");
+  assertOverflow("sliced-buffer string", () =>
+    typia.protobuf.decode<IString>(framed.subarray(1, 3)),
+  );
+
+  assertOverflow("optional string", () =>
+    typia.protobuf.decode<IOptional>(Uint8Array.of(0x0a, 2, 0x61)),
+  );
+  assertOverflow("repeated string", () =>
+    typia.protobuf.decode<IRepeated>(Uint8Array.of(0x0a, 2, 0x61)),
+  );
+  assertOverflow("map key", () =>
+    typia.protobuf.decode<IMap>(Uint8Array.of(0x0a, 2, 0x0a, 1, 0x61)),
+  );
+  assertOverflow("map value", () =>
+    typia.protobuf.decode<IMap>(Uint8Array.of(0x0a, 2, 0x12, 1, 0x61)),
+  );
+  assertOverflow("nested message", () =>
+    typia.protobuf.decode<INested>(Uint8Array.of(0x0a, 2, 0x0a, 1, 0x61)),
+  );
+  assertOverflow("packed uint32", () =>
+    typia.protobuf.decode<IPacked>(Uint8Array.of(0x0a, 1, 0x80, 1)),
+  );
+  assertOverflow("unknown length-delimited field", () =>
+    typia.protobuf.decode<IUnknown>(Uint8Array.of(0x12, 2, 0x61)),
+  );
+  assertOverflow("float", () =>
+    typia.protobuf.decode<IFloat>(Uint8Array.of(0x0d, 0, 0, 0)),
+  );
+  assertOverflow("double", () =>
+    typia.protobuf.decode<IDouble>(Uint8Array.of(0x09, 0, 0, 0, 0, 0, 0, 0)),
+  );
+
+  if (
+    typia.protobuf.decode<IRepeated>(Uint8Array.of(0x0a, 1, 0x61)).values[0] !==
+    "a"
+  )
+    throw new Error("exact repeated string did not decode.");
+  if (
+    typia.protobuf
+      .decode<IPacked>(Uint8Array.of(0x0a, 2, 1, 2))
+      .values.join() !== "1,2"
+  )
+    throw new Error("exact packed values did not decode.");
+  if (
+    typia.protobuf.decode<IMap>(
+      Uint8Array.of(0x0a, 6, 0x0a, 1, 0x61, 0x12, 1, 0x62),
+    ).values.a !== "b"
+  )
+    throw new Error("exact map entry did not decode.");
+  if (
+    typia.protobuf.decode<INested>(Uint8Array.of(0x0a, 3, 0x0a, 1, 0x61)).value
+      .text !== "a"
+  )
+    throw new Error("exact nested message did not decode.");
+  if (
+    typia.protobuf.decode<IFloat>(Uint8Array.of(0x0d, 0, 0, 0, 0)).value !==
+      0 ||
+    typia.protobuf.decode<IDouble>(Uint8Array.of(0x09, 0, 0, 0, 0, 0, 0, 0, 0))
+      .value !== 0
+  )
+    throw new Error("exact fixed-width values did not decode.");
+};
+
+interface IProduct {
+  text: string;
+  data: Uint8Array;
+}
+
+interface IString {
+  value: string;
+}
+
+interface IOptional {
+  value?: string;
+}
+
+interface IRepeated {
+  values: string[];
+}
+
+interface IMap {
+  values: Record<string, string>;
+}
+
+interface INested {
+  value: {
+    text: string;
+  };
+}
+
+interface IPacked {
+  values: Array<number & typia.tags.Type<"uint32">>;
+}
+
+interface IUnknown {
+  value?: string;
+}
+
+interface IFloat {
+  value: number & typia.tags.Type<"float">;
+}
+
+interface IDouble {
+  value: number & typia.tags.Type<"double">;
+}
+
+const assertOverflow = (label: string, closure: () => unknown): void => {
+  try {
+    closure();
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Error on typia.protobuf.decode(): buffer overflow."
+    )
+      return;
+    throw new Error(`${label} reported ${String(error)} instead of overflow.`);
+  }
+  throw new Error(`${label} accepted a truncated Protobuf payload.`);
+};

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_bounds.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_bounds.ts
@@ -1,0 +1,107 @@
+import { ProtobufWire } from "@typia/interface";
+import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
+
+/**
+ * Verifies the runtime Protobuf reader rejects incomplete sized reads
+ * atomically.
+ *
+ * Typed-array slicing clamps an oversized end instead of throwing, so the
+ * reader itself must own payload bounds and preserve its pointer on failure.
+ * The same invariant applies to fixed-width values and unknown-field skips.
+ *
+ * 1. Read zero-length, exact-end, and sliced-buffer payloads successfully.
+ * 2. Reject one-byte-short bytes, strings, float, double, and skip payloads.
+ * 3. Assert every rejected read reports the stable overflow and keeps its index.
+ */
+export const test_protobuf_reader_bounds = (): void => {
+  const empty: _ProtobufReader = new _ProtobufReader(Uint8Array.of(0));
+  if (empty.bytes().length !== 0 || empty.index() !== 1)
+    throw new Error("zero-length bytes did not consume exactly their prefix.");
+
+  const exact: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.of(2, 0x61, 0x62),
+  );
+  if (new TextDecoder().decode(exact.bytes()) !== "ab" || exact.index() !== 3)
+    throw new Error("exact-end bytes did not consume their complete payload.");
+
+  const backing: Uint8Array = Uint8Array.of(0xff, 2, 0x61, 0x62, 0xff);
+  const sliced: _ProtobufReader = new _ProtobufReader(backing.subarray(1, 4));
+  if (sliced.string() !== "ab" || sliced.index() !== 3)
+    throw new Error("a bounded Uint8Array view read outside its own payload.");
+
+  assertOverflow("bytes", new _ProtobufReader(Uint8Array.of(3, 1, 2)), (r) =>
+    r.bytes(),
+  );
+  assertOverflow("string", new _ProtobufReader(Uint8Array.of(2, 0xc3)), (r) =>
+    r.string(),
+  );
+  assertOverflow(
+    "sliced bytes",
+    new _ProtobufReader(backing.subarray(1, 3)),
+    (r) => r.bytes(),
+  );
+  assertOverflow("float", new _ProtobufReader(Uint8Array.of(0, 0, 0)), (r) =>
+    r.float(),
+  );
+  assertOverflow(
+    "double",
+    new _ProtobufReader(Uint8Array.of(0, 0, 0, 0, 0, 0, 0)),
+    (r) => r.double(),
+  );
+  assertOverflow(
+    "fixed32 skip",
+    new _ProtobufReader(Uint8Array.of(0, 0, 0)),
+    (r) => r.skipType(ProtobufWire.I32),
+  );
+  assertOverflow(
+    "fixed64 skip",
+    new _ProtobufReader(Uint8Array.of(0, 0, 0, 0, 0, 0, 0)),
+    (r) => r.skipType(ProtobufWire.I64),
+  );
+  assertOverflow(
+    "length-delimited skip",
+    new _ProtobufReader(Uint8Array.of(2, 1)),
+    (r) => r.skipType(ProtobufWire.LEN),
+  );
+  assertOverflow("varint skip", new _ProtobufReader(Uint8Array.of(0x80)), (r) =>
+    r.skipType(ProtobufWire.VARIANT),
+  );
+
+  const framed: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.of(2, 1, 2, 9),
+  );
+  const previous: number = framed.fork();
+  if (framed.size() !== 3 || framed.bytes()[0] !== 2)
+    throw new Error("fork did not expose exactly its declared payload.");
+  framed.close(previous);
+  if (framed.size() !== 4 || framed.uint32() !== 9)
+    throw new Error("close did not restore the enclosing reader boundary.");
+
+  assertOverflow("fork", new _ProtobufReader(Uint8Array.of(3, 1, 2)), (r) =>
+    r.fork(),
+  );
+};
+
+const assertOverflow = (
+  label: string,
+  reader: _ProtobufReader,
+  closure: (reader: _ProtobufReader) => unknown,
+): void => {
+  const index: number = reader.index();
+  const size: number = reader.size();
+  try {
+    closure(reader);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Error on typia.protobuf.decode(): buffer overflow." &&
+      reader.index() === index &&
+      reader.size() === size
+    )
+      return;
+    throw new Error(
+      `${label} reported ${String(error)} at index ${reader.index()} instead of the stable atomic overflow.`,
+    );
+  }
+  throw new Error(`${label} accepted a truncated Protobuf payload.`);
+};


### PR DESCRIPTION
## Intent

Reject truncated length-delimited Protobuf payloads before a decoder can return a partial string, byte array, nested message, packed value, or map entry as a successful product value.

## Scope

- Make `_ProtobufReader` validate fixed- and length-sized reads against one active boundary before mutating its pointer or constructing a view.
- Make `ProtobufDecodeProgrammer` fork and close that boundary for generated nested-message, map-entry, and packed-array subrecords, including cases where trailing outer bytes still exist.
- Cover direct and factory `decode`, `assertDecode`, `isDecode`, and `validateDecode` paths across string, bytes, optional, repeated, map, nested, packed, unknown-field, fixed-width, zero-length, exact-end, and sliced-buffer cases.
- Ship the native generator correction as the reserved `typia` 13.1.10 after the 13.1.9 predecessor lands.

## Deferred

- No changes to the already-landed 64-bit varint semantics.
- No unrelated Protobuf wire-semantic or compatibility changes beyond rejecting malformed truncated records.
- No repository-wide formatting; Post-Campaign Cleanup owns that phase.

## Verification

- Tests-first reproductions failed on partial top-level string/bytes and on bounded map/nested/packed overreads with trailing bytes outside the subrecord.
- Full `test-typia-schema`: pass with the new reader and generated-decoder matrix.
- Focused Protobuf programmer and full `cmd/ttsc-typia` tests: pass.
- Public Go suite: pass.
- Native Go suite: pass.
- Tagged native-internal tests, typia build, final semantic rebase after #2089/13.1.9, and findings-first solo Self-Review through a clean round remain pending.

Campaign Actions remain enabled and are cancelled only for this branch's exact pushed SHA after every push or pull-request mutation.

Closes #2083
