### PR TITLE
fix(typia): legalize OpenAPI component names

### DIFF
--- a/packages/typia/native/core/schemas/metadata/MetadataCollection.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataCollection.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+  "hash/fnv"
   "maps"
   "slices"
   "strconv"
@@ -557,15 +558,16 @@ func MetadataCollection_replaceOpenApi(str string) string {
   var escaped strings.Builder
   var quote rune
   quotedEscape := false
+  disambiguate := false
   for _, ch := range str {
     if quote != 0 {
       if quotedEscape {
-        metadataCollection_writeOpenApiNameRune(&escaped, ch)
+        disambiguate = metadataCollection_writeOpenApiNameRune(&escaped, ch) || disambiguate
         quotedEscape = false
         continue
       }
       if ch == '\\' {
-        metadataCollection_writeOpenApiNameRune(&escaped, ch)
+        disambiguate = metadataCollection_writeOpenApiNameRune(&escaped, ch) || disambiguate
         quotedEscape = true
         continue
       }
@@ -573,14 +575,18 @@ func MetadataCollection_replaceOpenApi(str string) string {
         quote = 0
         continue
       }
-      metadataCollection_writeOpenApiNameRune(&escaped, ch)
+      disambiguate = metadataCollection_writeOpenApiNameRune(&escaped, ch) || disambiguate
       continue
     }
     if ch == '\'' || ch == '"' || ch == '`' {
       quote = ch
       continue
     }
-    escaped.WriteRune(ch)
+    if ch == '$' {
+      disambiguate = metadataCollection_writeOpenApiNameRune(&escaped, ch) || disambiguate
+    } else {
+      escaped.WriteRune(ch)
+    }
   }
   normalized := MetadataCollection_replace(escaped.String())
   if len(normalized) == 0 {
@@ -588,19 +594,31 @@ func MetadataCollection_replaceOpenApi(str string) string {
   }
   var builder strings.Builder
   for _, ch := range normalized {
-    metadataCollection_writeOpenApiNameRune(&builder, ch)
+    disambiguate = metadataCollection_writeOpenApiNameRune(&builder, ch) || disambiguate
+  }
+  if disambiguate {
+    builder.WriteString(".x")
+    builder.WriteString(metadataCollection_openApiNameHash(str))
   }
   return builder.String()
 }
 
-func metadataCollection_writeOpenApiNameRune(builder *strings.Builder, ch rune) {
+func metadataCollection_writeOpenApiNameRune(builder *strings.Builder, ch rune) bool {
   if metadataCollection_isOpenApiNameRune(ch) {
     builder.WriteRune(ch)
-    return
+    return false
   }
   builder.WriteString("_x")
   builder.WriteString(strings.ToUpper(strconv.FormatInt(int64(ch), 16)))
   builder.WriteByte('_')
+  return true
+}
+
+func metadataCollection_openApiNameHash(str string) string {
+  hasher := fnv.New64a()
+  _, _ = hasher.Write([]byte(str))
+  encoded := strings.ToUpper(strconv.FormatUint(hasher.Sum64(), 16))
+  return strings.Repeat("0", 16-len(encoded)) + encoded
 }
 
 func metadataCollection_isOpenApiNameRune(ch rune) bool {

--- a/packages/typia/native/core/schemas/metadata/MetadataCollection.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataCollection.go
@@ -603,11 +603,20 @@ func MetadataCollection_replaceOpenApi(str string) string {
     disambiguate = metadataCollection_writeOpenApiNameRune(&builder, ch) || disambiguate
   }
   if disambiguate {
-    builder.WriteString(".x")
+    builder.WriteString(metadataCollection_openApiNameSuffix)
     builder.WriteString(metadataCollection_openApiNameHash(str))
   }
   return builder.String()
 }
+
+// metadataCollection_openApiNameSuffix separates an escaped base name from its
+// disambiguating hash. It must not be ".": JsonDescriptor.cascade reads a dot
+// in a component key as a namespace boundary and inherits the parent
+// component's description, so a dotted suffix would present the escaped base as
+// a fake parent and pull an unrelated type's description into the escaped
+// schema. "-" is in the OpenAPI key alphabet, needs no JSON Pointer or URI
+// escaping, and carries no such meaning.
+const metadataCollection_openApiNameSuffix = "-x"
 
 func metadataCollection_writeOpenApiNameRune(builder *strings.Builder, ch rune) bool {
   if metadataCollection_isOpenApiNameRune(ch) {

--- a/packages/typia/native/core/schemas/metadata/MetadataCollection.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataCollection.go
@@ -552,34 +552,39 @@ func MetadataCollection_replace(str string) string {
 // replacement used by LLM `$defs`: OpenAPI restricts keys to an ASCII grammar,
 // while an LLM definition map can own arbitrary JSON object keys.
 func MetadataCollection_replaceOpenApi(str string) string {
-  if len(str) == 0 {
-    return "_"
-  }
   var escaped strings.Builder
   var quote rune
+  quotedContent := false
   quotedEscape := false
   disambiguate := false
   for _, ch := range str {
     if quote != 0 {
       if quotedEscape {
         disambiguate = metadataCollection_writeOpenApiNameRune(&escaped, ch) || disambiguate
+        quotedContent = true
         quotedEscape = false
         continue
       }
       if ch == '\\' {
         disambiguate = metadataCollection_writeOpenApiNameRune(&escaped, ch) || disambiguate
+        quotedContent = true
         quotedEscape = true
         continue
       }
       if ch == quote {
+        if quotedContent == false {
+          disambiguate = true
+        }
         quote = 0
         continue
       }
       disambiguate = metadataCollection_writeOpenApiNameRune(&escaped, ch) || disambiguate
+      quotedContent = true
       continue
     }
     if ch == '\'' || ch == '"' || ch == '`' {
       quote = ch
+      quotedContent = false
       continue
     }
     if ch == '$' {
@@ -590,7 +595,8 @@ func MetadataCollection_replaceOpenApi(str string) string {
   }
   normalized := MetadataCollection_replace(escaped.String())
   if len(normalized) == 0 {
-    return "_"
+    normalized = "_"
+    disambiguate = true
   }
   var builder strings.Builder
   for _, ch := range normalized {

--- a/packages/typia/native/core/schemas/metadata/MetadataCollection.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataCollection.go
@@ -3,6 +3,7 @@ package metadata
 import (
   "maps"
   "slices"
+  "strconv"
   "strings"
 
   nativeast "github.com/microsoft/typescript-go/shim/ast"
@@ -543,6 +544,72 @@ func MetadataCollection_replace(str string) string {
     str = strings.ReplaceAll(str, pair.Before, pair.After)
   }
   return str
+}
+
+// MetadataCollection_replaceOpenApi converts a metadata display name into an
+// OpenAPI Components Object key. Keep this separate from the general metadata
+// replacement used by LLM `$defs`: OpenAPI restricts keys to an ASCII grammar,
+// while an LLM definition map can own arbitrary JSON object keys.
+func MetadataCollection_replaceOpenApi(str string) string {
+  if len(str) == 0 {
+    return "_"
+  }
+  var escaped strings.Builder
+  var quote rune
+  quotedEscape := false
+  for _, ch := range str {
+    if quote != 0 {
+      if quotedEscape {
+        metadataCollection_writeOpenApiNameRune(&escaped, ch)
+        quotedEscape = false
+        continue
+      }
+      if ch == '\\' {
+        metadataCollection_writeOpenApiNameRune(&escaped, ch)
+        quotedEscape = true
+        continue
+      }
+      if ch == quote {
+        quote = 0
+        continue
+      }
+      metadataCollection_writeOpenApiNameRune(&escaped, ch)
+      continue
+    }
+    if ch == '\'' || ch == '"' || ch == '`' {
+      quote = ch
+      continue
+    }
+    escaped.WriteRune(ch)
+  }
+  normalized := MetadataCollection_replace(escaped.String())
+  if len(normalized) == 0 {
+    return "_"
+  }
+  var builder strings.Builder
+  for _, ch := range normalized {
+    metadataCollection_writeOpenApiNameRune(&builder, ch)
+  }
+  return builder.String()
+}
+
+func metadataCollection_writeOpenApiNameRune(builder *strings.Builder, ch rune) {
+  if metadataCollection_isOpenApiNameRune(ch) {
+    builder.WriteRune(ch)
+    return
+  }
+  builder.WriteString("_x")
+  builder.WriteString(strings.ToUpper(strconv.FormatInt(int64(ch), 16)))
+  builder.WriteByte('_')
+}
+
+func metadataCollection_isOpenApiNameRune(ch rune) bool {
+  return (ch >= 'a' && ch <= 'z') ||
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= '0' && ch <= '9') ||
+    ch == '.' ||
+    ch == '-' ||
+    ch == '_'
 }
 
 func MetadataCollection_escape(str string) string {

--- a/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_cascade_test.go
+++ b/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_cascade_test.go
@@ -1,0 +1,55 @@
+package metadata
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestMetadataCollectionOpenApiNameCascade verifies the allocator never invents
+// a namespace parent for an escaped component name.
+//
+// JsonDescriptor.cascade reads every dotted prefix of a component key as a
+// parent namespace and inherits that parent's description. A disambiguating
+// suffix joined with "." would therefore present an escaped name's own base as
+// a fake parent, and an unrelated component owning that base would leak its
+// description into the escaped type's schema.
+//
+//  1. Allocate a legal name and the escaped name that shares its base.
+//  2. Collect every dotted prefix each allocation exposes.
+//  3. Require no allocation to expose another allocation as its parent.
+func TestMetadataCollectionOpenApiNameCascade(t *testing.T) {
+  inputs := []string{
+    "A_x2F_B",
+    "A/B",
+    "Recursive",
+    `Recursive<"">`,
+    `Recursive<"A/B">`,
+    "Qualified.Member",
+    "Café",
+    "$Plain",
+    "",
+  }
+  allocated := map[string]string{}
+  for _, input := range inputs {
+    output := MetadataCollection_replaceOpenApi(input)
+    if previous, ok := allocated[output]; ok {
+      t.Fatalf("allocation collided: %q and %q both produced %q", previous, input, output)
+    }
+    allocated[output] = input
+  }
+  for output, input := range allocated {
+    segments := strings.Split(output, ".")
+    for i := 1; i < len(segments); i++ {
+      parent := strings.Join(segments[:i], ".")
+      if owner, ok := allocated[parent]; ok {
+        t.Fatalf(
+          "allocation %q (from %q) claims unrelated allocation %q (from %q) as a namespace parent",
+          output,
+          input,
+          parent,
+          owner,
+        )
+      }
+    }
+  }
+}

--- a/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_test.go
+++ b/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_test.go
@@ -21,15 +21,21 @@ func TestMetadataCollectionOpenApiName(t *testing.T) {
     "Qualified.Member": "Qualified.Member",
     "A-B":              "A-B",
     "A_B":              "A_B",
+    "A_x2F_B":          "A_x2F_B",
   }
+  outputs := map[string]string{}
   for input, expected := range legal {
-    if actual := MetadataCollection_replaceOpenApi(input); actual != expected {
+    actual := MetadataCollection_replaceOpenApi(input)
+    if actual != expected {
       t.Fatalf("legal OpenAPI component name changed: input=%q actual=%q expected=%q", input, actual, expected)
     }
+    outputs[actual] = input
   }
 
   inputs := []string{
     "",
+    "$Plain",
+    "A/B",
     `Recursive<"A/B">`,
     `Recursive<"T~N">`,
     `Recursive<"C%D">`,
@@ -42,7 +48,6 @@ func TestMetadataCollectionOpenApiName(t *testing.T) {
     "한글",
   }
   grammar := regexp.MustCompile(`^[a-zA-Z0-9.\-_]+$`)
-  outputs := map[string]string{}
   for _, input := range inputs {
     first := MetadataCollection_replaceOpenApi(input)
     second := MetadataCollection_replaceOpenApi(input)

--- a/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_test.go
+++ b/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_test.go
@@ -1,8 +1,8 @@
 package metadata
 
 import (
-	"regexp"
-	"testing"
+  "regexp"
+  "testing"
 )
 
 // TestMetadataCollectionOpenApiName verifies the OpenAPI-specific metadata
@@ -16,45 +16,45 @@ import (
 //  2. Encode empty, punctuation, percent, fragment, and Unicode boundaries.
 //  3. Prove formerly colliding inputs remain legal, distinct, and repeatable.
 func TestMetadataCollectionOpenApiName(t *testing.T) {
-	legal := map[string]string{
-		"Plain":            "Plain",
-		"Qualified.Member": "Qualified.Member",
-		"A-B":              "A-B",
-		"A_B":              "A_B",
-	}
-	for input, expected := range legal {
-		if actual := MetadataCollection_replaceOpenApi(input); actual != expected {
-			t.Fatalf("legal OpenAPI component name changed: input=%q actual=%q expected=%q", input, actual, expected)
-		}
-	}
+  legal := map[string]string{
+    "Plain":            "Plain",
+    "Qualified.Member": "Qualified.Member",
+    "A-B":              "A-B",
+    "A_B":              "A_B",
+  }
+  for input, expected := range legal {
+    if actual := MetadataCollection_replaceOpenApi(input); actual != expected {
+      t.Fatalf("legal OpenAPI component name changed: input=%q actual=%q expected=%q", input, actual, expected)
+    }
+  }
 
-	inputs := []string{
-		"",
-		"A/B",
-		"T~N",
-		"C%D",
-		"A#B",
-		"A B",
-		"A:B",
-		"AB",
-		"///",
-		"Café",
-		"한글",
-	}
-	grammar := regexp.MustCompile(`^[a-zA-Z0-9.\-_]+$`)
-	outputs := map[string]string{}
-	for _, input := range inputs {
-		first := MetadataCollection_replaceOpenApi(input)
-		second := MetadataCollection_replaceOpenApi(input)
-		if first != second {
-			t.Fatalf("OpenAPI component allocation is not repeatable: input=%q first=%q second=%q", input, first, second)
-		}
-		if grammar.MatchString(first) == false {
-			t.Fatalf("illegal OpenAPI component name: input=%q output=%q", input, first)
-		}
-		if previous, ok := outputs[first]; ok && previous != input {
-			t.Fatalf("OpenAPI component allocation collided: first=%q second=%q output=%q", previous, input, first)
-		}
-		outputs[first] = input
-	}
+  inputs := []string{
+    "",
+    `Recursive<"A/B">`,
+    `Recursive<"T~N">`,
+    `Recursive<"C%D">`,
+    `Recursive<"A#B">`,
+    `Recursive<"A B">`,
+    `Recursive<"A:B">`,
+    `Recursive<"AB">`,
+    `Recursive<"///">`,
+    "Café",
+    "한글",
+  }
+  grammar := regexp.MustCompile(`^[a-zA-Z0-9.\-_]+$`)
+  outputs := map[string]string{}
+  for _, input := range inputs {
+    first := MetadataCollection_replaceOpenApi(input)
+    second := MetadataCollection_replaceOpenApi(input)
+    if first != second {
+      t.Fatalf("OpenAPI component allocation is not repeatable: input=%q first=%q second=%q", input, first, second)
+    }
+    if grammar.MatchString(first) == false {
+      t.Fatalf("illegal OpenAPI component name: input=%q output=%q", input, first)
+    }
+    if previous, ok := outputs[first]; ok && previous != input {
+      t.Fatalf("OpenAPI component allocation collided: first=%q second=%q output=%q", previous, input, first)
+    }
+    outputs[first] = input
+  }
 }

--- a/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_test.go
+++ b/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_test.go
@@ -22,6 +22,8 @@ func TestMetadataCollectionOpenApiName(t *testing.T) {
     "A-B":              "A-B",
     "A_B":              "A_B",
     "A_x2F_B":          "A_x2F_B",
+    "_":                "_",
+    "Recursive":        "Recursive",
   }
   outputs := map[string]string{}
   for input, expected := range legal {
@@ -36,6 +38,7 @@ func TestMetadataCollectionOpenApiName(t *testing.T) {
     "",
     "$Plain",
     "A/B",
+    `Recursive<"">`,
     `Recursive<"A/B">`,
     `Recursive<"T~N">`,
     `Recursive<"C%D">`,

--- a/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_test.go
+++ b/packages/typia/native/core/schemas/metadata/metadata_collection_openapi_name_test.go
@@ -1,0 +1,60 @@
+package metadata
+
+import (
+	"regexp"
+	"testing"
+)
+
+// TestMetadataCollectionOpenApiName verifies the OpenAPI-specific metadata
+// name allocator preserves legal controls while encoding every other rune.
+//
+// The schema generators use the allocated name as both a Components Object
+// key and a local-reference token. Deleting punctuation is insufficient:
+// distinct names can collapse, and the surviving key can still violate OAS.
+//
+//  1. Preserve ordinary, dotted, hyphenated, and underscored legal controls.
+//  2. Encode empty, punctuation, percent, fragment, and Unicode boundaries.
+//  3. Prove formerly colliding inputs remain legal, distinct, and repeatable.
+func TestMetadataCollectionOpenApiName(t *testing.T) {
+	legal := map[string]string{
+		"Plain":            "Plain",
+		"Qualified.Member": "Qualified.Member",
+		"A-B":              "A-B",
+		"A_B":              "A_B",
+	}
+	for input, expected := range legal {
+		if actual := MetadataCollection_replaceOpenApi(input); actual != expected {
+			t.Fatalf("legal OpenAPI component name changed: input=%q actual=%q expected=%q", input, actual, expected)
+		}
+	}
+
+	inputs := []string{
+		"",
+		"A/B",
+		"T~N",
+		"C%D",
+		"A#B",
+		"A B",
+		"A:B",
+		"AB",
+		"///",
+		"Café",
+		"한글",
+	}
+	grammar := regexp.MustCompile(`^[a-zA-Z0-9.\-_]+$`)
+	outputs := map[string]string{}
+	for _, input := range inputs {
+		first := MetadataCollection_replaceOpenApi(input)
+		second := MetadataCollection_replaceOpenApi(input)
+		if first != second {
+			t.Fatalf("OpenAPI component allocation is not repeatable: input=%q first=%q second=%q", input, first, second)
+		}
+		if grammar.MatchString(first) == false {
+			t.Fatalf("illegal OpenAPI component name: input=%q output=%q", input, first)
+		}
+		if previous, ok := outputs[first]; ok && previous != input {
+			t.Fatalf("OpenAPI component allocation collided: first=%q second=%q output=%q", previous, input, first)
+		}
+		outputs[first] = input
+	}
+}

--- a/packages/typia/native/transform/features/json/JsonApplicationTransformer.go
+++ b/packages/typia/native/transform/features/json/JsonApplicationTransformer.go
@@ -43,7 +43,7 @@ func (jsonApplicationTransformerNamespace) Transform(props nativetransform.ITran
 
   typ := props.Context.Checker.GetTypeFromTypeNode(top)
   collection := schemametadata.NewMetadataCollection(&schemametadata.MetadataCollection_IOptions{
-    Replace: schemametadata.MetadataCollection_replace,
+    Replace: schemametadata.MetadataCollection_replaceOpenApi,
   })
   result := nativefactories.MetadataFactory.Analyze(nativefactories.MetadataFactory_IProps{
     Checker: props.Context.Checker,

--- a/packages/typia/native/transform/features/json/JsonSchemaTransformer.go
+++ b/packages/typia/native/transform/features/json/JsonSchemaTransformer.go
@@ -66,7 +66,7 @@ func (jsonSchemaTransformerNamespace) Transform(props nativetransform.ITransform
         Validate: validator,
       },
       Components: schemametadata.NewMetadataCollection(&schemametadata.MetadataCollection_IOptions{
-        Replace: schemametadata.MetadataCollection_replace,
+        Replace: schemametadata.MetadataCollection_replaceOpenApi,
       }),
       Type: typ,
     })

--- a/packages/typia/native/transform/features/json/JsonSchemasTransformer.go
+++ b/packages/typia/native/transform/features/json/JsonSchemasTransformer.go
@@ -64,6 +64,9 @@ func (jsonSchemasTransformerNamespace) Transform(props nativetransform.ITransfor
   analyze := func(validate bool) []*schemametadata.MetadataSchema {
     metadatas := []*schemametadata.MetadataSchema{}
     errors := []nativefactories.MetadataFactory_IError{}
+    collection := schemametadata.NewMetadataCollection(&schemametadata.MetadataCollection_IOptions{
+      Replace: schemametadata.MetadataCollection_replaceOpenApi,
+    })
     var validator nativefactories.MetadataFactory_Validator
     if validate {
       validator = jsonTransformer_schemasValidator
@@ -77,10 +80,8 @@ func (jsonSchemasTransformerNamespace) Transform(props nativetransform.ITransfor
           Escape:   true,
           Validate: validator,
         },
-        Components: schemametadata.NewMetadataCollection(&schemametadata.MetadataCollection_IOptions{
-          Replace: schemametadata.MetadataCollection_replace,
-        }),
-        Type: typ,
+        Components: collection,
+        Type:       typ,
       })
       if result.Success == false {
         errors = append(errors, result.Errors...)

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.13",
+  "version": "13.1.14",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/src/converters/LlmSchemaConverter.ts
+++ b/packages/utils/src/converters/LlmSchemaConverter.ts
@@ -9,6 +9,7 @@ import {
 import { JsonDescriptor } from "../utils/internal/JsonDescriptor";
 import { LlmReference } from "../utils/internal/LlmReference";
 import { ObjectDictionary } from "../utils/internal/ObjectDictionary";
+import { OpenApiComponentName } from "../utils/internal/OpenApiComponentName";
 import { OpenApiSchemaSanitizer } from "../utils/internal/OpenApiSchemaSanitizer";
 import { LlmTypeChecker } from "../validators/LlmTypeChecker";
 import { OpenApiTypeChecker } from "../validators/OpenApiTypeChecker";
@@ -512,6 +513,25 @@ export namespace LlmSchemaConverter {
     components: OpenApi.IComponents;
     schema: ILlmSchema;
     $defs: Record<string, ILlmSchema>;
+  }): OpenApi.IJsonSchema =>
+    invertInternal({
+      ...props,
+      // One allocation per conversion, seeded with the component names the
+      // caller already owns. Recursive inversion reuses it instead of
+      // recomputing, so a reference and its stored component never disagree.
+      allocation: OpenApiComponentName.allocate({
+        keys: Object.keys(props.$defs ?? {}),
+        reserved: Object.keys(props.components.schemas ?? {}),
+      }),
+      emitted: new Set(),
+    });
+
+  const invertInternal = (props: {
+    components: OpenApi.IComponents;
+    schema: ILlmSchema;
+    $defs: Record<string, ILlmSchema>;
+    allocation: Map<string, string>;
+    emitted: Set<string>;
   }): OpenApi.IJsonSchema => {
     const union: OpenApi.IJsonSchema[] = [];
     const attribute: IJsonSchemaAttribute = {
@@ -530,10 +550,12 @@ export namespace LlmSchemaConverter {
     };
 
     const next = (schema: ILlmSchema): OpenApi.IJsonSchema =>
-      invert({
+      invertInternal({
         components: props.components,
         $defs: props.$defs,
         schema,
+        allocation: props.allocation,
+        emitted: props.emitted,
       });
     const visit = (schema: ILlmSchema): void => {
       if (LlmTypeChecker.isArray(schema))
@@ -567,11 +589,14 @@ export namespace LlmSchemaConverter {
           union.push({ oneOf: [] });
           return;
         }
-        const componentKey: string = resolved.key;
-        if (
-          ObjectDictionary.get(props.components.schemas, componentKey) ===
-          undefined
-        ) {
+        const componentKey: string =
+          props.allocation.get(resolved.key) ?? resolved.key;
+        // Gate on what this conversion has emitted, not on what the components
+        // already contain. A caller's pre-existing component of the same name
+        // is an allocation input, not a cache hit: treating it as one would
+        // silently drop this definition and alias it to an unrelated schema.
+        if (props.emitted.has(componentKey) === false) {
+          props.emitted.add(componentKey);
           props.components.schemas ??= {};
           ObjectDictionary.set(props.components.schemas, componentKey, {});
           ObjectDictionary.set(
@@ -647,6 +672,7 @@ export namespace LlmSchemaConverter {
                           ? invertDiscriminatorMapping(
                               props.$defs,
                               props.schema["x-discriminator"].mapping,
+                              props.allocation,
                             )
                           : undefined,
                     }
@@ -671,6 +697,7 @@ const convertDiscriminatorMapping = (
 const invertDiscriminatorMapping = (
   $defs: Record<string, ILlmSchema>,
   mapping: Record<string, string>,
+  allocation: Map<string, string>,
 ): Record<string, string> | undefined => {
   const entries: [string, string][] = [];
   for (const [discriminator, reference] of Object.entries(mapping)) {
@@ -679,7 +706,10 @@ const invertDiscriminatorMapping = (
       reference,
     );
     if (resolved === undefined) return undefined;
-    entries.push([discriminator, LlmReference.writeOpenApi(resolved.key)]);
+    entries.push([
+      discriminator,
+      LlmReference.writeOpenApi(allocation.get(resolved.key) ?? resolved.key),
+    ]);
   }
   return Object.fromEntries(entries);
 };

--- a/packages/utils/src/converters/LlmSchemaConverter.ts
+++ b/packages/utils/src/converters/LlmSchemaConverter.ts
@@ -519,9 +519,14 @@ export namespace LlmSchemaConverter {
       // One allocation per conversion, seeded with the component names the
       // caller already owns. Recursive inversion reuses it instead of
       // recomputing, so a reference and its stored component never disagree.
+      //
+      // Seed with getOwnPropertyNames, not keys: LlmReference.resolve finds a
+      // definition through ObjectDictionary.get, which keys off
+      // hasOwnProperty. Seeding with the enumerable-only view would let an own
+      // non-enumerable definition resolve without ever being allocated.
       allocation: OpenApiComponentName.allocate({
-        keys: Object.keys(props.$defs ?? {}),
-        reserved: Object.keys(props.components.schemas ?? {}),
+        keys: Object.getOwnPropertyNames(props.$defs ?? {}),
+        reserved: Object.getOwnPropertyNames(props.components.schemas ?? {}),
       }),
       emitted: new Set(),
     });
@@ -589,8 +594,13 @@ export namespace LlmSchemaConverter {
           union.push({ oneOf: [] });
           return;
         }
+        // The allocation seeds from the same own-property view that resolve
+        // uses, so a resolved key is always allocated. Escape rather than fall
+        // back to the raw key regardless: the grammar invariant must hold even
+        // if the two views ever diverge again.
         const componentKey: string =
-          props.allocation.get(resolved.key) ?? resolved.key;
+          props.allocation.get(resolved.key) ??
+          OpenApiComponentName.escape(resolved.key);
         // Gate on what this conversion has emitted, not on what the components
         // already contain. A caller's pre-existing component of the same name
         // is an allocation input, not a cache hit: treating it as one would
@@ -708,7 +718,10 @@ const invertDiscriminatorMapping = (
     if (resolved === undefined) return undefined;
     entries.push([
       discriminator,
-      LlmReference.writeOpenApi(allocation.get(resolved.key) ?? resolved.key),
+      LlmReference.writeOpenApi(
+        allocation.get(resolved.key) ??
+          OpenApiComponentName.escape(resolved.key),
+      ),
     ]);
   }
   return Object.fromEntries(entries);

--- a/packages/utils/src/utils/internal/OpenApiComponentName.ts
+++ b/packages/utils/src/utils/internal/OpenApiComponentName.ts
@@ -1,0 +1,83 @@
+/**
+ * Allocate OpenAPI Components Object keys for unrestricted LLM `$defs` keys.
+ *
+ * The two key spaces are not the same. An LLM definition map owns arbitrary
+ * JSON object keys, while the OpenAPI Components Object restricts every key to
+ * `^[a-zA-Z0-9.\-_]+$`. Encoding a reference is therefore not enough: a
+ * reference can carry `/` as `~1`, but the stored component key still may not.
+ *
+ * This mirrors the native allocator in
+ * `packages/typia/native/core/schemas/metadata/MetadataCollection.go`
+ * (`MetadataCollection_replaceOpenApi`), which owns the same contract for
+ * generated schemas. The two need not agree on how a forbidden name is
+ * disambiguated: a natively generated key is already legal, so it round-trips
+ * through {@link allocate} unchanged.
+ *
+ * @internal
+ */
+export namespace OpenApiComponentName {
+  export const GRAMMAR = /^[a-zA-Z0-9.\-_]+$/;
+
+  /**
+   * Separates an escaped base name from its disambiguating counter.
+   *
+   * Never `.`: `JsonDescriptor.cascade` reads a dot in a component key as a
+   * namespace boundary and inherits the parent component's description, so a
+   * dotted suffix would present the escaped base as a fake parent and pull an
+   * unrelated type's description into the escaped schema. `-` is in the OpenAPI
+   * key alphabet, needs no JSON Pointer or URI escaping, and carries no such
+   * meaning.
+   */
+  const SUFFIX = "-x";
+
+  /** Encode one raw key into a legal, nonempty base name. */
+  export const escape = (key: string): string => {
+    let base: string = "";
+    for (const character of key)
+      base += GRAMMAR.test(character)
+        ? character
+        : `_x${character.codePointAt(0)!.toString(16).toUpperCase()}_`;
+    return base.length === 0 ? "_" : base;
+  };
+
+  /**
+   * Allocate one legal, distinct component key per raw `$defs` key.
+   *
+   * Allocation runs in two passes so an escaped name can never squat a name
+   * that an already legal key owns: a legal key would otherwise lose its exact
+   * name to whichever forbidden key happened to sort first.
+   *
+   * The sorted iteration makes the result depend only on which keys exist,
+   * never on `$defs` insertion or traversal order.
+   *
+   * @param props.keys Raw `$defs` keys to allocate
+   * @param props.reserved Component keys the caller already owns
+   * @returns Raw `$defs` key to allocated component key
+   */
+  export const allocate = (props: {
+    keys: readonly string[];
+    reserved: readonly string[];
+  }): Map<string, string> => {
+    const taken: Set<string> = new Set(props.reserved);
+    const allocation: Map<string, string> = new Map();
+    const deferred: string[] = [];
+
+    // Pass 1: an already legal key keeps its exact name when it is free.
+    for (const key of [...props.keys].sort())
+      if (GRAMMAR.test(key) === true && taken.has(key) === false) {
+        taken.add(key);
+        allocation.set(key, key);
+      } else deferred.push(key);
+
+    // Pass 2: everything forbidden, empty, or outbid takes an escaped name.
+    for (const key of deferred) {
+      const base: string = escape(key);
+      let allocated: string = base;
+      for (let i: number = 0; taken.has(allocated); ++i)
+        allocated = `${base}${SUFFIX}${i}`;
+      taken.add(allocated);
+      allocation.set(key, allocated);
+    }
+    return allocation;
+  };
+}

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_name_cascade.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_name_cascade.ts
@@ -1,0 +1,89 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+/** UNRELATED INTERFACE that happens to own an escaped base name. */
+interface RecursiveObjectA_x2F_B {
+  unrelated: string;
+}
+
+/** GENERIC RECURSIVE OBJECT whose forbidden instantiation must be escaped. */
+type RecursiveObject<T extends string> = {
+  value: T;
+  children: RecursiveObject<T>[];
+};
+
+interface IArguments {
+  collision: RecursiveObjectA_x2F_B;
+  slash: RecursiveObject<"A/B">;
+}
+
+/**
+ * Verifies an escaped component name never inherits an unrelated description.
+ *
+ * `JsonDescriptor.cascade` reads every dotted prefix of a component key as a
+ * namespace parent and inherits that parent's description, which is the
+ * intended `Qualified.Member` behavior. The component-name allocator must
+ * therefore never join its disambiguating suffix with a dot: the escaped base
+ * of `RecursiveObject<"A/B">` is exactly the legal name of the unrelated
+ * `RecursiveObjectA_x2F_B` interface, so a dotted suffix would present that
+ * interface as a parent and leak its description into the escaped schema an
+ * LLM reads.
+ *
+ * 1. Declare an interface owning the escaped base name of a forbidden type.
+ * 2. Generate the schema so both land in `components.schemas`.
+ * 3. Assert the escaped name exposes no allocated component as a parent, and
+ *    that its escaped description never mentions the unrelated interface.
+ */
+export const test_json_schema_openapi_component_name_cascade = (): void => {
+  const collection = typia.json.schema<IArguments, "3.1">();
+  const components: OpenApi.IComponents =
+    collection.components as OpenApi.IComponents;
+  const schemas: Record<string, OpenApi.IJsonSchema> = components.schemas ?? {};
+
+  const escapedKey: string | undefined = Object.keys(schemas).find(
+    (key) => key.startsWith("RecursiveObjectA_x2F_B") && key !== base,
+  );
+  TestValidator.predicate(
+    "the forbidden instantiation is allocated a distinct legal key",
+    () =>
+      escapedKey !== undefined &&
+      /^[a-zA-Z0-9.\-_]+$/.test(escapedKey) &&
+      Object.prototype.hasOwnProperty.call(schemas, base),
+  );
+  if (escapedKey === undefined) return;
+
+  for (const key of Object.keys(schemas))
+    TestValidator.predicate(
+      `${JSON.stringify(key)} claims no allocated component as a namespace parent`,
+      () =>
+        key
+          .split(".")
+          .slice(0, -1)
+          .map((_, i, array) => array.slice(0, i + 1).join("."))
+          .every(
+            (parent) =>
+              Object.prototype.hasOwnProperty.call(schemas, parent) === false,
+          ),
+    );
+
+  const escaped = OpenApiTypeChecker.escape({
+    components,
+    schema: { $ref: `#/components/schemas/${escapedKey}` },
+    recursive: 1,
+  });
+  TestValidator.predicate("the escaped reference resolves", escaped.success);
+  if (escaped.success === false) return;
+  TestValidator.predicate(
+    "the escaped schema does not inherit the unrelated description",
+    () => (escaped.value?.description ?? "").includes("UNRELATED") === false,
+  );
+  TestValidator.predicate(
+    "the escaped schema keeps its own description",
+    () =>
+      (escaped.value?.description ?? "").includes("GENERIC RECURSIVE OBJECT"),
+  );
+};
+
+const base = "RecursiveObjectA_x2F_B";

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_names.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_names.ts
@@ -1,5 +1,13 @@
 import { TestValidator } from "@nestia/e2e";
-import { OpenApiTypeChecker, OpenApiValidator } from "@typia/utils";
+import { ILlmSchema, OpenApi, OpenApiV3 } from "@typia/interface";
+import {
+  HttpLlm,
+  HttpMigration,
+  LlmSchemaConverter,
+  OpenApiConverter,
+  OpenApiTypeChecker,
+  OpenApiValidator,
+} from "@typia/utils";
 import typia from "typia";
 
 type RecursiveObject<T extends string> = {
@@ -9,12 +17,26 @@ type RecursiveObject<T extends string> = {
 
 type RecursiveArray<T extends string> = Array<T | RecursiveArray<T>>;
 type AliasValue<T extends string> = T | number;
-type Variant<T extends string> = {
-  kind: T;
-  payload: RecursiveObject<T>;
-};
+
+interface CaféVariant {
+  kind: "café";
+  payload: RecursiveObject<"A/B">;
+}
+
+interface 한글Variant {
+  kind: "hangul";
+  payload: RecursiveObject<"T~N">;
+}
+
+namespace Qualified {
+  export interface Member {
+    value: string;
+    child?: Member;
+  }
+}
 
 interface IForward {
+  qualified: Qualified.Member;
   plain: RecursiveObject<"Plain">;
   dot: RecursiveObject<"A.B">;
   dash: RecursiveObject<"A-B">;
@@ -25,23 +47,25 @@ interface IForward {
   hash: RecursiveObject<"A#B">;
   unicode: RecursiveObject<"Café">;
   punctuation: RecursiveObject<"/~%#">;
+  empty: RecursiveObject<"">;
   space: RecursiveObject<"A B">;
   colon: RecursiveObject<"A:B">;
   compact: RecursiveObject<"AB">;
   alias: AliasValue<"A/B">;
   array: RecursiveArray<"A/B">;
-  variant: Variant<"A/B"> | Variant<"T~N">;
+  variant: CaféVariant | 한글Variant;
   createdAt: Date;
 }
 
 interface IReverse {
   createdAt: Date;
-  variant: Variant<"T~N"> | Variant<"A/B">;
+  variant: 한글Variant | CaféVariant;
   array: RecursiveArray<"A/B">;
   alias: AliasValue<"A/B">;
   compact: RecursiveObject<"AB">;
   colon: RecursiveObject<"A:B">;
   space: RecursiveObject<"A B">;
+  empty: RecursiveObject<"">;
   punctuation: RecursiveObject<"/~%#">;
   unicode: RecursiveObject<"Café">;
   hash: RecursiveObject<"A#B">;
@@ -52,6 +76,7 @@ interface IReverse {
   dash: RecursiveObject<"A-B">;
   dot: RecursiveObject<"A.B">;
   plain: RecursiveObject<"Plain">;
+  qualified: Qualified.Member;
 }
 
 interface IApplication {
@@ -97,6 +122,13 @@ export const test_json_schema_openapi_component_names = (): void => {
   TestValidator.equals("dot control", names["A.B"], "RecursiveObjectA.B");
   TestValidator.equals("hyphen control", names["A-B"], "RecursiveObjectA-B");
   TestValidator.equals("underscore control", names.A_B, "RecursiveObjectA_B");
+  TestValidator.predicate(
+    "qualified control",
+    Object.prototype.hasOwnProperty.call(
+      forward31.components.schemas ?? {},
+      "Qualified.Member",
+    ),
+  );
   TestValidator.equals(
     "discovery-order independent names 3.0",
     componentNamesByValue(forward30.components.schemas ?? {}),
@@ -107,13 +139,34 @@ export const test_json_schema_openapi_component_names = (): void => {
     names,
     componentNamesByValue(reverse31.components.schemas ?? {}),
   );
+  TestValidator.equals(
+    "discovery-order independent component set 3.0",
+    Object.keys(forward30.components.schemas ?? {})
+      .filter((key) => key !== "IForward")
+      .sort(),
+    Object.keys(reverse30.components.schemas ?? {})
+      .filter((key) => key !== "IReverse")
+      .sort(),
+  );
+  TestValidator.equals(
+    "discovery-order independent component set 3.1",
+    Object.keys(forward31.components.schemas ?? {})
+      .filter((key) => key !== "IForward")
+      .sort(),
+    Object.keys(reverse31.components.schemas ?? {})
+      .filter((key) => key !== "IReverse")
+      .sort(),
+  );
 
+  const slashReference = {
+    $ref: `#/components/schemas/${names["A/B"]}`,
+  } as const;
   TestValidator.predicate(
     "OpenApiValidator resolves generated names",
     OpenApiValidator.validate({
       components: forward31.components,
-      schema: forward31.schema,
-      value: sample,
+      schema: slashReference,
+      value: sample.slash,
       required: true,
     }).success,
   );
@@ -121,10 +174,105 @@ export const test_json_schema_openapi_component_names = (): void => {
     "OpenApiTypeChecker resolves generated names",
     OpenApiTypeChecker.escape({
       components: forward31.components,
-      schema: forward31.schema,
+      schema: slashReference,
       recursive: 2,
     }).success,
   );
+
+  const $defs: Record<string, ILlmSchema> = {};
+  const llmSchema = LlmSchemaConverter.schema({
+    components: forward31.components,
+    $defs,
+    schema: forward31.schema,
+  });
+  TestValidator.predicate(
+    "LlmSchemaConverter resolves generated names",
+    llmSchema.success,
+  );
+  TestValidator.predicate(
+    "LlmSchemaConverter emits legal definition names",
+    Object.keys($defs).every((key) => /^[a-zA-Z0-9.\-_]+$/.test(key)),
+  );
+
+  const document30: OpenApiV3.IDocument = {
+    openapi: "3.0.4",
+    info: { title: "component names", version: "1.0.0" },
+    components: forward30.components,
+    paths: {
+      "/component": {
+        post: {
+          operationId: "inspectComponent",
+          requestBody: {
+            content: {
+              "application/json": { schema: forward30.schema },
+            },
+          },
+          responses: {
+            200: {
+              description: "success",
+              content: {
+                "application/json": { schema: forward30.schema },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  const emended31: OpenApi.IDocument = {
+    openapi: "3.2.0",
+    info: { title: "component names", version: "1.0.0" },
+    components: forward31.components,
+    paths: {
+      "/component": {
+        post: {
+          operationId: "inspectComponent",
+          requestBody: {
+            content: {
+              "application/json": { schema: forward31.schema },
+            },
+          },
+          responses: {
+            200: {
+              description: "success",
+              content: {
+                "application/json": { schema: forward31.schema },
+              },
+            },
+          },
+        },
+      },
+    },
+    "x-typia-emended-v12": true,
+  };
+  const document31 = OpenApiConverter.downgradeDocument(emended31, "3.1");
+  for (const [label, document] of [
+    ["3.0", document30],
+    ["3.1", document31],
+  ] as const) {
+    const converted: OpenApi.IDocument =
+      OpenApiConverter.upgradeDocument(document);
+    TestValidator.predicate(
+      `OpenApiConverter ${label}`,
+      Object.keys(converted.components.schemas ?? {}).every((key) =>
+        /^[a-zA-Z0-9.\-_]+$/.test(key),
+      ),
+    );
+    const migration = HttpMigration.application(document);
+    TestValidator.equals(`HttpMigration errors ${label}`, migration.errors, []);
+    TestValidator.equals(
+      `HttpMigration routes ${label}`,
+      migration.routes.length,
+      1,
+    );
+    const httpLlm = HttpLlm.application({ document });
+    TestValidator.equals(`HttpLlm errors ${label}`, httpLlm.errors, []);
+    TestValidator.equals(
+      `HttpLlm functions ${label}`,
+      httpLlm.functions.length,
+      1,
+    );
+  }
 };
 
 interface IUnit {
@@ -182,6 +330,13 @@ const verifyUnit = (unit: IUnit): void => {
     `${unit.label}: references resolve`,
     refs.every((ref) => resolveLocalReference(ref, unit.schemas)),
   );
+  TestValidator.predicate(
+    `${unit.label}: discriminator mappings emitted`,
+    collectDiscriminatorMappings([
+      ...unit.roots,
+      ...Object.values(unit.schemas),
+    ]).length !== 0,
+  );
 };
 
 const collectReferences = (input: unknown): string[] => {
@@ -194,6 +349,26 @@ const collectReferences = (input: unknown): string[] => {
     if (value === null || typeof value !== "object") return;
     const record = value as Record<string, unknown>;
     if (typeof record.$ref === "string") output.push(record.$ref);
+    const discriminator = record.discriminator as
+      | { mapping?: Record<string, string> }
+      | undefined;
+    if (discriminator?.mapping !== undefined)
+      output.push(...Object.values(discriminator.mapping));
+    Object.values(record).forEach(visit);
+  };
+  visit(input);
+  return [...new Set(output)].sort();
+};
+
+const collectDiscriminatorMappings = (input: unknown): string[] => {
+  const output: string[] = [];
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (value === null || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
     const discriminator = record.discriminator as
       | { mapping?: Record<string, string> }
       | undefined;
@@ -251,6 +426,7 @@ const componentNamesByValue = (
   );
 
 const sample: IForward = {
+  qualified: { value: "qualified" },
   plain: { value: "Plain", children: [] },
   dot: { value: "A.B", children: [] },
   dash: { value: "A-B", children: [] },
@@ -261,13 +437,14 @@ const sample: IForward = {
   hash: { value: "A#B", children: [] },
   unicode: { value: "Café", children: [] },
   punctuation: { value: "/~%#", children: [] },
+  empty: { value: "", children: [] },
   space: { value: "A B", children: [] },
   colon: { value: "A:B", children: [] },
   compact: { value: "AB", children: [] },
   alias: "A/B",
   array: ["A/B", ["A/B"]],
   variant: {
-    kind: "A/B",
+    kind: "café",
     payload: { value: "A/B", children: [] },
   },
   createdAt: "2026-07-16T00:00:00.000Z" as unknown as Date,

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_names.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_names.ts
@@ -1,0 +1,274 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiTypeChecker, OpenApiValidator } from "@typia/utils";
+import typia from "typia";
+
+type RecursiveObject<T extends string> = {
+  value: T;
+  children: RecursiveObject<T>[];
+};
+
+type RecursiveArray<T extends string> = Array<T | RecursiveArray<T>>;
+type AliasValue<T extends string> = T | number;
+type Variant<T extends string> = {
+  kind: T;
+  payload: RecursiveObject<T>;
+};
+
+interface IForward {
+  plain: RecursiveObject<"Plain">;
+  dot: RecursiveObject<"A.B">;
+  dash: RecursiveObject<"A-B">;
+  underscore: RecursiveObject<"A_B">;
+  slash: RecursiveObject<"A/B">;
+  tilde: RecursiveObject<"T~N">;
+  percent: RecursiveObject<"C%D">;
+  hash: RecursiveObject<"A#B">;
+  unicode: RecursiveObject<"Café">;
+  punctuation: RecursiveObject<"/~%#">;
+  space: RecursiveObject<"A B">;
+  colon: RecursiveObject<"A:B">;
+  compact: RecursiveObject<"AB">;
+  alias: AliasValue<"A/B">;
+  array: RecursiveArray<"A/B">;
+  variant: Variant<"A/B"> | Variant<"T~N">;
+  createdAt: Date;
+}
+
+interface IReverse {
+  createdAt: Date;
+  variant: Variant<"T~N"> | Variant<"A/B">;
+  array: RecursiveArray<"A/B">;
+  alias: AliasValue<"A/B">;
+  compact: RecursiveObject<"AB">;
+  colon: RecursiveObject<"A:B">;
+  space: RecursiveObject<"A B">;
+  punctuation: RecursiveObject<"/~%#">;
+  unicode: RecursiveObject<"Café">;
+  hash: RecursiveObject<"A#B">;
+  percent: RecursiveObject<"C%D">;
+  tilde: RecursiveObject<"T~N">;
+  slash: RecursiveObject<"A/B">;
+  underscore: RecursiveObject<"A_B">;
+  dash: RecursiveObject<"A-B">;
+  dot: RecursiveObject<"A.B">;
+  plain: RecursiveObject<"Plain">;
+}
+
+interface IApplication {
+  exchange(input: IForward): Promise<IReverse>;
+}
+
+/**
+ * Verifies every generated OpenAPI component name is legal and resolvable.
+ *
+ * Metadata names feed component keys, recursive references, and discriminator
+ * mappings across all three public JSON generators. The same allocator must
+ * preserve legal controls, separate normalization collisions independently of
+ * discovery order, and keep typia's validators aligned with an RFC oracle.
+ *
+ * 1. Generate schema, schemas, and application output for OAS 3.0 and 3.1.
+ * 2. Check legal/illegal names, recursive alias/array/object refs, and mappings.
+ * 3. Reorder discovery and validate the generated graph through public utils.
+ */
+export const test_json_schema_openapi_component_names = (): void => {
+  const forward30 = typia.json.schema<IForward, "3.0">();
+  const forward31 = typia.json.schema<IForward, "3.1">();
+  const reverse30 = typia.json.schema<IReverse, "3.0">();
+  const reverse31 = typia.json.schema<IReverse, "3.1">();
+  const schemas30 = typia.json.schemas<[IForward, IReverse], "3.0">();
+  const schemas31 = typia.json.schemas<[IForward, IReverse], "3.1">();
+  const application30 = typia.json.application<IApplication, "3.0">();
+  const application31 = typia.json.application<IApplication, "3.1">();
+
+  const units: IUnit[] = [
+    unit("schema 3.0", forward30.components, [forward30.schema]),
+    unit("schema 3.1", forward31.components, [forward31.schema]),
+    unit("reverse schema 3.0", reverse30.components, [reverse30.schema]),
+    unit("reverse schema 3.1", reverse31.components, [reverse31.schema]),
+    unit("schemas 3.0", schemas30.components, schemas30.schemas),
+    unit("schemas 3.1", schemas31.components, schemas31.schemas),
+    applicationUnit("application 3.0", application30),
+    applicationUnit("application 3.1", application31),
+  ];
+  for (const output of units) verifyUnit(output);
+
+  const names = componentNamesByValue(forward31.components.schemas ?? {});
+  TestValidator.equals("ordinary control", names.Plain, "RecursiveObjectPlain");
+  TestValidator.equals("dot control", names["A.B"], "RecursiveObjectA.B");
+  TestValidator.equals("hyphen control", names["A-B"], "RecursiveObjectA-B");
+  TestValidator.equals("underscore control", names.A_B, "RecursiveObjectA_B");
+  TestValidator.equals(
+    "discovery-order independent names 3.0",
+    componentNamesByValue(forward30.components.schemas ?? {}),
+    componentNamesByValue(reverse30.components.schemas ?? {}),
+  );
+  TestValidator.equals(
+    "discovery-order independent names 3.1",
+    names,
+    componentNamesByValue(reverse31.components.schemas ?? {}),
+  );
+
+  TestValidator.predicate(
+    "OpenApiValidator resolves generated names",
+    OpenApiValidator.validate({
+      components: forward31.components,
+      schema: forward31.schema,
+      value: sample,
+      required: true,
+    }).success,
+  );
+  TestValidator.predicate(
+    "OpenApiTypeChecker resolves generated names",
+    OpenApiTypeChecker.escape({
+      components: forward31.components,
+      schema: forward31.schema,
+      recursive: 2,
+    }).success,
+  );
+};
+
+interface IUnit {
+  label: string;
+  schemas: Record<string, unknown>;
+  roots: unknown[];
+}
+
+const unit = (
+  label: string,
+  components: { schemas?: Record<string, unknown> },
+  roots: readonly unknown[],
+): IUnit => ({
+  label,
+  schemas: components.schemas ?? {},
+  roots: [...roots],
+});
+
+const applicationUnit = (
+  label: string,
+  application: {
+    components: { schemas?: Record<string, unknown> };
+    functions: Array<{
+      parameters: Array<{ schema: unknown }>;
+      output?: { schema: unknown };
+    }>;
+  },
+): IUnit =>
+  unit(
+    label,
+    application.components,
+    application.functions.flatMap((func) => [
+      ...func.parameters.map((parameter) => parameter.schema),
+      ...(func.output === undefined ? [] : [func.output.schema]),
+    ]),
+  );
+
+const verifyUnit = (unit: IUnit): void => {
+  const grammar = /^[a-zA-Z0-9.\-_]+$/;
+  const keys = Object.keys(unit.schemas);
+  TestValidator.predicate(
+    `${unit.label}: legal component keys`,
+    keys.length !== 0 && keys.every((key) => grammar.test(key)),
+  );
+
+  const refs = collectReferences([
+    ...unit.roots,
+    ...Object.values(unit.schemas),
+  ]);
+  TestValidator.predicate(
+    `${unit.label}: references emitted`,
+    refs.length !== 0,
+  );
+  TestValidator.predicate(
+    `${unit.label}: references resolve`,
+    refs.every((ref) => resolveLocalReference(ref, unit.schemas)),
+  );
+};
+
+const collectReferences = (input: unknown): string[] => {
+  const output: string[] = [];
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (value === null || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+    if (typeof record.$ref === "string") output.push(record.$ref);
+    const discriminator = record.discriminator as
+      | { mapping?: Record<string, string> }
+      | undefined;
+    if (discriminator?.mapping !== undefined)
+      output.push(...Object.values(discriminator.mapping));
+    Object.values(record).forEach(visit);
+  };
+  visit(input);
+  return [...new Set(output)].sort();
+};
+
+const resolveLocalReference = (
+  ref: string,
+  schemas: Record<string, unknown>,
+): boolean => {
+  if (ref.startsWith("#/") === false || ref.indexOf("#", 1) !== -1)
+    return false;
+  let pointer: string;
+  try {
+    pointer = decodeURIComponent(ref.slice(1));
+  } catch {
+    return false;
+  }
+  const rawTokens = pointer.split("/");
+  if (rawTokens[0] !== "" || rawTokens.length !== 4) return false;
+  const tokens = rawTokens.slice(1).map(decodePointerToken);
+  return (
+    tokens.every((token) => token !== null) &&
+    tokens[0] === "components" &&
+    tokens[1] === "schemas" &&
+    Object.prototype.hasOwnProperty.call(schemas, tokens[2]!)
+  );
+};
+
+const decodePointerToken = (token: string): string | null =>
+  /~(?:[^01]|$)/.test(token)
+    ? null
+    : token.replace(/~1/g, "/").replace(/~0/g, "~");
+
+const componentNamesByValue = (
+  schemas: Record<string, unknown>,
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(schemas).flatMap(([key, schema]) => {
+      if (schema === null || typeof schema !== "object") return [];
+      const properties = (schema as { properties?: Record<string, unknown> })
+        .properties;
+      const value = properties?.value;
+      return value !== null &&
+        typeof value === "object" &&
+        Object.prototype.hasOwnProperty.call(value, "const")
+        ? [[String((value as { const: unknown }).const), key]]
+        : [];
+    }),
+  );
+
+const sample: IForward = {
+  plain: { value: "Plain", children: [] },
+  dot: { value: "A.B", children: [] },
+  dash: { value: "A-B", children: [] },
+  underscore: { value: "A_B", children: [] },
+  slash: { value: "A/B", children: [] },
+  tilde: { value: "T~N", children: [] },
+  percent: { value: "C%D", children: [] },
+  hash: { value: "A#B", children: [] },
+  unicode: { value: "Café", children: [] },
+  punctuation: { value: "/~%#", children: [] },
+  space: { value: "A B", children: [] },
+  colon: { value: "A:B", children: [] },
+  compact: { value: "AB", children: [] },
+  alias: "A/B",
+  array: ["A/B", ["A/B"]],
+  variant: {
+    kind: "A/B",
+    payload: { value: "A/B", children: [] },
+  },
+  createdAt: "2026-07-16T00:00:00.000Z" as unknown as Date,
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_names.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_names.ts
@@ -28,6 +28,16 @@ interface 한글Variant {
   payload: RecursiveObject<"T~N">;
 }
 
+interface $Named {
+  value: "$Named";
+  child?: $Named;
+}
+
+interface Named {
+  value: "Named";
+  child?: Named;
+}
+
 namespace Qualified {
   export interface Member {
     value: string;
@@ -42,6 +52,7 @@ interface IForward {
   dash: RecursiveObject<"A-B">;
   underscore: RecursiveObject<"A_B">;
   slash: RecursiveObject<"A/B">;
+  escapedSlash: RecursiveObject<"A_x2F_B">;
   tilde: RecursiveObject<"T~N">;
   percent: RecursiveObject<"C%D">;
   hash: RecursiveObject<"A#B">;
@@ -54,11 +65,15 @@ interface IForward {
   alias: AliasValue<"A/B">;
   array: RecursiveArray<"A/B">;
   variant: CaféVariant | 한글Variant;
+  dollarNamed: $Named;
+  plainNamed: Named;
   createdAt: Date;
 }
 
 interface IReverse {
   createdAt: Date;
+  plainNamed: Named;
+  dollarNamed: $Named;
   variant: 한글Variant | CaféVariant;
   array: RecursiveArray<"A/B">;
   alias: AliasValue<"A/B">;
@@ -71,6 +86,7 @@ interface IReverse {
   hash: RecursiveObject<"A#B">;
   percent: RecursiveObject<"C%D">;
   tilde: RecursiveObject<"T~N">;
+  escapedSlash: RecursiveObject<"A_x2F_B">;
   slash: RecursiveObject<"A/B">;
   underscore: RecursiveObject<"A_B">;
   dash: RecursiveObject<"A-B">;
@@ -122,6 +138,21 @@ export const test_json_schema_openapi_component_names = (): void => {
   TestValidator.equals("dot control", names["A.B"], "RecursiveObjectA.B");
   TestValidator.equals("hyphen control", names["A-B"], "RecursiveObjectA-B");
   TestValidator.equals("underscore control", names.A_B, "RecursiveObjectA_B");
+  TestValidator.equals(
+    "escape-shaped legal control",
+    names.A_x2F_B,
+    "RecursiveObjectA_x2F_B",
+  );
+  TestValidator.notEquals(
+    "forbidden input does not alias escape-shaped legal input",
+    names["A/B"],
+    names.A_x2F_B,
+  );
+  TestValidator.notEquals(
+    "dollar identifier does not alias its normalized peer",
+    names.$Named,
+    names.Named,
+  );
   TestValidator.predicate(
     "qualified control",
     Object.prototype.hasOwnProperty.call(
@@ -432,6 +463,7 @@ const sample: IForward = {
   dash: { value: "A-B", children: [] },
   underscore: { value: "A_B", children: [] },
   slash: { value: "A/B", children: [] },
+  escapedSlash: { value: "A_x2F_B", children: [] },
   tilde: { value: "T~N", children: [] },
   percent: { value: "C%D", children: [] },
   hash: { value: "A#B", children: [] },
@@ -447,5 +479,7 @@ const sample: IForward = {
     kind: "café",
     payload: { value: "A/B", children: [] },
   },
+  dollarNamed: { value: "$Named" },
+  plainNamed: { value: "Named" },
   createdAt: "2026-07-16T00:00:00.000Z" as unknown as Date,
 };

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_non_enumerable_definition.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_non_enumerable_definition.ts
@@ -1,0 +1,79 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { LlmSchemaConverter, OpenApiTypeChecker } from "@typia/utils";
+import { ILlmSchema } from "typia";
+
+/**
+ * Verifies component allocation covers every definition inversion can resolve.
+ *
+ * `LlmReference.resolve` finds a definition through `ObjectDictionary.get`,
+ * which keys off `hasOwnProperty` and therefore sees own non-enumerable keys.
+ * Seeding the allocation from the enumerable-only view would let such a
+ * definition resolve while never being allocated, so it would bypass collision
+ * management and could seize a name an allocated definition already owns —
+ * silently dropping one of the two. Escaping the stray key is not enough: it
+ * produces exactly the name the legal definition holds.
+ *
+ * 1. Give `$defs` an own non-enumerable forbidden key whose escaped form
+ *    collides with a second, legal, enumerable key.
+ * 2. Invert references to both.
+ * 3. Assert each resolves to a distinct component carrying its own content.
+ */
+export const test_llm_invert_non_enumerable_definition = (): void => {
+  const $defs: Record<string, ILlmSchema> = {
+    A_x2F_B: { type: "string", description: "legal enumerable definition" },
+  };
+  Object.defineProperty($defs, "A/B", {
+    configurable: true,
+    enumerable: false,
+    writable: true,
+    value: { type: "string", description: "forbidden non-enumerable definition" },
+  });
+
+  const components: OpenApi.IComponents = { schemas: {} };
+  const inverted: OpenApi.IJsonSchema = LlmSchemaConverter.invert({
+    components,
+    $defs,
+    schema: {
+      type: "object",
+      properties: {
+        forbidden: { $ref: "#/$defs/A~1B" },
+        legal: { $ref: "#/$defs/A_x2F_B" },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+  });
+
+  const schemas: Record<string, OpenApi.IJsonSchema> = components.schemas ?? {};
+  TestValidator.predicate(
+    "every allocated component key is legal",
+    () => Object.keys(schemas).every((key) => /^[a-zA-Z0-9.\-_]+$/.test(key)),
+  );
+  TestValidator.equals(
+    "the legal definition keeps its exact name",
+    (schemas.A_x2F_B as { description?: string } | undefined)?.description,
+    "legal enumerable definition",
+  );
+
+  const describe = (property: string): string | undefined => {
+    const schema: OpenApi.IJsonSchema | undefined = OpenApiTypeChecker.isObject(
+      inverted,
+    )
+      ? inverted.properties?.[property]
+      : undefined;
+    if (schema === undefined || OpenApiTypeChecker.isReference(schema) === false)
+      return undefined;
+    const target: OpenApi.IJsonSchema | undefined =
+      schemas[schema.$ref.replace("#/components/schemas/", "")];
+    return (target as { description?: string } | undefined)?.description;
+  };
+  TestValidator.equals(
+    "each definition resolves to its own content",
+    { forbidden: describe("forbidden"), legal: describe("legal") },
+    {
+      forbidden: "forbidden non-enumerable definition",
+      legal: "legal enumerable definition",
+    },
+  );
+};

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_openapi_component_names.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_openapi_component_names.ts
@@ -1,0 +1,228 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { LlmSchemaConverter, OpenApiTypeChecker } from "@typia/utils";
+import { ILlmSchema } from "typia";
+
+export const test_llm_invert_openapi_component_names = (): void => {
+  const keys: string[] = [
+    "Legal.Control",
+    "A-B",
+    "A_B",
+    "Taken",
+    "",
+    "/",
+    "~",
+    "%",
+    "#",
+    " ",
+    "Café",
+    "_x2F_",
+    "//",
+    "_x2F_/",
+  ];
+  const propertyByKey: Map<string, string> = new Map(
+    keys.map((key, index) => [key, `case${index}`]),
+  );
+  const convert = (ordered: string[]): IConversion => {
+    const $defs: Record<string, ILlmSchema> = Object.fromEntries(
+      ordered.map((key) => [
+        key,
+        key === "/"
+          ? {
+              type: "object",
+              properties: {
+                next: { $ref: writeLlmReference(key) },
+              },
+              required: [],
+              additionalProperties: false,
+              description: describe(key),
+            }
+          : {
+              type: "string",
+              description: describe(key),
+            },
+      ]),
+    );
+    const components: OpenApi.IComponents = {
+      schemas: {
+        Taken: { type: "boolean", description: "pre-existing Taken" },
+        _x2F_: { type: "boolean", description: "pre-existing escape" },
+      },
+    };
+    const schema: ILlmSchema.IObject = {
+      type: "object",
+      properties: Object.fromEntries(
+        ordered.map((key) => [
+          propertyByKey.get(key)!,
+          { $ref: writeLlmReference(key) },
+        ]),
+      ),
+      required: [],
+      additionalProperties: false,
+    };
+    const inverted: OpenApi.IJsonSchema = LlmSchemaConverter.invert({
+      components,
+      $defs,
+      schema: {
+        ...schema,
+        properties: {
+          ...schema.properties,
+          choice: {
+            anyOf: [
+              { $ref: writeLlmReference("#") },
+              { $ref: writeLlmReference("Café") },
+            ],
+            "x-discriminator": {
+              propertyName: "kind",
+              mapping: {
+                hash: writeLlmReference("#"),
+                unicode: writeLlmReference("Café"),
+              },
+            },
+          },
+        },
+      },
+    });
+    if (OpenApiTypeChecker.isObject(inverted) === false)
+      throw new Error("LLM inversion did not return an object schema.");
+    return { components, inverted };
+  };
+
+  const first: IConversion = convert(keys);
+  const second: IConversion = convert([...keys].reverse());
+  for (const [label, conversion] of [
+    ["forward", first],
+    ["reverse", second],
+  ] as const) {
+    const schemas: Record<string, OpenApi.IJsonSchema> =
+      conversion.components.schemas ?? {};
+    TestValidator.predicate(
+      `${label}: every component name satisfies the OpenAPI grammar`,
+      () => Object.keys(schemas).every((key) => /^[a-zA-Z0-9.\-_]+$/.test(key)),
+    );
+    TestValidator.equals(
+      `${label}: an existing legal component is not overwritten`,
+      schemas.Taken,
+      { type: "boolean", description: "pre-existing Taken" },
+    );
+    TestValidator.equals(
+      `${label}: an existing escape-shaped component is not overwritten`,
+      schemas._x2F_,
+      { type: "boolean", description: "pre-existing escape" },
+    );
+    for (const key of keys) {
+      const property: OpenApi.IJsonSchema | undefined =
+        conversion.inverted.properties?.[propertyByKey.get(key)!];
+      TestValidator.predicate(
+        `${label}: ${JSON.stringify(key)} has a local component reference`,
+        () =>
+          property !== undefined && OpenApiTypeChecker.isReference(property),
+      );
+      if (
+        property === undefined ||
+        OpenApiTypeChecker.isReference(property) === false
+      )
+        continue;
+      const target: OpenApi.IJsonSchema | undefined = resolveLocalReference(
+        conversion.components,
+        property.$ref,
+      );
+      TestValidator.equals(
+        `${label}: ${JSON.stringify(key)} resolves to its own definition`,
+        target?.description,
+        describe(key),
+      );
+      if (key === "/") {
+        const next: OpenApi.IJsonSchema | undefined =
+          target !== undefined && OpenApiTypeChecker.isObject(target)
+            ? target.properties?.next
+            : undefined;
+        TestValidator.predicate(
+          `${label}: recursive reference reuses the allocated component`,
+          () =>
+            next !== undefined &&
+            OpenApiTypeChecker.isReference(next) &&
+            next.$ref === property.$ref,
+        );
+      }
+    }
+
+    const choice: OpenApi.IJsonSchema | undefined =
+      conversion.inverted.properties?.choice;
+    TestValidator.predicate(
+      `${label}: discriminator mapping references legal components`,
+      () =>
+        choice !== undefined &&
+        OpenApiTypeChecker.isOneOf(choice) &&
+        choice.discriminator?.mapping !== undefined &&
+        Object.values(choice.discriminator.mapping).every(
+          (reference) =>
+            resolveLocalReference(conversion.components, reference) !==
+            undefined,
+        ),
+    );
+  }
+
+  TestValidator.equals(
+    "component allocation is independent of definition and traversal order",
+    collectReferences(first),
+    collectReferences(second),
+  );
+  TestValidator.equals(
+    "legal component names are preserved when available",
+    Object.fromEntries(
+      ["Legal.Control", "A-B", "A_B"].map((key) => [
+        key,
+        collectReferences(first)[propertyByKey.get(key)!],
+      ]),
+    ),
+    {
+      "Legal.Control": "#/components/schemas/Legal.Control",
+      "A-B": "#/components/schemas/A-B",
+      A_B: "#/components/schemas/A_B",
+    },
+  );
+};
+
+interface IConversion {
+  components: OpenApi.IComponents;
+  inverted: OpenApi.IJsonSchema.IObject;
+}
+
+const collectReferences = (
+  conversion: IConversion,
+): Record<string, string | undefined> =>
+  Object.fromEntries(
+    Object.entries(conversion.inverted.properties ?? {})
+      .filter(([key]) => key.startsWith("case"))
+      .sort(([x], [y]) => x.localeCompare(y))
+      .map(([key, schema]) => [
+        key,
+        OpenApiTypeChecker.isReference(schema) ? schema.$ref : undefined,
+      ]),
+  );
+
+const describe = (key: string): string => `definition ${JSON.stringify(key)}`;
+
+const writeLlmReference = (key: string): string =>
+  `#/$defs/${encodeURIComponent(key.replace(/~/g, "~0").replace(/\//g, "~1"))}`;
+
+const resolveLocalReference = (
+  components: OpenApi.IComponents,
+  reference: string,
+): OpenApi.IJsonSchema | undefined => {
+  if (reference.startsWith("#/") === false) return undefined;
+  let current: unknown = { components };
+  let pointer: string;
+  try {
+    pointer = decodeURIComponent(reference.slice(2));
+  } catch {
+    return undefined;
+  }
+  for (const token of pointer.split("/")) {
+    const key: string = token.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current as OpenApi.IJsonSchema | undefined;
+};

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
@@ -102,9 +102,19 @@ export const test_llm_schema_json_pointer_references = (): void => {
           (schema) => (schema as { type?: string }).type === "number",
         ),
     );
+    // An unrestricted `$defs` key is not a legal Components Object key, so
+    // inversion allocates one. The definition must survive under that
+    // allocated name, and the emitted reference must resolve to it.
+    const componentKey: string | undefined = Object.keys(
+      components.schemas!,
+    ).find(
+      (name) => (components.schemas![name] as { type?: string }).type ===
+        "number",
+    );
     TestValidator.predicate(
-      `${label}: inversion keeps raw component identity`,
-      () => Object.hasOwn(components.schemas!, key),
+      `${label}: inversion allocates a legal component key`,
+      () =>
+        componentKey !== undefined && /^[a-zA-Z0-9.\-_]+$/.test(componentKey),
     );
     TestValidator.equals(
       `${label}: inverted reference resolves by JSON Pointer`,
@@ -114,7 +124,7 @@ export const test_llm_schema_json_pointer_references = (): void => {
           | OpenApi.IJsonSchema.IReference
           | undefined,
       ),
-      components.schemas![key],
+      components.schemas![componentKey!],
     );
     TestValidator.predicate(
       `${label}: inversion is not accept-all`,
@@ -479,21 +489,38 @@ export const test_llm_schema_json_pointer_references = (): void => {
     schema: discriminatorSchema,
     $defs: discriminatorDefinitions,
   });
-  TestValidator.equals(
-    "inversion preserves encoded discriminator identity",
+  // Inversion allocates a legal Components Object key for each unrestricted
+  // `$defs` key, so the mapping identifies the allocated component rather than
+  // the raw one. What must hold is that each discriminator value still selects
+  // the branch its raw key named.
+  const discriminatorMapping: Record<string, string> | undefined =
     "oneOf" in discriminatorInverted
       ? discriminatorInverted.discriminator?.mapping
-      : undefined,
-    {
-      slash: "#/components/schemas/A~1B",
-      tilde: "#/components/schemas/T~0N",
-    },
-  );
+      : undefined;
   TestValidator.predicate(
-    "discriminator component identities remain raw",
+    "inversion maps every discriminator to a legal component key",
     () =>
-      Object.hasOwn(discriminatorComponents.schemas!, "A/B") &&
-      Object.hasOwn(discriminatorComponents.schemas!, "T~N"),
+      discriminatorMapping !== undefined &&
+      Object.values(discriminatorMapping).every((reference) =>
+        /^#\/components\/schemas\/[a-zA-Z0-9.\-_]+$/.test(reference),
+      ),
+  );
+  TestValidator.equals(
+    "inversion keeps each discriminator on its own branch",
+    Object.fromEntries(
+      Object.entries(discriminatorMapping ?? {}).map(([tag, reference]) => [
+        tag,
+        (
+          discriminatorComponents.schemas![
+            reference.replace("#/components/schemas/", "")
+          ] as OpenApi.IJsonSchema.IObject | undefined
+        )?.properties?.kind,
+      ]),
+    ),
+    {
+      slash: { type: "string", const: "slash" },
+      tilde: { type: "string", const: "tilde" },
+    },
   );
   const validateDiscriminator = LlmJson.validate({
     type: "object",


### PR DESCRIPTION
## Intent

Reserve the complete implementation surface for #2103 before writing product or test code.

Closes #2103.

## Scope

- allocate deterministic, nonempty OpenAPI 3.0/3.1 component keys that satisfy `^[a-zA-Z0-9\.\-_]+$`;
- preserve legal alphanumeric, dotted, hyphenated, underscored, and qualified controls;
- keep component insertion, recursive `$ref`s, discriminator mappings, collision allocation, and downstream consumers synchronized;
- cover all three public JSON generators plus validator, type checker, converters, HTTP composition/migration, and generated LLM conversion surfaces;
- add tests first for illegal names, Unicode, empty/punctuation boundaries, legal controls, collisions, recursion, and independent reference resolution.

## Coordination

- Unrestricted LLM `$defs` reference parsing and encoding remains owned by #2102. This pull request legalizes generated OpenAPI names and does not claim the manual LLM dictionary contract.
- The implementation may proceed in parallel, but landing follows #2102 where shared converter/reference handling overlaps.
- Native source changes require a `typia` version bump. No version is changed on the claim or stale implementation base; the next version is selected only after rebasing onto the completed native landing chain.

## Verification

Pending tests-first implementation. The claim commit is intentionally empty and changes no product files.

Campaign Actions remain enabled. Runs for each exact campaign SHA are cancelled and locally scoped verification is the implementation gate.
