### PR TITLE
fix(native): classify default libraries by compiler ownership and pin bundler-cache invalidation end to end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ tests/test-typia-ttsc/fixtures/*/build/output/
 # transform test fixture scratch space (inside the npm-packed native tree)
 packages/typia/native/.tmp-ttsc-typia-tests/
 
+# bundler-cache e2e fixture scratch space (must stay inside the workspace so
+# the fixture resolves the suite's node_modules)
+tests/test-typia-bundler-cache/.tmp/
+
 package-lock.json
 !experiments/setup/package-lock.json
 

--- a/packages/typia/native/cmd/ttsc-typia/project_dependencies_custom_lib_name_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_dependencies_custom_lib_name_transform_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestProjectDependenciesCustomLibNameTransform verifies a project-owned
+// ambient declaration file named `lib.custom.d.ts` appears in the transform
+// envelope's `dependencies`.
+//
+// Default-library exclusion must come from the compiler's own classification,
+// never from a filename pattern: a basename predicate (`lib.*.d.ts`) silently
+// drops a project's own ambient file with that common naming, so its changes
+// never invalidate consumers and persistent bundler caches serve stale
+// validators (samchon/typia#2108). Compiler-owned default libraries must still
+// stay excluded.
+//
+//  1. Build a project where `a.ts` calls `typia.validate<Bee>()` with `Bee`
+//     declared in `b.ts` consuming the ambient `CustomAmbient` interface
+//     declared in `src/lib.custom.d.ts`, plus a `Date` property so the
+//     analysis touches real default libraries.
+//  2. Run project transform mode and decode the JSON envelope.
+//  3. Assert `dependencies["src/a.ts"]` contains `src/lib.custom.d.ts`.
+//  4. Assert no compiler-owned default library (virtual `bundled:///` URI or
+//     any value outside the project) leaks into the entry.
+func TestProjectDependenciesCustomLibNameTransform(t *testing.T) {
+  project := projectDependenciesCustomLibNameProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--output", "ts",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("project transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  var envelope struct {
+    TypeScript   map[string]string   `json:"typescript"`
+    Dependencies map[string][]string `json:"dependencies"`
+  }
+  if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+    t.Fatalf("decode envelope: %v\n%s", err, out)
+  }
+  entries := envelope.Dependencies["src/a.ts"]
+  if len(entries) == 0 {
+    t.Fatalf("dependencies must contain an entry for src/a.ts:\n%s", out)
+  }
+  found := map[string]bool{}
+  for _, entry := range entries {
+    found[entry] = true
+    if strings.Contains(entry, "://") {
+      t.Fatalf("dependencies must exclude virtual URI sources, got %q in %v", entry, entries)
+    }
+    if filepath.IsAbs(filepath.FromSlash(entry)) || strings.HasPrefix(entry, "../") {
+      t.Fatalf("dependencies must not report files outside the project, got %q in %v", entry, entries)
+    }
+  }
+  if !found["src/lib.custom.d.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the project-owned src/lib.custom.d.ts: %v", entries)
+  }
+  if !found["src/b.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the direct declaration file src/b.ts: %v", entries)
+  }
+}
+
+func projectDependenciesCustomLibNameProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "project-dependencies-custom-lib-name-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(projectDependenciesCustomLibNameTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  for name, body := range map[string]string{
+    "a.ts":            projectDependenciesCustomLibNameSourceA,
+    "b.ts":            projectDependenciesCustomLibNameSourceB,
+    "lib.custom.d.ts": projectDependenciesCustomLibNameSourceLib,
+  } {
+    if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  return dir
+}
+
+const projectDependenciesCustomLibNameTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}
+`
+
+const projectDependenciesCustomLibNameSourceA = `import typia from "typia";
+
+import { Bee } from "./b";
+
+export const validateBee = (input: unknown) => typia.validate<Bee>(input);
+`
+
+const projectDependenciesCustomLibNameSourceB = `export interface Bee {
+  id: string;
+  when: Date;
+  ambient: CustomAmbient;
+}
+`
+
+const projectDependenciesCustomLibNameSourceLib = `declare interface CustomAmbient {
+  tag: string;
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/transform.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform.go
@@ -127,7 +127,10 @@ func runTransformProject(
     Diagnostics: []transformCompilerDiagnostic{},
     TypeScript:  map[string]string{},
   }
-  collector := newTransformDependencyCollector(cwd)
+  collector := newTransformDependencyCollector(cwd, func(fileName string) bool {
+    sf := prog.SourceFile(fileName)
+    return sf != nil && prog.TSProgram.IsLibFile(sf)
+  })
   schemametadata.MetadataDependency_listen(prog.Checker, collector.Touch)
   defer schemametadata.MetadataDependency_release(prog.Checker)
   for _, sf := range prog.SourceFiles() {
@@ -249,9 +252,9 @@ type transformProjectOutput struct {
   // TypeScript) to the source files owning the declarations typia's analysis
   // consulted for it. Values are project-relative when the file lives under the
   // project and absolute otherwise; the consumer absolutizes against the
-  // project root and drops the file itself. Default `lib.*.d.ts` files are
-  // excluded (toolchain-versioned, not project inputs); `node_modules`
-  // declaration files are included.
+  // project root and drops the file itself. Compiler-owned default library
+  // files are excluded (toolchain-versioned, not project inputs);
+  // `node_modules` declaration files are included.
   Dependencies map[string][]string `json:"dependencies,omitempty"`
 }
 
@@ -262,16 +265,26 @@ type transformDependencyCollector struct {
   cwd     string
   current string
   files   map[string]map[string]bool
+  // isLibraryFile reports the compiler's own classification of a file as a
+  // default library. Classification must come from the program, never from a
+  // filename pattern: a project's own ambient declaration file may legitimately
+  // be named `lib.custom.d.ts`, and dropping it by basename silently loses
+  // cache invalidation for the types it declares (samchon/typia#2108).
+  isLibraryFile func(fileName string) bool
   // values memoizes fileName -> envelope value ("" for a dropped file): the
   // listener reports the same declaration files repeatedly across call sites.
   values map[string]string
 }
 
-func newTransformDependencyCollector(cwd string) *transformDependencyCollector {
+func newTransformDependencyCollector(
+  cwd string,
+  isLibraryFile func(fileName string) bool,
+) *transformDependencyCollector {
   return &transformDependencyCollector{
-    cwd:    cwd,
-    files:  map[string]map[string]bool{},
-    values: map[string]string{},
+    cwd:           cwd,
+    isLibraryFile: isLibraryFile,
+    files:         map[string]map[string]bool{},
+    values:        map[string]string{},
   }
 }
 
@@ -290,7 +303,7 @@ func (collector *transformDependencyCollector) Touch(fileName string) {
   }
   value, memoized := collector.values[fileName]
   if memoized == false {
-    value = transformDependencyValue(collector.cwd, fileName)
+    value = collector.value(fileName)
     collector.values[fileName] = value
   }
   if value == "" || value == collector.current {
@@ -304,13 +317,16 @@ func (collector *transformDependencyCollector) Touch(fileName string) {
   set[value] = true
 }
 
-// transformDependencyValue renders one reported file as its envelope value, or
-// "" when the file must be dropped (default library or virtual URI source).
-func transformDependencyValue(cwd string, fileName string) string {
-  if transformDependencyDefaultLib(fileName) || strings.Contains(fileName, "://") {
+// value renders one reported file as its envelope value, or "" when the file
+// must be dropped: virtual URI sources (e.g. tsgo's `bundled:///` embedded
+// libraries) cannot be watched, and files the compiler classifies as default
+// libraries (on-disk in `noembed` or `libReplacement` configurations) are
+// toolchain inputs, not project inputs.
+func (collector *transformDependencyCollector) value(fileName string) string {
+  if strings.Contains(fileName, "://") || collector.isLibraryFile(fileName) {
     return ""
   }
-  return sourceFileKey(cwd, filepath.ToSlash(fileName))
+  return sourceFileKey(collector.cwd, filepath.ToSlash(fileName))
 }
 
 // ToJSON renders the collected sets as the envelope's `dependencies` map with
@@ -335,14 +351,6 @@ func (collector *transformDependencyCollector) ToJSON() map[string][]string {
     return nil
   }
   return output
-}
-
-// transformDependencyDefaultLib reports whether the file is a TypeScript
-// default library (`lib.<target>.d.ts`), identified by base name because the
-// install directory varies by toolchain.
-func transformDependencyDefaultLib(fileName string) bool {
-  base := filepath.Base(filepath.FromSlash(fileName))
-  return strings.HasPrefix(base, "lib.") && strings.HasSuffix(base, ".d.ts")
 }
 
 type transformCompilerDiagnostic struct {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,6 +592,25 @@ importers:
         specifier: catalog:utils
         version: 11.0.0
 
+  tests/test-typia-bundler-cache:
+    dependencies:
+      typia:
+        specifier: workspace:^
+        version: link:../../packages/typia
+    devDependencies:
+      '@ttsc/unplugin':
+        specifier: catalog:typescript
+        version: 0.18.4
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.6.0
+      esbuild-loader:
+        specifier: ^4.5.0
+        version: 4.5.0(webpack@5.107.2)
+      webpack:
+        specifier: ^5.107.2
+        version: 5.107.2
+
   tests/test-typia-cli:
     devDependencies:
       '@types/node':
@@ -882,7 +901,7 @@ importers:
         version: 5.0.10
       ts-loader:
         specifier: ^9.5.1
-        version: 9.6.0(typescript@5.9.3)(webpack@5.107.2(postcss@8.5.10))
+        version: 9.6.0(loader-utils@2.0.4)(typescript@5.9.3)(webpack@5.107.2(postcss@8.5.10))
       typedoc:
         specifier: ^0.28.9
         version: 0.28.19(typescript@5.9.3)
@@ -1294,6 +1313,162 @@ packages:
 
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@fastify/ajv-compiler@3.6.0':
     resolution: {integrity: sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==}
@@ -3374,6 +3549,9 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
+  big.js@5.2.2:
+    resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -4096,6 +4274,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  emojis-list@3.0.0:
+    resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
+    engines: {node: '>= 4'}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -4146,6 +4328,16 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild-loader@4.5.0:
+    resolution: {integrity: sha512-rVYe97IN1+VoealVHQ3STEPbfTm+vvPk7AZPrL53Pt6JUGBhHTnIqyaow7EveMFlmQ2A1bLp7q19sP4PppaCDQ==}
+    peerDependencies:
+      webpack: ^4.40.0 || ^5.0.0
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -4437,6 +4629,9 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   gh-pages@5.0.0:
     resolution: {integrity: sha512-Nqp1SjkPIB94Xw/3yYNTUL+G2dxlhjvv1zeN/4kMC1jfViTEqhtVz/Ba1zSXHuvXCN9ADNS1dN4r5/J/nZWEQQ==}
@@ -5004,6 +5199,10 @@ packages:
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
+
+  loader-utils@2.0.4:
+    resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
+    engines: {node: '>=8.9.0'}
 
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
@@ -6049,6 +6248,9 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -7754,6 +7956,84 @@ snapshots:
   '@emotion/utils@1.4.2': {}
 
   '@emotion/weak-memoize@0.4.0': {}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
 
   '@fastify/ajv-compiler@3.6.0':
     dependencies:
@@ -9953,6 +10233,8 @@ snapshots:
       mathjax-full: 3.2.2
       react: 18.3.1
 
+  big.js@5.2.2: {}
+
   binary-extensions@2.3.0: {}
 
   binary-searching@2.0.5: {}
@@ -10738,6 +11020,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  emojis-list@3.0.0: {}
+
   encodeurl@2.0.0: {}
 
   enhanced-resolve@5.22.1:
@@ -10787,6 +11071,43 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild-loader@4.5.0(webpack@5.107.2):
+    dependencies:
+      esbuild: 0.28.1
+      get-tsconfig: 4.14.0
+      loader-utils: 2.0.4
+      webpack: 5.107.2
+      webpack-sources: 3.5.0
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -11166,6 +11487,10 @@ snapshots:
       es-object-atoms: 1.1.1
 
   get-stream@8.0.1: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   gh-pages@5.0.0:
     dependencies:
@@ -11814,6 +12139,12 @@ snapshots:
       uc.micro: 2.1.0
 
   loader-runner@4.3.2: {}
+
+  loader-utils@2.0.4:
+    dependencies:
+      big.js: 5.2.2
+      emojis-list: 3.0.0
+      json5: 2.2.3
 
   locate-character@3.0.0:
     optional: true
@@ -13295,6 +13626,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.12:
     dependencies:
       es-errors: 1.3.0
@@ -13812,6 +14145,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.10
 
+  terser-webpack-plugin@5.6.1(webpack@5.107.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.107.2
+
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -13914,7 +14255,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-loader@9.6.0(typescript@5.9.3)(webpack@5.107.2(postcss@8.5.10)):
+  ts-loader@9.6.0(loader-utils@2.0.4)(typescript@5.9.3)(webpack@5.107.2(postcss@8.5.10)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.22.1
@@ -13923,6 +14264,8 @@ snapshots:
       source-map: 0.7.6
       typescript: 5.9.3
       webpack: 5.107.2(postcss@8.5.10)
+    optionalDependencies:
+      loader-utils: 2.0.4
 
   ts-morph@27.0.2:
     dependencies:
@@ -14222,6 +14565,45 @@ snapshots:
   webpack-sources@3.5.0: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.107.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.22.1
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(webpack@5.107.2)
+      watchpack: 2.5.1
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   webpack@5.107.2(postcss@8.5.10):
     dependencies:

--- a/tests/test-typia-bundler-cache/package.json
+++ b/tests/test-typia-bundler-cache/package.json
@@ -1,0 +1,33 @@
+{
+  "private": true,
+  "name": "@typia/test-typia-bundler-cache",
+  "description": "Bundler persistent-cache invalidation end-to-end tests for typia.",
+  "scripts": {
+    "start": "ttsx src/index.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/typia"
+  },
+  "keywords": [
+    "typia",
+    "test",
+    "bundler",
+    "cache"
+  ],
+  "author": "Jeongho Nam",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/samchon/typia/issues"
+  },
+  "homepage": "https://typia.io",
+  "devDependencies": {
+    "@ttsc/unplugin": "catalog:typescript",
+    "@types/node": "catalog:utils",
+    "esbuild-loader": "^4.5.0",
+    "webpack": "^5.107.2"
+  },
+  "dependencies": {
+    "typia": "workspace:^"
+  }
+}

--- a/tests/test-typia-bundler-cache/src/index.ts
+++ b/tests/test-typia-bundler-cache/src/index.ts
@@ -1,0 +1,10 @@
+import { test_webpack_filesystem_cache_invalidation } from "./test_webpack_filesystem_cache_invalidation";
+
+const main = async (): Promise<void> => {
+  await test_webpack_filesystem_cache_invalidation();
+  console.log("Success");
+};
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
+++ b/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
@@ -1,0 +1,319 @@
+import cp from "child_process";
+import fs from "fs";
+import path from "path";
+
+interface ICommandResult {
+  status: number | null;
+  output: string;
+}
+
+interface IValidationLike {
+  success: boolean;
+  errors?: Array<{ path: string; expected: string }>;
+}
+
+const root: string = path.resolve(__dirname, "..");
+
+const run = (cwd: string, args: string[]): ICommandResult => {
+  const result: cp.SpawnSyncReturns<string> = cp.spawnSync(
+    process.execPath,
+    args,
+    {
+      cwd,
+      encoding: "utf8",
+      timeout: 600_000,
+    },
+  );
+  const error: string =
+    result.error instanceof Error
+      ? `\n${result.error.name}: ${result.error.message}`
+      : "";
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}\n${result.stderr ?? ""}${error}`,
+  };
+};
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const build = (project: string, stage: string): void => {
+  const result: ICommandResult = run(project, [
+    path.join(project, "build.cjs"),
+  ]);
+  if (result.status !== 0)
+    throw new Error(`webpack build failed ${stage}:\n${result.output}`);
+};
+
+const validate = (project: string, input: unknown): IValidationLike => {
+  const result: ICommandResult = run(project, [
+    path.join(project, "dist", "bundle.js"),
+    JSON.stringify(input),
+  ]);
+  if (result.status !== 0)
+    throw new Error(`bundle execution failed:\n${result.output}`);
+  const line: string | undefined = result.output
+    .split(/\r?\n/)
+    .find((candidate) => candidate.startsWith("{"));
+  if (line === undefined)
+    throw new Error(`bundle printed no validation JSON:\n${result.output}`);
+  return JSON.parse(line) as IValidationLike;
+};
+
+const assertSuccess = (stage: string, result: IValidationLike): void => {
+  if (result.success !== true)
+    throw new Error(
+      `${stage}: expected validation success, got ${JSON.stringify(result)}`,
+    );
+};
+
+const assertErrorPath = (
+  stage: string,
+  result: IValidationLike,
+  errorPath: string,
+): void => {
+  if (result.success !== false)
+    throw new Error(
+      `${stage}: expected validation failure at ${errorPath}, got success. ` +
+        `The persistent cache served a stale validator instead of ` +
+        `re-transforming the consumer after its type dependency changed.`,
+    );
+  const paths: string[] = (result.errors ?? []).map((error) => error.path);
+  if (paths.includes(errorPath) === false)
+    throw new Error(
+      `${stage}: expected an error at ${errorPath}, got ${JSON.stringify(result)}`,
+    );
+};
+
+/**
+ * Rewrites a fixture source and pushes its mtime forward so webpack's
+ * timestamp-based snapshot cannot mistake the new content for the old one on
+ * filesystems with coarse mtime resolution.
+ */
+const mutate = async (file: string, content: string): Promise<void> => {
+  await sleep(1_500);
+  fs.writeFileSync(file, content);
+  const forward: Date = new Date(Date.now() + 2_000);
+  fs.utimesSync(file, forward, forward);
+};
+
+const writeFixture = (project: string): void => {
+  fs.mkdirSync(path.join(project, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(project, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "esnext",
+          moduleResolution: "bundler",
+          ignoreDeprecations: "6.0",
+          esModuleInterop: true,
+          strict: true,
+          skipLibCheck: true,
+        },
+        include: ["src"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    path.join(project, "webpack.config.js"),
+    [
+      `const path = require("path");`,
+      `const ttsc = require("@ttsc/unplugin/webpack");`,
+      ``,
+      `module.exports = {`,
+      `  mode: "production",`,
+      `  context: __dirname,`,
+      `  entry: "./src/index.ts",`,
+      `  target: "node",`,
+      `  cache: {`,
+      `    type: "filesystem",`,
+      `    cacheDirectory: path.resolve(__dirname, ".webpack-cache"),`,
+      `  },`,
+      `  plugins: [ttsc.default()],`,
+      `  module: {`,
+      `    rules: [`,
+      `      {`,
+      `        test: /\\.ts$/,`,
+      `        loader: require.resolve("esbuild-loader"),`,
+      `        options: { loader: "ts", target: "es2020" },`,
+      `      },`,
+      `    ],`,
+      `  },`,
+      `  // Keep workspace-linked packages under their node_modules ids so the`,
+      `  // ttsc unplugin transforms only the fixture project, not the linked`,
+      `  // typia sources.`,
+      `  resolve: { extensions: [".ts", ".js"], symlinks: false },`,
+      `  output: {`,
+      `    path: path.resolve(__dirname, "dist"),`,
+      `    filename: "bundle.js",`,
+      `  },`,
+      `  optimization: { minimize: false },`,
+      `};`,
+      ``,
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(project, "build.cjs"),
+    [
+      `const webpack = require("webpack");`,
+      ``,
+      `const config = require("./webpack.config.js");`,
+      `const compiler = webpack(config);`,
+      `compiler.run((error, stats) => {`,
+      `  if (error) {`,
+      `    console.error(error.stack || String(error));`,
+      `    process.exit(1);`,
+      `  }`,
+      `  const failed = stats.hasErrors();`,
+      `  if (failed)`,
+      `    console.error(stats.toString({ errors: true, colors: false }));`,
+      `  // close() persists the filesystem cache; exiting earlier would leave`,
+      `  // the second build without the first build's snapshot.`,
+      `  compiler.close((closeError) => {`,
+      `    if (closeError) {`,
+      `      console.error(closeError.stack || String(closeError));`,
+      `      process.exit(1);`,
+      `    }`,
+      `    process.exit(failed ? 1 : 0);`,
+      `  });`,
+      `});`,
+      ``,
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(project, "src", "index.ts"),
+    [
+      `import typia from "typia";`,
+      ``,
+      `import { MyType } from "./mytype";`,
+      ``,
+      `console.log(`,
+      `  JSON.stringify(`,
+      `    typia.validate<MyType>(JSON.parse(process.argv[2] ?? "{}")),`,
+      `  ),`,
+      `);`,
+      ``,
+    ].join("\n"),
+  );
+  fs.writeFileSync(path.join(project, "src", "mytype.ts"), fixtureTypeV1);
+  fs.writeFileSync(
+    path.join(project, "src", "lib.custom.d.ts"),
+    fixtureAmbientV1,
+  );
+};
+
+const fixtureTypeV1: string = [
+  `export interface MyType {`,
+  `  id: string;`,
+  `  ambient: CustomLabel;`,
+  `}`,
+  ``,
+].join("\n");
+
+const fixtureTypeV2: string = [
+  `export interface MyType {`,
+  `  id: string;`,
+  `  age: number;`,
+  `  ambient: CustomLabel;`,
+  `}`,
+  ``,
+].join("\n");
+
+const fixtureAmbientV1: string = [
+  `declare interface CustomLabel {`,
+  `  tag: string;`,
+  `}`,
+  ``,
+].join("\n");
+
+const fixtureAmbientV2: string = [
+  `declare interface CustomLabel {`,
+  `  tag: string;`,
+  `  flag: boolean;`,
+  `}`,
+  ``,
+].join("\n");
+
+/**
+ * Verifies webpack's persistent filesystem cache rebuilds typia validators when
+ * only a consulted type's file changes.
+ *
+ * Bundlers erase type-only imports from their module graphs, so without the
+ * transform envelope's `dependencies` channel (native producer ->
+ * `@ttsc/unplugin` -> `addDependency` -> `fileDependencies` snapshot) a
+ * persistent cache serves the stale generated validator forever while every
+ * layer builds green (samchon/typia#2092, #2106). The ambient declaration step
+ * also pins samchon/typia#2108: a project file named `lib.custom.d.ts` must
+ * participate in invalidation instead of being dropped as a default library by
+ * its basename.
+ *
+ * 1. Bundle a fixture where `index.ts` calls `typia.validate<MyType>()`,
+ *    `mytype.ts` declares `MyType`, and the ambient `lib.custom.d.ts` declares
+ *    a consumed `CustomLabel`; assert the validator accepts a valid input and
+ *    rejects a broken one.
+ * 2. Add a required `age` property to `MyType` and rebuild with the cache kept;
+ *    assert the previously valid input now fails at `$input.age`.
+ * 3. Add a required `flag` property to `CustomLabel` inside `lib.custom.d.ts` and
+ *    rebuild with the cache kept; assert the previous input now fails at
+ *    `$input.ambient.flag` and a fully updated input succeeds.
+ */
+export const test_webpack_filesystem_cache_invalidation =
+  async (): Promise<void> => {
+    const scratch: string = path.join(root, ".tmp");
+    fs.mkdirSync(scratch, { recursive: true });
+    const project: string = fs.mkdtempSync(path.join(scratch, "cache-"));
+    try {
+      writeFixture(project);
+
+      // 1. cold build: the validator reflects MyType v1.
+      build(project, "on the cold run");
+      assertSuccess(
+        "cold build with a valid input",
+        validate(project, { id: "a", ambient: { tag: "t" } }),
+      );
+      assertErrorPath(
+        "cold build with a broken input",
+        validate(project, { ambient: { tag: "t" } }),
+        "$input.id",
+      );
+
+      // 2. type-only change in mytype.ts; the cache is deliberately kept.
+      await mutate(path.join(project, "src", "mytype.ts"), fixtureTypeV2);
+      build(project, "after changing mytype.ts");
+      assertErrorPath(
+        "cached rebuild after adding MyType.age",
+        validate(project, { id: "a", ambient: { tag: "t" } }),
+        "$input.age",
+      );
+      assertSuccess(
+        "cached rebuild with the updated input",
+        validate(project, { id: "a", age: 1, ambient: { tag: "t" } }),
+      );
+
+      // 3. type-only change in the project-owned lib.custom.d.ts (#2108).
+      await mutate(
+        path.join(project, "src", "lib.custom.d.ts"),
+        fixtureAmbientV2,
+      );
+      build(project, "after changing lib.custom.d.ts");
+      assertErrorPath(
+        "cached rebuild after adding CustomLabel.flag",
+        validate(project, { id: "a", age: 1, ambient: { tag: "t" } }),
+        "$input.ambient.flag",
+      );
+      assertSuccess(
+        "cached rebuild with the fully updated input",
+        validate(project, {
+          id: "a",
+          age: 1,
+          ambient: { tag: "t", flag: true },
+        }),
+      );
+    } finally {
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  };

--- a/tests/test-typia-bundler-cache/tsconfig.json
+++ b/tests/test-typia-bundler-cache/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../config/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  }
+}


### PR DESCRIPTION
## Scope

One batch, two issues sharing the dependency-invalidation channel and its verification harness:

- Closes #2108 — replace the `lib.*.d.ts` basename heuristic in `transformDependencyDefaultLib` (`packages/typia/native/cmd/ttsc-typia/transform.go`) with compiler-owned default-library classification. The issue's probe runs first: verify whether tsgo's `bundled:///` embedding makes the basename branch dead code on the standard path, and whether any configuration surfaces default libs as on-disk paths.
- Closes #2106 — committed end-to-end bundler-cache invalidation regression test: webpack 5 filesystem cache, `@ttsc/unplugin/webpack`, two-build scenario against the locally built typia, placed per the repository test-suite conventions.

The #2106 fixture includes a project-owned `lib.custom.d.ts` type participating in invalidation so the end-to-end run also pins #2108.

## Plan

1. Probe tsgo's default-library surface (issue #2108 evidence step) and record findings on this thread.
2. Fix the classification; add the Go fixture test (`lib.custom.d.ts` in the envelope, bundled libs still excluded).
3. Add the committed e2e cache-invalidation suite; verify it fails with the producer reverted and passes on this branch.
4. Narrow-then-broad local verification (native Go tests, then standard suites), `pnpm format`, solo Self-Review (3+ rounds, findings commented before acting), merge on green checks.

Draft until implementation and Self-Review complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3kDYEkHutvSMcHPBXhd7P
