### PR TITLE
fix(openapi): restore recursive union validation

### DIFF
--- a/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
@@ -351,6 +351,12 @@ interface IDiscriminator {
 interface IDiscriminatorBranch {
   schema: OpenApi.IJsonSchema;
   predicator: (value: unknown) => boolean;
+  /**
+   * Whether a failed predicate match may fall through to another candidate.
+   *
+   * Array first-element probes are tentative, while object key discriminators
+   * establish ordered ownership of the value and its validation errors.
+   */
   retryable: boolean;
 }
 

--- a/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
@@ -15,53 +15,73 @@ export namespace OpenApiOneOfValidator {
     const candidates: IDiscriminatorBranch[] = discriminator.branches.filter(
       (item) => item.predicator(ctx.value),
     );
-    let matched: OpenApi.IJsonSchema | undefined;
-    for (const item of candidates)
-      if (
-        OpenApiStationValidator.validate(
-          {
-            ...ctx,
-            schema: item.schema,
-            exceptionable: false,
-            equals: false,
-          },
-          undefined,
-          references,
-        )
-      ) {
-        matched = item.schema;
-        break;
-      }
-
-    if (matched === undefined)
-      for (const schema of discriminator.remainders)
+    if (candidates.length !== 0) {
+      for (const item of candidates)
         if (
           OpenApiStationValidator.validate(
             {
               ...ctx,
-              schema,
+              schema: item.schema,
               exceptionable: false,
               equals: false,
             },
             undefined,
             references,
           )
-        ) {
-          matched = schema;
-          break;
-        }
-
-    if (matched === undefined)
-      return candidates.length !== 0
-        ? OpenApiStationValidator.validate(
+        )
+          return ctx.equals === true
+            ? OpenApiStationValidator.validate(
+                {
+                  ...ctx,
+                  schema: item.schema,
+                },
+                undefined,
+                references,
+              )
+            : true;
+        else if (item.retryable === false)
+          return OpenApiStationValidator.validate(
             {
               ...ctx,
-              schema: candidates[0]!.schema,
+              schema: item.schema,
             },
             undefined,
             references,
-          )
-        : ctx.report(ctx);
+          );
+      return OpenApiStationValidator.validate(
+        {
+          ...ctx,
+          schema: candidates[0]!.schema,
+        },
+        undefined,
+        references,
+      );
+    }
+    if (discriminator.branches.length !== 0)
+      return validate(
+        {
+          ...ctx,
+          schema: {
+            oneOf: discriminator.remainders,
+          },
+        },
+        references,
+      );
+
+    const matched: OpenApi.IJsonSchema | undefined =
+      discriminator.remainders.find((schema) =>
+        OpenApiStationValidator.validate(
+          {
+            ...ctx,
+            schema,
+            exceptionable: false,
+            equals: false,
+          },
+          undefined,
+          references,
+        ),
+      );
+    if (matched === undefined) return ctx.report(ctx);
     return ctx.equals === true
       ? OpenApiStationValidator.validate(
           {
@@ -110,6 +130,7 @@ export namespace OpenApiOneOfValidator {
           {
             schema: significant[0]!.schema,
             predicator: (value) => value !== null,
+            retryable: false,
           },
         ],
         remainders: nullables.map((nullable) => nullable.schema),
@@ -153,6 +174,7 @@ export namespace OpenApiOneOfValidator {
         {
           schema: arraySchemas[0]!.schema,
           predicator: (value) => Array.isArray(value),
+          retryable: true,
         },
       ];
     return arraySchemas
@@ -182,6 +204,7 @@ export namespace OpenApiOneOfValidator {
                   exceptionable: false,
                   equals: false,
                 })),
+            retryable: true,
           }) satisfies IDiscriminatorBranch,
       );
   };
@@ -201,6 +224,7 @@ export namespace OpenApiOneOfValidator {
                 typeof value === "object" &&
                 value !== null &&
                 Array.isArray(value) === false,
+          retryable: false,
         },
       ];
 
@@ -284,6 +308,7 @@ export namespace OpenApiOneOfValidator {
                 typeof value === "object" &&
                 value !== null &&
                 ObjectDictionary.has(value, top),
+          retryable: false,
         } satisfies IDiscriminatorBranch;
       })
       .filter((b) => b !== null);
@@ -326,6 +351,7 @@ interface IDiscriminator {
 interface IDiscriminatorBranch {
   schema: OpenApi.IJsonSchema;
   predicator: (value: unknown) => boolean;
+  retryable: boolean;
 }
 
 interface IFlatSchema<

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_nested_discriminator.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_nested_discriminator.ts
@@ -13,6 +13,7 @@ import { OpenApiValidator } from "@typia/utils";
  * 1. Build base, middle, and top object variants with cumulative required keys.
  * 2. Accept a valid value from every level under both branch permutations.
  * 3. Reject invalid present middle/top keys at their exact diagnostic paths.
+ * 4. Keep the first matching object discriminator responsible for ambiguity.
  */
 export const test_openapi_validator_nested_discriminator = (): void => {
   const base: OpenApi.IJsonSchema.IObject = {
@@ -68,6 +69,41 @@ export const test_openapi_validator_nested_discriminator = (): void => {
         TestValidator.equals(`report ${path}`, result.errors[0]?.path, path);
     }
   }
+
+  const shared: OpenApi.IJsonSchema.IObject = {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      children: { type: "array", items: {} },
+      access: { oneOf: [{ const: "read" }, { const: "write" }] },
+    },
+    required: ["id", "children", "access"],
+  };
+  const shortcut: OpenApi.IJsonSchema.IObject = {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      target: {},
+    },
+    required: ["id", "target"],
+  };
+  const ambiguous = validate([shared, shortcut], {
+    id: "directory shortcut",
+    children: [],
+    access: "nothing",
+    target: {},
+  });
+  TestValidator.equals(
+    "reject the first matching object discriminator",
+    ambiguous.success,
+    false,
+  );
+  if (ambiguous.success === false)
+    TestValidator.equals(
+      "report the owning discriminator field",
+      ambiguous.errors[0]?.path,
+      "$input.access",
+    );
 };
 
 const validate = (

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_nested_discriminator.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_nested_discriminator.ts
@@ -1,0 +1,82 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiValidator } from "@typia/utils";
+
+/**
+ * Verifies nested object discriminators keep the most specific present field.
+ *
+ * A failed discriminator candidate must not fall through to a subsuming object
+ * branch that ignores the candidate's extra property. When no top-level
+ * discriminator matches, the remaining union must be discriminated again so a
+ * present middle-level property is still validated.
+ *
+ * 1. Build base, middle, and top object variants with cumulative required keys.
+ * 2. Accept a valid value from every level under both branch permutations.
+ * 3. Reject invalid present middle/top keys at their exact diagnostic paths.
+ */
+export const test_openapi_validator_nested_discriminator = (): void => {
+  const base: OpenApi.IJsonSchema.IObject = {
+    type: "object",
+    properties: {
+      p1: { type: "string" },
+    },
+    required: ["p1"],
+  };
+  const middle: OpenApi.IJsonSchema.IObject = {
+    type: "object",
+    properties: {
+      p1: { type: "string" },
+      p2: { type: "number" },
+    },
+    required: ["p1", "p2"],
+  };
+  const top: OpenApi.IJsonSchema.IObject = {
+    type: "object",
+    properties: {
+      p1: { type: "string" },
+      p2: { type: "number" },
+      p3: { type: "boolean" },
+    },
+    required: ["p1", "p2", "p3"],
+  };
+  for (const oneOf of [
+    [base, middle, top],
+    [top, middle, base],
+  ] as OpenApi.IJsonSchema.IObject[][]) {
+    for (const value of [
+      { p1: "base" },
+      { p1: "middle", p2: 2 },
+      { p1: "top", p2: 3, p3: true },
+    ])
+      TestValidator.equals(
+        `accept ${JSON.stringify(value)} in ${oneOf[0] === base ? "bmt" : "tmb"}`,
+        validate(oneOf, value).success,
+        true,
+      );
+
+    for (const [value, path] of [
+      [{ p1: "middle", p2: null }, "$input.p2"],
+      [{ p1: "top", p2: 3, p3: null }, "$input.p3"],
+    ] as Array<[Record<string, unknown>, string]>) {
+      const result = validate(oneOf, value);
+      TestValidator.equals(
+        `reject ${path} in ${oneOf[0] === base ? "bmt" : "tmb"}`,
+        result.success,
+        false,
+      );
+      if (result.success === false)
+        TestValidator.equals(`report ${path}`, result.errors[0]?.path, path);
+    }
+  }
+};
+
+const validate = (
+  oneOf: OpenApi.IJsonSchema.IObject[],
+  value: unknown,
+): ReturnType<typeof OpenApiValidator.validate> =>
+  OpenApiValidator.validate({
+    components: {},
+    schema: { oneOf },
+    value,
+    required: true,
+  });


### PR DESCRIPTION
## Overview

Restore OpenAPI union validation after the scalar-containment changes merged in #2074. Exact clean `master` at `e30b0ccf6ca1cfbede7da74c580454df1f092a35` regresses generated recursive, composite, pointer, implicit, and ultimate union fixtures in `test-utils-automated`.

Follow-up to #2044.

## Evidence

`pnpm --filter ./tests/test-utils-automated start` fails on exact merged master in `ArrayRecursiveUnionImplicit`, `ObjectUnionComposite`, `ObjectUnionCompositePointer`, `ObjectUnionImplicit`, `UltimateUnion`, and corresponding `validateEquals`/diagnostic-path cases. The same suite passed before #2074, and the downstream campaign lane reproduced the identical matrix without its own pending changes.

## Scope

This corrective batch will first preserve the failing generated matrix as the regression gate, then repair the general OneOf discrimination/fallback invariant without weakening the exact decimal, code-point length, or schema-containment contracts added by #2074. Fixture-specific branching and generated-tree edits are excluded.

## Verification

Exact HEAD: `2b6b1707969f6399b284ec0b06914775be13a508`

- focused nested object discriminator and existing array branch-permutation tests;
- full `test-utils-automated`, including every formerly failing recursive/composite/implicit/ultimate union and validateEquals case;
- full `test-utils`;
- full `test-typia-schema`, retaining #2074 decimal, Unicode, random, and schema contracts;
- `@typia/utils` package build;
- targeted Prettier check and `git diff --check`;
- two solo Self-Review rounds, with the final round clean;
- clean worktree, matching local/remote HEAD, and current `master` merge base.

Repository Actions are deliberately cancelled by exact campaign commit SHA after every push and pull-request event. No workflow or repository Actions setting is disabled; local verification is the campaign gate.
