### PR TITLE
fix(generate): preserve filesystem identity and traversal bounds

### DIFF
--- a/packages/typia/src/executable/FileSystemIdentity.ts
+++ b/packages/typia/src/executable/FileSystemIdentity.ts
@@ -1,0 +1,171 @@
+import fs from "fs";
+import path from "path";
+
+export namespace FileSystemIdentity {
+  export interface IIdentity {
+    readonly caseSensitive: boolean;
+    contains(file: string, directory: string): boolean;
+    filesystemKey(file: string): string;
+    isDeclarationFile(file: string): boolean;
+    isSamePath(x: string, y: string): boolean;
+    isSupportedExtension(file: string): boolean;
+    projectFileKey(file: string): string;
+  }
+
+  export function create(
+    caseSensitive: boolean,
+    pathApi: typeof path.posix = path,
+  ): IIdentity {
+    const fold = (value: string): string =>
+      caseSensitive ? value : value.toLowerCase();
+    const filesystemKey = (file: string): string =>
+      fold(pathApi.normalize(file));
+    return {
+      caseSensitive,
+      contains: (file, directory) => {
+        const fileKey: string = filesystemKey(pathApi.resolve(file));
+        const directoryKey: string = filesystemKey(pathApi.resolve(directory));
+        const prefix: string = directoryKey.endsWith(pathApi.sep)
+          ? directoryKey
+          : `${directoryKey}${pathApi.sep}`;
+        return fileKey === directoryKey || fileKey.startsWith(prefix);
+      },
+      filesystemKey,
+      isDeclarationFile: (file) =>
+        DTS_PATTERN.test(fold(pathApi.basename(file))),
+      isSamePath: (x, y) => filesystemKey(x) === filesystemKey(y),
+      isSupportedExtension: (file) => {
+        const filename: string = fold(pathApi.basename(file));
+        return (
+          TS_PATTERN.test(filename) && DTS_PATTERN.test(filename) === false
+        );
+      },
+      projectFileKey: fold,
+    };
+  }
+
+  export class Policy {
+    private caseSensitive_: boolean | undefined;
+    private location_: string | undefined;
+
+    public observe(caseSensitive: boolean | undefined, location: string): void {
+      if (caseSensitive === undefined) return;
+      if (this.caseSensitive_ === undefined) {
+        this.caseSensitive_ = caseSensitive;
+        this.location_ = location;
+      } else if (this.caseSensitive_ !== caseSensitive) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): inconsistent filesystem case behavior between ${this.location_} and ${location}.`,
+        );
+      }
+    }
+
+    public get(): IIdentity {
+      if (this.caseSensitive_ === undefined) {
+        throw new URIError(
+          "Error on TypiaGenerateWizard.generate(): unable to determine filesystem case behavior for this run.",
+        );
+      }
+      return create(this.caseSensitive_);
+    }
+  }
+
+  export async function inspectDirectory(
+    directory: string,
+  ): Promise<boolean | undefined> {
+    const names: string[] = await fs.promises.readdir(directory);
+    const entries: Set<string> = new Set(names);
+    for (const name of names) {
+      const alternate: string | undefined = alternateCase(name);
+      if (alternate === undefined) continue;
+      if (entries.has(alternate)) return true;
+      try {
+        await fs.promises.lstat(path.join(directory, alternate));
+        return false;
+      } catch (error) {
+        if (isMissingFileError(error)) return true;
+        throw error;
+      }
+    }
+    return undefined;
+  }
+
+  export async function probeDirectory(directory: string): Promise<boolean> {
+    const inspected: boolean | undefined = await inspectDirectory(directory);
+    if (inspected !== undefined) return inspected;
+
+    for (let attempt = 0; attempt < 10; ++attempt) {
+      const name: string =
+        `.typia-case-probe-${process.pid}-${Date.now()}-${Math.random()
+          .toString(36)
+          .slice(2)}`.toLowerCase();
+      const original: string = path.join(directory, name);
+      const alternate: string = path.join(directory, name.toUpperCase());
+      let handle: fs.promises.FileHandle;
+      try {
+        handle = await fs.promises.open(original, "wx");
+      } catch (error) {
+        if (isAlreadyExistsError(error)) continue;
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): unable to probe filesystem case behavior at ${directory}: ${formatUnknownError(error)}`,
+        );
+      }
+      try {
+        await handle.close();
+        try {
+          await fs.promises.lstat(alternate);
+          return false;
+        } catch (error) {
+          if (isMissingFileError(error)) return true;
+          throw error;
+        }
+      } finally {
+        await handle.close().catch(() => undefined);
+        await fs.promises.unlink(original).catch(() => undefined);
+      }
+    }
+    throw new URIError(
+      `Error on TypiaGenerateWizard.generate(): unable to reserve a filesystem case probe at ${directory}.`,
+    );
+  }
+
+  function alternateCase(name: string): string | undefined {
+    let changed: boolean = false;
+    let output: string = "";
+    for (const character of name) {
+      if (character >= "a" && character <= "z") {
+        output += character.toUpperCase();
+        changed = true;
+      } else if (character >= "A" && character <= "Z") {
+        output += character.toLowerCase();
+        changed = true;
+      } else output += character;
+    }
+    return changed ? output : undefined;
+  }
+
+  function isAlreadyExistsError(error: unknown): boolean {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "EEXIST"
+    );
+  }
+
+  function isMissingFileError(error: unknown): boolean {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    );
+  }
+
+  function formatUnknownError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+const TS_PATTERN = /\.[cm]?tsx?$/;
+const DTS_PATTERN = /\.d\.[cm]?tsx?$/;

--- a/packages/typia/src/executable/FileSystemIdentity.ts
+++ b/packages/typia/src/executable/FileSystemIdentity.ts
@@ -110,8 +110,10 @@ export namespace FileSystemIdentity {
           `Error on TypiaGenerateWizard.generate(): unable to probe filesystem case behavior at ${directory}: ${formatUnknownError(error)}`,
         );
       }
+      let closed: boolean = false;
       try {
         await handle.close();
+        closed = true;
         try {
           await fs.promises.lstat(alternate);
           return false;
@@ -120,8 +122,24 @@ export namespace FileSystemIdentity {
           throw error;
         }
       } finally {
-        await handle.close().catch(() => undefined);
-        await fs.promises.unlink(original).catch(() => undefined);
+        let cleanupError: unknown;
+        if (closed === false) {
+          try {
+            await handle.close();
+          } catch (error) {
+            cleanupError = error;
+          }
+        }
+        try {
+          await fs.promises.unlink(original);
+        } catch (error) {
+          if (isMissingFileError(error) === false) cleanupError ??= error;
+        }
+        if (cleanupError !== undefined) {
+          throw new URIError(
+            `Error on TypiaGenerateWizard.generate(): unable to clean filesystem case probe ${original}: ${formatUnknownError(cleanupError)}`,
+          );
+        }
       }
     }
     throw new URIError(

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -221,7 +221,7 @@ export namespace TypiaGenerateWizard {
         JSON.stringify({
           extends: props.project,
           exclude: [],
-          files: props.entries.map((entry) => entry.file),
+          files: props.entries.map((entry) => resolveRealPath(entry.file)),
           include: [],
         }),
         "utf8",

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -121,6 +121,11 @@ export namespace TypiaGenerateWizard {
         ? await prepareDirectoryInput(location, policy)
         : await prepareFileInputs(location, policy);
     const identity: FileSystemIdentity.IIdentity = policy.get();
+    await inspectTargetDirectories({
+      identity,
+      output: location.output,
+      targets: entries.map((entry) => entry.target),
+    });
 
     const binary = resolveTsgoBinary();
     const cwd = path.dirname(location.project);
@@ -247,25 +252,8 @@ export namespace TypiaGenerateWizard {
     output: string;
     targets: string[];
   }): Promise<void> {
-    const directories: Map<string, string> = new Map();
-    for (const target of props.targets) {
-      const directory: string = path.dirname(target);
-      directories.set(props.identity.filesystemKey(directory), directory);
-    }
-
-    for (const directory of directories.values()) {
-      await ensureOutputAncestorDirectories({
-        identity: props.identity,
-        output: props.output,
-        directory,
-      });
-      if (fs.existsSync(directory)) {
-        await ensureExistingDirectory({
-          label: "output parent path",
-          directory,
-        });
-      }
-    }
+    await inspectTargetDirectories(props);
+    const directories: Map<string, string> = targetDirectories(props);
     for (const directory of directories.values()) {
       try {
         await fs.promises.mkdir(directory, { recursive: true });
@@ -279,6 +267,39 @@ export namespace TypiaGenerateWizard {
         directory,
       });
     }
+  }
+
+  async function inspectTargetDirectories(props: {
+    identity: FileSystemIdentity.IIdentity;
+    output: string;
+    targets: string[];
+  }): Promise<void> {
+    const directories: Map<string, string> = targetDirectories(props);
+    for (const directory of directories.values()) {
+      await ensureOutputAncestorDirectories({
+        identity: props.identity,
+        output: props.output,
+        directory,
+      });
+      if (fs.existsSync(directory)) {
+        await ensureExistingDirectory({
+          label: "output parent path",
+          directory,
+        });
+      }
+    }
+  }
+
+  function targetDirectories(props: {
+    identity: FileSystemIdentity.IIdentity;
+    targets: string[];
+  }): Map<string, string> {
+    const directories: Map<string, string> = new Map();
+    for (const target of props.targets) {
+      const directory: string = path.dirname(target);
+      directories.set(props.identity.filesystemKey(directory), directory);
+    }
+    return directories;
   }
 
   async function ensureCreatableDirectory(directory: string): Promise<void> {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -2,12 +2,15 @@ import { createCommand } from "commander";
 import fs from "fs";
 import inquirer from "inquirer";
 import { createRequire } from "module";
+import os from "os";
 import path from "path";
 import { glob, isDynamicPattern } from "tinyglobby";
 import type {
   ITtscCompilerDiagnostic,
   ITtscCompilerTransformation,
 } from "ttsc";
+
+import { FileSystemIdentity } from "./FileSystemIdentity";
 
 export namespace TypiaGenerateWizard {
   export async function generate(): Promise<void> {
@@ -98,24 +101,56 @@ export namespace TypiaGenerateWizard {
     location.output = path.resolve(location.output);
     location.project = resolveProjectConfigFile(location.project);
 
+    const policy = new FileSystemIdentity.Policy();
+    const outputProbe: string = await nearestExistingAncestor(location.output);
+    await ensureExistingDirectoryPath({
+      label: "output parent path",
+      directory: outputProbe,
+    });
+    policy.observe(
+      await FileSystemIdentity.probeDirectory(outputProbe),
+      outputProbe,
+    );
+    policy.observe(
+      await FileSystemIdentity.inspectDirectory(path.dirname(location.project)),
+      path.dirname(location.project),
+    );
+
     const entries: IInputFile[] =
       location.files.length === 0
-        ? await prepareDirectoryInput(location)
-        : await prepareFileInputs(location);
+        ? await prepareDirectoryInput(location, policy)
+        : await prepareFileInputs(location, policy);
+    const identity: FileSystemIdentity.IIdentity = policy.get();
 
     const binary = resolveTsgoBinary();
     const cwd = path.dirname(location.project);
-    const transformed = transformProject({
-      binary,
-      cwd,
-      tsconfig: location.project,
+    const temporaryProject: ITemporaryProject = await createTemporaryProject({
+      entries,
+      project: location.project,
     });
-    const outputByKey: Map<string, string> =
-      indexTransformedOutputs(transformed);
+    let transformed: Record<string, string>;
+    try {
+      transformed = transformProject({
+        binary,
+        cwd,
+        projectRoot: cwd,
+        tsconfig: temporaryProject.config,
+      });
+    } finally {
+      await fs.promises.rm(temporaryProject.directory, {
+        force: true,
+        recursive: true,
+      });
+    }
+    const outputByKey: Map<string, string> = indexTransformedOutputs(
+      transformed,
+      identity,
+    );
     const outputs: IOutputFile[] = entries.map((entry) => {
       const output = getTransformedOutput({
         cwd,
         entry,
+        identity,
         outputByKey,
       });
       if (output === undefined) {
@@ -128,14 +163,19 @@ export namespace TypiaGenerateWizard {
 
     await ensureOutputDirectory(location.output);
     await ensureTargetDirectories({
+      identity,
       output: location.output,
       targets: outputs.map(({ entry }) => entry.target),
     });
     await ensurePhysicalTargets({
+      identity,
       output: location.output,
       entries: outputs.map(({ entry }) => entry),
     });
-    await ensureTargetFiles(outputs.map(({ entry }) => entry));
+    await ensureTargetFiles(
+      outputs.map(({ entry }) => entry),
+      identity,
+    );
     for (const { entry, output } of outputs) {
       await fs.promises.writeFile(entry.target, formatOutput(output), "utf8");
     }
@@ -151,6 +191,45 @@ export namespace TypiaGenerateWizard {
     output: string;
   }
 
+  interface ITraversalEntry {
+    file: string;
+    name: string;
+    stat: fs.Stats;
+  }
+
+  interface ITemporaryProject {
+    config: string;
+    directory: string;
+  }
+
+  async function createTemporaryProject(props: {
+    entries: IInputFile[];
+    project: string;
+  }): Promise<ITemporaryProject> {
+    const directory: string = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "typia-generate-project-"),
+    );
+    const config: string = path.join(directory, "tsconfig.json");
+    try {
+      await fs.promises.writeFile(
+        config,
+        JSON.stringify({
+          extends: props.project,
+          exclude: [],
+          files: props.entries.map((entry) => entry.file),
+          include: [],
+        }),
+        "utf8",
+      );
+      return { config, directory };
+    } catch (error) {
+      await fs.promises.rm(directory, { force: true, recursive: true });
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): unable to prepare the bounded input project: ${formatUnknownError(error)}`,
+      );
+    }
+  }
+
   async function ensureOutputDirectory(output: string): Promise<void> {
     if (fs.existsSync(output) === false) {
       await ensureCreatableDirectory(output);
@@ -164,17 +243,19 @@ export namespace TypiaGenerateWizard {
   }
 
   async function ensureTargetDirectories(props: {
+    identity: FileSystemIdentity.IIdentity;
     output: string;
     targets: string[];
   }): Promise<void> {
     const directories: Map<string, string> = new Map();
     for (const target of props.targets) {
       const directory: string = path.dirname(target);
-      directories.set(filesystemKey(directory), directory);
+      directories.set(props.identity.filesystemKey(directory), directory);
     }
 
     for (const directory of directories.values()) {
       await ensureOutputAncestorDirectories({
+        identity: props.identity,
         output: props.output,
         directory,
       });
@@ -223,12 +304,13 @@ export namespace TypiaGenerateWizard {
   }
 
   async function ensureOutputAncestorDirectories(props: {
+    identity: FileSystemIdentity.IIdentity;
     output: string;
     directory: string;
   }): Promise<void> {
     const output: string = path.resolve(props.output);
     const directory: string = path.resolve(props.directory);
-    if (isSameOrChildPath(directory, output) === false) {
+    if (props.identity.contains(directory, output) === false) {
       throw new URIError(
         `Error on TypiaGenerateWizard.generate(): output parent path escapes output directory: ${props.directory}`,
       );
@@ -285,7 +367,7 @@ export namespace TypiaGenerateWizard {
       current = path.join(current, segment);
       await ensureExistingDirectorySegment({
         label:
-          filesystemKey(current) === filesystemKey(directory)
+          path.normalize(current) === path.normalize(directory)
             ? props.label
             : `${props.label} ancestor`,
         directory: current,
@@ -311,26 +393,29 @@ export namespace TypiaGenerateWizard {
   }
 
   async function ensurePhysicalTargets(props: {
+    identity: FileSystemIdentity.IIdentity;
     output: string;
     entries: IInputFile[];
   }): Promise<void> {
     const output: string = await fs.promises.realpath(props.output);
     const inputs: Set<string> = new Set();
     for (const entry of props.entries) {
-      inputs.add(filesystemKey(await fs.promises.realpath(entry.file)));
+      inputs.add(
+        props.identity.filesystemKey(await fs.promises.realpath(entry.file)),
+      );
     }
 
     for (const entry of props.entries) {
       const parent: string = path.dirname(entry.target);
       const directory: string = await fs.promises.realpath(parent);
-      if (isSameOrChildPath(directory, output) === false) {
+      if (props.identity.contains(directory, output) === false) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): output parent path escapes output directory through a symbolic link: ${parent}`,
         );
       }
 
       const target: string = path.join(directory, path.basename(entry.target));
-      if (inputs.has(filesystemKey(target))) {
+      if (inputs.has(props.identity.filesystemKey(target))) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): output file would overwrite input file through a symbolic link: ${entry.target}`,
         );
@@ -338,12 +423,15 @@ export namespace TypiaGenerateWizard {
     }
   }
 
-  async function ensureTargetFiles(entries: IInputFile[]): Promise<void> {
+  async function ensureTargetFiles(
+    entries: IInputFile[],
+    identity: FileSystemIdentity.IIdentity,
+  ): Promise<void> {
     const inputs: Set<string> = new Set();
     const files: Map<string, IInputFile> = new Map();
     for (const entry of entries) {
       inputs.add(fileIdentityKey(await fs.promises.stat(entry.file)));
-      files.set(filesystemKey(entry.target), entry);
+      files.set(identity.filesystemKey(entry.target), entry);
     }
 
     for (const entry of files.values()) {
@@ -378,6 +466,7 @@ export namespace TypiaGenerateWizard {
 
   async function prepareDirectoryInput(
     location: IArguments,
+    policy: FileSystemIdentity.Policy,
   ): Promise<IInputFile[]> {
     if (location.input === undefined) {
       throw new URIError(
@@ -396,15 +485,19 @@ export namespace TypiaGenerateWizard {
       );
     }
 
+    const inputReal: string = await fs.promises.realpath(input);
+    const outputReal: string | undefined = await optionalRealPath(
+      location.output,
+    );
     const files: string[] = [];
     await gather({
-      location: {
-        input,
-        output: location.output,
-      },
       container: files,
       from: input,
-      to: location.output,
+      inputReal,
+      outputReal,
+      policy,
+      visitedDirectories: new Set(),
+      visitedFiles: new Set(),
     });
     return files.map((file) => ({
       file,
@@ -414,14 +507,21 @@ export namespace TypiaGenerateWizard {
 
   async function prepareFileInputs(
     location: IArguments,
+    policy: FileSystemIdentity.Policy,
   ): Promise<IInputFile[]> {
     const targets: Set<string> = new Set();
     const output: IInputFile[] = [];
     for (const input of await expandFileInputs(
       location.files,
       location.output,
+      policy,
     )) {
       const file: string = path.resolve(input);
+      policy.observe(
+        await FileSystemIdentity.inspectDirectory(path.dirname(file)),
+        path.dirname(file),
+      );
+      const identity: FileSystemIdentity.IIdentity = policy.get();
       if (fs.existsSync(file) === false) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): input file does not exist: ${input}`,
@@ -430,21 +530,21 @@ export namespace TypiaGenerateWizard {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): input path is not a file: ${input}`,
         );
-      } else if (isDeclarationFile(file)) {
+      } else if (identity.isDeclarationFile(file)) {
         continue;
-      } else if (isSupportedExtension(file) === false) {
+      } else if (identity.isSupportedExtension(file) === false) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): input file is not a supported TypeScript source: ${input}`,
         );
       }
 
       const target: string = path.join(location.output, path.basename(file));
-      if (isSamePath(file, target)) {
+      if (identity.isSamePath(file, target)) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): output file would overwrite input file: ${input}`,
         );
       }
-      const key: string = filesystemKey(target);
+      const key: string = identity.filesystemKey(target);
       if (targets.has(key)) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): duplicate output filename for ${target}`,
@@ -464,14 +564,21 @@ export namespace TypiaGenerateWizard {
   async function expandFileInputs(
     inputs: string[],
     directory: string,
+    policy: FileSystemIdentity.Policy,
   ): Promise<string[]> {
     const output: string[] = [];
     for (const input of inputs) {
       const pattern: string = toGlobPattern(input);
       if (isDynamicPattern(pattern, { caseSensitiveMatch: true })) {
+        const searchDirectory: string = await globSearchDirectory(input);
+        policy.observe(
+          await FileSystemIdentity.inspectDirectory(searchDirectory),
+          searchDirectory,
+        );
+        const identity: FileSystemIdentity.IIdentity = policy.get();
         const matches: string[] = await glob(pattern, {
           absolute: true,
-          caseSensitiveMatch: isCaseSensitive(),
+          caseSensitiveMatch: identity.caseSensitive,
           cwd: process.cwd(),
           onlyFiles: true,
         });
@@ -481,13 +588,17 @@ export namespace TypiaGenerateWizard {
           );
         }
         output.push(
-          ...excludeOutputFiles(matches, directory).filter(
-            isSupportedExtension,
+          ...excludeOutputFiles(matches, directory, identity).filter((file) =>
+            identity.isSupportedExtension(file),
           ),
         );
       } else {
         const file: string = path.resolve(input);
-        if (isSameOrChildPath(file, directory) === false) {
+        policy.observe(
+          await FileSystemIdentity.inspectDirectory(path.dirname(file)),
+          path.dirname(file),
+        );
+        if (policy.get().contains(file, directory) === false) {
           output.push(file);
         }
       }
@@ -495,8 +606,25 @@ export namespace TypiaGenerateWizard {
     return output;
   }
 
-  function excludeOutputFiles(files: string[], directory: string): string[] {
-    return files.filter((file) => isSameOrChildPath(file, directory) === false);
+  function excludeOutputFiles(
+    files: string[],
+    directory: string,
+    identity: FileSystemIdentity.IIdentity,
+  ): string[] {
+    return files.filter((file) => identity.contains(file, directory) === false);
+  }
+
+  async function globSearchDirectory(input: string): Promise<string> {
+    let current: string = path.resolve(input);
+    while (
+      isDynamicPattern(toGlobPattern(current), { caseSensitiveMatch: true })
+    ) {
+      const parent: string = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+    if (fs.existsSync(current) && (await isDirectory(current))) return current;
+    return nearestExistingAncestor(path.dirname(current));
   }
 
   function toGlobPattern(input: string): string {
@@ -506,12 +634,14 @@ export namespace TypiaGenerateWizard {
   function transformProject(props: {
     binary: string;
     cwd: string;
+    projectRoot: string;
     tsconfig: string;
   }): Record<string, string> {
     const TtscCompiler = loadTtscCompiler();
     const result: ITtscCompilerTransformation = new TtscCompiler({
       binary: props.binary,
       cwd: props.cwd,
+      projectRoot: props.projectRoot,
       tsconfig: props.tsconfig,
     }).transform();
     if (result.type === "success") {
@@ -690,47 +820,100 @@ export namespace TypiaGenerateWizard {
   }
 
   async function gather(props: {
-    location: {
-      input: string;
-      output: string;
-    };
     container: string[];
     from: string;
-    to: string;
+    inputReal: string;
+    outputReal: string | undefined;
+    policy: FileSystemIdentity.Policy;
+    visitedDirectories: Set<string>;
+    visitedFiles: Set<string>;
   }): Promise<void> {
-    if (isSamePath(props.from, props.location.output)) return;
+    const currentReal: string = await resolveTraversalPath(props.from);
+    if (
+      props.outputReal !== undefined &&
+      isPhysicalSameOrChildPath(currentReal, props.outputReal)
+    )
+      return;
+    ensurePhysicalInputContainment({
+      file: props.from,
+      input: props.inputReal,
+      real: currentReal,
+    });
 
-    for (const file of await fs.promises.readdir(props.from)) {
-      const next: string = path.join(props.from, file);
-      const stat: fs.Stats = await fs.promises.stat(next);
+    const currentStat: fs.Stats = await fs.promises.stat(props.from);
+    const directoryIdentity: string = fileIdentityKey(currentStat);
+    if (props.visitedDirectories.has(directoryIdentity)) {
+      const lexicalStat: fs.Stats = await fs.promises.lstat(props.from);
+      if (lexicalStat.isSymbolicLink()) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): input directory link revisits a physical directory: ${props.from}.`,
+        );
+      }
+      return;
+    }
+    props.visitedDirectories.add(directoryIdentity);
+
+    props.policy.observe(
+      await FileSystemIdentity.inspectDirectory(props.from),
+      props.from,
+    );
+    const identity: FileSystemIdentity.IIdentity = props.policy.get();
+    const entries: ITraversalEntry[] = await Promise.all(
+      (await fs.promises.readdir(props.from)).map(async (name) => {
+        const file: string = path.join(props.from, name);
+        try {
+          return { file, name, stat: await fs.promises.lstat(file) };
+        } catch (error) {
+          throw new URIError(
+            `Error on TypiaGenerateWizard.generate(): unable to inspect input path ${file}: ${formatUnknownError(error)}`,
+          );
+        }
+      }),
+    );
+    entries.sort((x, y) => {
+      const linkOrder: number =
+        Number(x.stat.isSymbolicLink()) - Number(y.stat.isSymbolicLink());
+      return linkOrder !== 0 ? linkOrder : x.name.localeCompare(y.name);
+    });
+
+    for (const entry of entries) {
+      let stat: fs.Stats;
+      let real: string;
+      try {
+        stat = await fs.promises.stat(entry.file);
+        real = await fs.promises.realpath(entry.file);
+      } catch (error) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): input link target is missing or unreadable: ${entry.file}: ${formatUnknownError(error)}`,
+        );
+      }
+
+      if (
+        props.outputReal !== undefined &&
+        isPhysicalSameOrChildPath(real, props.outputReal)
+      )
+        continue;
+      ensurePhysicalInputContainment({
+        file: entry.file,
+        input: props.inputReal,
+        real,
+      });
 
       if (stat.isDirectory()) {
-        await gather({
-          location: props.location,
-          container: props.container,
-          from: next,
-          to: path.join(props.to, file),
-        });
+        await gather({ ...props, from: entry.file });
         continue;
       }
-      if (isSupportedExtension(file)) {
-        props.container.push(next);
-      }
+      if (
+        stat.isFile() === false ||
+        identity.isSupportedExtension(entry.name) === false
+      )
+        continue;
+
+      const fileIdentity: string = fileIdentityKey(stat);
+      if (props.visitedFiles.has(fileIdentity)) continue;
+      props.visitedFiles.add(fileIdentity);
+      props.container.push(entry.file);
     }
-  }
-
-  function isSupportedExtension(filename: string): boolean {
-    const normalized: string = isCaseSensitive()
-      ? filename
-      : filename.toLowerCase();
-    return TS_PATTERN.test(normalized) && !DTS_PATTERN.test(normalized);
-  }
-
-  function isDeclarationFile(filename: string): boolean {
-    const normalized: string = isCaseSensitive()
-      ? filename
-      : filename.toLowerCase();
-    return DTS_PATTERN.test(normalized);
   }
 
   function formatOutput(output: string): string {
@@ -741,10 +924,17 @@ export namespace TypiaGenerateWizard {
 
   function indexTransformedOutputs(
     outputs: Record<string, string>,
+    identity: FileSystemIdentity.IIdentity,
   ): Map<string, string> {
     const map: Map<string, string> = new Map();
     for (const [file, output] of Object.entries(outputs)) {
-      map.set(projectFileKey(file), output);
+      const key: string = identity.projectFileKey(file);
+      if (map.has(key)) {
+        throw new URIError(
+          `Error on TypiaGenerateWizard.generate(): transformed outputs have ambiguous filesystem identities: ${file}.`,
+        );
+      }
+      map.set(key, output);
     }
     return map;
   }
@@ -752,10 +942,11 @@ export namespace TypiaGenerateWizard {
   function getTransformedOutput(props: {
     cwd: string;
     entry: IInputFile;
+    identity: FileSystemIdentity.IIdentity;
     outputByKey: Map<string, string>;
   }): string | undefined {
     const output = props.outputByKey.get(
-      projectFileKey(projectKey(props.cwd, props.entry.file)),
+      props.identity.projectFileKey(projectKey(props.cwd, props.entry.file)),
     );
     if (output !== undefined) {
       return output;
@@ -763,20 +954,18 @@ export namespace TypiaGenerateWizard {
 
     const real: string = resolveRealPath(props.entry.file);
     if (
-      isSamePath(real, props.entry.file) ||
-      isSameOrChildPath(real, props.cwd) === false
+      props.identity.isSamePath(real, props.entry.file) ||
+      props.identity.contains(real, props.cwd) === false
     ) {
       return undefined;
     }
-    return props.outputByKey.get(projectFileKey(projectKey(props.cwd, real)));
+    return props.outputByKey.get(
+      props.identity.projectFileKey(projectKey(props.cwd, real)),
+    );
   }
 
   function projectKey(root: string, file: string): string {
     return path.relative(root, file).replace(/\\/g, "/");
-  }
-
-  function projectFileKey(file: string): string {
-    return isCaseSensitive() ? file : file.toLowerCase();
   }
 
   function resolveRealPath(file: string): string {
@@ -787,26 +976,46 @@ export namespace TypiaGenerateWizard {
     }
   }
 
-  function isSamePath(x: string, y: string): boolean {
-    return filesystemKey(x) === filesystemKey(y);
+  async function optionalRealPath(file: string): Promise<string | undefined> {
+    try {
+      return await fs.promises.realpath(file);
+    } catch (error) {
+      if (isMissingFileError(error)) return undefined;
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): unable to resolve path ${file}: ${formatUnknownError(error)}`,
+      );
+    }
   }
 
-  function isSameOrChildPath(file: string, directory: string): boolean {
-    const fileKey: string = filesystemKey(path.resolve(file));
-    const directoryKey: string = filesystemKey(path.resolve(directory));
-    const directoryPrefix: string = directoryKey.endsWith(path.sep)
-      ? directoryKey
-      : `${directoryKey}${path.sep}`;
-    return fileKey === directoryKey || fileKey.startsWith(directoryPrefix);
+  async function resolveTraversalPath(file: string): Promise<string> {
+    try {
+      return await fs.promises.realpath(file);
+    } catch (error) {
+      throw new URIError(
+        `Error on TypiaGenerateWizard.generate(): unable to resolve input path ${file}: ${formatUnknownError(error)}`,
+      );
+    }
   }
 
-  function filesystemKey(file: string): string {
-    const normalized: string = path.normalize(file);
-    return isCaseSensitive() ? normalized : normalized.toLowerCase();
+  function ensurePhysicalInputContainment(props: {
+    file: string;
+    input: string;
+    real: string;
+  }): void {
+    if (isPhysicalSameOrChildPath(props.real, props.input)) return;
+    throw new URIError(
+      `Error on TypiaGenerateWizard.generate(): input path resolves outside the input directory: ${props.file}.`,
+    );
   }
 
-  function isCaseSensitive(): boolean {
-    return process.platform !== "win32" && process.platform !== "darwin";
+  function isPhysicalSameOrChildPath(file: string, directory: string): boolean {
+    const relative: string = path.relative(directory, file);
+    return (
+      relative === "" ||
+      (relative !== ".." &&
+        relative.startsWith(`..${path.sep}`) === false &&
+        path.isAbsolute(relative) === false)
+    );
   }
 
   function isMissingFileError(exp: unknown): boolean {
@@ -855,6 +1064,3 @@ export namespace TypiaGenerateWizard {
     return String(error);
   }
 }
-
-const TS_PATTERN = /\.[cm]?tsx?$/;
-const DTS_PATTERN = /\.d\.[cm]?tsx?$/;

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -221,7 +221,7 @@ export namespace TypiaGenerateWizard {
         JSON.stringify({
           extends: props.project,
           exclude: [],
-          files: props.entries.map((entry) => resolveRealPath(entry.file)),
+          files: props.entries.map((entry) => compilerInputPath(entry.file)),
           include: [],
         }),
         "utf8",
@@ -986,6 +986,17 @@ export namespace TypiaGenerateWizard {
       return output;
     }
 
+    const compilerFile: string = compilerInputPath(props.entry.file);
+    if (
+      props.identity.isSamePath(compilerFile, props.entry.file) === false &&
+      props.identity.contains(compilerFile, props.cwd)
+    ) {
+      const compiled: string | undefined = props.outputByKey.get(
+        props.identity.projectFileKey(projectKey(props.cwd, compilerFile)),
+      );
+      if (compiled !== undefined) return compiled;
+    }
+
     const real: string = resolveRealPath(props.entry.file);
     if (
       props.identity.isSamePath(real, props.entry.file) ||
@@ -1008,6 +1019,20 @@ export namespace TypiaGenerateWizard {
     } catch {
       return file;
     }
+  }
+
+  function compilerInputPath(file: string): string {
+    try {
+      if (fs.lstatSync(file).isSymbolicLink()) {
+        return path.join(
+          resolveRealPath(path.dirname(file)),
+          path.basename(file),
+        );
+      }
+    } catch {
+      return file;
+    }
+    return resolveRealPath(file);
   }
 
   async function optionalRealPath(file: string): Promise<string | undefined> {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -451,7 +451,12 @@ export namespace TypiaGenerateWizard {
     const inputs: Set<string> = new Set();
     const files: Map<string, IInputFile> = new Map();
     for (const entry of entries) {
-      inputs.add(fileIdentityKey(await fs.promises.stat(entry.file)));
+      inputs.add(
+        fileIdentityKey(
+          await fs.promises.stat(entry.file),
+          await fs.promises.realpath(entry.file),
+        ),
+      );
       files.set(identity.filesystemKey(entry.target), entry);
     }
 
@@ -472,7 +477,11 @@ export namespace TypiaGenerateWizard {
           `Error on TypiaGenerateWizard.generate(): output file path is not a regular file: ${entry.target}`,
         );
       }
-      if (inputs.has(fileIdentityKey(stat))) {
+      if (
+        inputs.has(
+          fileIdentityKey(stat, await fs.promises.realpath(entry.target)),
+        )
+      ) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): output file would overwrite input file through a physical file alias: ${entry.target}`,
         );
@@ -592,10 +601,14 @@ export namespace TypiaGenerateWizard {
       const pattern: string = toGlobPattern(input);
       if (isDynamicPattern(pattern, { caseSensitiveMatch: true })) {
         const searchDirectory: string = await globSearchDirectory(input);
-        policy.observe(
-          await FileSystemIdentity.inspectDirectory(searchDirectory),
-          searchDirectory,
-        );
+        const caseSensitive: boolean | undefined =
+          await FileSystemIdentity.inspectDirectory(searchDirectory);
+        if (caseSensitive === undefined) {
+          throw new URIError(
+            `Error on TypiaGenerateWizard.generate(): unable to determine filesystem case behavior for input pattern base ${searchDirectory}.`,
+          );
+        }
+        policy.observe(caseSensitive, searchDirectory);
         const identity: FileSystemIdentity.IIdentity = policy.get();
         const matches: string[] = await glob(pattern, {
           absolute: true,
@@ -862,7 +875,7 @@ export namespace TypiaGenerateWizard {
     });
 
     const currentStat: fs.Stats = await fs.promises.stat(props.from);
-    const directoryIdentity: string = fileIdentityKey(currentStat);
+    const directoryIdentity: string = fileIdentityKey(currentStat, currentReal);
     if (props.visitedDirectories.has(directoryIdentity)) {
       const lexicalStat: fs.Stats = await fs.promises.lstat(props.from);
       if (lexicalStat.isSymbolicLink()) {
@@ -930,7 +943,7 @@ export namespace TypiaGenerateWizard {
       )
         continue;
 
-      const fileIdentity: string = fileIdentityKey(stat);
+      const fileIdentity: string = fileIdentityKey(stat, real);
       if (props.visitedFiles.has(fileIdentity)) continue;
       props.visitedFiles.add(fileIdentity);
       props.container.push(entry.file);
@@ -1048,8 +1061,10 @@ export namespace TypiaGenerateWizard {
     );
   }
 
-  function fileIdentityKey(stat: fs.Stats): string {
-    return `${stat.dev}:${stat.ino}`;
+  function fileIdentityKey(stat: fs.Stats, realpath: string): string {
+    return stat.ino === 0
+      ? `path:${path.normalize(realpath)}`
+      : `inode:${stat.dev}:${stat.ino}`;
   }
 
   function formatDiagnostics(diagnostics: ITtscCompilerDiagnostic[]): string {

--- a/tests/test-typia-generate/package.json
+++ b/tests/test-typia-generate/package.json
@@ -15,19 +15,18 @@
     "generate:files:implicit-jsconfig": "pnpm run clean && ttsx --cwd jsconfig-dir/src ../../node_modules/typia/src/executable/typia.ts generate --output ../../src/output generate_jsconfig.ts",
     "generate:files:rerun": "ttsx node_modules/typia/src/executable/typia.ts generate --project tsconfig.files.json --output src/output \"src/**/generate_module.ts\"",
     "check:files:errors": "node scripts/check-file-errors.cjs",
+    "check:files:filesystem": "node --test --test-concurrency=1 scripts/filesystem/*.test.cjs",
+    "check:files:identity": "ttsx --cwd ../../packages/typia --project ../../tests/test-typia-generate/tsconfig.identity.json --no-plugins ../../tests/test-typia-generate/scripts/identity/run.ts",
     "check:files": "node -e \"require('fs').accessSync('src/output/generate_module.ts')\"",
     "check:files:project-directory": "node -e \"require('fs').accessSync('src/output/generate_project.ts')\"",
     "check:files:implicit-jsconfig": "node -e \"require('fs').accessSync('src/output/generate_jsconfig.ts')\"",
-    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:rerun && pnpm run check:files && pnpm run generate:files:literals && pnpm run check:files && pnpm run generate:files:project-directory && pnpm run check:files:project-directory && pnpm run generate:files:implicit-project && pnpm run check:files:project-directory && pnpm run generate:files:implicit-jsconfig && pnpm run check:files:implicit-jsconfig && pnpm run build"
+    "start": "pnpm run generate:directory && pnpm run build && pnpm run check:files:errors && pnpm run check:files:identity && pnpm run check:files:filesystem && pnpm run generate:files && pnpm run check:files && pnpm run generate:files:rerun && pnpm run check:files && pnpm run generate:files:literals && pnpm run check:files && pnpm run generate:files:project-directory && pnpm run check:files:project-directory && pnpm run generate:files:implicit-project && pnpm run check:files:project-directory && pnpm run generate:files:implicit-jsconfig && pnpm run check:files:implicit-jsconfig && pnpm run build"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/samchon/typia"
   },
-  "keywords": [
-    "typia",
-    "test"
-  ],
+  "keywords": ["typia", "test"],
   "author": "Jeongho Nam",
   "license": "MIT",
   "bugs": {

--- a/tests/test-typia-generate/scripts/filesystem/ambiguous-glob-case.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/ambiguous-glob-case.test.cjs
@@ -1,0 +1,39 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  createFixture,
+  diagnostic,
+  runFileGenerate,
+  writeSource,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies a glob fails safely when its base reveals no case behavior.
+ *
+ * Locks explicit-file expansion before tinyglobby selects a case policy; using
+ * output semantics here could silently miss sources on a different filesystem.
+ *
+ * 1. Place a source below a glob base whose immediate entry names contain no
+ *    letters.
+ * 2. Assert expansion reports ambiguous case behavior and creates no output.
+ */
+test("ambiguous glob case behavior is rejected", () => {
+  const fixture = createFixture();
+  try {
+    writeSource(path.join(fixture.input, "123", "source.ts"));
+    const result = runFileGenerate(fixture, [
+      path.join(fixture.input, "*", "*.ts"),
+    ]);
+    assert.equal(result.error, undefined, diagnostic(result));
+    assert.notEqual(result.status, 0, diagnostic(result));
+    assert.match(
+      diagnostic(result),
+      /unable to determine.*case behavior.*input pattern base/is,
+    );
+    assert.equal(fs.existsSync(fixture.output), false);
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/filesystem/broken-link.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/broken-link.test.cjs
@@ -1,0 +1,32 @@
+const { test } = require("node:test");
+const path = require("node:path");
+const {
+  createFixture,
+  expectFailureWithoutOutput,
+  linkDirectory,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies directory generation rejects a broken filesystem link explicitly.
+ *
+ * Locks the lstat-before-stat branch so missing link targets produce a bounded,
+ * path-specific failure instead of an unclassified traversal exception.
+ *
+ * 1. Add a directory link whose target does not exist.
+ * 2. Assert generation names the broken link and creates no output directory.
+ */
+test("broken input links are rejected", () => {
+  const fixture = createFixture();
+  try {
+    linkDirectory(
+      path.join(fixture.root, "missing"),
+      path.join(fixture.input, "broken"),
+    );
+    expectFailureWithoutOutput(
+      fixture,
+      /broken.*(missing|target|inspect)|(?:missing|target|inspect).*broken/is,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/filesystem/external-directory-link.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/external-directory-link.test.cjs
@@ -1,0 +1,34 @@
+const { test } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  createFixture,
+  expectFailureWithoutOutput,
+  linkDirectory,
+  writeSource,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies directory generation rejects links outside the physical input root.
+ *
+ * Locks the containment boundary so a lexically nested link cannot silently
+ * import an unrelated TypeScript tree.
+ *
+ * 1. Link an input entry to an external directory containing a source file.
+ * 2. Assert generation reports the link path and creates no output directory.
+ */
+test("external directory links are rejected", () => {
+  const fixture = createFixture();
+  try {
+    const external = path.join(fixture.root, "external");
+    fs.mkdirSync(external);
+    writeSource(path.join(external, "external.ts"));
+    linkDirectory(external, path.join(fixture.input, "external-link"));
+    expectFailureWithoutOutput(
+      fixture,
+      /external-link.*outside.*input|outside.*input.*external-link/is,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/filesystem/fixture.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/fixture.cjs
@@ -1,0 +1,137 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const workspace = path.resolve(__dirname, "..", "..");
+const repository = path.resolve(workspace, "..", "..");
+const ttscRoot = path.dirname(
+  require.resolve("ttsc/package.json", { paths: [repository] }),
+);
+const executable = path.join(ttscRoot, "lib", "launcher", "ttsx.js");
+const cli = path.join(
+  repository,
+  "packages",
+  "typia",
+  "src",
+  "executable",
+  "typia.ts",
+);
+
+const createFixture = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "typia-generate-fs-"));
+  const input = path.join(root, "input");
+  const output = path.join(root, "output");
+  fs.mkdirSync(input);
+  fs.writeFileSync(
+    path.join(root, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "commonjs",
+        strict: true,
+        target: "ES2022",
+      },
+      include: ["input/**/*.ts"],
+    }),
+  );
+  return {
+    input,
+    output,
+    root,
+    cleanup: () => fs.rmSync(root, { force: true, recursive: true }),
+  };
+};
+
+const writeSource = (file, value = path.basename(file)) => {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `export const value = ${JSON.stringify(value)};\n`);
+};
+
+const linkDirectory = (target, link) => {
+  fs.symlinkSync(
+    target,
+    link,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+};
+
+const linkFile = (target, link) => {
+  fs.symlinkSync(target, link, process.platform === "win32" ? "file" : "file");
+};
+
+const runGenerate = (fixture, timeout = 180_000) =>
+  spawnSync(
+    process.execPath,
+    [
+      executable,
+      "--no-plugins",
+      cli,
+      "generate",
+      "--input",
+      fixture.input,
+      "--output",
+      fixture.output,
+      "--project",
+      path.join(fixture.root, "tsconfig.json"),
+    ],
+    {
+      cwd: path.join(repository, "packages", "typia"),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        TTSC_CACHE_DIR: path.join(
+          repository,
+          "packages",
+          "typia",
+          "node_modules",
+          ".cache",
+          "ttsc",
+        ),
+      },
+      timeout,
+    },
+  );
+
+const diagnostic = (result) =>
+  [result.error?.message, result.stdout, result.stderr]
+    .filter((text) => text)
+    .join("\n");
+
+const expectSuccess = (fixture, expected) => {
+  const result = runGenerate(fixture);
+  assert.equal(result.error, undefined, diagnostic(result));
+  assert.equal(result.status, 0, diagnostic(result));
+  assert.deepEqual(listFiles(fixture.output), [...expected].sort());
+};
+
+const expectFailureWithoutOutput = (fixture, pattern) => {
+  const result = runGenerate(fixture);
+  assert.equal(result.error, undefined, diagnostic(result));
+  assert.notEqual(result.status, 0, diagnostic(result));
+  assert.match(diagnostic(result), pattern);
+  assert.equal(fs.existsSync(fixture.output), false, diagnostic(result));
+};
+
+const listFiles = (directory, prefix = "") => {
+  if (fs.existsSync(directory) === false) return [];
+  const output = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const relative = path.join(prefix, entry.name);
+    if (entry.isDirectory())
+      output.push(...listFiles(path.join(directory, entry.name), relative));
+    else output.push(relative.replace(/\\/g, "/"));
+  }
+  return output.sort();
+};
+
+module.exports = {
+  createFixture,
+  expectFailureWithoutOutput,
+  expectSuccess,
+  linkDirectory,
+  linkFile,
+  listFiles,
+  runGenerate,
+  writeSource,
+};

--- a/tests/test-typia-generate/scripts/filesystem/fixture.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/fixture.cjs
@@ -60,7 +60,7 @@ const linkFile = (target, link) => {
   fs.symlinkSync(target, link, process.platform === "win32" ? "file" : "file");
 };
 
-const runGenerate = (fixture, timeout = 180_000) =>
+const runCli = (fixture, args, timeout) =>
   spawnSync(
     process.execPath,
     [
@@ -68,12 +68,11 @@ const runGenerate = (fixture, timeout = 180_000) =>
       "--no-plugins",
       cli,
       "generate",
-      "--input",
-      fixture.input,
       "--output",
       fixture.output,
       "--project",
       path.join(fixture.root, "tsconfig.json"),
+      ...args,
     ],
     {
       cwd: path.join(repository, "packages", "typia"),
@@ -92,6 +91,12 @@ const runGenerate = (fixture, timeout = 180_000) =>
       timeout,
     },
   );
+
+const runGenerate = (fixture, timeout = 180_000) =>
+  runCli(fixture, ["--input", fixture.input], timeout);
+
+const runFileGenerate = (fixture, files, timeout = 180_000) =>
+  runCli(fixture, files, timeout);
 
 const diagnostic = (result) =>
   [result.error?.message, result.stdout, result.stderr]
@@ -132,6 +137,7 @@ const listFiles = (directory, prefix = "") => {
 
 module.exports = {
   createFixture,
+  diagnostic,
   expectFailure,
   expectFailureWithoutOutput,
   expectSuccess,
@@ -139,5 +145,6 @@ module.exports = {
   linkFile,
   listFiles,
   runGenerate,
+  runFileGenerate,
   writeSource,
 };

--- a/tests/test-typia-generate/scripts/filesystem/fixture.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/fixture.cjs
@@ -105,11 +105,16 @@ const expectSuccess = (fixture, expected) => {
   assert.deepEqual(listFiles(fixture.output), [...expected].sort());
 };
 
-const expectFailureWithoutOutput = (fixture, pattern) => {
+const expectFailure = (fixture, pattern) => {
   const result = runGenerate(fixture);
   assert.equal(result.error, undefined, diagnostic(result));
   assert.notEqual(result.status, 0, diagnostic(result));
   assert.match(diagnostic(result), pattern);
+  return result;
+};
+
+const expectFailureWithoutOutput = (fixture, pattern) => {
+  const result = expectFailure(fixture, pattern);
   assert.equal(fs.existsSync(fixture.output), false, diagnostic(result));
 };
 
@@ -127,6 +132,7 @@ const listFiles = (directory, prefix = "") => {
 
 module.exports = {
   createFixture,
+  expectFailure,
   expectFailureWithoutOutput,
   expectSuccess,
   linkDirectory,

--- a/tests/test-typia-generate/scripts/filesystem/mutual-cycle.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/mutual-cycle.test.cjs
@@ -1,0 +1,32 @@
+const { test } = require("node:test");
+const path = require("node:path");
+const {
+  createFixture,
+  expectFailureWithoutOutput,
+  linkDirectory,
+  writeSource,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies directory generation terminates across a two-directory link cycle.
+ *
+ * Locks physical identity tracking across sibling branches, where neither
+ * lexical link path is an ancestor of the other.
+ *
+ * 1. Link two input directories to one another and add a source to each.
+ * 2. Generate with a bounded subprocess and assert rejection precedes output.
+ */
+test("mutual directory links terminate", () => {
+  const fixture = createFixture();
+  try {
+    const left = path.join(fixture.input, "left");
+    const right = path.join(fixture.input, "right");
+    writeSource(path.join(left, "left.ts"));
+    writeSource(path.join(right, "right.ts"));
+    linkDirectory(right, path.join(left, "right-link"));
+    linkDirectory(left, path.join(right, "left-link"));
+    expectFailureWithoutOutput(fixture, /link.*revisits|revisits.*link/is);
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/filesystem/output-directory-alias.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/output-directory-alias.test.cjs
@@ -1,0 +1,38 @@
+const { test } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  createFixture,
+  expectSuccess,
+  linkDirectory,
+  writeSource,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies an input alias to the physical output tree is excluded.
+ *
+ * Locks physical output exclusion so a differently spelled path cannot turn
+ * stale generated files back into fresh inputs.
+ *
+ * 1. Pre-create the output with a stale source and link to it from the input.
+ * 2. Generate one real input and assert the alias tree is not copied.
+ */
+test("physical output aliases are excluded", () => {
+  const fixture = createFixture();
+  try {
+    writeSource(path.join(fixture.input, "source.ts"));
+    fs.mkdirSync(fixture.output);
+    writeSource(path.join(fixture.output, "stale.ts"));
+    linkDirectory(fixture.output, path.join(fixture.input, "output-alias"));
+    fs.writeFileSync(
+      path.join(fixture.root, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: { module: "commonjs", strict: true, target: "ES2022" },
+        files: ["input/source.ts"],
+      }),
+    );
+    expectSuccess(fixture, ["source.ts", "stale.ts"]);
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/filesystem/output-parent-link.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/output-parent-link.test.cjs
@@ -1,0 +1,38 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  createFixture,
+  expectFailure,
+  linkDirectory,
+  writeSource,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies generated targets cannot cross a linked output parent directory.
+ *
+ * Locks the handoff from bounded input gathering to the existing output safety
+ * checks, where matching input-relative segments can otherwise mask the link.
+ *
+ * 1. Map an input `link/new` source to an output whose `link` is an external
+ *    junction.
+ * 2. Assert generation rejects the parent and creates no directory outside output.
+ */
+test("linked output parent directories are rejected", () => {
+  const fixture = createFixture();
+  try {
+    const external = path.join(fixture.root, "external");
+    writeSource(path.join(fixture.input, "link", "new", "source.ts"));
+    fs.mkdirSync(fixture.output);
+    fs.mkdirSync(external);
+    linkDirectory(external, path.join(fixture.output, "link"));
+    expectFailure(
+      fixture,
+      /output parent path.*symbolic link|symbolic link.*output parent path/is,
+    );
+    assert.equal(fs.existsSync(path.join(external, "new")), false);
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/filesystem/parent-cycle.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/parent-cycle.test.cjs
@@ -1,0 +1,29 @@
+const { test } = require("node:test");
+const path = require("node:path");
+const {
+  createFixture,
+  expectFailureWithoutOutput,
+  linkDirectory,
+  writeSource,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies directory generation terminates when a child links to its parent.
+ *
+ * Locks ancestor identity tracking rather than relying on the link's lexical
+ * spelling, which grows on every recursive visit.
+ *
+ * 1. Put a source in a nested directory and link that directory to the input root.
+ * 2. Generate with a bounded subprocess and assert rejection precedes output.
+ */
+test("parent directory links terminate", () => {
+  const fixture = createFixture();
+  try {
+    const nested = path.join(fixture.input, "nested");
+    writeSource(path.join(nested, "source.ts"));
+    linkDirectory(fixture.input, path.join(nested, "parent"));
+    expectFailureWithoutOutput(fixture, /parent.*revisits|revisits.*parent/is);
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/filesystem/repeated-directory-aliases.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/repeated-directory-aliases.test.cjs
@@ -8,7 +8,7 @@ const {
 } = require("./fixture.cjs");
 
 /**
- * Verifies repeated directory aliases emit each physical source once.
+ * Verifies repeated directory aliases are rejected before transformation.
  *
  * Locks deterministic directory de-duplication so alias order cannot multiply
  * transformed output or choose different target trees between runs.
@@ -16,7 +16,7 @@ const {
  * 1. Add one real source directory and two links to that directory.
  * 2. Generate and assert aliases are rejected before output is created.
  */
-test("repeated directory aliases are deduplicated", () => {
+test("repeated directory aliases are rejected", () => {
   const fixture = createFixture();
   try {
     const actual = path.join(fixture.input, "actual");

--- a/tests/test-typia-generate/scripts/filesystem/repeated-directory-aliases.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/repeated-directory-aliases.test.cjs
@@ -1,0 +1,33 @@
+const { test } = require("node:test");
+const path = require("node:path");
+const {
+  createFixture,
+  expectFailureWithoutOutput,
+  linkDirectory,
+  writeSource,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies repeated directory aliases emit each physical source once.
+ *
+ * Locks deterministic directory de-duplication so alias order cannot multiply
+ * transformed output or choose different target trees between runs.
+ *
+ * 1. Add one real source directory and two links to that directory.
+ * 2. Generate and assert aliases are rejected before output is created.
+ */
+test("repeated directory aliases are deduplicated", () => {
+  const fixture = createFixture();
+  try {
+    const actual = path.join(fixture.input, "actual");
+    writeSource(path.join(actual, "source.ts"));
+    linkDirectory(actual, path.join(fixture.input, "alias-a"));
+    linkDirectory(actual, path.join(fixture.input, "alias-b"));
+    expectFailureWithoutOutput(
+      fixture,
+      /alias-a.*revisits|revisits.*alias-a/is,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/filesystem/self-cycle.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/self-cycle.test.cjs
@@ -1,0 +1,29 @@
+const { test } = require("node:test");
+const path = require("node:path");
+const {
+  createFixture,
+  expectFailureWithoutOutput,
+  linkDirectory,
+  writeSource,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies directory generation terminates at a self-referential link.
+ *
+ * Locks the visited-directory identity guard so a lexical path cannot re-enter
+ * the same physical root until path exhaustion.
+ *
+ * 1. Add one source and a directory link from the input root to itself; on Windows
+ *    the fixture creates the equivalent directory junction.
+ * 2. Generate with a bounded subprocess and assert rejection precedes output.
+ */
+test("self-referential directory links terminate", () => {
+  const fixture = createFixture();
+  try {
+    writeSource(path.join(fixture.input, "source.ts"));
+    linkDirectory(fixture.input, path.join(fixture.input, "loop"));
+    expectFailureWithoutOutput(fixture, /loop.*revisits|revisits.*loop/is);
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/filesystem/source-file-link.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/source-file-link.test.cjs
@@ -19,7 +19,7 @@ const {
 test("in-root source-file links remain supported", (context) => {
   const fixture = createFixture();
   try {
-    const source = path.join(fixture.input, "source.ts");
+    const source = path.join(fixture.input, "source.txt");
     writeSource(source);
     try {
       linkFile(source, path.join(fixture.input, "source-link.ts"));
@@ -30,7 +30,7 @@ test("in-root source-file links remain supported", (context) => {
       }
       throw error;
     }
-    expectSuccess(fixture, ["source.ts"]);
+    expectSuccess(fixture, ["source-link.ts"]);
   } finally {
     fixture.cleanup();
   }

--- a/tests/test-typia-generate/scripts/filesystem/source-file-link.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/source-file-link.test.cjs
@@ -1,0 +1,37 @@
+const { test } = require("node:test");
+const path = require("node:path");
+const {
+  createFixture,
+  expectSuccess,
+  linkFile,
+  writeSource,
+} = require("./fixture.cjs");
+
+/**
+ * Verifies an ordinary in-root source-file link remains supported.
+ *
+ * Locks the positive link branch while directory and containment guards reject
+ * only unsafe traversal, not every symbolic input entry.
+ *
+ * 1. Add a real TypeScript source and a second filename linked to it.
+ * 2. Generate and assert the physical source is emitted exactly once.
+ */
+test("in-root source-file links remain supported", (context) => {
+  const fixture = createFixture();
+  try {
+    const source = path.join(fixture.input, "source.ts");
+    writeSource(source);
+    try {
+      linkFile(source, path.join(fixture.input, "source-link.ts"));
+    } catch (error) {
+      if (error?.code === "EPERM") {
+        context.skip("file symbolic links require Windows developer mode");
+        return;
+      }
+      throw error;
+    }
+    expectSuccess(fixture, ["source.ts"]);
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/tests/test-typia-generate/scripts/identity/case-insensitive.ts
+++ b/tests/test-typia-generate/scripts/identity/case-insensitive.ts
@@ -1,0 +1,38 @@
+import assert from "assert";
+import path from "path";
+
+import { FileSystemIdentity } from "../../../../packages/typia/src/executable/FileSystemIdentity";
+
+/**
+ * Verifies modeled case-insensitive paths coalesce aliases consistently.
+ *
+ * Locks directory, explicit-file, target, declaration, and realpath decisions
+ * to one filesystem policy even when the test host uses different semantics.
+ *
+ * 1. Model Windows paths as case-insensitive and compare differently cased names.
+ * 2. Assert all path keys fold and uppercase declarations remain filtered.
+ */
+export function testCaseInsensitiveIdentity(): void {
+  const identity = FileSystemIdentity.create(false, path.win32);
+  assert.equal(
+    identity.filesystemKey("C:\\src\\Foo.ts"),
+    identity.filesystemKey("c:\\SRC\\foo.ts"),
+  );
+  assert.equal(
+    identity.projectFileKey("src/Foo.ts"),
+    identity.projectFileKey("SRC/foo.ts"),
+  );
+  assert.equal(
+    identity.isSamePath("C:\\real\\Foo.ts", "c:\\REAL\\foo.ts"),
+    true,
+  );
+  assert.equal(identity.isSupportedExtension("C:\\src\\Foo.TS"), true);
+  assert.equal(identity.isDeclarationFile("C:\\src\\Foo.D.TS"), true);
+
+  const policy = new FileSystemIdentity.Policy();
+  policy.observe(false, "C:\\src");
+  assert.throws(
+    () => policy.observe(true, "D:\\output"),
+    /inconsistent filesystem case behavior/,
+  );
+}

--- a/tests/test-typia-generate/scripts/identity/case-sensitive.ts
+++ b/tests/test-typia-generate/scripts/identity/case-sensitive.ts
@@ -1,0 +1,28 @@
+import assert from "assert";
+import path from "path";
+
+import { FileSystemIdentity } from "../../../../packages/typia/src/executable/FileSystemIdentity";
+
+/**
+ * Verifies modeled case-sensitive paths retain distinct source identities.
+ *
+ * Locks behavior to the supplied filesystem model rather than the host OS, so
+ * case-sensitive APFS and per-directory Windows settings use exact names.
+ *
+ * 1. Model POSIX paths as case-sensitive and compare directory and file inputs.
+ * 2. Assert targets, project keys, declarations, and realpath keys stay exact.
+ */
+export function testCaseSensitiveIdentity(): void {
+  const identity = FileSystemIdentity.create(true, path.posix);
+  assert.notEqual(
+    identity.filesystemKey("/src/Foo.ts"),
+    identity.filesystemKey("/src/foo.ts"),
+  );
+  assert.notEqual(
+    identity.projectFileKey("src/Foo.ts"),
+    identity.projectFileKey("src/foo.ts"),
+  );
+  assert.equal(identity.isSamePath("/real/Foo.ts", "/real/foo.ts"), false);
+  assert.equal(identity.isSupportedExtension("/src/Foo.TS"), false);
+  assert.equal(identity.isDeclarationFile("/src/Foo.D.TS"), false);
+}

--- a/tests/test-typia-generate/scripts/identity/run.ts
+++ b/tests/test-typia-generate/scripts/identity/run.ts
@@ -1,0 +1,5 @@
+import { testCaseInsensitiveIdentity } from "./case-insensitive";
+import { testCaseSensitiveIdentity } from "./case-sensitive";
+
+testCaseSensitiveIdentity();
+testCaseInsensitiveIdentity();

--- a/tests/test-typia-generate/tsconfig.identity.json
+++ b/tests/test-typia-generate/tsconfig.identity.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "typeRoots": ["../../packages/typia/node_modules/@types"],
+    "types": ["node"]
+  },
+  "include": [
+    "scripts/identity/**/*.ts",
+    "../../packages/typia/src/executable/FileSystemIdentity.ts"
+  ]
+}


### PR DESCRIPTION
## Intent

Make `typia generate` use observed filesystem case behavior instead of host-platform heuristics, and bound directory input traversal by physical containment and identity.

## Implementation

- Observe one consistent case policy across the project, input, and output locations; fail closed on inconsistent or ambiguous filesystems.
- Preserve case-distinct transformed outputs on sensitive filesystems and reject folded target collisions on insensitive filesystems.
- Track physical directories/files with inode plus realpath fallback, reject cyclic or repeated directory links, reject external links, and exclude physical output aliases.
- Build a temporary ttsc config from only the validated inputs so the compiler cannot independently re-enter rejected directory links.
- Preserve final-component source symlinks while canonicalizing aliased project parents.
- Preflight linked output ancestors before transformation or writes.

## Verification

- `pnpm --filter typia build` (ttsc + rolldown)
- `pnpm --dir tests/test-typia-generate run check:files:errors`
- Modeled case-sensitive and case-insensitive identity cases
- Filesystem matrix: 9 passed, 1 local Windows privilege skip for file-symlink creation; the case runs on Linux CI
- Directory, file, rerun, literal, project-directory, implicit-project, and jsconfig generation/build paths
- Four findings-first solo Self-Review rounds; final round clean

Campaign GitHub Actions were cancelled per exact-SHA policy; local verification is authoritative.

Closes #2081
Closes #2082