### PR TITLE
fix(typia): make native checks and failed builds atomic

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/build.go
+++ b/packages/typia/native/cmd/ttsc-typia/build.go
@@ -55,26 +55,50 @@ func runBuild(args []string) int {
       return 2
     }
   }
-  prog, diags, err := driver.LoadProgram(cwd, *tsconfigPath, driver.LoadProgramOptions{
+  loadProgram := func(options driver.LoadProgramOptions) (*driver.Program, int) {
+    prog, diags, err := driver.LoadProgram(cwd, *tsconfigPath, options)
+    if err != nil {
+      fmt.Fprintf(stderr, "ttsc-typia build: %v\n", err)
+      return nil, 2
+    }
+    if len(diags) > 0 {
+      if prog != nil {
+        prog.Close()
+      }
+      driver.WritePrettyDiagnostics(stderr, diags, cwd)
+      return nil, 2
+    }
+    if diags := prog.Diagnostics(); len(diags) > 0 {
+      prog.Close()
+      driver.WritePrettyDiagnostics(stderr, diags, cwd)
+      return nil, 2
+    }
+    return prog, 0
+  }
+  prog, code := loadProgram(driver.LoadProgramOptions{
     ForceEmit:   *emit,
     ForceNoEmit: *noEmit,
     OutDir:      *outDir,
   })
-  if err != nil {
-    fmt.Fprintf(stderr, "ttsc-typia build: %v\n", err)
-    return 2
+  if code != 0 {
+    return code
   }
-  if len(diags) > 0 {
-    driver.WritePrettyDiagnostics(stderr, diags, cwd)
-    return 2
+  shouldEmit := !prog.ParsedConfig.ParsedConfig.CompilerOptions.NoEmit.IsTrue()
+  if !shouldEmit {
+    // The plugin transformer is part of tsgo's emit pipeline. Reload with emit
+    // enabled so check/noEmit traverses the exact same source set, then discard
+    // every generated output below.
+    prog.Close()
+    prog, code = loadProgram(driver.LoadProgramOptions{
+      ForceEmit: true,
+      OutDir:    *outDir,
+    })
+    if code != 0 {
+      return code
+    }
   }
   defer prog.Close()
-  if diags := prog.Diagnostics(); len(diags) > 0 {
-    driver.WritePrettyDiagnostics(stderr, diags, cwd)
-    return 2
-  }
 
-  shouldEmit := !prog.ParsedConfig.ParsedConfig.CompilerOptions.NoEmit.IsTrue()
   transformDiags := []typiaTransformDiagnostic{}
   pluginOptions := readTypiaPluginOptions(cwd, *tsconfigPath)
   transformOptions := pluginOptions.TransformOptions()
@@ -96,19 +120,33 @@ func runBuild(args []string) int {
   if !*quiet {
     fmt.Fprintf(stdout, "// ttsc-typia build: tsconfig=%s cwd=%s emit=%v rewrite=%s\n", *tsconfigPath, cwd, shouldEmit, *rewriteMode)
   }
-  if shouldEmit {
-    emitted := []string{}
-    writeFile := shimcompiler.WriteFile(func(fileName, text string, data *shimcompiler.WriteFileData) error {
+  emitted := []string{}
+  pending := []buildPendingOutput{}
+  writeFile := shimcompiler.WriteFile(func(fileName, text string, data *shimcompiler.WriteFileData) error {
+    if shouldEmit {
       emitted = append(emitted, fileName)
-      return driver.DefaultWriteFile(fileName, text)
-    })
-    eDiags, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{typiaTransform}, writeFile)
-    if err != nil {
-      fmt.Fprintf(stderr, "ttsc-typia build: emit failed: %v\n", err)
-      return 3
+      pending = append(pending, buildPendingOutput{FileName: fileName, Text: text})
     }
-    for _, d := range eDiags {
-      fmt.Fprintln(stderr, "  -", d.String())
+    return nil
+  })
+  eDiags, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{typiaTransform}, writeFile)
+  if err != nil {
+    fmt.Fprintf(stderr, "ttsc-typia build: emit failed: %v\n", err)
+    return 3
+  }
+  for _, d := range eDiags {
+    fmt.Fprintln(stderr, "  -", d.String())
+  }
+  if len(transformDiags) > 0 {
+    writeTypiaTransformDiagnostics(stderr, transformDiags, cwd)
+    return 3
+  }
+  if shouldEmit {
+    for _, output := range pending {
+      if err := driver.DefaultWriteFile(output.FileName, output.Text); err != nil {
+        fmt.Fprintf(stderr, "ttsc-typia build: emit write failed: %v\n", err)
+        return 3
+      }
     }
     if !*quiet {
       fmt.Fprintf(stdout, "// ttsc-typia build: emitted=%d files\n", len(emitted))
@@ -136,11 +174,12 @@ func runBuild(args []string) int {
       }
     }
   }
-  if len(transformDiags) > 0 {
-    writeTypiaTransformDiagnostics(stderr, transformDiags, cwd)
-    return 3
-  }
   return 0
+}
+
+type buildPendingOutput struct {
+  FileName string
+  Text     string
 }
 
 type typiaTransformDiagnostic struct {

--- a/packages/typia/native/cmd/ttsc-typia/build.go
+++ b/packages/typia/native/cmd/ttsc-typia/build.go
@@ -55,7 +55,7 @@ func runBuild(args []string) int {
       return 2
     }
   }
-  loadProgram := func(options driver.LoadProgramOptions) (*driver.Program, int) {
+  loadProgram := func(options driver.LoadProgramOptions, diagnose bool) (*driver.Program, int) {
     prog, diags, err := driver.LoadProgram(cwd, *tsconfigPath, options)
     if err != nil {
       fmt.Fprintf(stderr, "ttsc-typia build: %v\n", err)
@@ -68,10 +68,12 @@ func runBuild(args []string) int {
       driver.WritePrettyDiagnostics(stderr, diags, cwd)
       return nil, 2
     }
-    if diags := prog.Diagnostics(); len(diags) > 0 {
-      prog.Close()
-      driver.WritePrettyDiagnostics(stderr, diags, cwd)
-      return nil, 2
+    if diagnose {
+      if diags := prog.Diagnostics(); len(diags) > 0 {
+        prog.Close()
+        driver.WritePrettyDiagnostics(stderr, diags, cwd)
+        return nil, 2
+      }
     }
     return prog, 0
   }
@@ -79,7 +81,7 @@ func runBuild(args []string) int {
     ForceEmit:   *emit,
     ForceNoEmit: *noEmit,
     OutDir:      *outDir,
-  })
+  }, true)
   if code != 0 {
     return code
   }
@@ -87,12 +89,14 @@ func runBuild(args []string) int {
   if !shouldEmit {
     // The plugin transformer is part of tsgo's emit pipeline. Reload with emit
     // enabled so check/noEmit traverses the exact same source set, then discard
-    // every generated output below.
+    // every generated output below. The original program already proved the
+    // project's diagnostics; diagnosing the private reload would reject valid
+    // analysis-only options such as allowImportingTsExtensions.
     prog.Close()
     prog, code = loadProgram(driver.LoadProgramOptions{
       ForceEmit: true,
       OutDir:    *outDir,
-    })
+    }, false)
     if code != 0 {
       return code
     }

--- a/packages/typia/native/cmd/ttsc-typia/build_no_emit_preserves_analysis_options_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/build_no_emit_preserves_analysis_options_test.go
@@ -53,6 +53,9 @@ export const isValue = (input: unknown): input is { value: number } =>
   if code != 0 {
     t.Fatalf("valid analysis-only project failed with code %d\nstdout=%s\nstderr=%s", code, out, errText)
   }
+  if strings.TrimSpace(errText) != "" {
+    t.Fatalf("valid analysis-only project reported private emit diagnostics:\n%s", errText)
+  }
   for _, path := range []string{
     filepath.Join(project, "dist"),
     filepath.Join(project, "cache.tsbuildinfo"),

--- a/packages/typia/native/cmd/ttsc-typia/build_no_emit_preserves_analysis_options_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/build_no_emit_preserves_analysis_options_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestBuildNoEmitPreservesAnalysisOnlyOptions verifies forced traversal does
+// not invalidate options that are legal precisely because the project emits
+// nothing.
+//
+// `allowImportingTsExtensions` is valid with `noEmit`, but invalid in an
+// emitting program. The private emit-enabled traversal must therefore reuse
+// the already-proven TypeScript analysis instead of reporting diagnostics
+// introduced only by its internal override.
+//
+//  1. Create a valid no-emit typia project with allowImportingTsExtensions.
+//  2. Run the native build command through its configured no-emit path.
+//  3. Require success and prove the private traversal publishes no output.
+func TestBuildNoEmitPreservesAnalysisOnlyOptions(t *testing.T) {
+  project := buildNoEmitDiagnosticProject(t, true)
+  configPath := filepath.Join(project, "tsconfig.json")
+  config, err := os.ReadFile(configPath)
+  if err != nil {
+    t.Fatalf("read tsconfig: %v", err)
+  }
+  configured := strings.Replace(
+    string(config),
+    `"noEmit": true`,
+    `"noEmit": true,
+    "allowImportingTsExtensions": true`,
+    1,
+  )
+  if err := os.WriteFile(configPath, []byte(configured), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  source := `import typia from "typia";
+export const isValue = (input: unknown): input is { value: number } =>
+  typia.is<{ value: number }>(input);
+`
+  if err := os.WriteFile(filepath.Join(project, "src", "main.ts"), []byte(source), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runBuild([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("valid analysis-only project failed with code %d\nstdout=%s\nstderr=%s", code, out, errText)
+  }
+  for _, path := range []string{
+    filepath.Join(project, "dist"),
+    filepath.Join(project, "cache.tsbuildinfo"),
+  } {
+    if _, err := os.Stat(path); !os.IsNotExist(err) {
+      t.Fatalf("analysis-only traversal published %s: %v", path, err)
+    }
+  }
+}

--- a/packages/typia/native/cmd/ttsc-typia/build_no_emit_transform_diagnostics_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/build_no_emit_transform_diagnostics_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestBuildNoEmitReportsTransformDiagnostics verifies analysis-only transforms.
+//
+// TypeScript-clean source can still be invalid for typia. Check mode, an
+// explicit --noEmit flag, and tsconfig-owned noEmit must all run the same typia
+// analysis as emit mode without publishing any compiler artifact.
+//
+//  1. Create equivalent invalid projects for all three no-emit entry paths.
+//  2. Require the preserved typia source location, code, and message.
+//  3. Prove quiet/verbose reporting while every output path stays absent.
+func TestBuildNoEmitReportsTransformDiagnostics(t *testing.T) {
+  cases := []struct {
+    name       string
+    configured bool
+    verbose    bool
+    run        func(project, manifest string) int
+  }{
+    {
+      name: "check-command",
+      run: func(project, manifest string) int {
+        return run([]string{
+          "check",
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--manifest", manifest,
+        })
+      },
+    },
+    {
+      name:    "explicit-no-emit",
+      verbose: true,
+      run: func(project, manifest string) int {
+        return runBuild([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--noEmit",
+          "--manifest", manifest,
+          "--verbose",
+        })
+      },
+    },
+    {
+      name:       "configured-no-emit",
+      configured: true,
+      run: func(project, manifest string) int {
+        return runBuild([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--manifest", manifest,
+        })
+      },
+    },
+  }
+  for _, tc := range cases {
+    t.Run(tc.name, func(t *testing.T) {
+      project := buildNoEmitDiagnosticProject(t, tc.configured)
+      manifest := filepath.Join(project, "artifacts", "manifest.json")
+      out, errText, code := ttscTypiaTestCapture(func() int {
+        return tc.run(project, manifest)
+      })
+      if code != 3 {
+        t.Fatalf("analysis-only transform should fail with code 3, got %d\nstdout=%s\nstderr=%s", code, out, errText)
+      }
+      normalized := filepath.ToSlash(errText)
+      if !strings.Contains(normalized, "src/main.ts:3:9 - error TS(typia.is):") ||
+        !strings.Contains(normalized, "non-specified generic argument") {
+        t.Fatalf("analysis-only diagnostic lost detail:\n%s", errText)
+      }
+      if tc.verbose {
+        if !strings.Contains(out, "emit=false") {
+          t.Fatalf("verbose no-emit summary missing:\n%s", out)
+        }
+      } else if strings.TrimSpace(out) != "" {
+        t.Fatalf("quiet no-emit run wrote stdout:\n%s", out)
+      }
+      for _, path := range []string{
+        filepath.Join(project, "dist"),
+        filepath.Join(project, "cache.tsbuildinfo"),
+        manifest,
+      } {
+        if _, err := os.Stat(path); !os.IsNotExist(err) {
+          t.Fatalf("analysis-only run published %s: %v", path, err)
+        }
+      }
+    })
+  }
+}
+
+func buildNoEmitDiagnosticProject(t *testing.T, noEmit bool) string {
+  t.Helper()
+  project := t.TempDir()
+  src := filepath.Join(project, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  configuredNoEmit := ""
+  if noEmit {
+    configuredNoEmit = `,
+    "noEmit": true`
+  }
+  config := `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "incremental": true,
+    "tsBuildInfoFile": "cache.tsbuildinfo"` + configuredNoEmit + `
+  },
+  "include": ["src"]
+}
+`
+  if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(config), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  transformDiagnosticWriteTypiaStub(t, project)
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(transformDiagnosticSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return project
+}

--- a/packages/typia/native/cmd/ttsc-typia/build_transactional_emit_success_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/build_transactional_emit_success_test.go
@@ -4,6 +4,7 @@ import (
   "encoding/json"
   "os"
   "path/filepath"
+  "reflect"
   "strings"
   "testing"
 )
@@ -43,22 +44,27 @@ func TestBuildTransactionalEmitPublishesCleanProject(t *testing.T) {
   if len(emitted) == 0 || !strings.Contains(out, "emitted=") {
     t.Fatalf("successful build did not report emitted outputs: %v\n%s", emitted, out)
   }
-  families := map[string]bool{
-    ".js":       false,
-    ".js.map":   false,
-    ".d.ts":     false,
-    ".d.ts.map": false,
+  expected := map[string]bool{
+    "dist/invalid.d.ts":     true,
+    "dist/invalid.d.ts.map": true,
+    "dist/invalid.js":       true,
+    "dist/invalid.js.map":   true,
+    "dist/valid.d.ts":       true,
+    "dist/valid.d.ts.map":   true,
+    "dist/valid.js":         true,
+    "dist/valid.js.map":     true,
   }
+  actual := map[string]bool{}
   for _, path := range emitted {
     if _, err := os.Stat(path); err != nil {
       t.Fatalf("manifest advertised missing output %s: %v", path, err)
     }
-    slash := filepath.ToSlash(path)
-    for suffix := range families {
-      if strings.HasSuffix(slash, suffix) {
-        families[suffix] = true
-      }
+    relative, err := filepath.Rel(project, path)
+    if err != nil {
+      t.Fatalf("relativize emitted output %s: %v", path, err)
     }
+    slash := filepath.ToSlash(relative)
+    actual[slash] = true
     if strings.HasSuffix(slash, ".js") {
       js, err := os.ReadFile(path)
       if err != nil {
@@ -69,9 +75,7 @@ func TestBuildTransactionalEmitPublishesCleanProject(t *testing.T) {
       }
     }
   }
-  for suffix, found := range families {
-    if !found {
-      t.Fatalf("manifest omitted %s output: %v", suffix, emitted)
-    }
+  if !reflect.DeepEqual(actual, expected) {
+    t.Fatalf("manifest output set changed:\nexpected=%v\nactual=%v", expected, actual)
   }
 }

--- a/packages/typia/native/cmd/ttsc-typia/build_transactional_emit_success_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/build_transactional_emit_success_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestBuildTransactionalEmitPublishesCleanProject verifies the commit path.
+//
+// Buffering failed transforms must not suppress or alter successful JavaScript,
+// declarations, maps, or manifest entries. A clean multi-file build publishes
+// every compiler output only after the shared transform phase succeeds.
+//
+//  1. Build two valid typia sources with declarations and source maps enabled.
+//  2. Read the emitted manifest and require every recorded file to exist.
+//  3. Check each output family and prove JavaScript no longer calls typia.is.
+func TestBuildTransactionalEmitPublishesCleanProject(t *testing.T) {
+  project := buildAtomicityProject(t, false)
+  manifest := filepath.Join(project, "artifacts", "manifest.json")
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runBuild([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--emit",
+      "--manifest", manifest,
+      "--verbose",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("clean transactional build failed with code %d\nstdout=%s\nstderr=%s", code, out, errText)
+  }
+  data, err := os.ReadFile(manifest)
+  if err != nil {
+    t.Fatalf("read manifest: %v", err)
+  }
+  var emitted []string
+  if err := json.Unmarshal(data, &emitted); err != nil {
+    t.Fatalf("decode manifest: %v\n%s", err, data)
+  }
+  if len(emitted) == 0 || !strings.Contains(out, "emitted=") {
+    t.Fatalf("successful build did not report emitted outputs: %v\n%s", emitted, out)
+  }
+  families := map[string]bool{
+    ".js":       false,
+    ".js.map":   false,
+    ".d.ts":     false,
+    ".d.ts.map": false,
+  }
+  for _, path := range emitted {
+    if _, err := os.Stat(path); err != nil {
+      t.Fatalf("manifest advertised missing output %s: %v", path, err)
+    }
+    slash := filepath.ToSlash(path)
+    for suffix := range families {
+      if strings.HasSuffix(slash, suffix) {
+        families[suffix] = true
+      }
+    }
+    if strings.HasSuffix(slash, ".js") {
+      js, err := os.ReadFile(path)
+      if err != nil {
+        t.Fatalf("read emitted JavaScript: %v", err)
+      }
+      if strings.Contains(string(js), "typia.is(") {
+        t.Fatalf("emitted JavaScript retained typia runtime stub:\n%s", js)
+      }
+    }
+  }
+  for suffix, found := range families {
+    if !found {
+      t.Fatalf("manifest omitted %s output: %v", suffix, emitted)
+    }
+  }
+}

--- a/packages/typia/native/cmd/ttsc-typia/build_transform_failure_atomicity_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/build_transform_failure_atomicity_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "reflect"
+  "strings"
+  "testing"
+)
+
+// TestBuildTransformFailurePreservesArtifacts verifies failed-build atomicity.
+//
+// A transform failure can arrive after valid siblings have already produced
+// JavaScript, declarations, maps, and a manifest candidate. None of those
+// buffered results may replace prior artifacts or escape as new files.
+//
+//  1. Seed output and manifest trees with byte-sensitive prior artifacts.
+//  2. Build one valid source beside one typia-invalid generic source.
+//  3. Require the diagnostic and compare both trees byte-for-byte.
+func TestBuildTransformFailurePreservesArtifacts(t *testing.T) {
+  project := buildAtomicityProject(t, true)
+  dist := filepath.Join(project, "dist")
+  manifest := filepath.Join(project, "artifacts", "manifest.json")
+  seeds := map[string]string{
+    filepath.Join(dist, "valid.js"):      "previous javascript\n",
+    filepath.Join(dist, "existing.d.ts"): "previous declaration\n",
+    filepath.Join(dist, "keep.txt"):      "unrelated output\n",
+    manifest:                             `["previous.js"]`,
+  }
+  for path, body := range seeds {
+    if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+      t.Fatalf("mkdir seed parent: %v", err)
+    }
+    if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+      t.Fatalf("write seed %s: %v", path, err)
+    }
+  }
+  beforeDist := buildReadTree(t, dist)
+  beforeArtifacts := buildReadTree(t, filepath.Dir(manifest))
+
+  _, errText, code := ttscTypiaTestCapture(func() int {
+    return runBuild([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--emit",
+      "--manifest", manifest,
+    })
+  })
+  if code != 3 {
+    t.Fatalf("invalid multi-file transform should fail with code 3, got %d\nstderr=%s", code, errText)
+  }
+  normalized := filepath.ToSlash(errText)
+  if !strings.Contains(normalized, "src/invalid.ts:3:9 - error TS(typia.is):") {
+    t.Fatalf("transform diagnostic missing invalid source location:\n%s", errText)
+  }
+  if after := buildReadTree(t, dist); !reflect.DeepEqual(after, beforeDist) {
+    t.Fatalf("failed transform mutated output tree:\nbefore=%q\nafter=%q", beforeDist, after)
+  }
+  if after := buildReadTree(t, filepath.Dir(manifest)); !reflect.DeepEqual(after, beforeArtifacts) {
+    t.Fatalf("failed transform mutated manifest tree:\nbefore=%q\nafter=%q", beforeArtifacts, after)
+  }
+}
+
+func buildReadTree(t *testing.T, root string) map[string]string {
+  t.Helper()
+  files := map[string]string{}
+  if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+    if err != nil {
+      return err
+    }
+    if entry.IsDir() {
+      return nil
+    }
+    data, err := os.ReadFile(path)
+    if err != nil {
+      return err
+    }
+    rel, err := filepath.Rel(root, path)
+    if err != nil {
+      return err
+    }
+    files[filepath.ToSlash(rel)] = string(data)
+    return nil
+  }); err != nil {
+    t.Fatalf("read tree %s: %v", root, err)
+  }
+  return files
+}
+
+func buildAtomicityProject(t *testing.T, invalid bool) string {
+  t.Helper()
+  project := t.TempDir()
+  src := filepath.Join(project, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  config := `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}
+`
+  if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(config), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  transformDiagnosticWriteTypiaStub(t, project)
+  validSource := `import typia from "typia";
+export const valid = (input: unknown): input is { value: number } =>
+  typia.is<{ value: number }>(input);
+`
+  if err := os.WriteFile(filepath.Join(src, "valid.ts"), []byte(validSource), 0o644); err != nil {
+    t.Fatalf("write valid source: %v", err)
+  }
+  secondSource := `import typia from "typia";
+export const second = (input: unknown): input is { name: string } =>
+  typia.is<{ name: string }>(input);
+`
+  if invalid {
+    secondSource = transformDiagnosticSource
+  }
+  if err := os.WriteFile(filepath.Join(src, "invalid.ts"), []byte(secondSource), 0o644); err != nil {
+    t.Fatalf("write second source: %v", err)
+  }
+  return project
+}

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.10",
+  "version": "13.1.11",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary

- run typia transform diagnostics in native check and explicit/configured no-emit modes
- make emitted JavaScript, declarations, maps, build info, and manifests transactional with respect to transform failures
- preserve pre-existing outputs byte-for-byte when a multi-file transform fails

This draft currently contains only the campaign claim commit. Tests-first implementation, full native/public verification, and solo Self-Review follow after the serialized native landing prerequisites.

Closes #2079