### PR TITLE
fix(ci): align release website compiler provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,20 @@ jobs:
       # through packages/typia/native/go.work, and the website is a pnpm
       # workspace member consuming catalog: versions, so it must be installed
       # from the workspace root (a standalone npm install cannot resolve it).
+      - name: Install Dependencies
+        run: pnpm install
+
+      # Match the sibling source to the installed browser host. Cloning latest
+      # ttsc master can select a different Go plugin interface than the locked
+      # @ttsc/wasm package used by the website.
       - name: Checkout ttsc sibling
-        run: git clone --depth 1 https://github.com/samchon/ttsc.git ../ttsc
+        run: |
+          TTSC_VERSION="$(node -p "require('./website/node_modules/@ttsc/wasm/package.json').version")"
+          test -n "${TTSC_VERSION}"
+          git clone --branch "v${TTSC_VERSION}" --depth 1 https://github.com/samchon/ttsc.git ../ttsc
+
       - name: Build Packages
         run: |
-          pnpm install
           pnpm run build
           pnpm run package:tgz
       - name: Website Build

--- a/website/src/compiler/workflowPathFilters.test.mjs
+++ b/website/src/compiler/workflowPathFilters.test.mjs
@@ -39,6 +39,28 @@ const workflowPaths = (text) => {
   return result;
 };
 
+const workflowJob = (text, name) => {
+  const lines = text.split(/\r?\n/);
+  const jobs = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  assert.notEqual(jobs, -1, "workflow omits jobs");
+
+  const pattern = new RegExp(`^  ${name}:\\s*$`);
+  const index = lines.findIndex(
+    (line, candidate) => candidate > jobs && pattern.test(line),
+  );
+  assert.notEqual(index, -1, `workflow omits ${name} job`);
+
+  const indent = /^\s*/.exec(lines[index])[0].length;
+  let end = index + 1;
+  while (
+    end < lines.length &&
+    (lines[end].trim().length === 0 ||
+      /^\s*/.exec(lines[end])[0].length > indent)
+  )
+    end += 1;
+  return lines.slice(index, end).join("\n");
+};
+
 const assertOrdered = (text, labels) => {
   let previous = -1;
   for (const label of labels) {
@@ -50,18 +72,20 @@ const assertOrdered = (text, labels) => {
 };
 
 /**
- * Verifies pull-request workflows watch every directly consumed input.
+ * Verifies workflows watch their inputs and pin the website compiler source.
  *
  * The website job builds packages, stages tarballs, and installs the complete
- * workspace, while the test job compiles workspaces that extend shared config.
- * Omitting those inputs defers failures until after a pull request merges.
+ * workspace, while the release-only copy must select the same ttsc source as
+ * its installed browser package. Omitting either contract defers failures until
+ * after a pull request merges or until a release has already published.
  *
  * 1. Read the website and test pull-request path filters.
  * 2. Assert each consumed workspace, compiler, and tarball input is present.
  * 3. Assert unrelated benchmark and README changes remain excluded.
- * 4. Verify dependency install, tag selection, compiler tests, and build order.
+ * 4. Verify both website jobs install before selecting the matching ttsc tag.
+ * 5. Verify compiler tests and package/website builds follow that checkout.
  */
-test("workflow path filters match consumed inputs", async () => {
+test("workflow contracts match consumed inputs and compiler provenance", async () => {
   const synthetic = workflowPaths(
     `on:\n  pull_request:\n    paths:\n      - 'inside/**'\njobs:\n  test:\n    strategy:\n      matrix:\n        include:\n          - 'outside/**'\n`,
   );
@@ -123,5 +147,32 @@ test("workflow path filters match consumed inputs", async () => {
   assertOrdered(websiteText, [
     "pnpm run test:compiler",
     "go -C compiler test ./cmd/playground",
+  ]);
+
+  const releaseWebsiteText = workflowJob(
+    await readWorkflow("release"),
+    "website",
+  );
+  assert.match(
+    releaseWebsiteText,
+    /require\('\.\/website\/node_modules\/@ttsc\/wasm\/package\.json'\)\.version/,
+  );
+  assert.match(releaseWebsiteText, /test -n "\$\{TTSC_VERSION\}"/);
+  assert.match(
+    releaseWebsiteText,
+    /git clone --branch "v\$\{TTSC_VERSION\}" --depth 1/,
+  );
+  assert.doesNotMatch(
+    releaseWebsiteText,
+    /git clone --depth 1 https:\/\/github\.com\/samchon\/ttsc\.git/,
+  );
+  assertOrdered(releaseWebsiteText, [
+    "- name: Install Dependencies",
+    "- name: Checkout ttsc sibling",
+    'TTSC_VERSION="$(node -p',
+    'git clone --branch "v${TTSC_VERSION}"',
+    "- name: Build Packages",
+    "- name: Website Build",
+    "- name: Deploy",
   ]);
 });

--- a/website/src/compiler/workflowPathFilters.test.mjs
+++ b/website/src/compiler/workflowPathFilters.test.mjs
@@ -160,7 +160,7 @@ test("workflow contracts match consumed inputs and compiler provenance", async (
   assert.match(releaseWebsiteText, /test -n "\$\{TTSC_VERSION\}"/);
   assert.match(
     releaseWebsiteText,
-    /git clone --branch "v\$\{TTSC_VERSION\}" --depth 1/,
+    /git clone --branch "v\$\{TTSC_VERSION\}" --depth 1 https:\/\/github\.com\/samchon\/ttsc\.git \.\.\/ttsc/,
   );
   assert.doesNotMatch(
     releaseWebsiteText,


### PR DESCRIPTION
## Intent

Make tagged releases build and deploy the website playground from the same ttsc source version as the lockfile-installed `@ttsc/wasm`, so an unrelated upstream merge cannot change or break a typia release.

## Scope

- Install the release website workspace before selecting its sibling ttsc source.
- Derive the exact `v${TTSC_VERSION}` checkout from the installed `website/node_modules/@ttsc/wasm/package.json`, matching the ordinary website workflow.
- Extend the workflow contract regression to cover the release website job's install, version derivation, matching-tag checkout, package build, and website build order.
- Verify the installed version resolves the matching tag rather than upstream master.

## Deferred

- No `@ttsc` dependency, catalog, lockfile, or release-version policy changes.
- No unrelated workflow, website compiler, or deployment redesign.
- No repository-wide formatting during the campaign implementation branch.

## Verification

Pending tests-first implementation. Campaign Actions runs are cancelled per exact SHA; focused workflow and website compiler verification will be recorded locally before merge.

Closes #2085
