### PR TITLE
fix(adapters): enforce reflected output schemas

### DIFF
--- a/packages/mcp/src/internal/McpControllerRegistrar.ts
+++ b/packages/mcp/src/internal/McpControllerRegistrar.ts
@@ -35,6 +35,10 @@ export namespace McpControllerRegistrar {
       registry.set(func.name, {
         function: func,
         execute: composeExecute(controller, func),
+        validateOutput:
+          func.output === undefined
+            ? undefined
+            : LlmJson.validate(func.output, true),
       });
     }
 
@@ -126,29 +130,38 @@ export namespace McpControllerRegistrar {
 
     try {
       const result: unknown = await entry.execute(validation.data);
-      if (result === undefined) {
-        return { content: [{ type: "text" as const, text: "Success" }] };
-      }
+      if (entry.validateOutput === undefined)
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: result === undefined ? "Success" : JSON.stringify(result),
+            },
+          ],
+        };
+      const output: IValidation<unknown> = entry.validateOutput(result);
+      if (!output.success)
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text:
+                `Type errors in "${entry.function.name}" output:\n\n` +
+                LlmJson.stringify(output),
+            },
+          ],
+        };
       // When the reflected return type schema exists, ship the result as
       // structured output, once. The spec's duplicate text fallback for
       // clients that ignore `outputSchema` doubles the payload, so it is
       // opt-in through `textFallback: true`.
       //
-      // A result that cannot ship as `structuredContent` keeps its text
-      // block regardless — dropping it would leave the call empty.
-      const structured: boolean =
-        entry.function.output !== undefined &&
-        typeof result === "object" &&
-        result !== null &&
-        !Array.isArray(result);
       return {
-        content:
-          structured && !textFallback
-            ? []
-            : [{ type: "text" as const, text: JSON.stringify(result) }],
-        ...(structured
-          ? { structuredContent: result as Record<string, unknown> }
-          : {}),
+        content: textFallback
+          ? [{ type: "text" as const, text: JSON.stringify(result) }]
+          : [],
+        structuredContent: output.data as Record<string, unknown>,
       };
     } catch (error) {
       return {
@@ -181,4 +194,5 @@ export namespace McpControllerRegistrar {
 interface IToolEntry {
   function: ILlmFunction;
   execute: (args: unknown) => Promise<unknown>;
+  validateOutput?: ((output: unknown) => IValidation<unknown>) | undefined;
 }

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -172,7 +172,7 @@ export namespace VercelToolsRegistrar {
                 success: false,
                 error:
                   `Type errors in "${name}" output:\n\n` +
-                  `\`\`\`json\n${LlmJson.stringify(output)}\n\`\`\``,
+                  LlmJson.stringify(output),
               } satisfies ITryResult);
         } catch (error) {
           return {

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -130,6 +130,12 @@ export namespace VercelToolsRegistrar {
     execute: (args: unknown) => Promise<unknown>;
   }): Tool => {
     const { name, func, execute } = props;
+    const validateOutput:
+      | ((output: unknown) => IValidation<unknown>)
+      | undefined =
+      func.output === undefined
+        ? undefined
+        : LlmJson.validate(func.output, true);
 
     return tool({
       description: func.description ?? "",
@@ -155,15 +161,19 @@ export namespace VercelToolsRegistrar {
           } satisfies ITryResult;
         try {
           const result: unknown = await execute(validation.data);
-          if (result === undefined) {
-            return func.output === undefined
+          if (validateOutput === undefined)
+            return result === undefined
               ? ({ success: true } satisfies ITryResult)
-              : ({
-                  success: false,
-                  error: `Function "${name}" returned undefined despite declaring an output schema`,
-                } satisfies ITryResult);
-          }
-          return { success: true, data: result } satisfies ITryResult;
+              : ({ success: true, data: result } satisfies ITryResult);
+          const output: IValidation<unknown> = validateOutput(result);
+          return output.success
+            ? ({ success: true, data: output.data } satisfies ITryResult)
+            : ({
+                success: false,
+                error:
+                  `Type errors in "${name}" output:\n\n` +
+                  `\`\`\`json\n${LlmJson.stringify(output)}\n\`\`\``,
+              } satisfies ITryResult);
         } catch (error) {
           return {
             success: false,

--- a/tests/test-mcp/src/features/test_mcp_http_controller_output_validation.ts
+++ b/tests/test-mcp/src/features/test_mcp_http_controller_output_validation.ts
@@ -1,0 +1,154 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { TestValidator } from "@nestia/e2e";
+import { IHttpLlmController, OpenApiV3_1 } from "@typia/interface";
+import { createMcpServer } from "@typia/mcp";
+import { HttpLlm } from "@typia/utils";
+
+/**
+ * Verifies HTTP controller bodies obey their advertised MCP output schema.
+ *
+ * HTTP execution has a separate response-body path from class methods. It must
+ * apply the same output trust boundary while leaving thrown transport or
+ * controller failures in the pre-existing execution-error channel.
+ *
+ * 1. Reflect a minimal HTTP operation with a nested response object.
+ * 2. Accept its valid body through an SDK client and in-memory transport.
+ * 3. Reject a wrong nested body with an actionable validation path.
+ * 4. Preserve a thrown HTTP executor exception as a tool error.
+ */
+export const test_mcp_http_controller_output_validation =
+  async (): Promise<void> => {
+    const controller: IHttpLlmController = HttpLlm.controller({
+      name: "http-output",
+      document: document(),
+      connection: { host: "http://localhost:0" },
+      execute: async (props) => {
+        const { variant } = (props.arguments as { body: { variant: Variant } })
+          .body;
+        if (variant === "throw") throw new Error("http execution failed");
+        return {
+          status: 200,
+          headers: {},
+          body:
+            variant === "valid"
+              ? { value: 1, nested: { label: "valid" } }
+              : { value: 1, nested: { label: 42 } },
+        };
+      },
+    });
+    const server: McpServer = createMcpServer(controller);
+    const client: Client = new Client({
+      name: "http-output-test",
+      version: "1.0",
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      const listed = await client.listTools();
+      const name: string = listed.tools[0]!.name;
+
+      const valid: CallToolResult = (await client.callTool({
+        name,
+        arguments: { body: { variant: "valid" } },
+      })) as CallToolResult;
+      TestValidator.equals(
+        "valid HTTP body is structured",
+        valid.structuredContent,
+        {
+          value: 1,
+          nested: { label: "valid" },
+        },
+      );
+
+      const invalid: CallToolResult = (await client.callTool({
+        name,
+        arguments: { body: { variant: "invalid" } },
+      })) as CallToolResult;
+      TestValidator.predicate(
+        "invalid HTTP body is an actionable tool error",
+        invalid.isError === true &&
+          invalid.structuredContent === undefined &&
+          getText(invalid).includes('Type errors in "read_post" output:') &&
+          getText(invalid).includes('"path":"$input.nested.label"'),
+      );
+
+      const thrown: CallToolResult = (await client.callTool({
+        name,
+        arguments: { body: { variant: "throw" } },
+      })) as CallToolResult;
+      TestValidator.predicate(
+        "HTTP executor exception remains a tool error",
+        thrown.isError === true &&
+          getText(thrown).includes("http execution failed"),
+      );
+    } finally {
+      await Promise.allSettled([client.close(), server.close()]);
+    }
+  };
+
+type Variant = "valid" | "invalid" | "throw";
+
+const document = (): OpenApiV3_1.IDocument => ({
+  openapi: "3.1.0",
+  info: { title: "Output validation", version: "1.0.0" },
+  paths: {
+    "/read": {
+      post: {
+        operationId: "post_httpOutput_read",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  variant: {
+                    type: "string",
+                    enum: ["valid", "invalid", "throw"],
+                  },
+                },
+                required: ["variant"],
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Nested output",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    value: { type: "number" },
+                    nested: {
+                      type: "object",
+                      properties: { label: { type: "string" } },
+                      required: ["label"],
+                      additionalProperties: false,
+                    },
+                  },
+                  required: ["value", "nested"],
+                  additionalProperties: false,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {},
+});
+
+const getText = (result: CallToolResult): string => {
+  const content = result.content[0];
+  return content?.type === "text" ? content.text : "";
+};

--- a/tests/test-mcp/src/features/test_mcp_tool_output_validation.ts
+++ b/tests/test-mcp/src/features/test_mcp_tool_output_validation.ts
@@ -1,0 +1,191 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { TestValidator } from "@nestia/e2e";
+import { createMcpServer } from "@typia/mcp";
+import typia from "typia";
+
+/**
+ * Verifies declared class outputs fail in-band before MCP schema enforcement.
+ *
+ * The SDK client validates `structuredContent` after `tools/list`, so a server
+ * that returns a malformed success leaks protocol errors instead of a tool
+ * error the model can repair. This matrix crosses the real in-memory transport
+ * with both text-fallback modes and distinguishes output failures from void and
+ * exception results.
+ *
+ * 1. Connect an SDK client to a reflected class controller.
+ * 2. Accept one valid nested object under both text-fallback modes.
+ * 3. Reject every non-object and wrong-shaped declared result with stable paths.
+ * 4. Preserve true void success and thrown-exception tool errors.
+ */
+export const test_mcp_tool_output_validation = async (): Promise<void> => {
+  for (const textFallback of [false, true]) {
+    const server: McpServer = createMcpServer(
+      typia.llm.controller<OutputController>("output", new OutputController()),
+      { textFallback },
+    );
+    const client: Client = new Client({ name: "output-test", version: "1.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      const listed = await client.listTools();
+      const read: Tool | undefined = listed.tools.find(
+        (tool) => tool.name === "read",
+      );
+      const reset: Tool | undefined = listed.tools.find(
+        (tool) => tool.name === "reset",
+      );
+      TestValidator.predicate(
+        "declared result advertises outputSchema",
+        read?.outputSchema !== undefined,
+      );
+      TestValidator.predicate(
+        "void result omits outputSchema",
+        reset !== undefined && reset.outputSchema === undefined,
+      );
+
+      const valid: CallToolResult = (await client.callTool({
+        name: "read",
+        arguments: { variant: "valid" },
+      })) as CallToolResult;
+      TestValidator.equals("valid structured output", valid.structuredContent, {
+        value: 1,
+        nested: { label: "valid" },
+      });
+      TestValidator.equals(
+        "valid text fallback",
+        valid.content,
+        textFallback
+          ? [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  value: 1,
+                  nested: { label: "valid" },
+                }),
+              },
+            ]
+          : [],
+      );
+
+      for (const [variant, path] of invalidCases) {
+        const result: CallToolResult = (await client.callTool({
+          name: "read",
+          arguments: { variant },
+        })) as CallToolResult;
+        const text: string = getText(result);
+        TestValidator.predicate(
+          `${variant} returns a tool error`,
+          result.isError === true && result.structuredContent === undefined,
+        );
+        TestValidator.predicate(
+          `${variant} reports its validation path`,
+          text.includes('Type errors in "read" output:') && text.includes(path),
+        );
+      }
+
+      const resetResult: CallToolResult = (await client.callTool({
+        name: "reset",
+        arguments: {},
+      })) as CallToolResult;
+      TestValidator.predicate(
+        "true void remains successful",
+        resetResult.isError !== true &&
+          resetResult.structuredContent === undefined &&
+          getText(resetResult) === "Success",
+      );
+
+      const thrown: CallToolResult = (await client.callTool({
+        name: "fail",
+        arguments: {},
+      })) as CallToolResult;
+      TestValidator.predicate(
+        "exceptions remain execution errors",
+        thrown.isError === true && getText(thrown).includes("execution failed"),
+      );
+    } finally {
+      await Promise.allSettled([client.close(), server.close()]);
+    }
+  }
+};
+
+class OutputController {
+  /** Return a nested result selected by the test variant. */
+  read(input: OutputController.IInput): OutputController.IResult {
+    const valid: OutputController.IResult = {
+      value: 1,
+      nested: { label: "valid" },
+    };
+    switch (input.variant) {
+      case "valid":
+        return valid;
+      case "undefined":
+        return undefined as never;
+      case "null":
+        return null as never;
+      case "array":
+        return [valid] as never;
+      case "primitive":
+        return "invalid" as never;
+      case "missing":
+        return { nested: valid.nested } as never;
+      case "extra":
+        return { ...valid, extra: true } as never;
+      case "wrongNested":
+        return { ...valid, nested: { label: 42 } } as never;
+    }
+  }
+
+  /** Complete without a declared result. */
+  reset(_: OutputController.IEmpty): void {}
+
+  /** Throw a controller execution error. */
+  fail(_: OutputController.IEmpty): OutputController.IResult {
+    throw new Error("execution failed");
+  }
+}
+
+namespace OutputController {
+  export interface IInput {
+    variant: Variant;
+  }
+  export interface IEmpty {}
+  export interface IResult {
+    value: number;
+    nested: {
+      label: string;
+    };
+  }
+}
+
+type Variant =
+  | "valid"
+  | "undefined"
+  | "null"
+  | "array"
+  | "primitive"
+  | "missing"
+  | "extra"
+  | "wrongNested";
+
+const invalidCases: ReadonlyArray<
+  readonly [Exclude<Variant, "valid">, string]
+> = [
+  ["undefined", "$input"],
+  ["null", "$input"],
+  ["array", "$input.value"],
+  ["primitive", "$input"],
+  ["missing", "$input.value"],
+  ["extra", "$input.extra"],
+  ["wrongNested", "$input.nested.label"],
+];
+
+const getText = (result: CallToolResult): string => {
+  const content = result.content[0];
+  return content?.type === "text" ? content.text : "";
+};

--- a/tests/test-vercel/src/features/test_vercel_http_controller_output_validation.ts
+++ b/tests/test-vercel/src/features/test_vercel_http_controller_output_validation.ts
@@ -1,0 +1,136 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpLlmController, OpenApiV3_1 } from "@typia/interface";
+import { HttpLlm } from "@typia/utils";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+
+/**
+ * Verifies HTTP controller bodies obey their advertised Vercel output schema.
+ *
+ * HTTP tools execute a response-body adapter distinct from class methods. Its
+ * valid data must use the typed success branch, while wrong response bodies and
+ * thrown executor errors must use the same advertised failure branch.
+ *
+ * 1. Reflect a minimal HTTP operation with a nested response object.
+ * 2. Accept a valid body through the public Vercel tool.
+ * 3. Reject a wrong nested body with an actionable validation path.
+ * 4. Preserve a thrown HTTP executor exception in the failure branch.
+ */
+export const test_vercel_http_controller_output_validation =
+  async (): Promise<void> => {
+    const controller: IHttpLlmController = HttpLlm.controller({
+      name: "http-output",
+      document: document(),
+      connection: { host: "http://localhost:0" },
+      execute: async (props) => {
+        const { variant } = (props.arguments as { body: { variant: Variant } })
+          .body;
+        if (variant === "throw") throw new Error("http execution failed");
+        return {
+          status: 200,
+          headers: {},
+          body:
+            variant === "valid"
+              ? { value: 1, nested: { label: "valid" } }
+              : { value: 1, nested: { label: 42 } },
+        };
+      },
+    });
+    const tools: Record<string, Tool> = toVercelTools(controller);
+    const tool: Tool = tools[controller.application.functions[0]!.name]!;
+
+    const valid: unknown = await execute(tool, "valid");
+    TestValidator.equals("valid HTTP body uses the success branch", valid, {
+      success: true,
+      data: { value: 1, nested: { label: "valid" } },
+    });
+
+    const invalid = (await execute(tool, "invalid")) as {
+      success?: boolean;
+      error?: string;
+    };
+    TestValidator.predicate(
+      "invalid HTTP body uses the actionable failure branch",
+      invalid.success === false &&
+        typeof invalid.error === "string" &&
+        invalid.error.includes('Type errors in "read_post" output:') &&
+        invalid.error.includes('"path":"$input.nested.label"'),
+    );
+
+    const thrown = (await execute(tool, "throw")) as {
+      success?: boolean;
+      error?: string;
+    };
+    TestValidator.predicate(
+      "HTTP executor exception remains a failure result",
+      thrown.success === false &&
+        typeof thrown.error === "string" &&
+        thrown.error.includes("http execution failed"),
+    );
+  };
+
+type Variant = "valid" | "invalid" | "throw";
+
+const execute = (tool: Tool, variant: Variant): Promise<unknown> =>
+  tool.execute!(
+    { body: { variant } },
+    {
+      toolCallId: `test-http-${variant}-output`,
+      messages: [],
+      abortSignal: undefined as any,
+    },
+  );
+
+const document = (): OpenApiV3_1.IDocument => ({
+  openapi: "3.1.0",
+  info: { title: "Output validation", version: "1.0.0" },
+  paths: {
+    "/read": {
+      post: {
+        operationId: "post_httpOutput_read",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  variant: {
+                    type: "string",
+                    enum: ["valid", "invalid", "throw"],
+                  },
+                },
+                required: ["variant"],
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Nested output",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    value: { type: "number" },
+                    nested: {
+                      type: "object",
+                      properties: { label: { type: "string" } },
+                      required: ["label"],
+                      additionalProperties: false,
+                    },
+                  },
+                  required: ["value", "nested"],
+                  additionalProperties: false,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {},
+});

--- a/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
@@ -6,6 +6,19 @@ import typia from "typia";
 
 import { Calculator } from "../structures/Calculator";
 
+/**
+ * Verifies Vercel tools validate every declared class output before success.
+ *
+ * The advertised result schema has a typed success branch and a textual failure
+ * branch, but the AI SDK does not validate a controller's return value for the
+ * adapter. The adapter must reject the complete non-object and wrong-shaped
+ * matrix itself, including exact-property violations.
+ *
+ * 1. Confirm the public output schema exposes success and failure branches.
+ * 2. Preserve a valid nested object in the typed success branch.
+ * 3. Route undefined, null, array, primitive, and wrong-shaped values through the
+ *    schema-conforming failure branch with actionable paths.
+ */
 export const test_vercel_tool_output_schema = async (): Promise<void> => {
   const controller: ILlmController<Calculator> =
     typia.llm.controller<Calculator>("calculator", new Calculator());
@@ -45,40 +58,103 @@ export const test_vercel_tool_output_schema = async (): Promise<void> => {
     },
   );
 
-  const broken: Record<string, Tool> = toVercelTools(
-    typia.llm.controller<BrokenOutput>("broken", new BrokenOutput()),
+  const outputs: Record<string, Tool> = toVercelTools(
+    typia.llm.controller<OutputController>("output", new OutputController()),
   );
-  const brokenResult: unknown = await broken["read"]!.execute!(
-    {},
+  const valid: unknown = await outputs["read"]!.execute!(
+    { variant: "valid" },
     {
-      toolCallId: "test-broken-output",
+      toolCallId: "test-valid-output",
       messages: [],
       abortSignal: undefined as any,
     },
   );
-  TestValidator.equals(
-    "typed undefined result should match outputSchema error branch",
-    brokenResult,
-    {
-      success: false,
-      error:
-        'Function "read" returned undefined despite declaring an output schema',
-    },
-  );
+  TestValidator.equals("valid nested output uses the success branch", valid, {
+    success: true,
+    data: { value: 1, nested: { label: "valid" } },
+  });
+
+  for (const [variant, path] of invalidCases) {
+    const result: unknown = await outputs["read"]!.execute!(
+      { variant },
+      {
+        toolCallId: `test-${variant}-output`,
+        messages: [],
+        abortSignal: undefined as any,
+      },
+    );
+    TestValidator.predicate(`${variant} uses the failure branch`, () => {
+      const failure = result as { success?: boolean; error?: string };
+      return (
+        failure.success === false &&
+        typeof failure.error === "string" &&
+        failure.error.includes('Type errors in "read" output:') &&
+        failure.error.includes(path)
+      );
+    });
+  }
 };
 
-class BrokenOutput {
-  /** Read a typed result but violate it at runtime. */
-  read(_: BrokenOutput.IProps): BrokenOutput.IResult {
-    return undefined as any;
+class OutputController {
+  /** Return a nested result selected by the test variant. */
+  read(input: OutputController.IInput): OutputController.IResult {
+    const valid: OutputController.IResult = {
+      value: 1,
+      nested: { label: "valid" },
+    };
+    switch (input.variant) {
+      case "valid":
+        return valid;
+      case "undefined":
+        return undefined as never;
+      case "null":
+        return null as never;
+      case "array":
+        return [valid] as never;
+      case "primitive":
+        return "invalid" as never;
+      case "missing":
+        return { nested: valid.nested } as never;
+      case "extra":
+        return { ...valid, extra: true } as never;
+      case "wrongNested":
+        return { ...valid, nested: { label: 42 } } as never;
+    }
   }
 }
-namespace BrokenOutput {
-  export interface IProps {}
+namespace OutputController {
+  export interface IInput {
+    variant: Variant;
+  }
   export interface IResult {
     value: number;
+    nested: {
+      label: string;
+    };
   }
 }
+
+type Variant =
+  | "valid"
+  | "undefined"
+  | "null"
+  | "array"
+  | "primitive"
+  | "missing"
+  | "extra"
+  | "wrongNested";
+
+const invalidCases: ReadonlyArray<
+  readonly [Exclude<Variant, "valid">, string]
+> = [
+  ["undefined", "$input"],
+  ["null", "$input"],
+  ["array", "$input.value"],
+  ["primitive", "$input"],
+  ["missing", "$input.value"],
+  ["extra", "$input.extra"],
+  ["wrongNested", "$input.nested.label"],
+];
 
 interface IJsonSchema {
   anyOf?: IJsonSchema[] | undefined;

--- a/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
@@ -89,7 +89,8 @@ export const test_vercel_tool_output_schema = async (): Promise<void> => {
         failure.success === false &&
         typeof failure.error === "string" &&
         failure.error.includes('Type errors in "read" output:') &&
-        failure.error.includes(path)
+        failure.error.includes(path) &&
+        !failure.error.includes("```json\n```json")
       );
     });
   }

--- a/tests/test-vercel/src/features/test_vercel_tool_void_result.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_void_result.ts
@@ -1,0 +1,46 @@
+import { TestValidator } from "@nestia/e2e";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+import typia from "typia";
+
+/**
+ * Verifies a true void Vercel tool remains a schema-free success.
+ *
+ * Runtime `undefined` is invalid only when a reflected output exists. A method
+ * declared as `void` must keep the existing `{ success: true }` result and must
+ * not advertise a fabricated typed data branch.
+ *
+ * 1. Reflect and convert a void class method.
+ * 2. Assert it has no output schema.
+ * 3. Execute it and assert the schema-free success result is preserved.
+ */
+export const test_vercel_tool_void_result = async (): Promise<void> => {
+  const tools: Record<string, Tool> = toVercelTools(
+    typia.llm.controller<VoidController>("void", new VoidController()),
+  );
+  const reset: Tool = tools["reset"]!;
+  TestValidator.predicate(
+    "void tool does not advertise outputSchema",
+    reset.outputSchema === undefined,
+  );
+  const result: unknown = await reset.execute!(
+    {},
+    {
+      toolCallId: "test-void-output",
+      messages: [],
+      abortSignal: undefined as any,
+    },
+  );
+  TestValidator.equals("void tool remains successful", result, {
+    success: true,
+  });
+};
+
+class VoidController {
+  /** Complete without a declared result. */
+  reset(_: VoidController.IProps): void {}
+}
+
+namespace VoidController {
+  export interface IProps {}
+}

--- a/website/src/content/docs/utilization/mcp.mdx
+++ b/website/src/content/docs/utilization/mcp.mdx
@@ -160,6 +160,8 @@ When a method's return type is reflected (`ILlmFunction.output`), the tool adver
 
 as its `outputSchema`, and a call returns `structuredContent: { value: 15 }` — once, with no duplicate rendering.
 
+Before returning a successful structured result, `@typia/mcp` validates the controller value against that reflected schema, including required fields, nested types, and additional properties. A mismatch returns `isError: true` with annotated validation paths and no `structuredContent`, so the client receives an in-band tool error instead of rejecting a malformed protocol response.
+
 The MCP spec also recommends serializing the same JSON into a text block, as a fallback for clients that ignore `outputSchema`. But that doubles every result on the wire, and a client that caps tool-result size counts both copies — a large result gets rejected at double its real size even though the payload itself fits. So the fallback is opt-in:
 
 ```typescript filename="src/main.ts" showLineNumbers {3}
@@ -188,12 +190,13 @@ For the mechanics of `parse` / `coerce` / `validate` / `stringify`, see [`LlmJso
 
 ## Runtime errors
 
-There are two distinct failure modes when a tool is called, and the server keeps the MCP conversation alive through both:
+There are three distinct failure modes when a tool is called, and the server keeps the MCP conversation alive through all of them:
 
 - **Validation error** — the LLM passed arguments that don't match the schema. The tool returns `isError: true` with the annotated input (the same `// ❌` markers as above) so the model can fix it.
+- **Output validation error** — the controller returned a value that doesn't match its reflected return type. The tool returns `isError: true` with annotated output paths instead of sending invalid `structuredContent`.
 - **Runtime error** — the tool itself threw (e.g. divide-by-zero, network failure, business-rule violation). The tool returns `isError: true` with the error name and message, instead of letting the exception propagate and crash the server.
 
-In both cases the model sees the failure and can either retry with different inputs or report back to the user, so a single bad call never tears down the session.
+In all three cases the model sees the failure and can either retry with different inputs or report back to the user, so a single bad call never tears down the session.
 
 ## Where to go next
 

--- a/website/src/content/docs/utilization/vercel.mdx
+++ b/website/src/content/docs/utilization/vercel.mdx
@@ -112,6 +112,8 @@ const result: GenerateTextResult = await generateText({
 
 The JSDoc on each method becomes the tool description; the parameter type becomes the JSON schema. Every method on `Calculator` is now a Vercel `Tool`. Tool names default to the bare method name; pass `{ prefix: true }` as the second argument to `toVercelTools` to get `{controllerName}_{methodName}` instead. Final tool names must be unique even with prefixes enabled, so controllers that still emit the same name are rejected before registration. The older `toVercelTools({ controllers: [...] })` form still works when that shape is clearer for multiple controllers. When a method has a reflected return type, the tool also advertises an `outputSchema` for the `{ success, data/error }` result wrapper returned by `execute`.
 
+`execute` validates each controller result against the reflected return schema before using the success branch. Missing fields, wrong nested types, additional properties, and non-object values return `{ success: false, error }` with annotated output paths, so every result still conforms to the advertised wrapper schema. A method declared as `void` keeps the schema-free `{ success: true }` result.
+
 <Tabs items={[
     <code>Calculator</code>,
     <code>BbsArticleService</code>,


### PR DESCRIPTION
## Intent

Enforce the reflected runtime output schemas that `@typia/mcp` and `@typia/vercel` already advertise so invalid controller return values become adapter-level tool errors instead of malformed successes.

## Scope

- Validate declared class and HTTP controller outputs before producing successful MCP or Vercel results.
- Preserve true `void` success, controller exceptions, argument-validation behavior, and MCP `textFallback` semantics.
- Cover the public MCP SDK client/transport boundary and both adapter integration matrices.

## Deferred

- LangChain remains unchanged because it does not advertise an output schema.
- Controller return types, dependency versions, and adapter dependencies remain unchanged.

## Verification

Pending tests-first implementation, package builds, public integration, full `test-mcp`/`test-vercel`, relevant utils/interface suites, and solo Self-Review. Campaign CI is cancelled per exact-SHA policy; local verification is authoritative.

Closes #2086
