### PR TITLE
Fix LLM local-reference integrity

### DIFF
--- a/packages/interface/src/schema/ILlmSchema.ts
+++ b/packages/interface/src/schema/ILlmSchema.ts
@@ -65,8 +65,9 @@ export namespace ILlmSchema {
      * Named schema definitions for reference.
      *
      * Contains type definitions that can be referenced throughout the schema
-     * using `$ref: "#/$defs/TypeName"`. Essential for recursive types and
-     * shared structures.
+     * using `$ref: "#/$defs/TypeName"`. Definition names are encoded as one RFC
+     * 6901 token in URI-fragment form. Essential for recursive types and shared
+     * structures.
      */
     $defs: Record<string, ILlmSchema>;
 
@@ -394,14 +395,15 @@ export namespace ILlmSchema {
    *
    * Points to a schema defined in the `$defs` map using a JSON pointer. Used to
    * avoid schema duplication and enable recursive type definitions. The
-   * reference path format is `#/$defs/TypeName`.
+   * reference path format is `#/$defs/TypeName`, where `TypeName` is one RFC
+   * 6901 token encoded as a URI fragment.
    */
   export interface IReference extends IJsonSchemaAttribute {
     /**
      * JSON pointer to the referenced schema.
      *
-     * Must be in the format `#/$defs/TypeName` where TypeName is a key in the
-     * parent schema's `$defs` map.
+     * Must be in the format `#/$defs/TypeName`, where `TypeName` decodes to a
+     * key in the parent schema's `$defs` map.
      */
     $ref: string;
   }

--- a/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
+++ b/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
@@ -318,7 +318,7 @@ func llmSchemaProgrammer_convert_schema_config(schema nativeiterate.JsonSchema, 
           defs[key] = llmSchemaProgrammer_convert_schema_config(target, components, defs, config)
         }
       }
-      union = append(union, map[string]any{"$ref": "#/$defs/" + key})
+      union = append(union, map[string]any{"$ref": llmSchemaProgrammer_encode_reference(key)})
       return
     }
     if input["type"] == "object" {
@@ -643,6 +643,23 @@ func llmSchemaProgrammer_ref_key(ref string) string {
   return ref[index+1:]
 }
 
+func llmSchemaProgrammer_encode_reference(key string) string {
+  token := strings.NewReplacer("~", "~0", "/", "~1").Replace(key)
+  var output strings.Builder
+  output.WriteString("#/$defs/")
+  for _, value := range []byte(token) {
+    if (value >= 'A' && value <= 'Z') ||
+      (value >= 'a' && value <= 'z') ||
+      (value >= '0' && value <= '9') ||
+      strings.ContainsRune("-_.!~*'()", rune(value)) {
+      output.WriteByte(value)
+    } else {
+      fmt.Fprintf(&output, "%%%02X", value)
+    }
+  }
+  return output.String()
+}
+
 func llmSchemaProgrammer_component(components *nativeiterate.OpenApi_IComponents, key string) (nativeiterate.JsonSchema, bool) {
   if components == nil || components.Schemas == nil {
     return nil, false
@@ -677,7 +694,7 @@ func llmSchemaProgrammer_discriminator(schema nativeiterate.JsonSchema, union []
   if rawMapping, ok := llmSchemaProgrammer_schema_map(discriminator["mapping"]); ok {
     mapping := map[string]any{}
     for key, value := range rawMapping {
-      mapping[key] = "#/$defs/" + llmSchemaProgrammer_ref_key(fmt.Sprint(value))
+      mapping[key] = llmSchemaProgrammer_encode_reference(llmSchemaProgrammer_ref_key(fmt.Sprint(value)))
     }
     output["mapping"] = mapping
   }

--- a/packages/typia/native/core/programmers/llm/llm_reference_codec_test.go
+++ b/packages/typia/native/core/programmers/llm/llm_reference_codec_test.go
@@ -1,0 +1,24 @@
+package llm
+
+import "testing"
+
+// TestLlmReferenceCodec locks JSON Pointer token escaping before URI-fragment encoding.
+func TestLlmReferenceCodec(t *testing.T) {
+  t.Parallel()
+  cases := map[string]string{
+    "Plain": "#/$defs/Plain",
+    "":      "#/$defs/",
+    "A/B":   "#/$defs/A~1B",
+    "T~N":   "#/$defs/T~0N",
+    "A~/B":  "#/$defs/A~0~1B",
+    "~1":    "#/$defs/~01",
+    "A B":   "#/$defs/A%20B",
+    "C%D":   "#/$defs/C%25D",
+    "Café":  "#/$defs/Caf%C3%A9",
+  }
+  for key, expected := range cases {
+    if actual := llmSchemaProgrammer_encode_reference(key); actual != expected {
+      t.Fatalf("encode %q: expected %q, got %q", key, expected, actual)
+    }
+  }
+}

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.11",
+  "version": "13.1.12",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/src/converters/LlmSchemaConverter.ts
+++ b/packages/utils/src/converters/LlmSchemaConverter.ts
@@ -7,6 +7,7 @@ import {
 } from "@typia/interface";
 
 import { JsonDescriptor } from "../utils/internal/JsonDescriptor";
+import { LlmReference } from "../utils/internal/LlmReference";
 import { ObjectDictionary } from "../utils/internal/ObjectDictionary";
 import { OpenApiSchemaSanitizer } from "../utils/internal/OpenApiSchemaSanitizer";
 import { LlmTypeChecker } from "../validators/LlmTypeChecker";
@@ -245,7 +246,7 @@ export namespace LlmSchemaConverter {
           const out = () => {
             union.push({
               ...input,
-              $ref: `#/$defs/${key}`,
+              $ref: LlmReference.write(key),
             });
           };
           if (ObjectDictionary.has(props.$defs, key)) return out();
@@ -433,7 +434,10 @@ export namespace LlmSchemaConverter {
                         Object.entries(props.schema.discriminator.mapping).map(
                           ([key, value]) => [
                             key,
-                            `#/$defs/${value.split("/").at(-1)}`,
+                            LlmReference.write(
+                              value.split("#/components/schemas/")[1] ??
+                                value.split("/").at(-1)!,
+                            ),
                           ],
                         ),
                       )
@@ -511,20 +515,28 @@ export namespace LlmSchemaConverter {
         );
       else if (LlmTypeChecker.isAnyOf(schema)) schema.anyOf.forEach(visit);
       else if (LlmTypeChecker.isReference(schema)) {
-        const key: string =
-          schema.$ref.split("#/$defs/")[1] ?? schema.$ref.split("/").at(-1)!;
-        if (ObjectDictionary.get(props.components.schemas, key) === undefined) {
+        const resolved: LlmReference.IResolved | undefined =
+          LlmReference.resolve(props.$defs, schema.$ref);
+        if (resolved === undefined) {
+          union.push({ oneOf: [] });
+          return;
+        }
+        const componentKey: string = LlmReference.componentKey(resolved.key);
+        if (
+          ObjectDictionary.get(props.components.schemas, componentKey) ===
+          undefined
+        ) {
           props.components.schemas ??= {};
-          ObjectDictionary.set(props.components.schemas, key, {});
+          ObjectDictionary.set(props.components.schemas, componentKey, {});
           ObjectDictionary.set(
             props.components.schemas,
-            key,
-            next(ObjectDictionary.get(props.$defs, key) ?? {}),
+            componentKey,
+            next(resolved.schema),
           );
         }
         union.push({
           ...schema,
-          $ref: `#/components/schemas/${key}`,
+          $ref: `#/components/schemas/${componentKey}`,
         });
       } else if (LlmTypeChecker.isBoolean(schema))
         if (!!schema.enum?.length)
@@ -586,13 +598,9 @@ export namespace LlmSchemaConverter {
                         props.schema["x-discriminator"].propertyName,
                       mapping:
                         props.schema["x-discriminator"].mapping !== undefined
-                          ? Object.fromEntries(
-                              Object.entries(
-                                props.schema["x-discriminator"].mapping,
-                              ).map(([key, value]) => [
-                                key,
-                                `#/components/schemas/${value.split("/").at(-1)}`,
-                              ]),
+                          ? invertDiscriminatorMapping(
+                              props.$defs,
+                              props.schema["x-discriminator"].mapping,
                             )
                           : undefined,
                     }
@@ -601,6 +609,23 @@ export namespace LlmSchemaConverter {
     } satisfies OpenApi.IJsonSchema;
   };
 }
+
+const invertDiscriminatorMapping = (
+  $defs: Record<string, ILlmSchema>,
+  mapping: Record<string, string>,
+): Record<string, string> | undefined => {
+  const entries: [string, string][] = [];
+  for (const [discriminator, reference] of Object.entries(mapping)) {
+    const resolved: LlmReference.IResolved | undefined =
+      LlmReference.resolve($defs, reference);
+    if (resolved === undefined) return undefined;
+    entries.push([
+      discriminator,
+      `#/components/schemas/${LlmReference.componentKey(resolved.key)}`,
+    ]);
+  }
+  return Object.fromEntries(entries);
+};
 
 const validateStrict = (
   schema: OpenApi.IJsonSchema,

--- a/packages/utils/src/converters/LlmSchemaConverter.ts
+++ b/packages/utils/src/converters/LlmSchemaConverter.ts
@@ -102,6 +102,7 @@ export namespace LlmSchemaConverter {
                 description: result.value.description,
               },
               escape: true,
+              key: LlmReference.readOpenApi(props.schema.$ref)!,
             })
           : result.value.description,
       } satisfies ILlmSchema.IParameters,
@@ -163,36 +164,90 @@ export namespace LlmSchemaConverter {
 
     // VALIDADTE SCHEMA
     const reasons: IJsonSchemaTransformError.IReason[] = [];
-    OpenApiTypeChecker.visit({
-      closure: (next, accessor) => {
-        if (props.config.strict === true) {
-          // STRICT MODE VALIDATION
-          reasons.push(...validateStrict(next, accessor));
-        }
-        if (OpenApiTypeChecker.isTuple(next))
-          reasons.push({
-            accessor,
-            schema: next,
-            message: `LLM does not allow tuple type.`,
-          });
-        else if (OpenApiTypeChecker.isReference(next)) {
-          // UNABLE TO FIND MATCHED REFERENCE
-          const key: string =
-            next.$ref.split("#/components/schemas/")[1] ??
-            next.$ref.split("/").at(-1)!;
-          if (ObjectDictionary.get(props.components.schemas, key) === undefined)
-            reasons.push({
-              schema: next,
-              accessor: accessor,
-              message: `unable to find reference type ${JSON.stringify(key)}.`,
-            });
-        }
-      },
-      components: props.components,
-      schema: props.schema,
-      accessor: props.accessor,
-      refAccessor: props.refAccessor,
-    });
+    const validateReference = (
+      schema: OpenApi.IJsonSchema,
+      reference: string,
+      accessor: string,
+    ): string | undefined => {
+      const key: string | undefined = LlmReference.readOpenApi(reference);
+      if (key === undefined) {
+        reasons.push({
+          schema,
+          accessor,
+          message: `invalid local schema reference ${JSON.stringify(reference)}.`,
+        });
+        return undefined;
+      } else if (
+        ObjectDictionary.get(props.components.schemas, key) === undefined
+      ) {
+        reasons.push({
+          schema,
+          accessor,
+          message: `unable to find reference type ${JSON.stringify(key)}.`,
+        });
+        return undefined;
+      }
+      return key;
+    };
+    const visited: Set<string> = new Set();
+    const validate = (next: OpenApi.IJsonSchema, accessor: string): void => {
+      if (props.config.strict === true)
+        reasons.push(...validateStrict(next, accessor));
+      if (OpenApiTypeChecker.isReference(next)) {
+        const key: string | undefined = validateReference(
+          next,
+          next.$ref,
+          accessor,
+        );
+        if (key === undefined || visited.has(key)) return;
+        visited.add(key);
+        validate(
+          ObjectDictionary.get(props.components.schemas, key)!,
+          `${props.refAccessor ?? "$input.components.schemas"}[${JSON.stringify(key)}]`,
+        );
+      } else if (OpenApiTypeChecker.isOneOf(next)) {
+        if (next.discriminator?.mapping !== undefined)
+          for (const [key, reference] of Object.entries(
+            next.discriminator.mapping,
+          ))
+            validateReference(
+              next,
+              reference,
+              `${accessor}.discriminator.mapping[${JSON.stringify(key)}]`,
+            );
+        next.oneOf.forEach((schema, index) =>
+          validate(schema, `${accessor}.oneOf[${index}]`),
+        );
+      } else if (OpenApiTypeChecker.isObject(next)) {
+        for (const [key, schema] of Object.entries(next.properties ?? {}))
+          validate(schema, `${accessor}.properties[${JSON.stringify(key)}]`);
+        if (
+          typeof next.additionalProperties === "object" &&
+          next.additionalProperties !== null
+        )
+          validate(
+            next.additionalProperties,
+            `${accessor}.additionalProperties`,
+          );
+      } else if (OpenApiTypeChecker.isArray(next))
+        validate(next.items, `${accessor}.items`);
+      else if (OpenApiTypeChecker.isTuple(next)) {
+        reasons.push({
+          accessor,
+          schema: next,
+          message: `LLM does not allow tuple type.`,
+        });
+        (next.prefixItems ?? []).forEach((schema, index) =>
+          validate(schema, `${accessor}.prefixItems[${index}]`),
+        );
+        if (
+          typeof next.additionalItems === "object" &&
+          next.additionalItems !== null
+        )
+          validate(next.additionalItems, `${accessor}.additionalItems`);
+      }
+    };
+    validate(props.schema, props.accessor ?? "$input.schema");
     if (reasons.length > 0)
       return {
         success: false,
@@ -233,9 +288,8 @@ export namespace LlmSchemaConverter {
         input.oneOf.forEach((s, i) => visit(s, `${accessor}.oneOf[${i}]`));
       } else if (OpenApiTypeChecker.isReference(input)) {
         // REFERENCE TYPE
-        const key: string =
-          input.$ref.split("#/components/schemas/")[1] ??
-          input.$ref.split("/").at(-1)!;
+        const key: string | undefined = LlmReference.readOpenApi(input.$ref);
+        if (key === undefined) return; // unreachable after validation
         const target: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
           props.components.schemas,
           key,
@@ -430,16 +484,8 @@ export namespace LlmSchemaConverter {
                 propertyName: props.schema.discriminator.propertyName,
                 mapping:
                   props.schema.discriminator.mapping !== undefined
-                    ? Object.fromEntries(
-                        Object.entries(props.schema.discriminator.mapping).map(
-                          ([key, value]) => [
-                            key,
-                            LlmReference.write(
-                              value.split("#/components/schemas/")[1] ??
-                                value.split("/").at(-1)!,
-                            ),
-                          ],
-                        ),
+                    ? convertDiscriminatorMapping(
+                        props.schema.discriminator.mapping,
                       )
                     : undefined,
               }
@@ -521,7 +567,7 @@ export namespace LlmSchemaConverter {
           union.push({ oneOf: [] });
           return;
         }
-        const componentKey: string = LlmReference.componentKey(resolved.key);
+        const componentKey: string = resolved.key;
         if (
           ObjectDictionary.get(props.components.schemas, componentKey) ===
           undefined
@@ -536,7 +582,7 @@ export namespace LlmSchemaConverter {
         }
         union.push({
           ...schema,
-          $ref: `#/components/schemas/${componentKey}`,
+          $ref: LlmReference.writeOpenApi(componentKey),
         });
       } else if (LlmTypeChecker.isBoolean(schema))
         if (!!schema.enum?.length)
@@ -610,19 +656,30 @@ export namespace LlmSchemaConverter {
   };
 }
 
+const convertDiscriminatorMapping = (
+  mapping: Record<string, string>,
+): Record<string, string> | undefined => {
+  const entries: [string, string][] = [];
+  for (const [discriminator, reference] of Object.entries(mapping)) {
+    const key: string | undefined = LlmReference.readOpenApi(reference);
+    if (key === undefined) return undefined;
+    entries.push([discriminator, LlmReference.write(key)]);
+  }
+  return Object.fromEntries(entries);
+};
+
 const invertDiscriminatorMapping = (
   $defs: Record<string, ILlmSchema>,
   mapping: Record<string, string>,
 ): Record<string, string> | undefined => {
   const entries: [string, string][] = [];
   for (const [discriminator, reference] of Object.entries(mapping)) {
-    const resolved: LlmReference.IResolved | undefined =
-      LlmReference.resolve($defs, reference);
+    const resolved: LlmReference.IResolved | undefined = LlmReference.resolve(
+      $defs,
+      reference,
+    );
     if (resolved === undefined) return undefined;
-    entries.push([
-      discriminator,
-      `#/components/schemas/${LlmReference.componentKey(resolved.key)}`,
-    ]);
+    entries.push([discriminator, LlmReference.writeOpenApi(resolved.key)]);
   }
   return Object.fromEntries(entries);
 };

--- a/packages/utils/src/converters/internal/LlmParametersComposer.ts
+++ b/packages/utils/src/converters/internal/LlmParametersComposer.ts
@@ -1,5 +1,7 @@
 import { IJsonSchemaTransformError, IResult, OpenApi } from "@typia/interface";
 
+import { LlmReference } from "../../utils/internal/LlmReference";
+import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../../validators/OpenApiTypeChecker";
 
 /** @internal */
@@ -11,22 +13,48 @@ export namespace LlmParametersFinder {
     accessor?: string;
     refAccessor?: string;
   }): IResult<OpenApi.IJsonSchema.IObject, IJsonSchemaTransformError> => {
-    const entity: IResult<OpenApi.IJsonSchema, IJsonSchemaTransformError> =
-      OpenApiTypeChecker.unreference(props);
-    if (entity.success === false) return entity;
-    else if (OpenApiTypeChecker.isObject(entity.value) === false)
+    let entity: OpenApi.IJsonSchema = props.schema;
+    const visited: Set<string> = new Set();
+    while (OpenApiTypeChecker.isReference(entity)) {
+      const key: string | undefined = LlmReference.readOpenApi(entity.$ref);
+      if (key === undefined)
+        return reportError({
+          ...props,
+          schema: entity,
+          message: `Invalid local schema reference ${JSON.stringify(entity.$ref)}.`,
+        });
+      if (visited.has(key))
+        return reportError({
+          ...props,
+          schema: entity,
+          message: `Circular schema reference ${JSON.stringify(key)} cannot be resolved.`,
+        });
+      visited.add(key);
+      const found: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+        props.components.schemas,
+        key,
+      );
+      if (found === undefined)
+        return reportError({
+          ...props,
+          schema: entity,
+          message: `Unable to resolve schema reference ${JSON.stringify(key)}.`,
+        });
+      entity = found;
+    }
+    if (OpenApiTypeChecker.isObject(entity) === false)
       return reportError({
         ...props,
         message: "LLM only accepts object type as parameters.",
       });
-    else if (!!entity.value.additionalProperties)
+    else if (!!entity.additionalProperties)
       return reportError({
         ...props,
         message: "LLM does not allow additional properties on parameters.",
       });
     return {
       success: true,
-      value: entity.value,
+      value: entity,
     };
   };
 

--- a/packages/utils/src/utils/internal/JsonDescriptor.ts
+++ b/packages/utils/src/utils/internal/JsonDescriptor.ts
@@ -10,8 +10,10 @@ export namespace JsonDescriptor {
     components: OpenApi.IComponents;
     schema: OpenApi.IJsonSchema.IReference;
     escape: boolean;
+    key?: string;
   }): string | undefined => {
     const accessors: string[] = (
+      props.key ??
       props.schema.$ref.split(props.prefix)[1] ??
       props.schema.$ref.split("/").at(-1)!
     ).split(".");

--- a/packages/utils/src/utils/internal/LlmReference.ts
+++ b/packages/utils/src/utils/internal/LlmReference.ts
@@ -5,6 +5,7 @@ import { ObjectDictionary } from "./ObjectDictionary";
 /** @internal */
 export namespace LlmReference {
   export const PREFIX = "#/$defs/" as const;
+  export const OPENAPI_PREFIX = "#/components/schemas/" as const;
 
   export interface IResolved {
     key: string;
@@ -13,14 +14,26 @@ export namespace LlmReference {
 
   /** Encode one unrestricted `$defs` key as a local URI-fragment reference. */
   export const write = (key: string): `#/$defs/${string}` =>
-    `${PREFIX}${encodeURIComponent(
-      key.replace(/~/g, "~0").replace(/\//g, "~1"),
-    )}`;
+    `${PREFIX}${encode(key)}`;
+
+  /** Encode one component key as an OpenAPI local URI-fragment reference. */
+  export const writeOpenApi = (key: string): `#/components/schemas/${string}` =>
+    `${OPENAPI_PREFIX}${encode(key)}`;
 
   /** Decode one supported local URI-fragment reference into its `$defs` key. */
-  export const read = (reference: string): string | undefined => {
-    if (reference.startsWith(PREFIX) === false) return undefined;
-    const fragment: string = reference.slice(PREFIX.length);
+  export const read = (reference: string): string | undefined =>
+    decode(PREFIX, reference);
+
+  /** Decode one OpenAPI component reference into its component key. */
+  export const readOpenApi = (reference: string): string | undefined =>
+    decode(OPENAPI_PREFIX, reference);
+
+  const encode = (key: string): string =>
+    encodeURIComponent(key.replace(/~/g, "~0").replace(/\//g, "~1"));
+
+  const decode = (prefix: string, reference: string): string | undefined => {
+    if (reference.startsWith(prefix) === false) return undefined;
+    const fragment: string = reference.slice(prefix.length);
     if (
       /^(?:[A-Za-z0-9._~!$&'()*+,;=:@?-]|%[0-9A-Fa-f]{2})*$/.test(fragment) ===
       false
@@ -61,7 +74,10 @@ export namespace LlmReference {
     return schema === undefined ? undefined : { key, schema };
   };
 
-  /** Flatten a reference-only chain, rejecting malformed, missing, or cyclic aliases. */
+  /**
+   * Flatten a reference-only chain, rejecting malformed, missing, or cyclic
+   * aliases.
+   */
   export const dereference = (
     $defs: Record<string, ILlmSchema> | undefined,
     schema: ILlmSchema,
@@ -75,8 +91,4 @@ export namespace LlmReference {
     }
     return schema;
   };
-
-  /** Produce the terminal component key used by LLM-to-OpenAPI inversion. */
-  export const componentKey = (key: string): string =>
-    write(key).slice(PREFIX.length);
 }

--- a/packages/utils/src/utils/internal/LlmReference.ts
+++ b/packages/utils/src/utils/internal/LlmReference.ts
@@ -1,0 +1,82 @@
+import { ILlmSchema } from "@typia/interface";
+
+import { ObjectDictionary } from "./ObjectDictionary";
+
+/** @internal */
+export namespace LlmReference {
+  export const PREFIX = "#/$defs/" as const;
+
+  export interface IResolved {
+    key: string;
+    schema: ILlmSchema;
+  }
+
+  /** Encode one unrestricted `$defs` key as a local URI-fragment reference. */
+  export const write = (key: string): `#/$defs/${string}` =>
+    `${PREFIX}${encodeURIComponent(
+      key.replace(/~/g, "~0").replace(/\//g, "~1"),
+    )}`;
+
+  /** Decode one supported local URI-fragment reference into its `$defs` key. */
+  export const read = (reference: string): string | undefined => {
+    if (reference.startsWith(PREFIX) === false) return undefined;
+    const fragment: string = reference.slice(PREFIX.length);
+    if (
+      /^(?:[A-Za-z0-9._~!$&'()*+,;=:@?-]|%[0-9A-Fa-f]{2})*$/.test(fragment) ===
+      false
+    )
+      return undefined;
+
+    let token: string;
+    try {
+      token = decodeURIComponent(fragment);
+    } catch {
+      return undefined;
+    }
+    if (token.includes("/")) return undefined;
+
+    let key: string = "";
+    for (let i: number = 0; i < token.length; ++i) {
+      const character: string = token[i]!;
+      if (character !== "~") {
+        key += character;
+        continue;
+      }
+      const escape: string | undefined = token[++i];
+      if (escape === "0") key += "~";
+      else if (escape === "1") key += "/";
+      else return undefined;
+    }
+    return key;
+  };
+
+  /** Resolve one supported local reference without flattening its target. */
+  export const resolve = (
+    $defs: Record<string, ILlmSchema> | undefined,
+    reference: string,
+  ): IResolved | undefined => {
+    const key: string | undefined = read(reference);
+    if (key === undefined) return undefined;
+    const schema: ILlmSchema | undefined = ObjectDictionary.get($defs, key);
+    return schema === undefined ? undefined : { key, schema };
+  };
+
+  /** Flatten a reference-only chain, rejecting malformed, missing, or cyclic aliases. */
+  export const dereference = (
+    $defs: Record<string, ILlmSchema> | undefined,
+    schema: ILlmSchema,
+  ): ILlmSchema | undefined => {
+    const visited: Set<string> = new Set();
+    while ("$ref" in schema) {
+      const resolved: IResolved | undefined = resolve($defs, schema.$ref);
+      if (resolved === undefined || visited.has(resolved.key)) return undefined;
+      visited.add(resolved.key);
+      schema = resolved.schema;
+    }
+    return schema;
+  };
+
+  /** Produce the terminal component key used by LLM-to-OpenAPI inversion. */
+  export const componentKey = (key: string): string =>
+    write(key).slice(PREFIX.length);
+}

--- a/packages/utils/src/utils/internal/coerceLlmArguments.ts
+++ b/packages/utils/src/utils/internal/coerceLlmArguments.ts
@@ -1,6 +1,7 @@
 import { IJsonParseResult, ILlmSchema } from "@typia/interface";
 
 import { LlmTypeChecker } from "../../validators/LlmTypeChecker";
+import { LlmReference } from "./LlmReference";
 import { ObjectDictionary } from "./ObjectDictionary";
 import { parseLenientJson } from "./parseLenientJson";
 
@@ -211,17 +212,7 @@ function resolveSchema(
   schema: ILlmSchema,
   $defs: Record<string, ILlmSchema> | undefined,
 ): ILlmSchema {
-  const origin: ILlmSchema = schema;
-  const visited: Set<string> = new Set();
-  while (LlmTypeChecker.isReference(schema)) {
-    const key: string = schema.$ref.replace("#/$defs/", "");
-    if (visited.has(key)) return origin;
-    visited.add(key);
-    const resolved: ILlmSchema | undefined = ObjectDictionary.get($defs, key);
-    if (resolved === undefined) return origin;
-    schema = resolved;
-  }
-  return schema;
+  return LlmReference.dereference($defs, schema) ?? schema;
 }
 
 /**

--- a/packages/utils/src/validators/LlmTypeChecker.ts
+++ b/packages/utils/src/validators/LlmTypeChecker.ts
@@ -1,6 +1,7 @@
 import { ILlmSchema } from "@typia/interface";
 
 import { MapUtil } from "../utils/MapUtil";
+import { LlmReference } from "../utils/internal/LlmReference";
 import { ObjectDictionary } from "../utils/internal/ObjectDictionary";
 import { OpenApiTypeCheckerBase } from "../utils/internal/OpenApiTypeCheckerBase";
 
@@ -149,14 +150,14 @@ export namespace LlmTypeChecker {
     const next = (schema: ILlmSchema, accessor: string): void => {
       props.closure(schema, accessor);
       if (LlmTypeChecker.isReference(schema)) {
-        const key: string = schema.$ref.split("#/$defs/").pop()!;
-        if (already.has(key) === true) return;
-        already.add(key);
-        const found: ILlmSchema | undefined = ObjectDictionary.get(
-          props.$defs,
-          key,
+        const resolved: LlmReference.IResolved | undefined =
+          LlmReference.resolve(props.$defs, schema.$ref);
+        if (resolved === undefined || already.has(resolved.key)) return;
+        already.add(resolved.key);
+        next(
+          resolved.schema,
+          `${refAccessor}[${JSON.stringify(resolved.key)}]`,
         );
-        if (found !== undefined) next(found, `${refAccessor}[${key}]`);
       } else if (LlmTypeChecker.isAnyOf(schema))
         schema.anyOf.forEach((s, i) => next(s, `${accessor}.anyOf[${i}]`));
       else if (LlmTypeChecker.isObject(schema)) {
@@ -221,9 +222,10 @@ export namespace LlmTypeChecker {
     y: ILlmSchema;
   }): boolean => {
     // CHECK EQUALITY
-    if (p.x === p.y) return true;
+    if (p.x === p.y)
+      return isReference(p.x) ? hasReference(p.$defs, p.x) : true;
     else if (isReference(p.x) && isReference(p.y) && p.x.$ref === p.y.$ref)
-      return true;
+      return hasReference(p.$defs, p.x);
 
     // COMPARE WITH FLATTENING
     const alpha: ILlmSchema[] = flatSchema(p.$defs, p.x);
@@ -249,7 +251,8 @@ export namespace LlmTypeChecker {
     y: ILlmSchema;
   }): boolean => {
     // CHECK EQUALITY
-    if (p.x === p.y) return true;
+    if (p.x === p.y)
+      return isReference(p.x) ? hasReference(p.$defs, p.x) : true;
     else if (isUnknown(p.x)) return true;
     else if (isUnknown(p.y)) return false;
     else if (isNull(p.x)) return isNull(p.y);
@@ -402,16 +405,10 @@ export namespace LlmTypeChecker {
   const escapeReference = (
     $defs: Record<string, ILlmSchema> | undefined,
     schema: ILlmSchema,
-  ): ILlmSchema => {
-    const visited: Set<string> = new Set();
-    while (isReference(schema)) {
-      const key: string = schema.$ref.replace("#/$defs/", "");
-      if (visited.has(key)) return schema;
-      visited.add(key);
-      const resolved: ILlmSchema | undefined = ObjectDictionary.get($defs, key);
-      if (resolved === undefined) return schema;
-      schema = resolved;
-    }
-    return schema;
-  };
+  ): ILlmSchema => LlmReference.dereference($defs, schema) ?? schema;
+
+  const hasReference = (
+    $defs: Record<string, ILlmSchema> | undefined,
+    schema: ILlmSchema.IReference,
+  ): boolean => LlmReference.dereference($defs, schema) !== undefined;
 }

--- a/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiOneOfValidator.ts
@@ -1,6 +1,7 @@
 import { OpenApi } from "@typia/interface";
 
 import { MapUtil } from "../../utils";
+import { LlmReference } from "../../utils/internal/LlmReference";
 import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../OpenApiTypeChecker";
 import { IOpenApiValidatorContext } from "./IOpenApiValidatorContext";
@@ -321,17 +322,26 @@ const getFlattened = (props: {
   visited: Set<string>;
 }): IFlatSchema => {
   if (OpenApiTypeChecker.isReference(props.schema)) {
-    const key: string = props.schema.$ref.split("/").pop() ?? "";
-    if (props.visited.has(key))
+    const key: string | undefined = LlmReference.readOpenApi(props.schema.$ref);
+    if (key === undefined || props.visited.has(key))
       return {
         schema: props.schema,
-        escaped: {},
+        escaped: { oneOf: [] },
       };
     props.visited.add(key);
+    const found: OpenApi.IJsonSchema | undefined = ObjectDictionary.get(
+      props.components.schemas,
+      key,
+    );
+    if (found === undefined)
+      return {
+        schema: props.schema,
+        escaped: { oneOf: [] },
+      };
     return {
       ...getFlattened({
         components: props.components,
-        schema: ObjectDictionary.get(props.components.schemas, key) ?? {},
+        schema: found,
         visited: props.visited,
       }),
       schema: props.schema,

--- a/packages/utils/src/validators/internal/OpenApiStationValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiStationValidator.ts
@@ -1,5 +1,6 @@
 import { OpenApi } from "@typia/interface";
 
+import { LlmReference } from "../../utils/internal/LlmReference";
 import { ObjectDictionary } from "../../utils/internal/ObjectDictionary";
 import { OpenApiTypeChecker } from "../OpenApiTypeChecker";
 import { IOpenApiValidatorContext } from "./IOpenApiValidatorContext";
@@ -49,7 +50,13 @@ export namespace OpenApiStationValidator {
       let schema: OpenApi.IJsonSchema = ctx.schema;
       const visited: Set<string> = new Set(references);
       while (OpenApiTypeChecker.isReference(schema)) {
-        const key: string = schema.$ref.split("/").pop() ?? "";
+        const key: string | undefined = LlmReference.readOpenApi(schema.$ref);
+        if (key === undefined)
+          return ctx.report({
+            ...ctx,
+            expected,
+            description: `Malformed schema reference ${JSON.stringify(schema.$ref)}.`,
+          });
         if (visited.has(key))
           return ctx.report({
             ...ctx,

--- a/tests/test-langchain/src/features/test_langchain_json_pointer_reference_arguments.ts
+++ b/tests/test-langchain/src/features/test_langchain_json_pointer_reference_arguments.ts
@@ -1,0 +1,60 @@
+import {
+  DynamicStructuredTool,
+  ToolInputParsingException,
+} from "@langchain/core/tools";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toLangChainTools } from "@typia/langchain";
+import typia from "typia";
+
+/**
+ * Verifies LangChain consumes generated canonical local references.
+ *
+ * 1. Advertise a recursive argument whose generated definition key contains `/`.
+ * 2. Invoke the real LangChain tool with a valid recursive value.
+ * 3. Reject an invalid referenced literal through the adapter boundary.
+ */
+export const test_langchain_json_pointer_reference_arguments =
+  async (): Promise<void> => {
+    const controller: ILlmController<PointerService> =
+      typia.llm.controller<PointerService>("pointer", new PointerService());
+    const tool: DynamicStructuredTool = toLangChainTools({
+      controllers: [controller],
+    })[0]!;
+    TestValidator.predicate("advertises a canonical slash reference", () =>
+      JSON.stringify(controller.application).includes(
+        '"$ref":"#/$defs/RecursiveA~1B"',
+      ),
+    );
+
+    const tree: Recursive<"A/B"> = {
+      value: "A/B",
+      children: [{ value: "A/B", children: [] }],
+    };
+    const valid = await tool.invoke({ input: tree });
+    TestValidator.equals("valid referenced argument executes", valid, {
+      success: true,
+      data: tree,
+    });
+
+    try {
+      await tool.invoke({ input: { value: "wrong", children: [] } });
+      throw new Error("Expected referenced argument validation to fail.");
+    } catch (error) {
+      TestValidator.predicate(
+        "invalid referenced argument is rejected",
+        () => error instanceof ToolInputParsingException,
+      );
+    }
+  };
+
+type Recursive<T extends string> = {
+  value: T;
+  children: Recursive<T>[];
+};
+
+class PointerService {
+  public echo(props: { input: Recursive<"A/B"> }): Recursive<"A/B"> {
+    return props.input;
+  }
+}

--- a/tests/test-langchain/src/features/test_langchain_json_pointer_reference_arguments.ts
+++ b/tests/test-langchain/src/features/test_langchain_json_pointer_reference_arguments.ts
@@ -8,11 +8,16 @@ import { toLangChainTools } from "@typia/langchain";
 import typia from "typia";
 
 /**
- * Verifies LangChain consumes generated canonical local references.
+ * Verifies LangChain resolves generated canonical local references.
+ *
+ * LangChain validates tool input against the advertised schema before typia's
+ * own coercion runs, so this boundary is an independent JSON Schema oracle: it
+ * can only reject a violation of the referenced definition after resolving
+ * `#/$defs/RecursiveA~1B`. A fail-open reference would admit both negatives.
  *
  * 1. Advertise a recursive argument whose generated definition key contains `/`.
- * 2. Invoke the real LangChain tool with a valid recursive value.
- * 3. Reject an invalid referenced literal through the adapter boundary.
+ * 2. Execute a valid recursive value through the real LangChain tool.
+ * 3. Reject values violating only the referenced schema at LangChain's own gate.
  */
 export const test_langchain_json_pointer_reference_arguments =
   async (): Promise<void> => {
@@ -29,7 +34,8 @@ export const test_langchain_json_pointer_reference_arguments =
 
     const tree: Recursive<"A/B"> = {
       value: "A/B",
-      children: [{ value: "A/B", children: [] }],
+      count: 42,
+      children: [{ value: "A/B", count: 7, children: [] }],
     };
     const valid = await tool.invoke({ input: tree });
     TestValidator.equals("valid referenced argument executes", valid, {
@@ -37,19 +43,29 @@ export const test_langchain_json_pointer_reference_arguments =
       data: tree,
     });
 
-    try {
-      await tool.invoke({ input: { value: "wrong", children: [] } });
-      throw new Error("Expected referenced argument validation to fail.");
-    } catch (error) {
-      TestValidator.predicate(
-        "invalid referenced argument is rejected",
-        () => error instanceof ToolInputParsingException,
-      );
+    // Both negatives violate only the referenced `Recursive<"A/B">` definition,
+    // so LangChain can reject them only by resolving the encoded reference.
+    for (const [label, input] of [
+      ["referenced numeric property", { value: "A/B", count: "42" }],
+      ["referenced literal property", { value: "wrong", count: 0 }],
+    ] as const) {
+      try {
+        await tool.invoke({ input: { ...input, children: [] } });
+        throw new Error(`Expected ${label} to be rejected.`);
+      } catch (error) {
+        TestValidator.predicate(
+          `LangChain resolves the encoded reference to reject a ${label}`,
+          () =>
+            error instanceof ToolInputParsingException &&
+            error.message.includes("did not match expected schema"),
+        );
+      }
     }
   };
 
 type Recursive<T extends string> = {
   value: T;
+  count: number;
   children: Recursive<T>[];
 };
 

--- a/tests/test-mcp/src/features/test_mcp_json_pointer_reference_validation.ts
+++ b/tests/test-mcp/src/features/test_mcp_json_pointer_reference_validation.ts
@@ -11,7 +11,7 @@ import typia from "typia";
  * Verifies MCP advertises and enforces generated canonical local references.
  *
  * 1. List a recursive slash-key schema through a real in-memory SDK client.
- * 2. Execute and validate a correct referenced result.
+ * 2. Coerce numeric input strings and validate the referenced result.
  * 3. Reject a wrong referenced result through MCP's output error channel.
  */
 export const test_mcp_json_pointer_reference_validation =
@@ -34,10 +34,15 @@ export const test_mcp_json_pointer_reference_validation =
         ),
       );
 
-      const tree: Recursive<"A/B"> = { value: "A/B", children: [] };
+      const raw = { value: "A/B", count: "42", children: [] };
+      const tree: Recursive<"A/B"> = {
+        value: "A/B",
+        count: 42,
+        children: [],
+      };
       const valid = (await client.callTool({
         name,
-        arguments: { input: tree, invalid: false },
+        arguments: { input: raw, invalid: false },
       })) as CallToolResult;
       TestValidator.equals(
         "valid referenced output is structured",
@@ -60,6 +65,7 @@ export const test_mcp_json_pointer_reference_validation =
 
 type Recursive<T extends string> = {
   value: T;
+  count: number;
   children: Recursive<T>[];
 };
 
@@ -69,7 +75,7 @@ class PointerService {
   } {
     return {
       result: props.invalid
-        ? ({ value: "wrong", children: [] } as any)
+        ? ({ value: "wrong", count: 0, children: [] } as any)
         : props.input,
     };
   }

--- a/tests/test-mcp/src/features/test_mcp_json_pointer_reference_validation.ts
+++ b/tests/test-mcp/src/features/test_mcp_json_pointer_reference_validation.ts
@@ -1,0 +1,76 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { createMcpServer } from "@typia/mcp";
+import typia from "typia";
+
+/**
+ * Verifies MCP advertises and enforces generated canonical local references.
+ *
+ * 1. List a recursive slash-key schema through a real in-memory SDK client.
+ * 2. Execute and validate a correct referenced result.
+ * 3. Reject a wrong referenced result through MCP's output error channel.
+ */
+export const test_mcp_json_pointer_reference_validation =
+  async (): Promise<void> => {
+    const controller: ILlmController<PointerService> =
+      typia.llm.controller<PointerService>("pointer", new PointerService());
+    const server: McpServer = createMcpServer(controller);
+    const client: Client = new Client({ name: "pointer-test", version: "1.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      const listed = await client.listTools();
+      const name: string = listed.tools[0]!.name;
+      TestValidator.predicate("lists a canonical slash reference", () =>
+        JSON.stringify(listed.tools[0]).includes(
+          '"$ref":"#/$defs/RecursiveA~1B"',
+        ),
+      );
+
+      const tree: Recursive<"A/B"> = { value: "A/B", children: [] };
+      const valid = (await client.callTool({
+        name,
+        arguments: { input: tree, invalid: false },
+      })) as CallToolResult;
+      TestValidator.equals(
+        "valid referenced output is structured",
+        valid.structuredContent,
+        { result: tree },
+      );
+
+      const invalid = (await client.callTool({
+        name,
+        arguments: { input: tree, invalid: true },
+      })) as CallToolResult;
+      TestValidator.predicate(
+        "invalid referenced output is rejected",
+        invalid.isError === true && invalid.structuredContent === undefined,
+      );
+    } finally {
+      await Promise.allSettled([client.close(), server.close()]);
+    }
+  };
+
+type Recursive<T extends string> = {
+  value: T;
+  children: Recursive<T>[];
+};
+
+class PointerService {
+  public echo(props: { input: Recursive<"A/B">; invalid: boolean }): {
+    result: Recursive<"A/B">;
+  } {
+    return {
+      result: props.invalid
+        ? ({ value: "wrong", children: [] } as any)
+        : props.input,
+    };
+  }
+}

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_json_pointer_references.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_json_pointer_references.ts
@@ -1,0 +1,66 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import typia from "typia";
+
+/**
+ * Verifies native LLM generation emits canonical local `$defs` references.
+ *
+ * Recursive generic names can contain JSON Pointer and URI-fragment reserved
+ * characters. The generated definition keys remain unchanged while each local
+ * reference encodes that key as one RFC 6901 token.
+ *
+ * 1. Generate recursive definitions containing reserved and Unicode text.
+ * 2. Collect every local reference from the root schema and `$defs` graph.
+ * 3. Match unchanged keys with their canonical URI-fragment references.
+ */
+export const test_llm_parameters_json_pointer_references = (): void => {
+  type Recursive<T extends string> = {
+    value: T;
+    children: Recursive<T>[];
+  };
+  interface IArguments {
+    slash: Recursive<"A/B">;
+    tilde: Recursive<"T~N">;
+    combined: Recursive<"A~/B">;
+    pointerOrder: Recursive<"~1">;
+    percent: Recursive<"C%D">;
+    unicode: Recursive<"Café">;
+    plain: Recursive<"Plain">;
+  }
+
+  const parameters: ILlmSchema.IParameters = typia.llm.parameters<IArguments>();
+  const expected = [
+    ["RecursiveA/B", "#/$defs/RecursiveA~1B"],
+    ["RecursiveT~N", "#/$defs/RecursiveT~0N"],
+    ["RecursiveA~/B", "#/$defs/RecursiveA~0~1B"],
+    ["Recursive~1", "#/$defs/Recursive~01"],
+    ["RecursiveC%D", "#/$defs/RecursiveC%25D"],
+    ["RecursiveCafé", "#/$defs/RecursiveCaf%C3%A9"],
+    ["RecursivePlain", "#/$defs/RecursivePlain"],
+  ] as const;
+
+  const refs: string[] = [];
+  const collect = (schema: ILlmSchema): void => {
+    if ("$ref" in schema) refs.push(schema.$ref);
+    else if ("anyOf" in schema) schema.anyOf.forEach(collect);
+    else if (schema.type === "object") {
+      Object.values(schema.properties).forEach(collect);
+      if (
+        typeof schema.additionalProperties === "object" &&
+        schema.additionalProperties !== null
+      )
+        collect(schema.additionalProperties);
+    } else if (schema.type === "array") collect(schema.items);
+  };
+  collect(parameters);
+  Object.values(parameters.$defs).forEach(collect);
+
+  for (const [key, $ref] of expected) {
+    TestValidator.predicate(`owns definition ${key}`, () =>
+      Object.hasOwn(parameters.$defs, key),
+    );
+    TestValidator.predicate(`emits canonical reference ${$ref}`, () =>
+      refs.includes($ref),
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_json_pointer_references.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_json_pointer_references.ts
@@ -10,7 +10,7 @@ import typia from "typia";
  * reference encodes that key as one RFC 6901 token.
  *
  * 1. Generate recursive definitions containing reserved and Unicode text.
- * 2. Collect every local reference from the root schema and `$defs` graph.
+ * 2. Collect every local reference and discriminator mapping from the graph.
  * 3. Match unchanged keys with their canonical URI-fragment references.
  */
 export const test_llm_parameters_json_pointer_references = (): void => {
@@ -18,6 +18,10 @@ export const test_llm_parameters_json_pointer_references = (): void => {
     value: T;
     children: Recursive<T>[];
   };
+  interface IVariant<T extends string> {
+    kind: T;
+    value: number;
+  }
   interface IArguments {
     slash: Recursive<"A/B">;
     tilde: Recursive<"T~N">;
@@ -26,6 +30,7 @@ export const test_llm_parameters_json_pointer_references = (): void => {
     percent: Recursive<"C%D">;
     unicode: Recursive<"Café">;
     plain: Recursive<"Plain">;
+    discriminated: IVariant<"A/B"> | IVariant<"T~N">;
   }
 
   const parameters: ILlmSchema.IParameters = typia.llm.parameters<IArguments>();
@@ -37,13 +42,19 @@ export const test_llm_parameters_json_pointer_references = (): void => {
     ["RecursiveC%D", "#/$defs/RecursiveC%25D"],
     ["RecursiveCafé", "#/$defs/RecursiveCaf%C3%A9"],
     ["RecursivePlain", "#/$defs/RecursivePlain"],
+    ["IVariantA/B", "#/$defs/IVariantA~1B"],
+    ["IVariantT~N", "#/$defs/IVariantT~0N"],
   ] as const;
 
   const refs: string[] = [];
+  const mappings: Record<string, string>[] = [];
   const collect = (schema: ILlmSchema): void => {
     if ("$ref" in schema) refs.push(schema.$ref);
-    else if ("anyOf" in schema) schema.anyOf.forEach(collect);
-    else if (schema.type === "object") {
+    else if ("anyOf" in schema) {
+      if (schema["x-discriminator"]?.mapping !== undefined)
+        mappings.push(schema["x-discriminator"].mapping);
+      schema.anyOf.forEach(collect);
+    } else if (schema.type === "object") {
       Object.values(schema.properties).forEach(collect);
       if (
         typeof schema.additionalProperties === "object" &&
@@ -63,4 +74,11 @@ export const test_llm_parameters_json_pointer_references = (): void => {
       refs.includes($ref),
     );
   }
+  TestValidator.predicate("encodes discriminator mapping references", () =>
+    mappings.some(
+      (mapping) =>
+        mapping["A/B"] === "#/$defs/IVariantA~1B" &&
+        mapping["T~N"] === "#/$defs/IVariantT~0N",
+    ),
+  );
 };

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
@@ -20,6 +20,7 @@ export const test_llm_schema_json_pointer_references = (): void => {
     ["Plain", "#/$defs/Plain"],
     ["", "#/$defs/"],
     ["A/B", "#/$defs/A~1B"],
+    ["A~1B", "#/$defs/A~01B"],
     ["T~N", "#/$defs/T~0N"],
     ["~1", "#/$defs/~01"],
     ["A B", "#/$defs/A%20B"],
@@ -100,6 +101,20 @@ export const test_llm_schema_json_pointer_references = (): void => {
         Object.values(components.schemas!).some(
           (schema) => (schema as { type?: string }).type === "number",
         ),
+    );
+    TestValidator.predicate(
+      `${label}: inversion keeps raw component identity`,
+      () => Object.hasOwn(components.schemas!, key),
+    );
+    TestValidator.equals(
+      `${label}: inverted reference resolves by JSON Pointer`,
+      resolveLocalReference(
+        { components },
+        (inverted as OpenApi.IJsonSchema.IObject).properties?.value as
+          | OpenApi.IJsonSchema.IReference
+          | undefined,
+      ),
+      components.schemas![key],
     );
     TestValidator.predicate(
       `${label}: inversion is not accept-all`,
@@ -229,7 +244,12 @@ export const test_llm_schema_json_pointer_references = (): void => {
     schema: {
       type: "object",
       properties: Object.fromEntries(
-        valid.map(([key]) => [key, { $ref: `#/components/schemas/${key}` }]),
+        valid.map(([key, $ref]) => [
+          key,
+          {
+            $ref: $ref.replace("#/$defs/", "#/components/schemas/"),
+          },
+        ]),
       ),
       required: valid.map(([key]) => key),
     },
@@ -249,6 +269,133 @@ export const test_llm_schema_json_pointer_references = (): void => {
         refs.includes($ref),
       );
   }
+
+  const collisionDefinitions: Record<string, ILlmSchema> = {};
+  const collision = LlmSchemaConverter.schema({
+    components: {
+      schemas: {
+        "A/B": { type: "number" },
+        "A~1B": {
+          type: "array",
+          prefixItems: [{ type: "string" }],
+        },
+      },
+    },
+    $defs: collisionDefinitions,
+    schema: { $ref: "#/components/schemas/A~1B" },
+  });
+  TestValidator.equals(
+    "encoded reference does not validate the colliding raw key",
+    collision.success,
+    true,
+  );
+  TestValidator.equals(
+    "encoded reference selects the decoded raw component identity",
+    collisionDefinitions,
+    { "A/B": { type: "number" } },
+  );
+
+  const rootParameters = LlmSchemaConverter.parameters({
+    components: {
+      schemas: {
+        "Root/A": {
+          type: "number",
+          description: "parent slash description",
+        },
+        "Root/A.Child": {
+          type: "object",
+          properties: { value: { type: "number" } },
+          required: ["value"],
+          additionalProperties: false,
+        },
+        "Root~1A.Child": { type: "number" },
+      },
+    },
+    schema: { $ref: "#/components/schemas/Root~1A.Child" },
+  });
+  TestValidator.equals(
+    "root parameters decode the raw component identity",
+    rootParameters.success,
+    true,
+  );
+  if (rootParameters.success)
+    TestValidator.predicate(
+      "root parameters cascade the decoded parent description",
+      () =>
+        rootParameters.value.description?.includes(
+          "parent slash description",
+        ) === true,
+    );
+
+  for (const $ref of [
+    "#/components/schemas/A/B",
+    "#/components/schemas/T~N",
+    "#/components/schemas/C%D",
+    "#/components/schemas/A B",
+    "#/components/schemas/A%",
+    "https://example.com/schema.json#/components/schemas/A",
+  ])
+    TestValidator.equals(
+      `${$ref}: malformed OpenAPI reference fails conversion`,
+      LlmSchemaConverter.schema({
+        components: {
+          schemas: {
+            [$ref.replace("#/components/schemas/", "")]: {
+              type: "number",
+            },
+          },
+        },
+        $defs: {},
+        schema: { $ref },
+      }).success,
+      false,
+    );
+
+  const forwardDiscriminatorDefinitions: Record<string, ILlmSchema> = {};
+  const forwardDiscriminator = LlmSchemaConverter.schema({
+    components: {
+      schemas: {
+        "A/B": { type: "number" },
+        "T~N": { type: "string" },
+      },
+    },
+    $defs: forwardDiscriminatorDefinitions,
+    schema: {
+      oneOf: [
+        { $ref: "#/components/schemas/A~1B" },
+        { $ref: "#/components/schemas/T~0N" },
+      ],
+      discriminator: {
+        propertyName: "kind",
+        mapping: {
+          slash: "#/components/schemas/A~1B",
+          tilde: "#/components/schemas/T~0N",
+        },
+      },
+    },
+  });
+  TestValidator.equals(
+    "forward discriminator conversion succeeds",
+    forwardDiscriminator.success,
+    true,
+  );
+  if (forwardDiscriminator.success)
+    TestValidator.equals(
+      "forward discriminator preserves raw component identities",
+      LlmTypeChecker.isAnyOf(forwardDiscriminator.value)
+        ? forwardDiscriminator.value["x-discriminator"]?.mapping
+        : undefined,
+      {
+        slash: "#/$defs/A~1B",
+        tilde: "#/$defs/T~0N",
+      },
+    );
+  TestValidator.predicate(
+    "forward discriminator stores raw component identities",
+    () =>
+      Object.hasOwn(forwardDiscriminatorDefinitions, "A/B") &&
+      Object.hasOwn(forwardDiscriminatorDefinitions, "T~N"),
+  );
 
   const discriminatorDefinitions: Record<string, ILlmSchema> = {
     "A/B": {
@@ -290,4 +437,42 @@ export const test_llm_schema_json_pointer_references = (): void => {
       tilde: "#/components/schemas/T~0N",
     },
   );
+  TestValidator.predicate(
+    "discriminator component identities remain raw",
+    () =>
+      Object.hasOwn(discriminatorComponents.schemas!, "A/B") &&
+      Object.hasOwn(discriminatorComponents.schemas!, "T~N"),
+  );
+  const validateDiscriminator = LlmJson.validate({
+    type: "object",
+    properties: { value: discriminatorSchema },
+    required: ["value"],
+    additionalProperties: false,
+    $defs: discriminatorDefinitions,
+  });
+  TestValidator.equals(
+    "encoded discriminator validates its first branch",
+    validateDiscriminator({ value: { kind: "slash" } }).success,
+    true,
+  );
+  TestValidator.equals(
+    "encoded discriminator validates its later branch",
+    validateDiscriminator({ value: { kind: "tilde" } }).success,
+    true,
+  );
+};
+
+const resolveLocalReference = (
+  document: { components: OpenApi.IComponents },
+  schema: OpenApi.IJsonSchema.IReference | undefined,
+): OpenApi.IJsonSchema | undefined => {
+  if (schema === undefined || schema.$ref.startsWith("#/") === false)
+    return undefined;
+  let current: unknown = document;
+  for (const token of decodeURIComponent(schema.$ref.slice(2)).split("/")) {
+    const key: string = token.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current as OpenApi.IJsonSchema | undefined;
 };

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
@@ -182,6 +182,58 @@ export const test_llm_schema_json_pointer_references = (): void => {
     );
   }
 
+  // A percent-encoded separator is a well-formed triplet, so it passes the
+  // fragment regex and decodes to the multi-token pointer `/$defs/A/B` rather
+  // than the single `$defs` key `A/B`. Only rejecting it keeps one canonical
+  // spelling per key, so the raw target must be present for this to bite.
+  const extraSegment: ILlmSchema.IParameters = {
+    type: "object",
+    properties: { value: { $ref: "#/$defs/A%2FB" } },
+    required: ["value"],
+    additionalProperties: false,
+    $defs: { "A/B": { type: "number" } },
+  };
+  TestValidator.equals(
+    "percent-encoded pointer separator does not resolve its raw key",
+    LlmJson.coerce<{ value: unknown }>({ value: "42" }, extraSegment).value,
+    "42",
+  );
+  TestValidator.equals(
+    "percent-encoded pointer separator fails closed",
+    LlmJson.validate(extraSegment)({ value: 42 }).success,
+    false,
+  );
+  TestValidator.equals(
+    "percent-encoded pointer separator fails OpenAPI conversion",
+    LlmSchemaConverter.schema({
+      components: { schemas: { "A/B": { type: "number" } } },
+      $defs: {},
+      schema: { $ref: "#/components/schemas/A%2FB" },
+    }).success,
+    false,
+  );
+
+  // Percent-decoding precedes token-decoding, so these are alternate spellings
+  // of the same keys and must still resolve.
+  for (const [$ref, key] of [
+    ["#/$defs/A%7E1B", "A/B"],
+    ["#/$defs/A%7E0B", "A~B"],
+  ] as const)
+    TestValidator.equals(
+      `${$ref}: percent-encoded tilde resolves ${key}`,
+      LlmJson.coerce<{ value: unknown }>(
+        { value: "42" },
+        {
+          type: "object",
+          properties: { value: { $ref } },
+          required: ["value"],
+          additionalProperties: false,
+          $defs: Object.fromEntries([[key, { type: "number" }]]),
+        },
+      ).value,
+      42,
+    );
+
   const chained: ILlmSchema.IParameters = {
     type: "object",
     properties: { value: { $ref: "#/$defs/Alias" } },

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
@@ -1,0 +1,293 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema, OpenApi } from "@typia/interface";
+import { LlmJson, LlmSchemaConverter, LlmTypeChecker } from "@typia/utils";
+
+/**
+ * Verifies local LLM references obey JSON Pointer and URI-fragment semantics.
+ *
+ * Definition keys are unrestricted JSON object keys. References must encode one
+ * `$defs` key as one RFC 6901 token, then encode that token as a URI fragment.
+ * Valid references must resolve consistently for traversal, conversion,
+ * coercion, parsing, coverage, and validation. Malformed or missing references
+ * must never degrade to an accept-all schema.
+ *
+ * 1. Resolve the complete escaped and URI-encoded key matrix in every utility.
+ * 2. Reject malformed, missing, and transitively broken reference chains.
+ * 3. Preserve canonical references through conversion and discriminators.
+ */
+export const test_llm_schema_json_pointer_references = (): void => {
+  const valid = [
+    ["Plain", "#/$defs/Plain"],
+    ["", "#/$defs/"],
+    ["A/B", "#/$defs/A~1B"],
+    ["T~N", "#/$defs/T~0N"],
+    ["~1", "#/$defs/~01"],
+    ["A B", "#/$defs/A%20B"],
+    ["C%D", "#/$defs/C%25D"],
+    ["Café", "#/$defs/Caf%C3%A9"],
+    ["A~/B", "#/$defs/A~0~1B"],
+    ["__proto__", "#/$defs/__proto__"],
+  ] as const;
+
+  for (const [key, $ref] of valid) {
+    const parameters: ILlmSchema.IParameters = {
+      type: "object",
+      properties: { value: { $ref } },
+      required: ["value"],
+      additionalProperties: false,
+      $defs: Object.fromEntries([[key, { type: "number" }]]),
+    };
+    const label: string = key.length === 0 ? "empty" : key;
+
+    TestValidator.equals(
+      `${label}: coerce encoded reference`,
+      LlmJson.coerce<{ value: unknown }>({ value: "42" }, parameters).value,
+      42,
+    );
+    const parsed = LlmJson.parse<{ value: unknown }>(
+      '{"value":"42"}',
+      parameters,
+    );
+    TestValidator.equals(`${label}: parse succeeds`, parsed.success, true);
+    if (parsed.success)
+      TestValidator.equals(`${label}: parse coerces`, parsed.data.value, 42);
+
+    const validate = LlmJson.validate(parameters);
+    TestValidator.equals(
+      `${label}: referenced number passes`,
+      validate({ value: 42 }).success,
+      true,
+    );
+    TestValidator.equals(
+      `${label}: referenced string fails`,
+      validate({ value: "wrong" }).success,
+      false,
+    );
+    TestValidator.equals(
+      `${label}: structured output fails closed`,
+      LlmJson.structuredOutput(parameters).validate({ value: "wrong" }).success,
+      false,
+    );
+
+    const visited: ILlmSchema[] = [];
+    LlmTypeChecker.visit({
+      schema: parameters.properties.value!,
+      $defs: parameters.$defs,
+      closure: (schema) => visited.push(schema),
+    });
+    TestValidator.predicate(`${label}: traversal resolves`, () =>
+      visited.some(LlmTypeChecker.isNumber),
+    );
+    TestValidator.equals(
+      `${label}: coverage resolves`,
+      LlmTypeChecker.covers({
+        $defs: parameters.$defs,
+        x: parameters.properties.value!,
+        y: { type: "number" },
+      }),
+      true,
+    );
+
+    const components: OpenApi.IComponents = { schemas: {} };
+    const inverted: OpenApi.IJsonSchema = LlmSchemaConverter.invert({
+      components,
+      schema: parameters,
+      $defs: parameters.$defs,
+    });
+    TestValidator.predicate(
+      `${label}: inversion keeps a reference target`,
+      () =>
+        Object.values(components.schemas!).some(
+          (schema) => (schema as { type?: string }).type === "number",
+        ),
+    );
+    TestValidator.predicate(
+      `${label}: inversion is not accept-all`,
+      () => "type" in inverted || "oneOf" in inverted || "$ref" in inverted,
+    );
+  }
+
+  const malformed = [
+    "#/$defs/A/B",
+    "#/$defs/T~N",
+    "#/$defs/C%D",
+    "#/$defs/A B",
+    "#/$defs/Café",
+    "#/$defs/A%",
+    "#/$defs/%C3%28",
+    "#/$defs/A#B",
+    "#/wrong/A",
+    "https://example.com/schema.json#/$defs/A",
+  ] as const;
+  for (const $ref of [...malformed, "#/$defs/Missing"]) {
+    const parameters: ILlmSchema.IParameters = {
+      type: "object",
+      properties: { value: { $ref } as ILlmSchema.IReference },
+      required: ["value"],
+      additionalProperties: false,
+      $defs: Object.fromEntries([
+        [$ref.replace("#/$defs/", ""), { type: "number" }],
+      ]),
+    };
+    if ($ref.endsWith("Missing")) parameters.$defs = {};
+
+    TestValidator.equals(
+      `${$ref}: no malformed coercion`,
+      LlmJson.coerce<{ value: unknown }>({ value: "42" }, parameters).value,
+      "42",
+    );
+    const validate = LlmJson.validate(parameters);
+    TestValidator.equals(
+      `${$ref}: number fails closed`,
+      validate({ value: 42 }).success,
+      false,
+    );
+    TestValidator.equals(
+      `${$ref}: string fails closed`,
+      validate({ value: "wrong" }).success,
+      false,
+    );
+    TestValidator.equals(
+      `${$ref}: malformed coverage fails`,
+      LlmTypeChecker.covers({
+        $defs: parameters.$defs,
+        x: parameters.properties.value!,
+        y: { type: "number" },
+      }),
+      false,
+    );
+    TestValidator.equals(
+      `${$ref}: identical unresolved references do not cover`,
+      LlmTypeChecker.covers({
+        $defs: parameters.$defs,
+        x: parameters.properties.value!,
+        y: parameters.properties.value!,
+      }),
+      false,
+    );
+  }
+
+  const chained: ILlmSchema.IParameters = {
+    type: "object",
+    properties: { value: { $ref: "#/$defs/Alias" } },
+    required: ["value"],
+    additionalProperties: false,
+    $defs: {
+      Alias: { $ref: "#/$defs/Encoded~1Target" },
+      "Encoded/Target": { type: "number" },
+    },
+  };
+  TestValidator.equals(
+    "valid reference chain coerces",
+    LlmJson.coerce<{ value: unknown }>({ value: "42" }, chained).value,
+    42,
+  );
+  TestValidator.equals(
+    "valid reference chain validates",
+    LlmJson.validate(chained)({ value: 42 }).success,
+    true,
+  );
+  TestValidator.equals(
+    "valid reference chain covers its target",
+    LlmTypeChecker.covers({
+      $defs: chained.$defs,
+      x: chained.properties.value!,
+      y: { type: "number" },
+    }),
+    true,
+  );
+
+  const brokenChain: ILlmSchema.IParameters = {
+    ...chained,
+    $defs: {
+      Alias: { $ref: "#/$defs/Missing" },
+    },
+  };
+  TestValidator.equals(
+    "transitively missing reference fails validation",
+    LlmJson.validate(brokenChain)({ value: 42 }).success,
+    false,
+  );
+  TestValidator.equals(
+    "transitively missing reference does not cover",
+    LlmTypeChecker.covers({
+      $defs: brokenChain.$defs,
+      x: brokenChain.properties.value!,
+      y: brokenChain.properties.value!,
+    }),
+    false,
+  );
+
+  const convertedDefinitions: Record<string, ILlmSchema> = {};
+  const converted = LlmSchemaConverter.schema({
+    components: {
+      schemas: Object.fromEntries(
+        valid.map(([key]) => [key, { type: "number" }]),
+      ),
+    },
+    $defs: convertedDefinitions,
+    schema: {
+      type: "object",
+      properties: Object.fromEntries(
+        valid.map(([key]) => [key, { $ref: `#/components/schemas/${key}` }]),
+      ),
+      required: valid.map(([key]) => key),
+    },
+  });
+  TestValidator.equals("OpenAPI conversion succeeds", converted.success, true);
+  if (converted.success) {
+    const refs: string[] = [];
+    LlmTypeChecker.visit({
+      schema: converted.value,
+      $defs: convertedDefinitions,
+      closure: (schema) => {
+        if (LlmTypeChecker.isReference(schema)) refs.push(schema.$ref);
+      },
+    });
+    for (const [, $ref] of valid)
+      TestValidator.predicate(`converter emits ${$ref}`, () =>
+        refs.includes($ref),
+      );
+  }
+
+  const discriminatorDefinitions: Record<string, ILlmSchema> = {
+    "A/B": {
+      type: "object",
+      properties: { kind: { type: "string", enum: ["slash"] } },
+      required: ["kind"],
+      additionalProperties: false,
+    },
+    "T~N": {
+      type: "object",
+      properties: { kind: { type: "string", enum: ["tilde"] } },
+      required: ["kind"],
+      additionalProperties: false,
+    },
+  };
+  const discriminatorSchema: ILlmSchema = {
+    anyOf: [{ $ref: "#/$defs/A~1B" }, { $ref: "#/$defs/T~0N" }],
+    "x-discriminator": {
+      propertyName: "kind",
+      mapping: {
+        slash: "#/$defs/A~1B",
+        tilde: "#/$defs/T~0N",
+      },
+    },
+  };
+  const discriminatorComponents: OpenApi.IComponents = { schemas: {} };
+  const discriminatorInverted = LlmSchemaConverter.invert({
+    components: discriminatorComponents,
+    schema: discriminatorSchema,
+    $defs: discriminatorDefinitions,
+  });
+  TestValidator.equals(
+    "inversion preserves encoded discriminator identity",
+    "oneOf" in discriminatorInverted
+      ? discriminatorInverted.discriminator?.mapping
+      : undefined,
+    {
+      slash: "#/components/schemas/A~1B",
+      tilde: "#/components/schemas/T~0N",
+    },
+  );
+};

--- a/tests/test-vercel/src/features/test_vercel_json_pointer_reference_validation.ts
+++ b/tests/test-vercel/src/features/test_vercel_json_pointer_reference_validation.ts
@@ -8,7 +8,7 @@ import typia from "typia";
  * Verifies Vercel advertises and enforces generated canonical local references.
  *
  * 1. Convert a recursive slash-key controller through the public adapter.
- * 2. Execute and validate a correct referenced result.
+ * 2. Coerce numeric input strings and validate the referenced result.
  * 3. Reject a wrong referenced result through Vercel's failure branch.
  */
 export const test_vercel_json_pointer_reference_validation =
@@ -22,8 +22,13 @@ export const test_vercel_json_pointer_reference_validation =
       ),
     );
 
-    const tree: Recursive<"A/B"> = { value: "A/B", children: [] };
-    const valid = await execute(tool, tree, false);
+    const raw = { value: "A/B", count: "42", children: [] };
+    const tree: Recursive<"A/B"> = {
+      value: "A/B",
+      count: 42,
+      children: [],
+    };
+    const valid = await execute(tool, raw, false);
     TestValidator.equals("valid referenced output succeeds", valid, {
       success: true,
       data: { result: tree },
@@ -41,6 +46,7 @@ export const test_vercel_json_pointer_reference_validation =
 
 type Recursive<T extends string> = {
   value: T;
+  count: number;
   children: Recursive<T>[];
 };
 
@@ -50,7 +56,7 @@ class PointerService {
   } {
     return {
       result: props.invalid
-        ? ({ value: "wrong", children: [] } as any)
+        ? ({ value: "wrong", count: 0, children: [] } as any)
         : props.input,
     };
   }
@@ -58,7 +64,7 @@ class PointerService {
 
 const execute = (
   tool: Tool,
-  input: Recursive<"A/B">,
+  input: unknown,
   invalid: boolean,
 ): Promise<unknown> =>
   tool.execute!(

--- a/tests/test-vercel/src/features/test_vercel_json_pointer_reference_validation.ts
+++ b/tests/test-vercel/src/features/test_vercel_json_pointer_reference_validation.ts
@@ -1,0 +1,71 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+import typia from "typia";
+
+/**
+ * Verifies Vercel advertises and enforces generated canonical local references.
+ *
+ * 1. Convert a recursive slash-key controller through the public adapter.
+ * 2. Execute and validate a correct referenced result.
+ * 3. Reject a wrong referenced result through Vercel's failure branch.
+ */
+export const test_vercel_json_pointer_reference_validation =
+  async (): Promise<void> => {
+    const controller: ILlmController<PointerService> =
+      typia.llm.controller<PointerService>("pointer", new PointerService());
+    const tool: Tool = toVercelTools({ controllers: [controller] })["echo"]!;
+    TestValidator.predicate("advertises a canonical slash reference", () =>
+      JSON.stringify(controller.application).includes(
+        '"$ref":"#/$defs/RecursiveA~1B"',
+      ),
+    );
+
+    const tree: Recursive<"A/B"> = { value: "A/B", children: [] };
+    const valid = await execute(tool, tree, false);
+    TestValidator.equals("valid referenced output succeeds", valid, {
+      success: true,
+      data: { result: tree },
+    });
+
+    const invalid = (await execute(tool, tree, true)) as {
+      success?: boolean;
+      error?: string;
+    };
+    TestValidator.predicate(
+      "invalid referenced output fails",
+      invalid.success === false && typeof invalid.error === "string",
+    );
+  };
+
+type Recursive<T extends string> = {
+  value: T;
+  children: Recursive<T>[];
+};
+
+class PointerService {
+  public echo(props: { input: Recursive<"A/B">; invalid: boolean }): {
+    result: Recursive<"A/B">;
+  } {
+    return {
+      result: props.invalid
+        ? ({ value: "wrong", children: [] } as any)
+        : props.input,
+    };
+  }
+}
+
+const execute = (
+  tool: Tool,
+  input: Recursive<"A/B">,
+  invalid: boolean,
+): Promise<unknown> =>
+  tool.execute!(
+    { input, invalid },
+    {
+      toolCallId: `pointer-${invalid ? "invalid" : "valid"}`,
+      messages: [],
+      abortSignal: undefined as any,
+    },
+  );

--- a/website/src/content/docs/llm/json.mdx
+++ b/website/src/content/docs/llm/json.mdx
@@ -253,6 +253,10 @@ What `coerce` actually does, step by step:
 4. **Recursive descent** — coerce nested objects and arrays based on `properties` and `items`
 5. **Leave unknown extras alone** — extras pass through; validation later decides whether to accept them
 
+A `$ref` must be a local URI-fragment JSON Pointer of the form `#/$defs/TypeName`, where `TypeName` encodes one `$defs` key: `~` becomes `~0`, `/` becomes `~1`, and the result is percent-encoded. A key of `A/B` is therefore referenced as `#/$defs/A~1B`. Definition keys themselves stay unrestricted — only the reference is encoded. See [`llm.schema`](/docs/llm/schema) for the generated form.
+
+A reference that is malformed or points at a missing definition is an error, not an unconstrained schema. `coerce` leaves such a value untouched, and `parse` and `validate` fail instead of accepting it.
+
 ## `LlmJson.validate`
 
 ```typescript copy

--- a/website/src/content/docs/llm/schema.mdx
+++ b/website/src/content/docs/llm/schema.mdx
@@ -22,6 +22,8 @@ namespace llm {
 
 You pass a `$defs` object as the runtime argument. Any named types referenced in `T` will be added to `$defs` and surfaced through `$ref`. So you can call `llm.schema` multiple times against the same `$defs` and the referenced sub-schemas will be deduplicated.
 
+Each `$ref` is a local URI-fragment JSON Pointer such as `#/$defs/Animal`. typia preserves the `$defs` key and encodes `/` as `~1`, `~` as `~0`, and URI-fragment characters with percent encoding. When you construct `ILlmSchema` manually, use that canonical form; malformed references and references to missing definitions fail validation instead of acting as unconstrained schemas.
+
 > Most users want [`parameters`](/docs/llm/parameters), [`structuredOutput`](/docs/llm/structuredOutput), or [`application`](/docs/llm/application) — they all generate full top-level schemas for you. `schema` is the building block.
 
 ## First example


### PR DESCRIPTION
## Overview

This draft claims one coordinated repair for #2102 across LLM schema generation and every internal consumer of local `$defs` references.

The implementation will establish a single RFC 6901 token plus URI-fragment codec, emit canonical references from native generation and OpenAPI-to-LLM conversion, decode them consistently in checking/coercion/inversion, and fail deterministically for malformed or missing references through `LlmJson` and the LangChain, MCP, and Vercel adapter boundaries.

OpenAPI component-key allocation is intentionally excluded and tracked separately by #2103: OpenAPI names have a restrictive grammar, while LLM `$defs` keys remain unrestricted and require lossless reference encoding.

## Delivery state

- [x] Lead-vetted issue and evidence packet published
- [x] Isolated worktree and claim-only Lore commit
- [ ] Regression tests demonstrating current failures
- [ ] Implementation
- [ ] Package-scoped verification
- [ ] Solo Self-Review rounds
- [ ] Fresh-master semantic rebase and current native package version assignment

The native version is deliberately not speculated on this claim commit. This branch will take the next valid version only after the active native landing chain has completed and the branch has been refreshed from `master`.

Closes #2102
