### PR TITLE
fix(typia): classify promised return types semantically

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/functional_promised_type_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/functional_promised_type_transform_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestFunctionalPromisedTypeTransform verifies semantic async wrappers.
+//
+// Every functional family shares the return-type classifier. A derived Promise
+// must produce an async wrapper that validates the fulfilled value, while a
+// non-thenable class merely named Promise must remain synchronous.
+//
+//  1. Transform all assert, is/equals, and validate function variants.
+//  2. Exercise derived class/interface and branded Promise results.
+//  3. Pin invalid parameters, invalid fulfilled values, rejection, and the
+//     shadowed-name negative control without regressing receiver forwarding.
+func TestFunctionalPromisedTypeTransform(t *testing.T) {
+  project := compareEqualCoverProject(t, "functional-promised-type-", functionalPromisedTypeSource)
+  ttscTypiaTestTypecheck(t, project)
+  js := compareEqualCoverTransform(t, project)
+  if !strings.Contains(js, "async function") || !strings.Contains(js, "await Reflect.apply") {
+    t.Fatalf("promised wrappers do not emit async/await:\n%s", js)
+  }
+  if !strings.Contains(js, "Reflect.apply") {
+    t.Fatalf("promised wrappers do not preserve receiver forwarding:\n%s", js)
+  }
+
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(ttscTypiaTestRewriteCommonJS(t, js)), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(functionalPromisedTypeRuntime), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  if output, err := cmd.CombinedOutput(); err != nil {
+    t.Fatalf("functional promised-type runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const functionalPromisedTypeSource = `import typia from "typia";
+
+export interface Receiver { base: number; }
+export interface Input { value: number; }
+export interface Output { total: number; }
+
+export class DerivedPromise<T> extends Promise<T> {}
+export interface InterfacePromise<T> extends Promise<T> {}
+export type BrandedPromise<T> = Promise<T> & { readonly __brand: unique symbol };
+export namespace Shadow {
+  export class Promise<T> {
+    public constructor(public value: T) {}
+  }
+}
+
+export function promisedTarget(this: Receiver, input: Input): DerivedPromise<Output> {
+  return new DerivedPromise((resolve) => resolve({ total: this.base + input.value }));
+}
+export function interfaceTarget(input: Input): InterfacePromise<Output> {
+  return Promise.resolve({ total: input.value }) as InterfacePromise<Output>;
+}
+export function brandedTarget(input: Input): BrandedPromise<Output> {
+  return Promise.resolve({ total: input.value }) as BrandedPromise<Output>;
+}
+export function shadowedTarget(input: Input): Shadow.Promise<Output> {
+  return new Shadow.Promise({ total: input.value });
+}
+export function rejectingTarget(): DerivedPromise<Output> {
+  return new DerivedPromise((_resolve, reject) => reject(new Error("promised rejection")));
+}
+
+export const promised = {
+  assertFunction: typia.functional.assertFunction(promisedTarget),
+  assertParameters: typia.functional.assertParameters(promisedTarget),
+  assertReturn: typia.functional.assertReturn(promisedTarget),
+  assertEqualsFunction: typia.functional.assertEqualsFunction(promisedTarget),
+  assertEqualsParameters: typia.functional.assertEqualsParameters(promisedTarget),
+  assertEqualsReturn: typia.functional.assertEqualsReturn(promisedTarget),
+  isFunction: typia.functional.isFunction(promisedTarget),
+  isParameters: typia.functional.isParameters(promisedTarget),
+  isReturn: typia.functional.isReturn(promisedTarget),
+  equalsFunction: typia.functional.equalsFunction(promisedTarget),
+  equalsParameters: typia.functional.equalsParameters(promisedTarget),
+  equalsReturn: typia.functional.equalsReturn(promisedTarget),
+  validateFunction: typia.functional.validateFunction(promisedTarget),
+  validateParameters: typia.functional.validateParameters(promisedTarget),
+  validateReturn: typia.functional.validateReturn(promisedTarget),
+  validateEqualsFunction: typia.functional.validateEqualsFunction(promisedTarget),
+  validateEqualsParameters: typia.functional.validateEqualsParameters(promisedTarget),
+  validateEqualsReturn: typia.functional.validateEqualsReturn(promisedTarget),
+};
+
+export const shadowed = {
+  assertFunction: typia.functional.assertFunction(shadowedTarget),
+  assertParameters: typia.functional.assertParameters(shadowedTarget),
+  assertReturn: typia.functional.assertReturn(shadowedTarget),
+  assertEqualsFunction: typia.functional.assertEqualsFunction(shadowedTarget),
+  assertEqualsParameters: typia.functional.assertEqualsParameters(shadowedTarget),
+  assertEqualsReturn: typia.functional.assertEqualsReturn(shadowedTarget),
+  isFunction: typia.functional.isFunction(shadowedTarget),
+  isParameters: typia.functional.isParameters(shadowedTarget),
+  isReturn: typia.functional.isReturn(shadowedTarget),
+  equalsFunction: typia.functional.equalsFunction(shadowedTarget),
+  equalsParameters: typia.functional.equalsParameters(shadowedTarget),
+  equalsReturn: typia.functional.equalsReturn(shadowedTarget),
+  validateFunction: typia.functional.validateFunction(shadowedTarget),
+  validateParameters: typia.functional.validateParameters(shadowedTarget),
+  validateReturn: typia.functional.validateReturn(shadowedTarget),
+  validateEqualsFunction: typia.functional.validateEqualsFunction(shadowedTarget),
+  validateEqualsParameters: typia.functional.validateEqualsParameters(shadowedTarget),
+  validateEqualsReturn: typia.functional.validateEqualsReturn(shadowedTarget),
+};
+
+export const semanticShapes = {
+  interfaceAssert: typia.functional.assertReturn<(input: Input) => InterfacePromise<Output>>(interfaceTarget),
+  interfaceIs: typia.functional.isReturn(interfaceTarget),
+  interfaceValidate: typia.functional.validateReturn(interfaceTarget),
+  brandedAssert: typia.functional.assertReturn(brandedTarget),
+  brandedIs: typia.functional.isReturn<(input: Input) => BrandedPromise<Output>>(brandedTarget),
+  brandedValidate: typia.functional.validateReturn(brandedTarget),
+};
+export const rejecting = typia.functional.assertReturn(rejectingTarget);
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
+type Assert<T extends true> = T;
+export type PromisedWrapperCases = [
+  Assert<Equal<ReturnType<typeof promised.isFunction>, Promise<Output | null>>>,
+  Assert<Equal<ReturnType<typeof promised.validateReturn>, Promise<typia.IValidation<Output>>>>,
+  Assert<Equal<ReturnType<typeof shadowed.isFunction>, Shadow.Promise<Output> | null>>,
+  Assert<Equal<ReturnType<typeof shadowed.validateReturn>, typia.IValidation<Shadow.Promise<Output>>>>,
+];
+`
+
+const functionalPromisedTypeRuntime = `const mod = require("./main.cjs");
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) throw new Error(label + ": expected " + expected + ", got " + actual);
+};
+const assertNames = new Set([
+  "assertFunction", "assertParameters", "assertReturn",
+  "assertEqualsFunction", "assertEqualsParameters", "assertEqualsReturn",
+]);
+const validateNames = new Set([
+  "validateFunction", "validateParameters", "validateReturn",
+  "validateEqualsFunction", "validateEqualsParameters", "validateEqualsReturn",
+]);
+
+(async () => {
+  for (const [name, wrapped] of Object.entries(mod.promised)) {
+    const pending = wrapped.call({ base: 40 }, { value: 2 });
+    expect("promised " + name + " returns Promise", pending instanceof Promise, true);
+    const result = await pending;
+    if (validateNames.has(name)) {
+      expect("promised " + name + " succeeds", result.success, true);
+      expect("promised " + name + " fulfilled total", result.data.total, 42);
+    } else {
+      expect("promised " + name + " is non-null", result === null, false);
+      expect("promised " + name + " fulfilled total", result.total, 42);
+    }
+
+    const invalid = wrapped.call({ base: 40 }, { value: "bad" });
+    expect("invalid " + name + " keeps Promise shape", invalid instanceof Promise, true);
+    if (assertNames.has(name)) {
+      let error;
+      try { await invalid; } catch (exp) { error = exp; }
+      expect("invalid " + name + " rejects", Boolean(error), true);
+    } else {
+      const failure = await invalid;
+      if (validateNames.has(name)) expect("invalid " + name + " validation fails", failure.success, false);
+      else expect("invalid " + name + " returns null", failure, null);
+    }
+  }
+
+  for (const [name, wrapped] of Object.entries(mod.semanticShapes)) {
+    const pending = wrapped({ value: 7 });
+    expect(name + " returns Promise", pending instanceof Promise, true);
+    const result = await pending;
+    if (name.endsWith("Validate")) {
+      expect(name + " succeeds", result.success, true);
+      expect(name + " total", result.data.total, 7);
+    } else expect(name + " total", result.total, 7);
+  }
+
+  for (const [name, wrapped] of Object.entries(mod.shadowed)) {
+    const result = wrapped({ value: 9 });
+    expect("shadowed " + name + " stays synchronous", result instanceof Promise, false);
+    if (validateNames.has(name)) {
+      expect("shadowed " + name + " succeeds", result.success, true);
+      expect("shadowed " + name + " value", result.data.value.total, 9);
+    } else {
+      expect("shadowed " + name + " is non-null", result === null, false);
+      expect("shadowed " + name + " value", result.value.total, 9);
+    }
+  }
+
+  let rejection;
+  try { await mod.rejecting(); } catch (error) { rejection = error; }
+  expect("rejection propagates", rejection && rejection.message, "promised rejection");
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+`

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_function.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_function.go
@@ -3,6 +3,7 @@ package metadata
 import (
   nativechecker "github.com/microsoft/typescript-go/shim/checker"
   schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  nativeutils "github.com/samchon/typia/packages/typia/native/core/utils"
 )
 
 func Iterate_metadata_function(props IMetadataIteratorProps) bool {
@@ -36,16 +37,8 @@ func Iterate_metadata_function(props IMetadataIteratorProps) bool {
 
   signature := signatures[0]
   returnType := props.Checker.GetReturnTypeOfSignature(signature)
-  async := false
-  if returnType != nil {
-    if symbol := returnType.Symbol(); symbol != nil && symbol.Name == "Promise" {
-      generic := metadata_get_type_arguments(props.Checker, returnType)
-      if len(generic) != 0 {
-        returnType = generic[0]
-      }
-      async = true
-    }
-  }
+  promised := nativeutils.PromiseTypeFactory.Resolve(props.Checker, returnType)
+  returnType = promised.Type
 
   parameters := make([]*schemametadata.MetadataParameter, 0, len(signature.Parameters()))
   for _, p := range signature.Parameters() {
@@ -87,7 +80,7 @@ func Iterate_metadata_function(props IMetadataIteratorProps) bool {
   props.Metadata.Functions = append(props.Metadata.Functions, schemametadata.MetadataFunction_create(schemametadata.MetadataFunction{
     Parameters: parameters,
     Output:     output,
-    Async:      async,
+    Async:      promised.Async,
   }))
   return true
 }

--- a/packages/typia/native/core/programmers/functional/internal/FunctionalGeneralProgrammer.go
+++ b/packages/typia/native/core/programmers/functional/internal/FunctionalGeneralProgrammer.go
@@ -3,6 +3,7 @@ package internal
 import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimchecker "github.com/microsoft/typescript-go/shim/checker"
+  nativeutils "github.com/samchon/typia/packages/typia/native/core/utils"
 )
 
 type functionalGeneralProgrammerNamespace struct{}
@@ -31,23 +32,9 @@ func (functionalGeneralProgrammerNamespace) GetReturnType(props FunctionalGenera
   if t == nil && props.Checker != nil {
     t = props.Checker.GetAnyType()
   }
-  if t != nil {
-    if symbol := t.Symbol(); symbol != nil && symbol.Name == "Promise" {
-      generic := props.Checker.GetTypeArguments(t)
-      if len(generic) == 1 {
-        return FunctionalGeneralProgrammer_IOutput{
-          Type:  generic[0],
-          Async: true,
-        }
-      }
-      return FunctionalGeneralProgrammer_IOutput{
-        Type:  props.Checker.GetAnyType(),
-        Async: false,
-      }
-    }
-  }
+  promised := nativeutils.PromiseTypeFactory.Resolve(props.Checker, t)
   return FunctionalGeneralProgrammer_IOutput{
-    Type:  t,
-    Async: false,
+    Type:  promised.Type,
+    Async: promised.Async,
   }
 }

--- a/packages/typia/native/core/utils/PromiseTypeFactory.go
+++ b/packages/typia/native/core/utils/PromiseTypeFactory.go
@@ -1,0 +1,32 @@
+package utils
+
+import shimchecker "github.com/microsoft/typescript-go/shim/checker"
+
+type promiseTypeFactoryNamespace struct{}
+
+var PromiseTypeFactory = promiseTypeFactoryNamespace{}
+
+type PromiseTypeFactory_IOutput struct {
+  Type  *shimchecker.Type
+  Async bool
+}
+
+func (promiseTypeFactoryNamespace) Resolve(checker *shimchecker.Checker, t *shimchecker.Type) PromiseTypeFactory_IOutput {
+  if checker != nil && t != nil {
+    promised := checker.GetPromisedTypeOfPromise(t)
+    // The checker helper deliberately accepts the weaker PromiseLike/thenable
+    // contract. Public typia functional types discriminate against Promise,
+    // whose baseline ES5 contract additionally requires a callable catch.
+    catch := checker.GetTypeOfPropertyOfType(t, "catch")
+    if promised != nil && catch != nil && len(checker.GetSignaturesOfType(catch, shimchecker.SignatureKindCall)) != 0 {
+      return PromiseTypeFactory_IOutput{
+        Type:  promised,
+        Async: true,
+      }
+    }
+  }
+  return PromiseTypeFactory_IOutput{
+    Type:  t,
+    Async: false,
+  }
+}

--- a/packages/typia/native/core/utils/PromiseTypeFactory.go
+++ b/packages/typia/native/core/utils/PromiseTypeFactory.go
@@ -31,27 +31,27 @@ func (promiseTypeFactoryNamespace) Resolve(checker *shimchecker.Checker, t *shim
 }
 
 func (promiseTypeFactoryNamespace) satisfiesGlobalContract(checker *shimchecker.Checker, t *shimchecker.Type) bool {
-  symbol := checker.GetGlobalSymbol("Promise", shimast.SymbolFlagsType, nil)
+  symbol := checker.GetGlobalSymbol("Promise", shimast.SymbolFlagsValue, nil)
   if symbol == nil {
     return false
   }
-  global := checker.GetDeclaredTypeOfSymbol(symbol)
-  if global == nil {
+  constructor := checker.GetTypeOfSymbol(symbol)
+  if constructor == nil {
     return false
   }
-  for _, property := range checker.GetPropertiesOfType(global) {
+  contract := checker.GetTypeOfPropertyOfType(constructor, "prototype")
+  if contract == nil {
+    return false
+  }
+  for _, property := range checker.GetPropertiesOfType(contract) {
     if property.Name == "then" || (len(property.Name) != 0 && property.Name[0] == 0xfe) {
-      // GetPromisedTypeOfPromise already verifies the complete thenable shape.
-      // Conditional Promise inference ignores well-known-symbol augmentations.
+      // GetPromisedTypeOfPromise verifies the thenable shape. Conditional
+      // Promise inference ignores well-known-symbol augmentations.
       continue
     }
-    required := checker.GetTypeOfPropertyOfType(global, property.Name)
+    required := checker.GetTypeOfPropertyOfType(contract, property.Name)
     candidate := checker.GetTypeOfPropertyOfType(t, property.Name)
-    if candidate == nil {
-      return false
-    }
-    if required != nil && len(checker.GetSignaturesOfType(required, shimchecker.SignatureKindCall)) != 0 &&
-      len(checker.GetSignaturesOfType(candidate, shimchecker.SignatureKindCall)) == 0 {
+    if required == nil || candidate == nil || !checker.IsTypeAssignableTo(candidate, required) {
       return false
     }
   }

--- a/packages/typia/native/core/utils/PromiseTypeFactory.go
+++ b/packages/typia/native/core/utils/PromiseTypeFactory.go
@@ -1,6 +1,9 @@
 package utils
 
-import shimchecker "github.com/microsoft/typescript-go/shim/checker"
+import (
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
+)
 
 type promiseTypeFactoryNamespace struct{}
 
@@ -14,11 +17,7 @@ type PromiseTypeFactory_IOutput struct {
 func (promiseTypeFactoryNamespace) Resolve(checker *shimchecker.Checker, t *shimchecker.Type) PromiseTypeFactory_IOutput {
   if checker != nil && t != nil {
     promised := checker.GetPromisedTypeOfPromise(t)
-    // The checker helper deliberately accepts the weaker PromiseLike/thenable
-    // contract. Public typia functional types discriminate against Promise,
-    // whose baseline ES5 contract additionally requires a callable catch.
-    catch := checker.GetTypeOfPropertyOfType(t, "catch")
-    if promised != nil && catch != nil && len(checker.GetSignaturesOfType(catch, shimchecker.SignatureKindCall)) != 0 {
+    if promised != nil && PromiseTypeFactory.satisfiesGlobalContract(checker, t) {
       return PromiseTypeFactory_IOutput{
         Type:  promised,
         Async: true,
@@ -29,4 +28,32 @@ func (promiseTypeFactoryNamespace) Resolve(checker *shimchecker.Checker, t *shim
     Type:  t,
     Async: false,
   }
+}
+
+func (promiseTypeFactoryNamespace) satisfiesGlobalContract(checker *shimchecker.Checker, t *shimchecker.Type) bool {
+  symbol := checker.GetGlobalSymbol("Promise", shimast.SymbolFlagsType, nil)
+  if symbol == nil {
+    return false
+  }
+  global := checker.GetDeclaredTypeOfSymbol(symbol)
+  if global == nil {
+    return false
+  }
+  for _, property := range checker.GetPropertiesOfType(global) {
+    if property.Name == "then" || (len(property.Name) != 0 && property.Name[0] == 0xfe) {
+      // GetPromisedTypeOfPromise already verifies the complete thenable shape.
+      // Conditional Promise inference ignores well-known-symbol augmentations.
+      continue
+    }
+    required := checker.GetTypeOfPropertyOfType(global, property.Name)
+    candidate := checker.GetTypeOfPropertyOfType(t, property.Name)
+    if candidate == nil {
+      return false
+    }
+    if required != nil && len(checker.GetSignaturesOfType(required, shimchecker.SignatureKindCall)) != 0 &&
+      len(checker.GetSignaturesOfType(candidate, shimchecker.SignatureKindCall)) == 0 {
+      return false
+    }
+  }
+  return true
 }

--- a/packages/typia/native/core/utils/promise_type_factory_semantics_test.go
+++ b/packages/typia/native/core/utils/promise_type_factory_semantics_test.go
@@ -1,0 +1,104 @@
+package utils
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestPromiseTypeFactorySemantics verifies semantic promised-type resolution.
+//
+// Promise identity is structural in the checker rather than a symbol spelling.
+// Derived classes, interfaces, and branded intersections must unwrap while an
+// unrelated class named Promise and the weaker PromiseLike contract must remain
+// synchronous.
+//
+//  1. Load eight return-shape declarations through the real checker.
+//  2. Resolve the fulfilled type for every genuine Promise shape.
+//  3. Keep PromiseLike, shadowed-name, and ordinary controls unchanged.
+func TestPromiseTypeFactorySemantics(t *testing.T) {
+  dir := t.TempDir()
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}`), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+    t.Fatalf("mkdir src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "src", "main.ts"), []byte(`
+class DerivedPromise<T> extends Promise<T> {}
+interface InterfacePromise<T> extends Promise<T> {}
+type BrandedPromise<T> = Promise<T> & { readonly __brand: unique symbol };
+namespace Shadow { export class Promise<T> { public constructor(public value: T) {} } }
+let builtin!: Promise<string>;
+let derivedClass!: DerivedPromise<number>;
+let derivedInterface!: InterfacePromise<boolean>;
+let branded!: BrandedPromise<bigint>;
+let shadowed!: Shadow.Promise<Date>;
+let synchronous!: { value: RegExp };
+let promiseLike!: PromiseLike<string>;
+let structural!: Pick<Promise<URL>, "then" | "catch" | "finally">;
+`), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  program, diagnostics, err := driver.LoadProgram(dir, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatalf("load program: %v", err)
+  }
+  if len(diagnostics) != 0 {
+    t.Fatalf("fixture diagnostics: %+v", diagnostics)
+  }
+  defer program.Close()
+
+  source := program.SourceFile(filepath.Join(dir, "src", "main.ts"))
+  if source == nil || source.Statements == nil || len(source.Statements.Nodes) != 12 {
+    t.Fatal("fixture declarations were not loaded")
+  }
+  variableType := func(index int) *shimchecker.Type {
+    declaration := source.Statements.Nodes[index].AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes[0]
+    return program.Checker.GetTypeAtLocation(declaration)
+  }
+  tests := []struct {
+    name      string
+    index     int
+    async     bool
+    fulfilled string
+  }{
+    {"builtin", 4, true, "string"},
+    {"derived-class", 5, true, "number"},
+    {"derived-interface", 6, true, "boolean"},
+    {"branded-intersection", 7, true, "bigint"},
+    {"shadowed-name", 8, false, ""},
+    {"synchronous", 9, false, ""},
+    {"promise-like", 10, false, ""},
+    {"structural", 11, true, "URL"},
+  }
+  for _, tc := range tests {
+    t.Run(tc.name, func(t *testing.T) {
+      input := variableType(tc.index)
+      output := PromiseTypeFactory.Resolve(program.Checker, input)
+      if output.Async != tc.async {
+        t.Fatalf("async mismatch: got %v, want %v", output.Async, tc.async)
+      }
+      if tc.async {
+        if got := program.Checker.TypeToString(output.Type); got != tc.fulfilled {
+          t.Fatalf("fulfilled type mismatch: got %q, want %q", got, tc.fulfilled)
+        }
+      } else if output.Type != input {
+        t.Fatal("non-Promise type was replaced")
+      }
+    })
+  }
+}

--- a/packages/typia/native/core/utils/promise_type_factory_semantics_test.go
+++ b/packages/typia/native/core/utils/promise_type_factory_semantics_test.go
@@ -13,12 +13,12 @@ import (
 //
 // Promise identity is structural in the checker rather than a symbol spelling.
 // Derived classes, interfaces, and branded intersections must unwrap while an
-// unrelated class named Promise and the weaker PromiseLike contract must remain
-// synchronous.
+// unrelated class named Promise and weaker PromiseLike contracts must remain
+// synchronous, even when a thenable adds only part of the Promise surface.
 //
-//  1. Load eight return-shape declarations through the real checker.
+//  1. Load nine return-shape declarations through the real checker.
 //  2. Resolve the fulfilled type for every genuine Promise shape.
-//  3. Keep PromiseLike, shadowed-name, and ordinary controls unchanged.
+//  3. Keep plain and catchable PromiseLike, shadowed-name, and ordinary controls unchanged.
 func TestPromiseTypeFactorySemantics(t *testing.T) {
   dir := t.TempDir()
   if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{
@@ -41,6 +41,9 @@ func TestPromiseTypeFactorySemantics(t *testing.T) {
 class DerivedPromise<T> extends Promise<T> {}
 interface InterfacePromise<T> extends Promise<T> {}
 type BrandedPromise<T> = Promise<T> & { readonly __brand: unique symbol };
+type CatchablePromiseLike<T> = PromiseLike<T> & {
+  catch(onrejected?: (reason: any) => any): CatchablePromiseLike<T>;
+};
 namespace Shadow { export class Promise<T> { public constructor(public value: T) {} } }
 let builtin!: Promise<string>;
 let derivedClass!: DerivedPromise<number>;
@@ -50,6 +53,9 @@ let shadowed!: Shadow.Promise<Date>;
 let synchronous!: { value: RegExp };
 let promiseLike!: PromiseLike<string>;
 let structural!: Pick<Promise<URL>, "then" | "catch" | "finally">;
+let catchablePromiseLike!: CatchablePromiseLike<string>;
+const structuralBoundary: Pick<Promise<URL>, "then" | "catch" | "finally"> extends Promise<infer _> ? true : false = true;
+const catchableBoundary: CatchablePromiseLike<string> extends Promise<infer _> ? true : false = false;
 `), 0o644); err != nil {
     t.Fatalf("write source: %v", err)
   }
@@ -63,7 +69,7 @@ let structural!: Pick<Promise<URL>, "then" | "catch" | "finally">;
   defer program.Close()
 
   source := program.SourceFile(filepath.Join(dir, "src", "main.ts"))
-  if source == nil || source.Statements == nil || len(source.Statements.Nodes) != 12 {
+  if source == nil || source.Statements == nil || len(source.Statements.Nodes) != 16 {
     t.Fatal("fixture declarations were not loaded")
   }
   variableType := func(index int) *shimchecker.Type {
@@ -76,14 +82,15 @@ let structural!: Pick<Promise<URL>, "then" | "catch" | "finally">;
     async     bool
     fulfilled string
   }{
-    {"builtin", 4, true, "string"},
-    {"derived-class", 5, true, "number"},
-    {"derived-interface", 6, true, "boolean"},
-    {"branded-intersection", 7, true, "bigint"},
-    {"shadowed-name", 8, false, ""},
-    {"synchronous", 9, false, ""},
-    {"promise-like", 10, false, ""},
-    {"structural", 11, true, "URL"},
+    {"builtin", 5, true, "string"},
+    {"derived-class", 6, true, "number"},
+    {"derived-interface", 7, true, "boolean"},
+    {"branded-intersection", 8, true, "bigint"},
+    {"shadowed-name", 9, false, ""},
+    {"synchronous", 10, false, ""},
+    {"promise-like", 11, false, ""},
+    {"structural", 12, true, "URL"},
+    {"catchable-promise-like", 13, false, ""},
   }
   for _, tc := range tests {
     t.Run(tc.name, func(t *testing.T) {

--- a/packages/typia/native/core/utils/promise_type_factory_semantics_test.go
+++ b/packages/typia/native/core/utils/promise_type_factory_semantics_test.go
@@ -16,9 +16,9 @@ import (
 // unrelated class named Promise and weaker PromiseLike contracts must remain
 // synchronous, even when a thenable adds only part of the Promise surface.
 //
-//  1. Load nine return-shape declarations through the real checker.
+//  1. Load ten return-shape declarations through the real checker.
 //  2. Resolve the fulfilled type for every genuine Promise shape.
-//  3. Keep plain and catchable PromiseLike, shadowed-name, and ordinary controls unchanged.
+//  3. Reject plain, partial, and malformed PromiseLike controls without replacing their types.
 func TestPromiseTypeFactorySemantics(t *testing.T) {
   dir := t.TempDir()
   if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{
@@ -44,6 +44,10 @@ type BrandedPromise<T> = Promise<T> & { readonly __brand: unique symbol };
 type CatchablePromiseLike<T> = PromiseLike<T> & {
   catch(onrejected?: (reason: any) => any): CatchablePromiseLike<T>;
 };
+type MalformedPromiseLike<T> = PromiseLike<T> & {
+  catch(): number;
+  finally(): number;
+};
 namespace Shadow { export class Promise<T> { public constructor(public value: T) {} } }
 let builtin!: Promise<string>;
 let derivedClass!: DerivedPromise<number>;
@@ -54,8 +58,10 @@ let synchronous!: { value: RegExp };
 let promiseLike!: PromiseLike<string>;
 let structural!: Pick<Promise<URL>, "then" | "catch" | "finally">;
 let catchablePromiseLike!: CatchablePromiseLike<string>;
+let malformedPromiseLike!: MalformedPromiseLike<string>;
 const structuralBoundary: Pick<Promise<URL>, "then" | "catch" | "finally"> extends Promise<infer _> ? true : false = true;
 const catchableBoundary: CatchablePromiseLike<string> extends Promise<infer _> ? true : false = false;
+const malformedBoundary: MalformedPromiseLike<string> extends Promise<infer _> ? true : false = false;
 `), 0o644); err != nil {
     t.Fatalf("write source: %v", err)
   }
@@ -69,7 +75,7 @@ const catchableBoundary: CatchablePromiseLike<string> extends Promise<infer _> ?
   defer program.Close()
 
   source := program.SourceFile(filepath.Join(dir, "src", "main.ts"))
-  if source == nil || source.Statements == nil || len(source.Statements.Nodes) != 16 {
+  if source == nil || source.Statements == nil || len(source.Statements.Nodes) != 19 {
     t.Fatal("fixture declarations were not loaded")
   }
   variableType := func(index int) *shimchecker.Type {
@@ -82,15 +88,16 @@ const catchableBoundary: CatchablePromiseLike<string> extends Promise<infer _> ?
     async     bool
     fulfilled string
   }{
-    {"builtin", 5, true, "string"},
-    {"derived-class", 6, true, "number"},
-    {"derived-interface", 7, true, "boolean"},
-    {"branded-intersection", 8, true, "bigint"},
-    {"shadowed-name", 9, false, ""},
-    {"synchronous", 10, false, ""},
-    {"promise-like", 11, false, ""},
-    {"structural", 12, true, "URL"},
-    {"catchable-promise-like", 13, false, ""},
+    {"builtin", 6, true, "string"},
+    {"derived-class", 7, true, "number"},
+    {"derived-interface", 8, true, "boolean"},
+    {"branded-intersection", 9, true, "bigint"},
+    {"shadowed-name", 10, false, ""},
+    {"synchronous", 11, false, ""},
+    {"promise-like", 12, false, ""},
+    {"structural", 13, true, "URL"},
+    {"catchable-promise-like", 14, false, ""},
+    {"malformed-promise-like", 15, false, ""},
   }
   for _, tc := range tests {
     t.Run(tc.name, func(t *testing.T) {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.8",
+  "version": "13.1.9",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_application_promised_return_semantics.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_application_promised_return_semantics.ts
@@ -1,0 +1,145 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+interface IPromisedReturnInput {
+  value: number;
+}
+interface IPromisedReturnOutput {
+  total: number;
+}
+class PromisedReturnDerivedPromise<T> extends Promise<T> {}
+interface IPromisedReturnInterfacePromise<T> extends Promise<T> {}
+type PromisedReturnBrandedPromise<T> = Promise<T> & {
+  readonly __brand: unique symbol;
+};
+namespace PromisedReturnShadow {
+  export class Promise<T> {
+    public constructor(public value: T) {}
+  }
+}
+interface IPromisedReturnApplication {
+  derivedClass(
+    input: IPromisedReturnInput,
+  ): PromisedReturnDerivedPromise<IPromisedReturnOutput>;
+  derivedInterface(
+    input: IPromisedReturnInput,
+  ): IPromisedReturnInterfacePromise<IPromisedReturnOutput>;
+  branded(
+    input: IPromisedReturnInput,
+  ): PromisedReturnBrandedPromise<IPromisedReturnOutput>;
+  shadowed(
+    input: IPromisedReturnInput,
+  ): PromisedReturnShadow.Promise<IPromisedReturnOutput>;
+  synchronous(input: IPromisedReturnInput): IPromisedReturnOutput;
+}
+
+/**
+ * Verifies promised return semantics reach every metadata consumer.
+ *
+ * Functional metadata feeds reflection, JSON Schema applications, LLM
+ * applications, and controllers. These surfaces must agree on both async
+ * classification and the fulfilled output schema instead of trusting a type's
+ * symbol spelling.
+ *
+ * 1. Declare derived class/interface and branded Promise return shapes.
+ * 2. Contrast them with synchronous and shadowed-name controls.
+ * 3. Assert reflection, JSON, LLM, and controller output parity.
+ */
+export const test_llm_application_promised_return_semantics = (): void => {
+  const unit = typia.reflect.schema<IPromisedReturnApplication>();
+  const application = unit.components.objects.find(
+    (object) => object.name === "IPromisedReturnApplication",
+  );
+  TestValidator.predicate(
+    "reflected application component exists",
+    () => application !== undefined,
+  );
+  const reflected = new Map(
+    (application?.properties ?? []).map((property) => [
+      property.key.constants[0]?.values[0]?.value,
+      property.value.functions[0],
+    ]),
+  );
+  for (const name of ["derivedClass", "derivedInterface", "branded"])
+    TestValidator.equals(
+      `reflect ${name} async`,
+      reflected.get(name)?.async,
+      true,
+    );
+  for (const name of ["shadowed", "synchronous"])
+    TestValidator.equals(
+      `reflect ${name} sync`,
+      reflected.get(name)?.async,
+      false,
+    );
+  TestValidator.predicate(
+    "reflected derived output is fulfilled",
+    () =>
+      reflected.get("derivedClass")?.output.objects[0]?.name ===
+      "IPromisedReturnOutput",
+  );
+  TestValidator.predicate(
+    "reflected fake Promise output is not unwrapped",
+    () =>
+      reflected
+        .get("shadowed")
+        ?.output.objects.some((object) => object.name.includes("Promise")) ===
+      true,
+  );
+
+  const json = typia.json.application<IPromisedReturnApplication>();
+  const jsonFunctions = new Map(json.functions.map((fn) => [fn.name, fn]));
+  for (const name of ["derivedClass", "derivedInterface", "branded"])
+    TestValidator.equals(
+      `json ${name} async`,
+      jsonFunctions.get(name)?.async,
+      true,
+    );
+  for (const name of ["shadowed", "synchronous"])
+    TestValidator.equals(
+      `json ${name} sync`,
+      jsonFunctions.get(name)?.async,
+      false,
+    );
+  const shadowedSchema = jsonFunctions.get("shadowed")?.output?.schema as
+    | { $ref?: string }
+    | undefined;
+  const shadowedComponent =
+    json.components.schemas?.[shadowedSchema?.$ref?.split("/").at(-1) ?? ""];
+  TestValidator.predicate("JSON fake Promise output retains value", () =>
+    JSON.stringify(shadowedComponent).includes("value"),
+  );
+
+  const llm = typia.llm.application<IPromisedReturnApplication>();
+  TestValidator.predicate("LLM derived output uses fulfilled schema", () =>
+    JSON.stringify(
+      llm.functions.find((fn) => fn.name === "derivedClass")?.output,
+    ).includes("total"),
+  );
+  TestValidator.predicate("LLM fake Promise output retains value", () =>
+    JSON.stringify(
+      llm.functions.find((fn) => fn.name === "shadowed")?.output,
+    ).includes("value"),
+  );
+
+  const executor = null as unknown as IPromisedReturnApplication;
+  const controller = typia.llm.controller<IPromisedReturnApplication>(
+    "promised-return",
+    executor,
+  );
+  TestValidator.predicate(
+    "controller derived output uses fulfilled schema",
+    () =>
+      JSON.stringify(
+        controller.application.functions.find(
+          (fn) => fn.name === "derivedClass",
+        )?.output,
+      ).includes("total"),
+  );
+  TestValidator.predicate("controller fake Promise output retains value", () =>
+    JSON.stringify(
+      controller.application.functions.find((fn) => fn.name === "shadowed")
+        ?.output,
+    ).includes("value"),
+  );
+};

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_application_promised_return_semantics.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_application_promised_return_semantics.ts
@@ -46,6 +46,11 @@ interface IPromisedReturnApplication {
  * 3. Assert reflection, JSON, LLM, and controller output parity.
  */
 export const test_llm_application_promised_return_semantics = (): void => {
+  const promisedNames = [
+    "derivedClass",
+    "derivedInterface",
+    "branded",
+  ] as const;
   const unit = typia.reflect.schema<IPromisedReturnApplication>();
   const application = unit.components.objects.find(
     (object) => object.name === "IPromisedReturnApplication",
@@ -60,24 +65,28 @@ export const test_llm_application_promised_return_semantics = (): void => {
       property.value.functions[0],
     ]),
   );
-  for (const name of ["derivedClass", "derivedInterface", "branded"])
+  for (const name of promisedNames) {
     TestValidator.equals(
       `reflect ${name} async`,
       reflected.get(name)?.async,
       true,
     );
+    TestValidator.predicate(
+      `reflect ${name} output is fulfilled`,
+      () =>
+        reflected
+          .get(name)
+          ?.output.objects.some(
+            (object) => object.name === "IPromisedReturnOutput",
+          ) === true,
+    );
+  }
   for (const name of ["shadowed", "synchronous"])
     TestValidator.equals(
       `reflect ${name} sync`,
       reflected.get(name)?.async,
       false,
     );
-  TestValidator.predicate(
-    "reflected derived output is fulfilled",
-    () =>
-      reflected.get("derivedClass")?.output.objects[0]?.name ===
-      "IPromisedReturnOutput",
-  );
   TestValidator.predicate(
     "reflected fake Promise output is not unwrapped",
     () =>
@@ -89,12 +98,18 @@ export const test_llm_application_promised_return_semantics = (): void => {
 
   const json = typia.json.application<IPromisedReturnApplication>();
   const jsonFunctions = new Map(json.functions.map((fn) => [fn.name, fn]));
-  for (const name of ["derivedClass", "derivedInterface", "branded"])
+  for (const name of promisedNames) {
     TestValidator.equals(
       `json ${name} async`,
       jsonFunctions.get(name)?.async,
       true,
     );
+    TestValidator.predicate(`JSON ${name} output is fulfilled`, () =>
+      JSON.stringify(jsonFunctions.get(name)?.output).includes(
+        "IPromisedReturnOutput",
+      ),
+    );
+  }
   for (const name of ["shadowed", "synchronous"])
     TestValidator.equals(
       `json ${name} sync`,
@@ -111,11 +126,12 @@ export const test_llm_application_promised_return_semantics = (): void => {
   );
 
   const llm = typia.llm.application<IPromisedReturnApplication>();
-  TestValidator.predicate("LLM derived output uses fulfilled schema", () =>
-    JSON.stringify(
-      llm.functions.find((fn) => fn.name === "derivedClass")?.output,
-    ).includes("total"),
-  );
+  for (const name of promisedNames)
+    TestValidator.predicate(`LLM ${name} output uses fulfilled schema`, () =>
+      JSON.stringify(
+        llm.functions.find((fn) => fn.name === name)?.output,
+      ).includes("total"),
+    );
   TestValidator.predicate("LLM fake Promise output retains value", () =>
     JSON.stringify(
       llm.functions.find((fn) => fn.name === "shadowed")?.output,
@@ -127,15 +143,15 @@ export const test_llm_application_promised_return_semantics = (): void => {
     "promised-return",
     executor,
   );
-  TestValidator.predicate(
-    "controller derived output uses fulfilled schema",
-    () =>
-      JSON.stringify(
-        controller.application.functions.find(
-          (fn) => fn.name === "derivedClass",
-        )?.output,
-      ).includes("total"),
-  );
+  for (const name of promisedNames)
+    TestValidator.predicate(
+      `controller ${name} output uses fulfilled schema`,
+      () =>
+        JSON.stringify(
+          controller.application.functions.find((fn) => fn.name === name)
+            ?.output,
+        ).includes("total"),
+    );
   TestValidator.predicate("controller fake Promise output retains value", () =>
     JSON.stringify(
       controller.application.functions.find((fn) => fn.name === "shadowed")

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -343,7 +343,7 @@ const checked = typia.functional.assertFunction(add);
 checked.call({ base: 10 }, 2); // 12
 ```
 
-Assertion wrappers throw on the first mismatch, `is` / `equals` wrappers return `null`, and validation wrappers return `IValidation`. Async targets retain both their receiver and their `Promise` result shape.
+Assertion wrappers throw on the first mismatch, `is` / `equals` wrappers return `null`, and validation wrappers return `IValidation`. Async targets retain both their receiver and their `Promise` result shape, including Promise subclasses, extended interfaces, and branded intersections. `PromiseLike<T>` alone does not satisfy the `Promise<T>` contract used by these wrappers.
 
 <Tabs items={['TypeScript Source', 'Compiled JavaScript']}>
   <Tabs.Tab>

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -321,10 +321,28 @@ Types with no sound total order (`any`, `Function`, `Set`, `Map`, `WeakSet`, `We
 The `functional` module wraps an existing function with parameter and return-value validation while preserving its call contract. Every wrapper forwards the call-site receiver, so a target with an explicit TypeScript `this` parameter still works through method calls, `.call`, `.apply`, and `.bind`.
 
 ```typescript copy filename="signatures"
+type FunctionalIs<T extends (...args: any[]) => any> = T extends (
+  this: infer This,
+  ...args: infer Args
+) => infer Output
+  ? Output extends Promise<infer R>
+    ? (this: This, ...args: Args) => Promise<R | null>
+    : (this: This, ...args: Args) => Output | null
+  : never;
+
+type FunctionalValidate<T extends (...args: any[]) => any> = T extends (
+  this: infer This,
+  ...args: infer Args
+) => infer Output
+  ? Output extends Promise<infer R>
+    ? (this: This, ...args: Args) => Promise<IValidation<R>>
+    : (this: This, ...args: Args) => IValidation<Output>
+  : never;
+
 namespace functional {
   function assertFunction<T extends (...args: any[]) => any>(func: T): T;
-  function isFunction<This, Args extends any[], Output>(func: (this: This, ...args: Args) => Output): (this: This, ...args: Args) => Output | null;
-  function validateFunction<This, Args extends any[], Output>(func: (this: This, ...args: Args) => Output): (this: This, ...args: Args) => IValidation<Output>;
+  function isFunction<T extends (...args: any[]) => any>(func: T): FunctionalIs<T>;
+  function validateFunction<T extends (...args: any[]) => any>(func: T): FunctionalValidate<T>;
 }
 ```
 


### PR DESCRIPTION
## Intent

Replace name-based Promise recognition in the native transformer with compiler-semantic promised-type classification so generated functional wrappers and reflected metadata agree with TypeScript's public Promise contract.

Closes #2080.

## Scope

- classify built-in Promise returns, derived classes and interfaces, and branded Promise intersections by semantic awaited-type resolution;
- reject shadowed non-thenable types that merely carry the name `Promise`;
- use one shared classification path for functional wrapper generation and reflected function metadata;
- preserve receiver behavior merged in #2072;
- cover direct and factory functional families, fulfilled-value validation, invalid-parameter Promise shape, rejection propagation, reflection, LLM/JSON/controller consumers, and generated output;
- reserve `typia` version 13.1.9 after the preceding native release sequence through 13.1.8 is integrated.

## Deferred coordination

This branch is initially based on `ed1b565cedaa772927bafbb8a4dea781b94fe62d`. It must not become ready or merge until PRs #2071, #2075, #2074, #2077, and #2068 are merged sequentially and this branch is semantically rebased onto that resulting master.

## Verification

Pending tests-first implementation. Planned verification covers focused native/public Go tests, functional runtime matrices, reflected metadata, JSON/LLM/controller consumers, package build, and the broader repository suite required after the final semantic rebase.

Campaign CI is deliberately cancelled per exact pushed SHA. Local verification and solo Self-Review are the merge gates.
