### PR TITLE
fix(typia): reject invalid Protobuf UTF-8 strings

### DIFF
--- a/packages/typia/src/internal/_ProtobufReader.ts
+++ b/packages/typia/src/internal/_ProtobufReader.ts
@@ -77,7 +77,15 @@ export class _ProtobufReader {
   }
 
   public string(): string {
-    return utf8.get().decode(this.bytes());
+    const bytes: Uint8Array = this.bytes();
+    const decoder: TextDecoder = utf8.get();
+    try {
+      return decoder.decode(bytes);
+    } catch {
+      throw new Error(
+        "Error on typia.protobuf.decode(): invalid UTF-8 string.",
+      );
+    }
   }
 
   public fork(): number {
@@ -231,4 +239,6 @@ export class _ProtobufReader {
   }
 }
 
-const utf8 = new Singleton(() => new TextDecoder("utf-8"));
+const utf8 = new Singleton(
+  () => new TextDecoder("utf-8", { fatal: true }),
+);

--- a/packages/typia/src/internal/_ProtobufReader.ts
+++ b/packages/typia/src/internal/_ProtobufReader.ts
@@ -240,5 +240,5 @@ export class _ProtobufReader {
 }
 
 const utf8 = new Singleton(
-  () => new TextDecoder("utf-8", { fatal: true }),
+  () => new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }),
 );

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_invalid_utf8.ts
@@ -1,13 +1,23 @@
 import typia from "typia";
 
-/** Verifies every generated proto3 string position rejects malformed UTF-8. */
+/**
+ * Verifies every generated proto3 string position rejects malformed UTF-8.
+ *
+ * Generated decode wrappers share the reader but add distinct assertion,
+ * predicate, and validation layers. This matrix prevents any wrapper or
+ * structural position from turning replacement text into a successful value.
+ *
+ * 1. Decode valid strings and arbitrary bytes through all eight public paths.
+ * 2. Move each malformed UTF-8 class through every generated string position.
+ * 3. Require one wire error while the identical bytes field remains valid.
+ */
 export const test_protobuf_decode_invalid_utf8 = (): void => {
-  for (const [, text] of VALID_TEXTS) {
+  for (const [label, text] of VALID_TEXTS) {
     const payload: Uint8Array = ENCODER.encode(text);
     const bytes: Uint8Array = Uint8Array.of(0xff, 0x80, 0xc0, 0xaf);
     const wire: Uint8Array = message({ bytes, defaultString: payload });
     for (const [decoder, decode] of DECODERS)
-      assertDecoded(decoder, decode(wire), text, bytes);
+      assertDecoded(`${decoder}: valid ${label}`, decode(wire), text, bytes);
   }
 
   for (const [label, payload] of INVALID_UTF8) {
@@ -16,7 +26,12 @@ export const test_protobuf_decode_invalid_utf8 = (): void => {
       defaultString: ASCII,
     });
     for (const [decoder, decode] of DECODERS)
-      assertDecoded(decoder, decode(bytesOnly), ASCII_TEXT, payload);
+      assertDecoded(
+        `${decoder}: bytes negative twin: ${label}`,
+        decode(bytesOnly),
+        ASCII_TEXT,
+        payload,
+      );
 
     for (const position of STRING_POSITIONS) {
       const wire: Uint8Array = message({

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_invalid_utf8.ts
@@ -5,9 +5,11 @@ import typia from "typia";
  *
  * Generated decode wrappers share the reader but add distinct assertion,
  * predicate, and validation layers. This matrix prevents any wrapper or
- * structural position from turning replacement text into a successful value.
+ * structural position from turning replacement text into a successful value, or
+ * from silently dropping a leading U+FEFF that the writer encoded verbatim.
  *
- * 1. Decode valid strings and arbitrary bytes through all eight public paths.
+ * 1. Decode valid strings, byte order marks, and arbitrary bytes through all eight
+ *    public paths.
  * 2. Move each malformed UTF-8 class through every generated string position.
  * 3. Require one wire error while the identical bytes field remains valid.
  */
@@ -65,9 +67,7 @@ const directIs = (input: Uint8Array): typia.Resolved<IUtf8Surface> => {
   if (value === null) throw new Error("direct isDecode returned null");
   return value;
 };
-const directValidate = (
-  input: Uint8Array,
-): typia.Resolved<IUtf8Surface> =>
+const directValidate = (input: Uint8Array): typia.Resolved<IUtf8Surface> =>
   unwrap(
     "direct validateDecode",
     typia.protobuf.validateDecode<IUtf8Surface>(input),
@@ -165,11 +165,7 @@ const message = (props: {
 };
 
 const field = (sequence: number, payload: Uint8Array): Uint8Array =>
-  Uint8Array.from([
-    (sequence << 3) | 2,
-    ...varint(payload.length),
-    ...payload,
-  ]);
+  Uint8Array.from([(sequence << 3) | 2, ...varint(payload.length), ...payload]);
 
 const concat = (...arrays: readonly Uint8Array[]): Uint8Array =>
   Uint8Array.from(arrays.flatMap((array) => [...array]));
@@ -203,9 +199,15 @@ const VALID_TEXTS = [
   ["empty", ""],
   ["ASCII", "Protocol Buffers"],
   ["literal replacement character", "\ufffd"],
+  ["leading byte order mark", "\ufefftext"],
+  ["byte order mark only", "\ufeff"],
+  ["interior byte order mark", "a\ufeffb"],
   ["multibyte", "é水값"],
   ["emoji", "🫢"],
-  ["UTF-8 boundaries", "\u0000\u007f\u0080\u07ff\u0800\uffff\u{10000}\u{10ffff}"],
+  [
+    "UTF-8 boundaries",
+    "\u0000\u007f\u0080\u07ff\u0800\uffff\u{10000}\u{10ffff}",
+  ],
 ] as const;
 
 const INVALID_UTF8 = [

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_invalid_utf8.ts
@@ -1,0 +1,202 @@
+import typia from "typia";
+
+/** Verifies every generated proto3 string position rejects malformed UTF-8. */
+export const test_protobuf_decode_invalid_utf8 = (): void => {
+  for (const [, text] of VALID_TEXTS) {
+    const payload: Uint8Array = ENCODER.encode(text);
+    const bytes: Uint8Array = Uint8Array.of(0xff, 0x80, 0xc0, 0xaf);
+    const wire: Uint8Array = message({ bytes, defaultString: payload });
+    for (const [decoder, decode] of DECODERS)
+      assertDecoded(decoder, decode(wire), text, bytes);
+  }
+
+  for (const [label, payload] of INVALID_UTF8) {
+    const bytesOnly: Uint8Array = message({
+      bytes: payload,
+      defaultString: ASCII,
+    });
+    for (const [decoder, decode] of DECODERS)
+      assertDecoded(decoder, decode(bytesOnly), ASCII_TEXT, payload);
+
+    for (const position of STRING_POSITIONS) {
+      const wire: Uint8Array = message({
+        bytes: payload,
+        defaultString: ASCII,
+        malformed: { payload, position },
+      });
+      for (const [decoder, decode] of DECODERS)
+        assertInvalid(`${decoder}: ${position}: ${label}`, () => decode(wire));
+    }
+  }
+};
+
+interface IUtf8Surface {
+  singular: string;
+  optional?: string;
+  repeated: string[];
+  nested: IUtf8Nested;
+  dictionary: Map<string, string>;
+  bytes: Uint8Array;
+}
+
+interface IUtf8Nested {
+  value: string;
+}
+
+type StringPosition = (typeof STRING_POSITIONS)[number];
+
+const directIs = (input: Uint8Array): typia.Resolved<IUtf8Surface> => {
+  const value = typia.protobuf.isDecode<IUtf8Surface>(input);
+  if (value === null) throw new Error("direct isDecode returned null");
+  return value;
+};
+const directValidate = (
+  input: Uint8Array,
+): typia.Resolved<IUtf8Surface> =>
+  unwrap(
+    "direct validateDecode",
+    typia.protobuf.validateDecode<IUtf8Surface>(input),
+  );
+
+const factoryDecode = typia.protobuf.createDecode<IUtf8Surface>();
+const factoryAssert = typia.protobuf.createAssertDecode<IUtf8Surface>();
+const factoryIs = typia.protobuf.createIsDecode<IUtf8Surface>();
+const factoryValidate = typia.protobuf.createValidateDecode<IUtf8Surface>();
+
+const DECODERS: readonly (readonly [
+  string,
+  (input: Uint8Array) => typia.Resolved<IUtf8Surface>,
+])[] = [
+  ["direct decode", (input) => typia.protobuf.decode<IUtf8Surface>(input)],
+  [
+    "direct assertDecode",
+    (input) => typia.protobuf.assertDecode<IUtf8Surface>(input),
+  ],
+  ["direct isDecode", directIs],
+  ["direct validateDecode", directValidate],
+  ["factory decode", factoryDecode],
+  ["factory assertDecode", factoryAssert],
+  [
+    "factory isDecode",
+    (input) => {
+      const value = factoryIs(input);
+      if (value === null) throw new Error("factory isDecode returned null");
+      return value;
+    },
+  ],
+  [
+    "factory validateDecode",
+    (input) => unwrap("factory validateDecode", factoryValidate(input)),
+  ],
+];
+
+const unwrap = <T>(label: string, validation: typia.IValidation<T>): T => {
+  if (validation.success === false)
+    throw new Error(`${label} rejected a structurally valid message.`);
+  return validation.data;
+};
+
+const assertDecoded = (
+  decoder: string,
+  value: typia.Resolved<IUtf8Surface>,
+  text: string,
+  bytes: Uint8Array,
+): void => {
+  const mapValue: string | undefined = value.dictionary.get(text);
+  if (
+    value.singular !== text ||
+    value.optional !== text ||
+    value.repeated.length !== 1 ||
+    value.repeated[0] !== text ||
+    value.nested.value !== text ||
+    value.dictionary.size !== 1 ||
+    mapValue !== text ||
+    value.bytes.length !== bytes.length ||
+    value.bytes.some((byte, index) => byte !== bytes[index])
+  )
+    throw new Error(`${decoder} changed a valid string or bytes payload.`);
+};
+
+const assertInvalid = (label: string, task: () => unknown): void => {
+  try {
+    task();
+  } catch (error) {
+    if (error instanceof Error && error.message === INVALID_UTF8_ERROR) return;
+    throw new Error(`${label} raised an unstable error.`, { cause: error });
+  }
+  throw new Error(`${label} accepted invalid UTF-8.`);
+};
+
+const message = (props: {
+  bytes: Uint8Array;
+  defaultString: Uint8Array;
+  malformed?: { payload: Uint8Array; position: StringPosition };
+}): Uint8Array => {
+  const string = (position: StringPosition): Uint8Array =>
+    props.malformed?.position === position
+      ? props.malformed.payload
+      : props.defaultString;
+  return concat(
+    field(1, string("singular")),
+    field(2, string("optional")),
+    field(3, string("repeated")),
+    field(4, field(1, string("nested"))),
+    field(
+      5,
+      concat(field(1, string("map key")), field(2, string("map value"))),
+    ),
+    field(6, props.bytes),
+  );
+};
+
+const field = (sequence: number, payload: Uint8Array): Uint8Array =>
+  Uint8Array.from([
+    (sequence << 3) | 2,
+    ...varint(payload.length),
+    ...payload,
+  ]);
+
+const concat = (...arrays: readonly Uint8Array[]): Uint8Array =>
+  Uint8Array.from(arrays.flatMap((array) => [...array]));
+
+const varint = (value: number): number[] => {
+  const output: number[] = [];
+  do {
+    const byte: number = value & 0x7f;
+    value >>>= 7;
+    output.push(value === 0 ? byte : byte | 0x80);
+  } while (value !== 0);
+  return output;
+};
+
+const INVALID_UTF8_ERROR =
+  "Error on typia.protobuf.decode(): invalid UTF-8 string.";
+const ENCODER = new TextEncoder();
+const ASCII_TEXT = "valid";
+const ASCII = ENCODER.encode(ASCII_TEXT);
+
+const STRING_POSITIONS = [
+  "singular",
+  "optional",
+  "repeated",
+  "nested",
+  "map key",
+  "map value",
+] as const;
+
+const VALID_TEXTS = [
+  ["empty", ""],
+  ["ASCII", "Protocol Buffers"],
+  ["multibyte", "é水값"],
+  ["emoji", "🫢"],
+  ["UTF-8 boundaries", "\u0000\u007f\u0080\u07ff\u0800\uffff\u{10000}\u{10ffff}"],
+] as const;
+
+const INVALID_UTF8 = [
+  ["invalid leading byte", Uint8Array.of(0xff)],
+  ["lone continuation", Uint8Array.of(0x80)],
+  ["overlong encoding", Uint8Array.of(0xc0, 0xaf)],
+  ["truncated multibyte", Uint8Array.of(0xe2, 0x82)],
+  ["encoded surrogate", Uint8Array.of(0xed, 0xa0, 0x80)],
+  ["out-of-range code point", Uint8Array.of(0xf4, 0x90, 0x80, 0x80)],
+] as const;

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_invalid_utf8.ts
@@ -202,6 +202,7 @@ const STRING_POSITIONS = [
 const VALID_TEXTS = [
   ["empty", ""],
   ["ASCII", "Protocol Buffers"],
+  ["literal replacement character", "\ufffd"],
   ["multibyte", "é水값"],
   ["emoji", "🫢"],
   ["UTF-8 boundaries", "\u0000\u007f\u0080\u07ff\u0800\uffff\u{10000}\u{10ffff}"],

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
@@ -33,6 +33,32 @@ export const test_protobuf_reader_invalid_utf8 = (): void => {
     )
       throw new Error(`${label} bytes payload was changed.`);
   }
+
+  for (const [label, buffer] of TRUNCATED_FRAMES)
+    assertOverflow(label, () => new _ProtobufReader(buffer).string());
+};
+
+/**
+ * Requires a framing fault to keep its own error across the string boundary.
+ *
+ * `string()` must resolve its bytes before entering the decoder's `try`, so a
+ * declared length that overruns the buffer stays a boundary error instead of
+ * being relabelled as an encoding fault. Reporting `invalid UTF-8 string` here
+ * would blame the payload's encoding for a wire-framing defect.
+ */
+const assertOverflow = (label: string, task: () => unknown): void => {
+  try {
+    task();
+  } catch (error) {
+    if (error instanceof Error && error.message === OVERFLOW_ERROR) return;
+    if (error instanceof Error && error.message === INVALID_UTF8_ERROR)
+      throw new Error(
+        `${label} was relabelled as an encoding fault.`,
+        { cause: error },
+      );
+    throw new Error(`${label} raised an unstable error.`, { cause: error });
+  }
+  throw new Error(`${label} was accepted as a Protobuf string.`);
 };
 
 const assertInvalid = (label: string, task: () => unknown): void => {
@@ -60,7 +86,20 @@ const varint = (value: number): number[] => {
 
 const INVALID_UTF8_ERROR =
   "Error on typia.protobuf.decode(): invalid UTF-8 string.";
+const OVERFLOW_ERROR = "Error on typia.protobuf.decode(): buffer overflow.";
 const ENCODER = new TextEncoder();
+
+/**
+ * Length-delimited frames whose declared length overruns the buffer.
+ *
+ * Each payload is valid UTF-8, so the only thing that can fail is the frame's
+ * length. That isolates the boundary contract from the encoding contract.
+ */
+const TRUNCATED_FRAMES = [
+  ["declared length past the buffer", Uint8Array.of(0x08, ...ENCODER.encode("abc"))],
+  ["declared length with no payload", Uint8Array.of(0x04)],
+  ["declared length one byte short", Uint8Array.of(0x05, ...ENCODER.encode("text"))],
+] as const;
 
 const VALID_TEXTS = [
   ["empty", ""],

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
@@ -1,0 +1,66 @@
+import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
+
+/** Verifies Protobuf strings reject malformed UTF-8 without narrowing bytes. */
+export const test_protobuf_reader_invalid_utf8 = (): void => {
+  for (const [label, text] of VALID_TEXTS) {
+    const payload: Uint8Array = ENCODER.encode(text);
+    const decoded: string = new _ProtobufReader(frame(payload)).string();
+    if (decoded !== text)
+      throw new Error(`${label} decoded as ${JSON.stringify(decoded)}.`);
+  }
+
+  for (const [label, payload] of INVALID_UTF8) {
+    assertInvalid(label, () => new _ProtobufReader(frame(payload)).string());
+
+    const bytes: Uint8Array = new _ProtobufReader(frame(payload)).bytes();
+    if (
+      bytes.length !== payload.length ||
+      bytes.some((value, index) => value !== payload[index])
+    )
+      throw new Error(`${label} bytes payload was changed.`);
+  }
+};
+
+const assertInvalid = (label: string, task: () => unknown): void => {
+  try {
+    task();
+  } catch (error) {
+    if (error instanceof Error && error.message === INVALID_UTF8_ERROR) return;
+    throw new Error(`${label} raised an unstable error.`, { cause: error });
+  }
+  throw new Error(`${label} was accepted as a Protobuf string.`);
+};
+
+const frame = (payload: Uint8Array): Uint8Array =>
+  Uint8Array.from([...varint(payload.length), ...payload]);
+
+const varint = (value: number): number[] => {
+  const output: number[] = [];
+  do {
+    const byte: number = value & 0x7f;
+    value >>>= 7;
+    output.push(value === 0 ? byte : byte | 0x80);
+  } while (value !== 0);
+  return output;
+};
+
+const INVALID_UTF8_ERROR =
+  "Error on typia.protobuf.decode(): invalid UTF-8 string.";
+const ENCODER = new TextEncoder();
+
+const VALID_TEXTS = [
+  ["empty", ""],
+  ["ASCII", "Protocol Buffers"],
+  ["multibyte", "é水값"],
+  ["emoji", "🫢"],
+  ["UTF-8 boundaries", "\u0000\u007f\u0080\u07ff\u0800\uffff\u{10000}\u{10ffff}"],
+] as const;
+
+const INVALID_UTF8 = [
+  ["invalid leading byte", Uint8Array.of(0xff)],
+  ["lone continuation", Uint8Array.of(0x80)],
+  ["overlong encoding", Uint8Array.of(0xc0, 0xaf)],
+  ["truncated multibyte", Uint8Array.of(0xe2, 0x82)],
+  ["encoded surrogate", Uint8Array.of(0xed, 0xa0, 0x80)],
+  ["out-of-range code point", Uint8Array.of(0xf4, 0x90, 0x80, 0x80)],
+] as const;

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
@@ -61,6 +61,7 @@ const ENCODER = new TextEncoder();
 const VALID_TEXTS = [
   ["empty", ""],
   ["ASCII", "Protocol Buffers"],
+  ["literal replacement character", "\ufffd"],
   ["multibyte", "é水값"],
   ["emoji", "🫢"],
   ["UTF-8 boundaries", "\u0000\u007f\u0080\u07ff\u0800\uffff\u{10000}\u{10ffff}"],

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
@@ -4,10 +4,14 @@ import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
  * Verifies Protobuf strings reject malformed UTF-8 without narrowing bytes.
  *
  * Locks the shared reader boundary where proto3 `string` and `bytes` stop
- * sharing semantics. A regression here either accepts lossy replacement text
- * or incorrectly rejects arbitrary octets from a bytes field.
+ * sharing semantics. A regression here either accepts lossy replacement text or
+ * incorrectly rejects arbitrary octets from a bytes field. The byte order mark
+ * cases pin the decoder's second lossy branch: a payload is a length-delimited
+ * byte string with no encoding preamble to strip, so a leading U+FEFF must
+ * survive exactly as the writer's `TextEncoder` emitted it.
  *
- * 1. Decode valid empty, ASCII, multibyte, emoji, and boundary strings.
+ * 1. Decode valid empty, ASCII, byte order mark, multibyte, emoji, and boundary
+ *    strings without altering a single code point.
  * 2. Reject every authoritative malformed UTF-8 class with one stable error.
  * 3. Read the same malformed octets through `bytes()` without changing them.
  */
@@ -62,9 +66,15 @@ const VALID_TEXTS = [
   ["empty", ""],
   ["ASCII", "Protocol Buffers"],
   ["literal replacement character", "\ufffd"],
+  ["leading byte order mark", "\ufefftext"],
+  ["byte order mark only", "\ufeff"],
+  ["interior byte order mark", "a\ufeffb"],
   ["multibyte", "é水값"],
   ["emoji", "🫢"],
-  ["UTF-8 boundaries", "\u0000\u007f\u0080\u07ff\u0800\uffff\u{10000}\u{10ffff}"],
+  [
+    "UTF-8 boundaries",
+    "\u0000\u007f\u0080\u07ff\u0800\uffff\u{10000}\u{10ffff}",
+  ],
 ] as const;
 
 const INVALID_UTF8 = [

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
@@ -1,6 +1,16 @@
 import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
 
-/** Verifies Protobuf strings reject malformed UTF-8 without narrowing bytes. */
+/**
+ * Verifies Protobuf strings reject malformed UTF-8 without narrowing bytes.
+ *
+ * Locks the shared reader boundary where proto3 `string` and `bytes` stop
+ * sharing semantics. A regression here either accepts lossy replacement text
+ * or incorrectly rejects arbitrary octets from a bytes field.
+ *
+ * 1. Decode valid empty, ASCII, multibyte, emoji, and boundary strings.
+ * 2. Reject every authoritative malformed UTF-8 class with one stable error.
+ * 3. Read the same malformed octets through `bytes()` without changing them.
+ */
 export const test_protobuf_reader_invalid_utf8 = (): void => {
   for (const [label, text] of VALID_TEXTS) {
     const payload: Uint8Array = ENCODER.encode(text);

--- a/website/src/content/docs/protobuf/decode.mdx
+++ b/website/src/content/docs/protobuf/decode.mdx
@@ -60,7 +60,7 @@ const user = typia.protobuf.assertDecode<User>(bytes);
 >
 > **What the `*Decode` validators actually verify.**
 >
-> They check **custom tag constraints** — `tags.Format<"uuid">`, `tags.Minimum<0>`, etc. They do **not** re-verify that the bytes were structurally valid Protocol Buffer for `T` — the decoder already did that decoding work. So you can rely on these to catch "the producer encoded a UUID that's actually not a UUID" but not "someone fed me random bytes."
+> They check **custom tag constraints** — `tags.Format<"uuid">`, `tags.Minimum<0>`, etc. They do **not** re-verify that the bytes were structurally valid Protocol Buffer for `T` — the decoder already did that decoding work. So you can rely on these to catch "the producer encoded a UUID that's actually not a UUID", but not to tell you that someone fed you random bytes that happen to parse.
 >
 > The safe pattern is: producer uses `protobuf.assertEncode` (or `validateEncode`), consumer uses `protobuf.assertDecode` (or `validateDecode`). Then both ends of the wire are checked.
 
@@ -96,6 +96,24 @@ export namespace protobuf {
       showLineNumbers />
   </Tabs.Tab>
 </Tabs>
+
+## Wire errors
+
+The table above describes what happens when **validation** fails. A malformed payload is different: the binary reader raises an `Error` while reading the bytes, before any validator runs. That error propagates out of every variant, including `isDecode` and `validateDecode`, so it is not reported as a `null` or as an unsuccessful `IValidation`.
+
+Wrap the call in `try`/`catch` when the bytes come from an untrusted producer.
+
+```typescript copy
+try {
+  const user: User = typia.protobuf.assertDecode<User>(buffer);
+} catch (error) {
+  // malformed wire bytes, or a failed tag constraint
+}
+```
+
+`string` fields are one source of these errors. proto3 requires a `string` to hold valid UTF-8, so typia rejects a payload containing a lone continuation byte, an overlong encoding, a truncated multi-byte sequence, an encoded surrogate, or an out-of-range code point, instead of substituting `U+FFFD` replacement characters and returning text the producer never sent.
+
+Use `Uint8Array` when a field must carry arbitrary octets. It maps to proto3 `bytes`, which has no encoding requirement and accepts the same octets a `string` field rejects.
 
 ## Reusable factories
 

--- a/website/src/content/docs/protobuf/decode.mdx
+++ b/website/src/content/docs/protobuf/decode.mdx
@@ -105,7 +105,7 @@ Wrap the call in `try`/`catch` when the bytes come from an untrusted producer.
 
 ```typescript copy
 try {
-  const user: User = typia.protobuf.assertDecode<User>(buffer);
+  const user = typia.protobuf.assertDecode<User>(bytes);
 } catch (error) {
   // malformed wire bytes, or a failed tag constraint
 }


### PR DESCRIPTION
## Intent

Reject invalid UTF-8 in proto3 `string` payloads before generated decoders can return lossy U+FFFD replacement text as a successful product value.

## Scope

- Apply strict UTF-8 decoding only to Protobuf `string` reads.
- Preserve arbitrary octets in Protobuf `bytes` fields as the negative compatibility control.
- Cover direct and factory `decode`, `assertDecode`, `isDecode`, and `validateDecode` across singular, repeated, nested, and map key/value string positions.
- Pin valid ASCII, multibyte, and emoji controls plus lone-continuation, overlong, truncated-multibyte, encoded-surrogate, and out-of-range failures.
- Keep this TypeScript-runtime-only repair version-neutral.

## Deferred

- #2083 / PR #2084 owns truncated length-delimited bounds; this pull request does not duplicate that repair.
- Final verification and merge wait for PR #2084, followed by a semantic rebase that preserves its bounds regressions.
- No non-Protobuf text-decoder policy changes and no repository-wide formatting; Post-Campaign Cleanup owns formatting.

## Verification

Pending tests-first reader and generated-decoder regressions, focused suites, full `test-typia-schema`, `typia` build, public/native Go gates, and findings-first solo Self-Review through a clean round.

Campaign Actions remain enabled and are cancelled only for this branch's exact pushed SHA after every push or pull-request mutation. Local verification is the implementation gate.

Closes #2088
