### PR TITLE
test(automation): fail on fatal asynchronous events

### DIFF
--- a/tests/template/src/utils/TestProcessFailure.ts
+++ b/tests/template/src/utils/TestProcessFailure.ts
@@ -1,10 +1,21 @@
 export namespace TestProcessFailure {
-  export const listen = (): void => {
+  export const listen = (): IListener => {
+    let failed: boolean = false;
+    const report = (type: string, error: unknown): void => {
+      failed = true;
+      process.exitCode = 1;
+      console.error(type, error);
+    };
     process.on("uncaughtException", (error) => {
-      console.log("exception", error);
+      report("exception", error);
     });
     process.on("unhandledRejection", (error) => {
-      console.log("rejection", error);
+      report("rejection", error);
     });
+    return { failed: () => failed };
   };
+
+  export interface IListener {
+    failed(): boolean;
+  }
 }

--- a/tests/template/src/utils/TestProcessFailure.ts
+++ b/tests/template/src/utils/TestProcessFailure.ts
@@ -1,0 +1,10 @@
+export namespace TestProcessFailure {
+  export const listen = (): void => {
+    process.on("uncaughtException", (error) => {
+      console.log("exception", error);
+    });
+    process.on("unhandledRejection", (error) => {
+      console.log("rejection", error);
+    });
+  };
+}

--- a/tests/template/src/utils/TestProcessFailureTester.ts
+++ b/tests/template/src/utils/TestProcessFailureTester.ts
@@ -1,0 +1,62 @@
+import cp from "child_process";
+
+import { TestProcessFailure } from "./TestProcessFailure";
+
+export namespace TestProcessFailureTester {
+  export const assert = (): void => {
+    const normal: cp.SpawnSyncReturns<string> = execute(null, null);
+    if (normal.status !== 0)
+      throw new Error(
+        `Normal process unexpectedly failed (${normal.status}).\n${output(normal)}`,
+      );
+
+    for (const event of ["uncaughtException", "unhandledRejection"] as const)
+      for (const phase of ["before", "during", "after"] as const) {
+        const result: cp.SpawnSyncReturns<string> = execute(event, phase);
+        if (result.status === 0)
+          throw new Error(
+            `${event} during ${phase} lifecycle unexpectedly exited zero.\n${output(result)}`,
+          );
+        if (output(result).includes(MARKER) === false)
+          throw new Error(
+            `${event} during ${phase} lifecycle lost its diagnostic.\n${output(result)}`,
+          );
+      }
+  };
+
+  const execute = (
+    event: "uncaughtException" | "unhandledRejection" | null,
+    phase: "before" | "during" | "after" | null,
+  ): cp.SpawnSyncReturns<string> =>
+    cp.spawnSync(process.execPath, ["-e", script(event, phase)], {
+      encoding: "utf8",
+    });
+
+  const script = (
+    event: "uncaughtException" | "unhandledRejection" | null,
+    phase: "before" | "during" | "after" | null,
+  ): string => `
+    (${TestProcessFailure.listen.toString()})();
+    const trigger = () => {
+      if (${JSON.stringify(event)} === "uncaughtException")
+        queueMicrotask(() => { throw new Error(${JSON.stringify(MARKER)}); });
+      else if (${JSON.stringify(event)} === "unhandledRejection")
+        void Promise.reject(new Error(${JSON.stringify(MARKER)}));
+    };
+    if (${JSON.stringify(phase)} === "before") {
+      trigger();
+      setImmediate(() => console.log("Success"));
+    } else if (${JSON.stringify(phase)} === "during") {
+      setImmediate(trigger);
+      setTimeout(() => console.log("Success"), 5);
+    } else if (${JSON.stringify(phase)} === "after") {
+      console.log("Success");
+      setImmediate(trigger);
+    } else console.log("Success");
+  `;
+
+  const output = (result: cp.SpawnSyncReturns<string>): string =>
+    `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+  const MARKER = "injected fatal test event";
+}

--- a/tests/template/src/utils/TestProcessFailureTester.ts
+++ b/tests/template/src/utils/TestProcessFailureTester.ts
@@ -5,21 +5,42 @@ import { TestProcessFailure } from "./TestProcessFailure";
 export namespace TestProcessFailureTester {
   export const assert = (): void => {
     const normal: cp.SpawnSyncReturns<string> = execute(null, null);
-    if (normal.status !== 0)
+    if (
+      normal.status !== 0 ||
+      normal.signal !== null ||
+      normal.error !== undefined
+    )
       throw new Error(
         `Normal process unexpectedly failed (${normal.status}).\n${output(normal)}`,
+      );
+    if (output(normal).includes("failure-state:false") === false)
+      throw new Error(
+        `Normal process lost its clean state.\n${output(normal)}`,
       );
 
     for (const event of ["uncaughtException", "unhandledRejection"] as const)
       for (const phase of ["before", "during", "after"] as const) {
         const result: cp.SpawnSyncReturns<string> = execute(event, phase);
-        if (result.status === 0)
+        if (
+          result.status !== 1 ||
+          result.signal !== null ||
+          result.error !== undefined
+        )
           throw new Error(
-            `${event} during ${phase} lifecycle unexpectedly exited zero.\n${output(result)}`,
+            `${event} during ${phase} lifecycle exited with ${result.status}.\n${output(result)}`,
           );
-        if (output(result).includes(MARKER) === false)
+        const label: string =
+          event === "uncaughtException" ? "exception" : "rejection";
+        if (
+          output(result).includes(label) === false ||
+          output(result).includes(MARKER) === false
+        )
           throw new Error(
             `${event} during ${phase} lifecycle lost its diagnostic.\n${output(result)}`,
+          );
+        if (output(result).includes("failure-state:true") === false)
+          throw new Error(
+            `${event} during ${phase} lifecycle lost its fatal state.\n${output(result)}`,
           );
       }
   };
@@ -30,13 +51,17 @@ export namespace TestProcessFailureTester {
   ): cp.SpawnSyncReturns<string> =>
     cp.spawnSync(process.execPath, ["-e", script(event, phase)], {
       encoding: "utf8",
+      timeout: 5_000,
     });
 
   const script = (
     event: "uncaughtException" | "unhandledRejection" | null,
     phase: "before" | "during" | "after" | null,
   ): string => `
-    (${TestProcessFailure.listen.toString()})();
+    const failure = (${TestProcessFailure.listen.toString()})();
+    process.on("beforeExit", () =>
+      console.log("failure-state:" + failure.failed()),
+    );
     const trigger = () => {
       if (${JSON.stringify(event)} === "uncaughtException")
         queueMicrotask(() => { throw new Error(${JSON.stringify(MARKER)}); });
@@ -56,7 +81,11 @@ export namespace TestProcessFailureTester {
   `;
 
   const output = (result: cp.SpawnSyncReturns<string>): string =>
-    `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    `${result.stdout ?? ""}${result.stderr ?? ""}${
+      result.error === undefined
+        ? ""
+        : `${result.error.name}: ${result.error.message}\n`
+    }signal: ${result.signal ?? "none"}`;
 
   const MARKER = "injected fatal test event";
 }

--- a/tests/template/src/utils/index.ts
+++ b/tests/template/src/utils/index.ts
@@ -1,5 +1,7 @@
 export * from "./Spoiler";
 export * from "./StopWatch";
 export * from "./TestRandomGenerator";
+export * from "./TestProcessFailure";
+export * from "./TestProcessFailureTester";
 export * from "./TestServant";
 export * from "./TestStructure";

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -4,6 +4,7 @@
   "version": "13.1.1",
   "description": "Automated test features of typia.",
   "scripts": {
+    "prestart": "ttsx src/regressions/test_process_fatal_events.ts",
     "start": "ttsx src/index.ts"
   },
   "repository": {

--- a/tests/test-typia-automated/src/index.ts
+++ b/tests/test-typia-automated/src/index.ts
@@ -1,4 +1,4 @@
-import { TestServant } from "@typia/template";
+import { TestProcessFailure, TestServant } from "@typia/template";
 import { WorkerConnector } from "tgrid";
 
 import { TestGlobal } from "./TestGlobal";
@@ -28,7 +28,7 @@ async function main(): Promise<void> {
       await connector.close();
     }
   });
-  if (exceptions.length === 0) {
+  if (exceptions.length === 0 && failure.failed() === false) {
     console.log("Success");
   } else {
     for (const exp of exceptions) console.log(exp);
@@ -37,12 +37,7 @@ async function main(): Promise<void> {
   }
 }
 
-global.process.on("uncaughtException", (error) => {
-  console.log("exception", error);
-});
-global.process.on("unhandledRejection", (error) => {
-  console.log("rejection", error);
-});
+const failure: TestProcessFailure.IListener = TestProcessFailure.listen();
 main().catch((error) => {
   console.log("critical error", error);
   process.exit(-1);

--- a/tests/test-typia-automated/src/regressions/test_process_fatal_events.ts
+++ b/tests/test-typia-automated/src/regressions/test_process_fatal_events.ts
@@ -1,0 +1,18 @@
+import { TestProcessFailureTester } from "@typia/template";
+
+/**
+ * Verifies fatal asynchronous events cannot leave an automated run successful.
+ *
+ * The runner's global listeners historically logged uncaught exceptions and
+ * unhandled rejections without changing the exit status. A subprocess matrix
+ * pins Node's real final status before, during, and after normal completion.
+ *
+ * 1. Require an ordinary subprocess to finish successfully.
+ * 2. Inject both fatal event kinds at three lifecycle boundaries.
+ * 3. Require every fatal subprocess to retain diagnostics and exit nonzero.
+ */
+export const test_process_fatal_events = (): void => {
+  TestProcessFailureTester.assert();
+};
+
+test_process_fatal_events();

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -4,6 +4,7 @@
   "version": "13.1.1",
   "description": "Automated test features of openapi.",
   "scripts": {
+    "prestart": "ttsx src/regressions/test_process_fatal_events.ts",
     "start": "ttsx src/index.ts"
   },
   "repository": {

--- a/tests/test-utils-automated/src/index.ts
+++ b/tests/test-utils-automated/src/index.ts
@@ -1,4 +1,4 @@
-import { TestServant } from "@typia/template";
+import { TestProcessFailure, TestServant } from "@typia/template";
 import { WorkerConnector } from "tgrid";
 
 import { TestAutomation } from "./TestAutomation";
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
     await connector.close();
   }
 
-  if (exceptions.length === 0) {
+  if (exceptions.length === 0 && failure.failed() === false) {
     console.log("Success");
   } else {
     for (const exp of exceptions) console.log(exp);
@@ -36,12 +36,7 @@ async function main(): Promise<void> {
   }
 }
 
-global.process.on("uncaughtException", (error) => {
-  console.log("exception", error);
-});
-global.process.on("unhandledRejection", (error) => {
-  console.log("rejection", error);
-});
+const failure: TestProcessFailure.IListener = TestProcessFailure.listen();
 main().catch((error) => {
   console.log("critical error", error);
   process.exit(-1);

--- a/tests/test-utils-automated/src/regressions/test_process_fatal_events.ts
+++ b/tests/test-utils-automated/src/regressions/test_process_fatal_events.ts
@@ -1,0 +1,18 @@
+import { TestProcessFailureTester } from "@typia/template";
+
+/**
+ * Verifies fatal asynchronous events cannot leave an automated run successful.
+ *
+ * The runner's global listeners historically logged uncaught exceptions and
+ * unhandled rejections without changing the exit status. A subprocess matrix
+ * pins Node's real final status before, during, and after normal completion.
+ *
+ * 1. Require an ordinary subprocess to finish successfully.
+ * 2. Inject both fatal event kinds at three lifecycle boundaries.
+ * 3. Require every fatal subprocess to retain diagnostics and exit nonzero.
+ */
+export const test_process_fatal_events = (): void => {
+  TestProcessFailureTester.assert();
+};
+
+test_process_fatal_events();


### PR DESCRIPTION
## Intent

Make fatal asynchronous events in both generated automation runners fail closed instead of logging an error and allowing a successful process exit.

## Scope

- Replace the `uncaughtException` and `unhandledRejection` success-masking behavior in `test-typia-automated` and `test-utils-automated`.
- Cover normal completion plus both fatal event kinds through subprocess tests at lifecycle boundaries.
- Preserve worker/servant cleanup where possible while guaranteeing a nonzero final status.

## Deferred

- Direct/factory matrix restoration remains a later #2035 unit after its product-fix prerequisite PRs merge.
- `resolved_equal_to` and `protobuf_equal_to` hardening remains a later #2035 unit for the same dependency reason.
- This PR is only part of #2035 and intentionally does not close the issue.
- No repository-wide formatting; Post-Campaign Cleanup owns formatting.

## Verification

- Tests-first subprocess regressions demonstrated the old zero-exit `Success` behavior for fatal events.
- Both runner prestart matrices now pass normal completion and both fatal event kinds before, during, and after the lifecycle.
- Both complete affected automated workspaces and root `pnpm test` passed on the implementation's original base.
- Both affected prestart matrices pass on the final repaired base.
- Full `test-typia-automated` and full `test-utils-automated` pass on the final head.
- Root `pnpm test` passes across all twelve TypeScript workspaces, public Go, and native Go.
- Findings-first solo Self-Review hardened the subprocess oracle against hangs, signals, and lost listener state; fresh full-diff rounds, including one after the final repaired-base rebase, found no remaining issue.

Campaign Actions remain enabled and are cancelled only for this branch's exact pushed SHA after every push or pull-request mutation. Local verification is the implementation gate.

Part of #2035
