### PR TITLE
fix(typia): invalidate bundlers on type-only changes

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/transform.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform.go
@@ -7,6 +7,7 @@ import (
   "fmt"
   "os"
   "path/filepath"
+  "sort"
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
@@ -118,9 +119,11 @@ func runTransformProject(
   transformDiags *[]typiaTransformDiagnostic,
 ) int {
   out := transformProjectOutput{
-    Diagnostics: []transformCompilerDiagnostic{},
-    TypeScript:  map[string]string{},
+    Dependencies: map[string][]string{},
+    Diagnostics:  []transformCompilerDiagnostic{},
+    TypeScript:   map[string]string{},
   }
+  dependencySources := transformProjectDependencySources(prog, cwd)
   for _, sf := range prog.SourceFiles() {
     if sf.IsDeclarationFile {
       continue
@@ -129,7 +132,11 @@ func runTransformProject(
     if filepath.IsAbs(key) || key == ".." || strings.HasPrefix(key, "../") {
       continue
     }
-    out.TypeScript[key] = transformFileToTypeScript(prog, typiaTransform, sf)
+    transformed := transformFileToTypeScriptResult(prog, typiaTransform, sf)
+    out.TypeScript[key] = transformed.TypeScript
+    if transformed.Changed {
+      out.Dependencies[key] = excludeTransformDependency(dependencySources, key)
+    }
   }
   for _, diag := range *transformDiags {
     out.Diagnostics = append(out.Diagnostics, transformDiagnosticToCompilerDiagnostic(diag))
@@ -152,6 +159,19 @@ func transformFileToTypeScript(
   typiaTransform driver.PluginTransform,
   sf *shimast.SourceFile,
 ) string {
+  return transformFileToTypeScriptResult(prog, typiaTransform, sf).TypeScript
+}
+
+type transformFileOutput struct {
+  Changed    bool
+  TypeScript string
+}
+
+func transformFileToTypeScriptResult(
+  prog *driver.Program,
+  typiaTransform driver.PluginTransform,
+  sf *shimast.SourceFile,
+) transformFileOutput {
   options := prog.TSProgram.Options()
   ec := shimprinter.NewEmitContext()
   result := sf
@@ -162,7 +182,53 @@ func transformFileToTypeScript(
   writer := shimprinter.NewTextWriter(options.NewLine.GetNewLineCharacter(), 0)
   printer := shimprinter.NewPrinter(shimprinter.PrinterOptions{NewLine: options.NewLine}, shimprinter.PrintHandlers{}, ec)
   printer.Write(result.AsNode(), result, writer, nil)
-  return writer.String()
+  return transformFileOutput{
+    Changed:    result != sf,
+    TypeScript: writer.String(),
+  }
+}
+
+// transformProjectDependencySources returns a conservative source universe.
+// The checker does not expose per-transform query provenance, so omitting any
+// program source could leave a type alias, augmentation, or ambient declaration
+// unwatched. Bundled TypeScript libraries use URI names and have no watchable
+// filesystem path; all other sources remain relative to cwd when possible.
+func transformProjectDependencySources(prog *driver.Program, cwd string) []string {
+  seen := map[string]struct{}{}
+  for _, sf := range prog.TSProgram.SourceFiles() {
+    file := filepath.ToSlash(sf.FileName())
+    if file == "" || strings.Contains(file, "://") {
+      continue
+    }
+    dependency := sourceFileDependency(cwd, file)
+    if dependency != "" {
+      seen[dependency] = struct{}{}
+    }
+  }
+  dependencies := make([]string, 0, len(seen))
+  for dependency := range seen {
+    dependencies = append(dependencies, dependency)
+  }
+  sort.Strings(dependencies)
+  return dependencies
+}
+
+func sourceFileDependency(cwd string, file string) string {
+  key := sourceFileKey(cwd, file)
+  if filepath.IsAbs(key) || key == ".." || strings.HasPrefix(key, "../") {
+    return filepath.ToSlash(file)
+  }
+  return key
+}
+
+func excludeTransformDependency(dependencies []string, self string) []string {
+  output := make([]string, 0, len(dependencies))
+  for _, dependency := range dependencies {
+    if dependency != self {
+      output = append(output, dependency)
+    }
+  }
+  return output
 }
 
 // runTransformSingleJS emits a single file's JS through the full node-path emit
@@ -232,8 +298,9 @@ func defaultTransformOutput() string {
 }
 
 type transformProjectOutput struct {
-  Diagnostics []transformCompilerDiagnostic `json:"diagnostics,omitempty"`
-  TypeScript  map[string]string             `json:"typescript"`
+  Dependencies map[string][]string           `json:"dependencies,omitempty"`
+  Diagnostics  []transformCompilerDiagnostic `json:"diagnostics,omitempty"`
+  TypeScript   map[string]string              `json:"typescript"`
 }
 
 type transformCompilerDiagnostic struct {

--- a/packages/typia/native/cmd/ttsc-typia/transform_dependencies_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_dependencies_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+// TestTransformProjectReportsTypeDependencies verifies the bundler envelope.
+//
+// A validator's emitted JavaScript depends on type-only source files that are
+// absent from the JavaScript import graph. The project transform must expose a
+// deterministic conservative source set without making the validator watch
+// itself or reporting dependencies for an explicitly disabled rewrite.
+//
+// 1. Transform a validator whose generic type crosses imports and re-exports.
+// 2. Assert aliases, declarations, unrelated project sources, and package types.
+// 3. Repeat for determinism, then disable rewriting as the negative control.
+func TestTransformProjectReportsTypeDependencies(t *testing.T) {
+	project := transformDependenciesProject(t)
+	first := transformDependenciesRun(t, project)
+	dependencies := first.Dependencies["src/validator.ts"]
+	if len(dependencies) == 0 {
+		t.Fatal("validator transform did not report any type dependencies")
+	}
+	if !slices.IsSorted(dependencies) {
+		t.Fatalf("validator dependencies are not deterministic: %v", dependencies)
+	}
+
+	seen := map[string]bool{}
+	for _, dependency := range dependencies {
+		if seen[dependency] {
+			t.Fatalf("validator dependency was duplicated: %s in %v", dependency, dependencies)
+		}
+		seen[dependency] = true
+	}
+	if seen["src/validator.ts"] {
+		t.Fatalf("validator reported itself as a dependency: %v", dependencies)
+	}
+	for _, expected := range []string{
+		"node_modules/typia/lib/module.d.ts",
+		"src/alias.ts",
+		"src/barrel.ts",
+		"src/globals.d.ts",
+		"src/model.ts",
+		"src/unrelated.ts",
+	} {
+		if !seen[expected] {
+			t.Fatalf("validator dependency set omitted %s: %v", expected, dependencies)
+		}
+	}
+	if _, ok := first.Dependencies["src/unrelated.ts"]; ok {
+		t.Fatalf("an unchanged non-typia source received a dependency list: %+v", first.Dependencies)
+	}
+
+	second := transformDependenciesRun(t, project)
+	if !reflect.DeepEqual(first.Dependencies, second.Dependencies) {
+		t.Fatalf("dependency envelope changed across identical transforms:\nfirst=%+v\nsecond=%+v", first.Dependencies, second.Dependencies)
+	}
+
+	disabled := transformDependenciesRun(t, project, "--rewrite-mode", "none")
+	if len(disabled.Dependencies) != 0 {
+		t.Fatalf("disabled typia rewriting reported dependencies: %+v", disabled.Dependencies)
+	}
+}
+
+type transformDependenciesOutput struct {
+	Dependencies map[string][]string `json:"dependencies"`
+	TypeScript   map[string]string   `json:"typescript"`
+}
+
+func transformDependenciesRun(t *testing.T, project string, extra ...string) transformDependenciesOutput {
+	t.Helper()
+	args := []string{"--cwd", project, "--tsconfig", "tsconfig.json"}
+	args = append(args, extra...)
+	out, errText, code := ttscTypiaTestCapture(func() int {
+		return runTransform(args)
+	})
+	if code != 0 {
+		t.Fatalf("project transform failed: code=%d\nstdout=%s\nstderr=%s", code, out, errText)
+	}
+	var result transformDependenciesOutput
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode transform dependency envelope: %v\n%s", err, out)
+	}
+	return result
+}
+
+func transformDependenciesProject(t *testing.T) string {
+	t.Helper()
+	project := t.TempDir()
+	src := filepath.Join(project, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir fixture src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(transformDependenciesTSConfig), 0o644); err != nil {
+		t.Fatalf("write tsconfig: %v", err)
+	}
+	transformDiagnosticWriteTypiaStub(t, project)
+	files := map[string]string{
+		"alias.ts": `import type { Model as ImportedModel } from "./model";
+export type Box<T> = { data: T };
+export type Alias = Box<ImportedModel>;
+`,
+		"barrel.ts": `export type { Alias as Reexported } from "./alias";
+`,
+		"globals.d.ts": `interface DeclaredMetadata { tag: string }
+`,
+		"model.ts": `export interface Model { value: string }
+`,
+		"unrelated.ts": `export const unrelated = "still a project input";
+`,
+		"validator.ts": `import typia from "typia";
+import type { Reexported } from "./barrel";
+type Product<T> = { payload: T; meta: DeclaredMetadata };
+export const check = (input: unknown): boolean => typia.is<Product<Reexported>>(input);
+`,
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write fixture %s: %v", name, err)
+		}
+	}
+	return project
+}
+
+const transformDependenciesTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/transform_dependencies_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_dependencies_test.go
@@ -55,10 +55,23 @@ func TestTransformProjectReportsTypeDependencies(t *testing.T) {
 	if _, ok := first.Dependencies["src/unrelated.ts"]; ok {
 		t.Fatalf("an unchanged non-typia source received a dependency list: %+v", first.Dependencies)
 	}
+	if len(first.Dependencies) != 1 {
+		t.Fatalf("only the transformed validator should report dependencies: %+v", first.Dependencies)
+	}
 
 	second := transformDependenciesRun(t, project)
 	if !reflect.DeepEqual(first.Dependencies, second.Dependencies) {
 		t.Fatalf("dependency envelope changed across identical transforms:\nfirst=%+v\nsecond=%+v", first.Dependencies, second.Dependencies)
+	}
+	if err := os.WriteFile(filepath.Join(project, "src", "model.ts"), []byte("export interface Model { value: number }\n"), 0o644); err != nil {
+		t.Fatalf("change type-only model: %v", err)
+	}
+	changed := transformDependenciesRun(t, project)
+	if changed.TypeScript["src/validator.ts"] == first.TypeScript["src/validator.ts"] {
+		t.Fatal("changing only the imported model did not regenerate the validator")
+	}
+	if !reflect.DeepEqual(first.Dependencies, changed.Dependencies) {
+		t.Fatalf("type-only change altered the stable dependency graph:\nbefore=%+v\nafter=%+v", first.Dependencies, changed.Dependencies)
 	}
 
 	disabled := transformDependenciesRun(t, project, "--rewrite-mode", "none")
@@ -114,7 +127,7 @@ export type Alias = Box<ImportedModel>;
 		"unrelated.ts": `export const unrelated = "still a project input";
 `,
 		"validator.ts": `import typia from "typia";
-import type { Reexported } from "./barrel";
+import type { Reexported } from "@model/barrel";
 type Product<T> = { payload: T; meta: DeclaredMetadata };
 export const check = (input: unknown): boolean => typia.is<Product<Reexported>>(input);
 `,
@@ -132,8 +145,10 @@ const transformDependenciesTSConfig = `{
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "bundler",
-    "ignoreDeprecations": "6.0",
-    "types": ["*"],
+		"ignoreDeprecations": "6.0",
+		"types": ["*"],
+		"baseUrl": ".",
+		"paths": { "@model/*": ["src/*"] },
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,

--- a/packages/typia/native/cmd/ttsc-typia/transform_dependencies_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_dependencies_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -51,6 +52,10 @@ func TestTransformProjectReportsTypeDependencies(t *testing.T) {
 		if !seen[expected] {
 			t.Fatalf("validator dependency set omitted %s: %v", expected, dependencies)
 		}
+	}
+	external := filepath.ToSlash(transformDependenciesExternalPath(project))
+	if !seen[external] {
+		t.Fatalf("validator dependency set omitted outside-root declaration %s: %v", external, dependencies)
 	}
 	if _, ok := first.Dependencies["src/unrelated.ts"]; ok {
 		t.Fatalf("an unchanged non-typia source received a dependency list: %+v", first.Dependencies)
@@ -109,7 +114,13 @@ func transformDependenciesProject(t *testing.T) string {
 	if err := os.MkdirAll(src, 0o755); err != nil {
 		t.Fatalf("mkdir fixture src: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(transformDependenciesTSConfig), 0o644); err != nil {
+	external := transformDependenciesExternalPath(project)
+	t.Cleanup(func() { _ = os.Remove(external) })
+	if err := os.WriteFile(external, []byte("export interface External { outside: boolean }\n"), 0o644); err != nil {
+		t.Fatalf("write outside-root declaration: %v", err)
+	}
+	tsconfig := strings.ReplaceAll(transformDependenciesTSConfig, "__EXTERNAL__", filepath.ToSlash(filepath.Join("..", filepath.Base(external))))
+	if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(tsconfig), 0o644); err != nil {
 		t.Fatalf("write tsconfig: %v", err)
 	}
 	transformDiagnosticWriteTypiaStub(t, project)
@@ -128,7 +139,8 @@ export type Alias = Box<ImportedModel>;
 `,
 		"validator.ts": `import typia from "typia";
 import type { Reexported } from "@model/barrel";
-type Product<T> = { payload: T; meta: DeclaredMetadata };
+import type { External } from "@external";
+type Product<T> = { payload: T; meta: DeclaredMetadata; external: External };
 export const check = (input: unknown): boolean => typia.is<Product<Reexported>>(input);
 `,
 	}
@@ -140,6 +152,10 @@ export const check = (input: unknown): boolean => typia.is<Product<Reexported>>(
 	return project
 }
 
+func transformDependenciesExternalPath(project string) string {
+	return filepath.Join(filepath.Dir(project), filepath.Base(project)+"-external.d.ts")
+}
+
 const transformDependenciesTSConfig = `{
   "compilerOptions": {
     "target": "ES2022",
@@ -148,7 +164,10 @@ const transformDependenciesTSConfig = `{
 		"ignoreDeprecations": "6.0",
 		"types": ["*"],
 		"baseUrl": ".",
-		"paths": { "@model/*": ["src/*"] },
+		"paths": {
+			"@external": ["__EXTERNAL__"],
+			"@model/*": ["src/*"]
+		},
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Intent

Emit the type-source dependency graph that Typia's native transformer consults so `@ttsc/unplugin` can invalidate unchanged validator call sites after type-only changes.

## Scope

- Produce the released ttsc `dependencies` transform-envelope field from Typia's native host.
- Keep dependency paths deterministic, deduplicated, and self-excluding.
- Cover type-only imports, re-exports, aliases, generic instantiations, and declaration inputs conservatively.
- Verify cache replay and incremental invalidation through the existing released `@ttsc/unplugin` contract without mutating the sibling ttsc repository.

## Deferred

- TypeScript 6 legacy unplugin behavior remains owned by #2092 / PR #2094.
- Final native version `13.1.12`, semantic rebase, and merge wait for #2096.
- No repository-wide formatting; Post-Campaign Cleanup owns formatting.

## Verification

Pending tests-first native transform-envelope coverage, deterministic/deduplicated/self-exclusion controls, released `@ttsc/unplugin` compatibility, incremental two-build reproduction, Typia build, public/native Go suites, and findings-first solo Self-Review through a clean round.

Campaign Actions remain enabled and are cancelled only for this branch's exact pushed SHA after every push or pull-request mutation. Local verification is the implementation gate.

Closes #2095
