### PR TITLE
fix(utils): make NamingConvention.variable an identifier-legality predicate

### DIFF
--- a/packages/utils/src/utils/NamingConvention.ts
+++ b/packages/utils/src/utils/NamingConvention.ts
@@ -141,18 +141,18 @@ export namespace NamingConvention {
   /**
    * Check if string is valid JavaScript variable name.
    *
-   * Returns `true` only when `str` can be used as a *binding* identifier — a
-   * declaration, parameter, or import name — in the dialect typia generates:
-   * an ES module, which is always strict mode. A string is a valid binding
-   * when it has identifier shape and is neither {@link reserved} nor one of
-   * the strict-mode restricted binding names (`eval`, `arguments`).
+   * Returns `true` only when `str` can be used as a _binding_ identifier — a
+   * declaration, parameter, or import name — in the dialect typia generates: an
+   * ES module, which is always strict mode. A string is a valid binding when it
+   * has identifier shape and is neither {@link reserved} nor one of the
+   * strict-mode restricted binding names (`eval`, `arguments`).
    *
    * The restricted binding names are why this is not derived from
    * {@link reserved} alone. `eval` and `arguments` are not reserved words at
    * all; they are rejected only in binding position under strict mode, so no
    * reserved-word list can express this predicate.
    *
-   * Property *access* is a weaker requirement than binding, since dot notation
+   * Property _access_ is a weaker requirement than binding, since dot notation
    * accepts reserved words (`x.let` is legal). Callers escaping a property key
    * rather than declaring a name are therefore held to a stricter rule than
    * they need; that is safe, but they cannot rely on this predicate to mean
@@ -178,8 +178,8 @@ export namespace NamingConvention {
    * it is a legal identifier, but shadowing it would break `module.exports` in
    * CommonJS output.
    *
-   * `eval` and `arguments` are deliberately absent. They are not reserved
-   * words — they are merely illegal as binding names in strict code — so
+   * `eval` and `arguments` are deliberately absent. They are not reserved words
+   * — they are merely illegal as binding names in strict code — so
    * {@link variable} rejects them separately.
    *
    * @param str String to check
@@ -191,12 +191,12 @@ export namespace NamingConvention {
 /**
  * Identifier shape, ASCII subset.
  *
- * Declared without the `g` flag on purpose: a global regular expression
- * carries `lastIndex` across `test()` calls, which would make
- * {@link NamingConvention.variable} alternate between answers for the same
- * input once the pattern is hoisted out of the function body.
+ * Declared without the `g` flag on purpose: a global regular expression carries
+ * `lastIndex` across `test()` calls, which would make
+ * {@link NamingConvention.variable} alternate between answers for the same input
+ * once the pattern is hoisted out of the function body.
  */
-const IDENTIFIER = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
+const IDENTIFIER: RegExp = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 
 /** ECMAScript `ReservedWord`. */
 const RESERVED_WORDS: string[] = [

--- a/packages/utils/src/utils/NamingConvention.ts
+++ b/packages/utils/src/utils/NamingConvention.ts
@@ -12,7 +12,8 @@
  * - {@link pascal}: Convert to PascalCase (`FooBar`)
  * - {@link snake}: Convert to snake_case (`foo_bar`)
  * - {@link kebab}: Convert to kebab-case (`foo-bar`)
- * - {@link variable}: Test if string is valid JavaScript variable name
+ * - {@link variable}: Test if string is a legal binding identifier
+ * - {@link reserved}: Test if string is a JavaScript reserved word
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
@@ -140,14 +141,46 @@ export namespace NamingConvention {
   /**
    * Check if string is valid JavaScript variable name.
    *
+   * Returns `true` only when `str` can be used as a *binding* identifier — a
+   * declaration, parameter, or import name — in the dialect typia generates:
+   * an ES module, which is always strict mode. A string is a valid binding
+   * when it has identifier shape and is neither {@link reserved} nor one of
+   * the strict-mode restricted binding names (`eval`, `arguments`).
+   *
+   * The restricted binding names are why this is not derived from
+   * {@link reserved} alone. `eval` and `arguments` are not reserved words at
+   * all; they are rejected only in binding position under strict mode, so no
+   * reserved-word list can express this predicate.
+   *
+   * Property *access* is a weaker requirement than binding, since dot notation
+   * accepts reserved words (`x.let` is legal). Callers escaping a property key
+   * rather than declaring a name are therefore held to a stricter rule than
+   * they need; that is safe, but they cannot rely on this predicate to mean
+   * "needs bracket notation".
+   *
+   * Identifier shape is restricted to ASCII. JavaScript also admits Unicode
+   * identifiers, so this may report `false` for an otherwise legal name. The
+   * bias is deliberate: it can only cause a name to be escaped, never to leak
+   * an illegal binding.
+   *
    * @param str String to check
    * @returns True if valid variable name
    */
   export const variable = (str: string): boolean =>
-    reserved(str) === false && /^[a-zA-Z_$][a-zA-Z_$0-9]*$/g.test(str);
+    IDENTIFIER.test(str) && RESTRICTED.has(str) === false;
 
   /**
    * Check if string is JavaScript reserved word.
+   *
+   * Covers every ECMAScript `ReservedWord` plus the future reserved words that
+   * apply in strict mode, since typia generates ES modules, which are always
+   * strict. `module` is reserved by typia policy rather than by the language:
+   * it is a legal identifier, but shadowing it would break `module.exports` in
+   * CommonJS output.
+   *
+   * `eval` and `arguments` are deliberately absent. They are not reserved
+   * words — they are merely illegal as binding names in strict code — so
+   * {@link variable} rejects them separately.
    *
    * @param str String to check
    * @returns True if reserved word
@@ -155,7 +188,19 @@ export namespace NamingConvention {
   export const reserved = (str: string): boolean => RESERVED.has(str);
 }
 
-const RESERVED: Set<string> = new Set([
+/**
+ * Identifier shape, ASCII subset.
+ *
+ * Declared without the `g` flag on purpose: a global regular expression
+ * carries `lastIndex` across `test()` calls, which would make
+ * {@link NamingConvention.variable} alternate between answers for the same
+ * input once the pattern is hoisted out of the function body.
+ */
+const IDENTIFIER = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
+
+/** ECMAScript `ReservedWord`. */
+const RESERVED_WORDS: string[] = [
+  "await",
   "break",
   "case",
   "catch",
@@ -178,13 +223,8 @@ const RESERVED: Set<string> = new Set([
   "import",
   "in",
   "instanceof",
-  "module",
   "new",
   "null",
-  "package",
-  "public",
-  "private",
-  "protected",
   "return",
   "super",
   "switch",
@@ -197,6 +237,53 @@ const RESERVED: Set<string> = new Set([
   "void",
   "while",
   "with",
+  "yield",
+];
+
+/**
+ * Future reserved words that apply only in strict mode.
+ *
+ * Generated ES modules are always strict, so these are reserved for every name
+ * typia emits.
+ */
+const STRICT_RESERVED_WORDS: string[] = [
+  "implements",
+  "interface",
+  "let",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "static",
+];
+
+/**
+ * Reserved by typia policy rather than by the language.
+ *
+ * `module` is a legal JavaScript identifier, but a generated name that shadows
+ * it would break `module.exports` in CommonJS output.
+ */
+const POLICY_RESERVED_WORDS: string[] = ["module"];
+
+/**
+ * Names that are illegal in binding position under strict mode without being
+ * reserved words.
+ *
+ * These are the reason {@link NamingConvention.variable} cannot be a
+ * reserved-word lookup: `x.eval` and `const { eval: e } = x` are fine, while
+ * `function f(eval) {}` is a `SyntaxError` in strict code.
+ */
+const STRICT_RESTRICTED_BINDINGS: string[] = ["eval", "arguments"];
+
+const RESERVED: Set<string> = new Set([
+  ...RESERVED_WORDS,
+  ...STRICT_RESERVED_WORDS,
+  ...POLICY_RESERVED_WORDS,
+]);
+
+const RESTRICTED: Set<string> = new Set([
+  ...RESERVED,
+  ...STRICT_RESTRICTED_BINDINGS,
 ]);
 
 const unsnake =

--- a/tests/test-utils/src/features/migrate/test_http_migrate_route_accessor_identifier.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_route_accessor_identifier.ts
@@ -1,0 +1,121 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpMigrateApplication } from "@typia/interface";
+import { HttpMigration } from "@typia/utils";
+import { OpenApi } from "typia";
+
+import {
+  _isLegalBinding,
+  _isLegalDeclaration,
+} from "../../internal/_isLegalBinding";
+
+/**
+ * Verifies HttpMigration.application derives only legal binding identifiers for
+ * accessors and parameter keys.
+ *
+ * `IHttpMigrateRoute.accessor` and each parameter `key` are documented as the
+ * generated RPC accessor and parameter variable name, and downstream SDK
+ * generators emit them directly into an ES module. Because both are derived
+ * from `NamingConvention.variable`, that predicate's false positives (#2111)
+ * turned legal OpenAPI paths such as `/let/{let}` into `getByLet(connection,
+ * let)` — a real `SyntaxError`, not a hypothetical. A set-only unit test
+ * cannot prove this contract, so each route's emitted declaration is compiled.
+ *
+ * 1. Build one route per restricted word, plus controls that must not change.
+ * 2. Assert every accessor segment and parameter key is a legal binding.
+ * 3. Compile the SDK-shaped declaration each route implies.
+ * 4. Assert the already-escaped and ordinary routes keep their exact names.
+ */
+export const test_http_migrate_route_accessor_identifier = (): void => {
+  const words: string[] = [
+    // the eight #2111 false positives
+    "await", "yield", "let", "static", "implements", "interface", "eval",
+    "arguments",
+    // words already escaped before #2111 -- must not regress
+    "package", "private", "protected", "public", "case", "class", "enum",
+    "module",
+    // ordinary names -- must stay untouched
+    "foo", "async", "of", "get",
+  ];
+  const document: OpenApi.IDocument = {
+    openapi: "3.2.0",
+    "x-typia-emended-v12": true,
+    paths: Object.fromEntries(
+      words.map((word) => [
+        `/${word}/{${word}}`,
+        {
+          get: {
+            parameters: [
+              {
+                name: word,
+                in: "path" as const,
+                required: true,
+                schema: { type: "string" as const },
+              },
+            ],
+          },
+        },
+      ]),
+    ),
+    components: {},
+  };
+  const app: IHttpMigrateApplication = HttpMigration.application(document);
+  TestValidator.equals("every route migrated", app.routes.length, words.length);
+
+  for (const route of app.routes) {
+    // 2. EVERY DERIVED NAME IS A LEGAL BINDING
+    for (const accessor of route.accessor)
+      TestValidator.equals(
+        `accessor segment ${JSON.stringify(accessor)} of ${route.path} is a legal binding`,
+        _isLegalBinding(accessor),
+        true,
+      );
+    for (const parameter of route.parameters)
+      TestValidator.equals(
+        `parameter key ${JSON.stringify(parameter.key)} of ${route.path} is a legal binding`,
+        _isLegalBinding(parameter.key),
+        true,
+      );
+
+    // 3. THE DECLARATION THE ROUTE IMPLIES MUST COMPILE
+    //
+    // This is the contract that actually breaks: the accessor becomes the
+    // function name and each parameter key becomes one of its parameters.
+    // Compiling the whole declaration also proves the keys do not collide.
+    TestValidator.equals(
+      `generated declaration for ${route.path} compiles`,
+      _isLegalDeclaration({
+        name: route.accessor.at(-1)!,
+        parameters: ["connection", ...route.parameters.map((p) => p.key)],
+      }),
+      true,
+    );
+  }
+
+  // 4. CONTROLS KEEP THEIR EXACT NAMES
+  const accessorOf = (path: string): string[] =>
+    app.routes.find((r) => r.path === path)!.accessor;
+  const keyOf = (path: string): string =>
+    app.routes.find((r) => r.path === path)!.parameters[0]!.key;
+
+  TestValidator.equals("ordinary route is untouched", accessorOf("/foo/{foo}"), [
+    "foo",
+    "getByFoo",
+  ]);
+  TestValidator.equals("ordinary parameter key is untouched", keyOf("/foo/{foo}"), "foo");
+  TestValidator.equals("contextual keyword is untouched", accessorOf("/async/{async}"), [
+    "async",
+    "getByAsync",
+  ]);
+  TestValidator.equals(
+    "already-escaped route is unchanged",
+    accessorOf("/package/{package}"),
+    ["_package", "getBy_package"],
+  );
+  TestValidator.equals("newly escaped route", accessorOf("/let/{let}"), [
+    "_let",
+    "getBy_let",
+  ]);
+  TestValidator.equals("newly escaped parameter key", keyOf("/let/{let}"), "_let");
+  TestValidator.equals("eval is escaped", keyOf("/eval/{eval}"), "_eval");
+  TestValidator.equals("arguments is escaped", keyOf("/arguments/{arguments}"), "_arguments");
+};

--- a/tests/test-utils/src/features/migrate/test_http_migrate_route_accessor_identifier.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_route_accessor_identifier.ts
@@ -3,10 +3,8 @@ import { IHttpMigrateApplication } from "@typia/interface";
 import { HttpMigration } from "@typia/utils";
 import { OpenApi } from "typia";
 
-import {
-  _isLegalBinding,
-  _isLegalDeclaration,
-} from "../../internal/_isLegalBinding";
+import { _isLegalBinding } from "../../internal/_isLegalBinding";
+import { _isLegalDeclaration } from "../../internal/_isLegalDeclaration";
 
 /**
  * Verifies HttpMigration.application derives only legal binding identifiers for
@@ -17,8 +15,8 @@ import {
  * generators emit them directly into an ES module. Because both are derived
  * from `NamingConvention.variable`, that predicate's false positives (#2111)
  * turned legal OpenAPI paths such as `/let/{let}` into `getByLet(connection,
- * let)` — a real `SyntaxError`, not a hypothetical. A set-only unit test
- * cannot prove this contract, so each route's emitted declaration is compiled.
+ * let)` — a real `SyntaxError`, not a hypothetical. A set-only unit test cannot
+ * prove this contract, so each route's emitted declaration is compiled.
  *
  * 1. Build one route per restricted word, plus controls that must not change.
  * 2. Assert every accessor segment and parameter key is a legal binding.
@@ -28,13 +26,28 @@ import {
 export const test_http_migrate_route_accessor_identifier = (): void => {
   const words: string[] = [
     // the eight #2111 false positives
-    "await", "yield", "let", "static", "implements", "interface", "eval",
+    "await",
+    "yield",
+    "let",
+    "static",
+    "implements",
+    "interface",
+    "eval",
     "arguments",
     // words already escaped before #2111 -- must not regress
-    "package", "private", "protected", "public", "case", "class", "enum",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "case",
+    "class",
+    "enum",
     "module",
     // ordinary names -- must stay untouched
-    "foo", "async", "of", "get",
+    "foo",
+    "async",
+    "of",
+    "get",
   ];
   const document: OpenApi.IDocument = {
     openapi: "3.2.0",
@@ -97,25 +110,62 @@ export const test_http_migrate_route_accessor_identifier = (): void => {
   const keyOf = (path: string): string =>
     app.routes.find((r) => r.path === path)!.parameters[0]!.key;
 
-  TestValidator.equals("ordinary route is untouched", accessorOf("/foo/{foo}"), [
+  TestValidator.equals(
+    "ordinary route is untouched",
+    accessorOf("/foo/{foo}"),
+    ["foo", "getByFoo"],
+  );
+  TestValidator.equals(
+    "ordinary parameter key is untouched",
+    keyOf("/foo/{foo}"),
     "foo",
-    "getByFoo",
-  ]);
-  TestValidator.equals("ordinary parameter key is untouched", keyOf("/foo/{foo}"), "foo");
-  TestValidator.equals("contextual keyword is untouched", accessorOf("/async/{async}"), [
-    "async",
-    "getByAsync",
-  ]);
+  );
+  TestValidator.equals(
+    "contextual keyword is untouched",
+    accessorOf("/async/{async}"),
+    ["async", "getByAsync"],
+  );
+  // Words that were already escaped before #2111 must keep their exact names.
+  // A legality sweep alone cannot prove this: it would still pass if the fix
+  // silently re-escaped them to `__case`.
   TestValidator.equals(
     "already-escaped route is unchanged",
     accessorOf("/package/{package}"),
     ["_package", "getBy_package"],
   );
+  TestValidator.equals(
+    "already-escaped parameter key is unchanged",
+    keyOf("/package/{package}"),
+    "_package",
+  );
+  TestValidator.equals(
+    "reserved word is unchanged",
+    accessorOf("/case/{case}"),
+    ["_case", "getBy_case"],
+  );
+  TestValidator.equals(
+    "reserved parameter key is unchanged",
+    keyOf("/case/{case}"),
+    "_case",
+  );
+  TestValidator.equals(
+    "module policy is unchanged",
+    accessorOf("/module/{module}"),
+    ["_module", "getBy_module"],
+  );
   TestValidator.equals("newly escaped route", accessorOf("/let/{let}"), [
     "_let",
     "getBy_let",
   ]);
-  TestValidator.equals("newly escaped parameter key", keyOf("/let/{let}"), "_let");
+  TestValidator.equals(
+    "newly escaped parameter key",
+    keyOf("/let/{let}"),
+    "_let",
+  );
   TestValidator.equals("eval is escaped", keyOf("/eval/{eval}"), "_eval");
-  TestValidator.equals("arguments is escaped", keyOf("/arguments/{arguments}"), "_arguments");
+  TestValidator.equals(
+    "arguments is escaped",
+    keyOf("/arguments/{arguments}"),
+    "_arguments",
+  );
 };

--- a/tests/test-utils/src/features/migrate/test_http_migrate_route_parameter_key_escape.ts
+++ b/tests/test-utils/src/features/migrate/test_http_migrate_route_parameter_key_escape.ts
@@ -1,0 +1,88 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpMigrateApplication } from "@typia/interface";
+import { HttpMigration } from "@typia/utils";
+import { OpenApi } from "typia";
+
+import { _isLegalDeclaration } from "../../internal/_isLegalDeclaration";
+
+/**
+ * Verifies parameter-key escaping still composes once the identifier gate
+ * rejects more words.
+ *
+ * `HttpMigrateRouteComposer` escapes a key with `while
+ * (NamingConvention.variable(key) === false || used.has(key)) key = `
+ * _${key}``, so the identifier gate and the duplicate gate share one loop.
+ * Widening the gate for #2111 moves `let` from the second iteration to the
+ * first, which is exactly where an off-by-one collision would appear: `{let}`
+ * and a sibling `{_let}` must not both settle on `_let`. Numeric-leading
+ * segments and the reserved `connection` receiver run through the same loop and
+ * must be unaffected.
+ *
+ * 1. Declare routes pairing a newly restricted word with its escaped spelling.
+ * 2. Assert each pair resolves to distinct, legal keys rather than colliding.
+ * 3. Assert numeric-leading and `connection` escaping are unchanged.
+ * 4. Compile each declaration, since duplicate parameters are a `SyntaxError`.
+ */
+export const test_http_migrate_route_parameter_key_escape = (): void => {
+  const path = (route: string, names: string[]) => ({
+    [route]: {
+      get: {
+        parameters: names.map((name) => ({
+          name,
+          in: "path" as const,
+          required: true,
+          schema: { type: "string" as const },
+        })),
+      },
+    },
+  });
+  const document: OpenApi.IDocument = {
+    openapi: "3.2.0",
+    "x-typia-emended-v12": true,
+    paths: {
+      // a reserved word beside its already-escaped spelling
+      ...path("/a/{let}/b/{_let}", ["let", "_let"]),
+      // a restricted binding name beside its already-escaped spelling
+      ...path("/e/{eval}/f/{_eval}", ["eval", "_eval"]),
+      // escaping that predates #2111 and must not shift
+      ...path("/c/{9foo}", ["9foo"]),
+      ...path("/d/{connection}", ["connection"]),
+    },
+    components: {},
+  };
+  const app: IHttpMigrateApplication = HttpMigration.application(document);
+  const keysOf = (route: string): string[] =>
+    app.routes.find((r) => r.path === route)!.parameters.map((p) => p.key);
+
+  // 2. THE NEWLY RESTRICTED WORD AND ITS ESCAPED SIBLING STAY DISTINCT
+  TestValidator.equals(
+    "reserved word beside its escape",
+    keysOf("/a/{let}/b/{_let}"),
+    ["_let", "__let"],
+  );
+  TestValidator.equals(
+    "restricted binding beside its escape",
+    keysOf("/e/{eval}/f/{_eval}"),
+    ["_eval", "__eval"],
+  );
+
+  // 3. ESCAPING THAT PREDATES #2111 IS UNCHANGED
+  TestValidator.equals("numeric-leading key", keysOf("/c/{9foo}"), ["_9foo"]);
+  TestValidator.equals("connection receiver key", keysOf("/d/{connection}"), [
+    "_connection",
+  ]);
+
+  // 4. EVERY DECLARATION COMPILES
+  //
+  // Strict mode rejects duplicate parameter names, so this fails if any pair
+  // above collided.
+  for (const route of app.routes)
+    TestValidator.equals(
+      `generated declaration for ${route.path} compiles`,
+      _isLegalDeclaration({
+        name: route.accessor.at(-1)!,
+        parameters: ["connection", ...route.parameters.map((p) => p.key)],
+      }),
+      true,
+    );
+};

--- a/tests/test-utils/src/features/naming/test_naming_convention_reserved.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_reserved.ts
@@ -1,0 +1,96 @@
+import { TestValidator } from "@nestia/e2e";
+import { NamingConvention } from "@typia/utils";
+
+/**
+ * Verifies NamingConvention.reserved covers every word reserved in the dialect
+ * typia generates.
+ *
+ * The set shipped `package`, `private`, `protected`, and `public` while
+ * omitting `implements`, `interface`, `let`, and `static` — the same
+ * strict-mode future-reserved class — and omitted `await`/`yield` outright
+ * (#2111). `EndpointUtil.normalize` escapes path segments through this
+ * predicate, so an omission silently produces a keyword where an escaped name
+ * was intended.
+ *
+ * `eval` and `arguments` are deliberately *not* reserved words: they are only
+ * restricted as BoundNames in strict code. Keeping them out of `reserved()` is
+ * what makes it an honest reserved-word predicate, and is exactly why
+ * `variable()` cannot be derived from it alone.
+ *
+ * 1. Assert every ECMAScript `ReservedWord` is reserved.
+ * 2. Assert every strict-mode future reserved word is reserved.
+ * 3. Assert `eval`/`arguments` are not reserved words, though not valid
+ *    bindings.
+ * 4. Assert ordinary names are not reserved, and pin the `module` policy.
+ */
+export const test_naming_convention_reserved = (): void => {
+  // 1. ECMAScript ReservedWord (ECMA-262, Keywords and Reserved Words)
+  const RESERVED_WORDS: string[] = [
+    "await", "break", "case", "catch", "class", "const", "continue",
+    "debugger", "default", "delete", "do", "else", "enum", "export",
+    "extends", "false", "finally", "for", "function", "if", "import", "in",
+    "instanceof", "new", "null", "return", "super", "switch", "this", "throw",
+    "true", "try", "typeof", "var", "void", "while", "with", "yield",
+  ];
+  for (const word of RESERVED_WORDS)
+    TestValidator.equals(
+      `reserved(${JSON.stringify(word)}) is a ReservedWord`,
+      NamingConvention.reserved(word),
+      true,
+    );
+
+  // 2. STRICT-MODE FUTURE RESERVED WORDS
+  //
+  // The four that shipped and the four that were omitted are one class; assert
+  // them together so the set cannot drift apart again.
+  for (const word of [
+    "implements",
+    "interface",
+    "let",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "static",
+  ])
+    TestValidator.equals(
+      `reserved(${JSON.stringify(word)}) is a strict future reserved word`,
+      NamingConvention.reserved(word),
+      true,
+    );
+
+  // 3. `eval`/`arguments` ARE NOT RESERVED WORDS
+  //
+  // They are illegal bindings without being reserved words. This split is the
+  // root cause recorded in #2111: no reserved-word set can classify them.
+  for (const word of ["eval", "arguments"]) {
+    TestValidator.equals(
+      `reserved(${JSON.stringify(word)}) is not a reserved word`,
+      NamingConvention.reserved(word),
+      false,
+    );
+    TestValidator.equals(
+      `variable(${JSON.stringify(word)}) is still not a legal binding`,
+      NamingConvention.variable(word),
+      false,
+    );
+  }
+
+  // 4a. ORDINARY AND CONTEXTUAL NAMES
+  for (const word of ["foo", "async", "of", "get", "set", "from", "as", "undefined", "NaN"])
+    TestValidator.equals(
+      `reserved(${JSON.stringify(word)}) is not reserved`,
+      NamingConvention.reserved(word),
+      false,
+    );
+
+  // 4b. THE DELIBERATE `module` POLICY
+  //
+  // `module` is not an ECMAScript reserved word. typia reserves it so that
+  // generated names cannot shadow `module.exports` in CommonJS output.
+  TestValidator.equals(
+    "module is reserved by typia policy",
+    NamingConvention.reserved("module"),
+    true,
+  );
+};

--- a/tests/test-utils/src/features/naming/test_naming_convention_reserved.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_reserved.ts
@@ -12,25 +12,57 @@ import { NamingConvention } from "@typia/utils";
  * predicate, so an omission silently produces a keyword where an escaped name
  * was intended.
  *
- * `eval` and `arguments` are deliberately *not* reserved words: they are only
+ * `eval` and `arguments` are deliberately _not_ reserved words: they are only
  * restricted as BoundNames in strict code. Keeping them out of `reserved()` is
  * what makes it an honest reserved-word predicate, and is exactly why
  * `variable()` cannot be derived from it alone.
  *
  * 1. Assert every ECMAScript `ReservedWord` is reserved.
  * 2. Assert every strict-mode future reserved word is reserved.
- * 3. Assert `eval`/`arguments` are not reserved words, though not valid
- *    bindings.
+ * 3. Assert `eval`/`arguments` are not reserved words, though not valid bindings.
  * 4. Assert ordinary names are not reserved, and pin the `module` policy.
  */
 export const test_naming_convention_reserved = (): void => {
   // 1. ECMAScript ReservedWord (ECMA-262, Keywords and Reserved Words)
   const RESERVED_WORDS: string[] = [
-    "await", "break", "case", "catch", "class", "const", "continue",
-    "debugger", "default", "delete", "do", "else", "enum", "export",
-    "extends", "false", "finally", "for", "function", "if", "import", "in",
-    "instanceof", "new", "null", "return", "super", "switch", "this", "throw",
-    "true", "try", "typeof", "var", "void", "while", "with", "yield",
+    "await",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "import",
+    "in",
+    "instanceof",
+    "new",
+    "null",
+    "return",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "yield",
   ];
   for (const word of RESERVED_WORDS)
     TestValidator.equals(
@@ -77,7 +109,17 @@ export const test_naming_convention_reserved = (): void => {
   }
 
   // 4a. ORDINARY AND CONTEXTUAL NAMES
-  for (const word of ["foo", "async", "of", "get", "set", "from", "as", "undefined", "NaN"])
+  for (const word of [
+    "foo",
+    "async",
+    "of",
+    "get",
+    "set",
+    "from",
+    "as",
+    "undefined",
+    "NaN",
+  ])
     TestValidator.equals(
       `reserved(${JSON.stringify(word)}) is not reserved`,
       NamingConvention.reserved(word),

--- a/tests/test-utils/src/features/naming/test_naming_convention_variable.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_variable.ts
@@ -12,17 +12,17 @@ import { _isLegalBinding } from "../../internal/_isLegalBinding";
  * shape". That gap let eight strings through (#2111), and `eval`/`arguments`
  * prove a reserved-word list can never express the rule: they are not reserved
  * words at all, only illegal as BoundNames in strict code. Because
- * `HttpMigrateRouteAccessor` and `HttpMigrateRouteComposer` derive real
- * binding identifiers from this predicate, a false positive emits a module
- * that cannot parse. Expectations therefore come from Node's parser rather
- * than from typia's current output.
+ * `HttpMigrateRouteAccessor` and `HttpMigrateRouteComposer` derive real binding
+ * identifiers from this predicate, a false positive emits a module that cannot
+ * parse. Expectations therefore come from Node's parser rather than from
+ * typia's current output.
  *
- * 1. Cross-check every reserved, strict-reserved, and restricted word against
- *    the engine oracle, so the predicate cannot drift from the grammar.
+ * 1. Cross-check every reserved, strict-reserved, and restricted word against the
+ *    engine oracle, so the predicate cannot drift from the grammar.
  * 2. Pin the eight words #2111 reported as false positives.
  * 3. Pin ordinary and contextual names that must stay valid.
- * 4. Assert the deliberate `module` policy, the identifier-shape boundaries,
- *    and that repeated calls are stable.
+ * 4. Assert the deliberate `module` policy, the identifier-shape boundaries, and
+ *    that repeated calls are stable.
  */
 export const test_naming_convention_variable = (): void => {
   // 1. THE ENGINE IS THE ORACLE
@@ -33,20 +33,75 @@ export const test_naming_convention_variable = (): void => {
   // held out of this sweep.
   const words: string[] = [
     // ECMAScript ReservedWord
-    "await", "break", "case", "catch", "class", "const", "continue",
-    "debugger", "default", "delete", "do", "else", "enum", "export",
-    "extends", "false", "finally", "for", "function", "if", "import", "in",
-    "instanceof", "new", "null", "return", "super", "switch", "this", "throw",
-    "true", "try", "typeof", "var", "void", "while", "with", "yield",
+    "await",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "import",
+    "in",
+    "instanceof",
+    "new",
+    "null",
+    "return",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "yield",
     // strict-mode future reserved words
-    "implements", "interface", "let", "package", "private", "protected",
-    "public", "static",
+    "implements",
+    "interface",
+    "let",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "static",
     // strict-mode BoundNames restrictions
-    "eval", "arguments",
+    "eval",
+    "arguments",
     // not reserved -- must stay valid
-    "foo", "value", "async", "of", "get", "set", "from", "as", "target",
-    "meta", "undefined", "NaN", "Infinity", "globalThis", "constructor",
-    "prototype", "name", "length",
+    "foo",
+    "value",
+    "async",
+    "of",
+    "get",
+    "set",
+    "from",
+    "as",
+    "target",
+    "meta",
+    "undefined",
+    "NaN",
+    "Infinity",
+    "globalThis",
+    "constructor",
+    "prototype",
+    "name",
+    "length",
   ];
   for (const word of words) {
     TestValidator.equals(
@@ -83,7 +138,16 @@ export const test_naming_convention_variable = (): void => {
   }
 
   // 3. ORDINARY AND CONTEXTUAL NAMES STAY VALID
-  for (const word of ["foo", "async", "of", "get", "undefined", "NaN", "_", "$"])
+  for (const word of [
+    "foo",
+    "async",
+    "of",
+    "get",
+    "undefined",
+    "NaN",
+    "_",
+    "$",
+  ])
     TestValidator.equals(
       `variable(${JSON.stringify(word)}) stays valid`,
       NamingConvention.variable(word),
@@ -96,8 +160,16 @@ export const test_naming_convention_variable = (): void => {
   // typia reserves it anyway: shadowing `module` would break `module.exports`
   // in CommonJS output. This asymmetry is policy, not a grammar claim, so it
   // is asserted explicitly rather than swept.
-  TestValidator.equals("module is a legal binding per the engine", _isLegalBinding("module"), true);
-  TestValidator.equals("module is reserved by typia policy", NamingConvention.variable("module"), false);
+  TestValidator.equals(
+    "module is a legal binding per the engine",
+    _isLegalBinding("module"),
+    true,
+  );
+  TestValidator.equals(
+    "module is reserved by typia policy",
+    NamingConvention.variable("module"),
+    false,
+  );
 
   // 4b. IDENTIFIER SHAPE BOUNDARIES
   const shapes: [string, boolean][] = [
@@ -122,7 +194,15 @@ export const test_naming_convention_variable = (): void => {
   // The predicate must not carry a stateful `/g` regex whose `lastIndex`
   // survives between calls.
   for (let i = 0; i < 4; ++i) {
-    TestValidator.equals(`variable("foo") is stable on call ${i}`, NamingConvention.variable("foo"), true);
-    TestValidator.equals(`variable("let") is stable on call ${i}`, NamingConvention.variable("let"), false);
+    TestValidator.equals(
+      `variable("foo") is stable on call ${i}`,
+      NamingConvention.variable("foo"),
+      true,
+    );
+    TestValidator.equals(
+      `variable("let") is stable on call ${i}`,
+      NamingConvention.variable("let"),
+      false,
+    );
   }
 };

--- a/tests/test-utils/src/features/naming/test_naming_convention_variable.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_variable.ts
@@ -1,0 +1,128 @@
+import { TestValidator } from "@nestia/e2e";
+import { NamingConvention } from "@typia/utils";
+
+import { _isLegalBinding } from "../../internal/_isLegalBinding";
+
+/**
+ * Verifies NamingConvention.variable agrees with the JavaScript engine on
+ * binding-identifier legality.
+ *
+ * `variable()` is documented as an identifier-legality predicate, but was
+ * implemented as "not in my reserved-word list, and matches an identifier
+ * shape". That gap let eight strings through (#2111), and `eval`/`arguments`
+ * prove a reserved-word list can never express the rule: they are not reserved
+ * words at all, only illegal as BoundNames in strict code. Because
+ * `HttpMigrateRouteAccessor` and `HttpMigrateRouteComposer` derive real
+ * binding identifiers from this predicate, a false positive emits a module
+ * that cannot parse. Expectations therefore come from Node's parser rather
+ * than from typia's current output.
+ *
+ * 1. Cross-check every reserved, strict-reserved, and restricted word against
+ *    the engine oracle, so the predicate cannot drift from the grammar.
+ * 2. Pin the eight words #2111 reported as false positives.
+ * 3. Pin ordinary and contextual names that must stay valid.
+ * 4. Assert the deliberate `module` policy, the identifier-shape boundaries,
+ *    and that repeated calls are stable.
+ */
+export const test_naming_convention_variable = (): void => {
+  // 1. THE ENGINE IS THE ORACLE
+  //
+  // Every word the grammar rejects as a binding must be rejected by
+  // `variable()`, and every word it accepts must be accepted. `module` is the
+  // one deliberate departure and is asserted separately in step 4a, so it is
+  // held out of this sweep.
+  const words: string[] = [
+    // ECMAScript ReservedWord
+    "await", "break", "case", "catch", "class", "const", "continue",
+    "debugger", "default", "delete", "do", "else", "enum", "export",
+    "extends", "false", "finally", "for", "function", "if", "import", "in",
+    "instanceof", "new", "null", "return", "super", "switch", "this", "throw",
+    "true", "try", "typeof", "var", "void", "while", "with", "yield",
+    // strict-mode future reserved words
+    "implements", "interface", "let", "package", "private", "protected",
+    "public", "static",
+    // strict-mode BoundNames restrictions
+    "eval", "arguments",
+    // not reserved -- must stay valid
+    "foo", "value", "async", "of", "get", "set", "from", "as", "target",
+    "meta", "undefined", "NaN", "Infinity", "globalThis", "constructor",
+    "prototype", "name", "length",
+  ];
+  for (const word of words) {
+    TestValidator.equals(
+      `variable(${JSON.stringify(word)}) matches the engine`,
+      NamingConvention.variable(word),
+      _isLegalBinding(word),
+    );
+  }
+
+  // 2. THE EIGHT WORDS #2111 REPORTED
+  //
+  // Stated explicitly so a regression names the defect rather than only
+  // failing the oracle sweep above.
+  for (const word of [
+    "await",
+    "yield",
+    "let",
+    "static",
+    "implements",
+    "interface",
+    "eval",
+    "arguments",
+  ]) {
+    TestValidator.equals(
+      `variable(${JSON.stringify(word)}) is not a legal binding`,
+      NamingConvention.variable(word),
+      false,
+    );
+    TestValidator.equals(
+      `escaping ${JSON.stringify(word)} yields a legal binding`,
+      NamingConvention.variable(`_${word}`),
+      true,
+    );
+  }
+
+  // 3. ORDINARY AND CONTEXTUAL NAMES STAY VALID
+  for (const word of ["foo", "async", "of", "get", "undefined", "NaN", "_", "$"])
+    TestValidator.equals(
+      `variable(${JSON.stringify(word)}) stays valid`,
+      NamingConvention.variable(word),
+      true,
+    );
+
+  // 4a. THE DELIBERATE `module` POLICY
+  //
+  // `function f(module) {}` is legal JavaScript, so the engine accepts it.
+  // typia reserves it anyway: shadowing `module` would break `module.exports`
+  // in CommonJS output. This asymmetry is policy, not a grammar claim, so it
+  // is asserted explicitly rather than swept.
+  TestValidator.equals("module is a legal binding per the engine", _isLegalBinding("module"), true);
+  TestValidator.equals("module is reserved by typia policy", NamingConvention.variable("module"), false);
+
+  // 4b. IDENTIFIER SHAPE BOUNDARIES
+  const shapes: [string, boolean][] = [
+    ["", false],
+    ["9foo", false],
+    ["foo bar", false],
+    ["foo-bar", false],
+    ["foo.bar", false],
+    ["foo$bar9", true],
+    ["_private", true],
+    ["$", true],
+  ];
+  for (const [input, expected] of shapes)
+    TestValidator.equals(
+      `variable(${JSON.stringify(input)}) shape`,
+      NamingConvention.variable(input),
+      expected,
+    );
+
+  // 4c. REPEATED CALLS ARE STABLE
+  //
+  // The predicate must not carry a stateful `/g` regex whose `lastIndex`
+  // survives between calls.
+  for (let i = 0; i < 4; ++i) {
+    TestValidator.equals(`variable("foo") is stable on call ${i}`, NamingConvention.variable("foo"), true);
+    TestValidator.equals(`variable("let") is stable on call ${i}`, NamingConvention.variable("let"), false);
+  }
+};

--- a/tests/test-utils/src/internal/_isLegalBinding.ts
+++ b/tests/test-utils/src/internal/_isLegalBinding.ts
@@ -1,24 +1,6 @@
 import vm from "node:vm";
 
 /**
- * Compile `code` and report whether the engine accepts it.
- *
- * `vm.Script` is used deliberately in place of `vm.SourceTextModule`, which
- * would require the `--experimental-vm-modules` flag this suite does not run
- * with. Every probe below supplies module-goal semantics explicitly instead:
- * `"use strict"` for the strict-mode restrictions, and an `async` context for
- * the `await` reservation.
- */
-const compiles = (code: string): boolean => {
-  try {
-    new vm.Script(code);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-/**
  * Ask the JavaScript engine whether `name` can be a binding identifier in the
  * dialect typia generates.
  *
@@ -31,33 +13,20 @@ const compiles = (code: string): boolean => {
  * exactly: strict mode supplies the future-reserved words (`let`, `static`,
  * `implements`, `interface`, `yield`) and the `eval`/`arguments` BoundNames
  * restriction, while the async context supplies the `await` reservation.
+ * `vm.Script` is used deliberately in place of `vm.SourceTextModule`, which
+ * would require the `--experimental-vm-modules` flag this suite does not run
+ * with.
  *
  * @param name Candidate binding identifier
  * @returns True when the engine accepts `name` as a binding identifier
  */
-export const _isLegalBinding = (name: string): boolean =>
-  compiles(`"use strict"; async function getBy(${name}) { return ${name}; }`);
-
-/**
- * Ask the engine whether a generated SDK function declaration compiles.
- *
- * This is the contract `IHttpMigrateRoute` actually has to satisfy: the
- * accessor becomes the function name and each parameter key becomes one of its
- * parameters. Compiling the whole declaration — rather than each name in
- * isolation — additionally proves the parameter keys neither collide with each
- * other nor with `connection`, since strict mode rejects duplicate parameter
- * names.
- *
- * @param props.name Function name taken from the route accessor
- * @param props.parameters Parameter names taken from the route parameter keys
- * @returns True when the engine accepts the declaration
- */
-export const _isLegalDeclaration = (props: {
-  name: string;
-  parameters: string[];
-}): boolean => {
-  const parameters: string = props.parameters.join(", ");
-  return compiles(
-    `"use strict"; async function ${props.name}(${parameters}) { return [${parameters}]; }`,
-  );
+export const _isLegalBinding = (name: string): boolean => {
+  try {
+    new vm.Script(
+      `"use strict"; async function getBy(${name}) { return ${name}; }`,
+    );
+    return true;
+  } catch {
+    return false;
+  }
 };

--- a/tests/test-utils/src/internal/_isLegalBinding.ts
+++ b/tests/test-utils/src/internal/_isLegalBinding.ts
@@ -1,0 +1,63 @@
+import vm from "node:vm";
+
+/**
+ * Compile `code` and report whether the engine accepts it.
+ *
+ * `vm.Script` is used deliberately in place of `vm.SourceTextModule`, which
+ * would require the `--experimental-vm-modules` flag this suite does not run
+ * with. Every probe below supplies module-goal semantics explicitly instead:
+ * `"use strict"` for the strict-mode restrictions, and an `async` context for
+ * the `await` reservation.
+ */
+const compiles = (code: string): boolean => {
+  try {
+    new vm.Script(code);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Ask the JavaScript engine whether `name` can be a binding identifier in the
+ * dialect typia generates.
+ *
+ * Generated SDK artifacts are ES modules, which are always strict and always
+ * reserve `await`. Rather than restate the ECMAScript grammar in a word list —
+ * the very mistake that produced #2111 — this asks Node's own parser, so the
+ * expectation is derived from the engine instead of from typia's output.
+ *
+ * The `"use strict"` + `async` context reproduces module-goal binding legality
+ * exactly: strict mode supplies the future-reserved words (`let`, `static`,
+ * `implements`, `interface`, `yield`) and the `eval`/`arguments` BoundNames
+ * restriction, while the async context supplies the `await` reservation.
+ *
+ * @param name Candidate binding identifier
+ * @returns True when the engine accepts `name` as a binding identifier
+ */
+export const _isLegalBinding = (name: string): boolean =>
+  compiles(`"use strict"; async function getBy(${name}) { return ${name}; }`);
+
+/**
+ * Ask the engine whether a generated SDK function declaration compiles.
+ *
+ * This is the contract `IHttpMigrateRoute` actually has to satisfy: the
+ * accessor becomes the function name and each parameter key becomes one of its
+ * parameters. Compiling the whole declaration — rather than each name in
+ * isolation — additionally proves the parameter keys neither collide with each
+ * other nor with `connection`, since strict mode rejects duplicate parameter
+ * names.
+ *
+ * @param props.name Function name taken from the route accessor
+ * @param props.parameters Parameter names taken from the route parameter keys
+ * @returns True when the engine accepts the declaration
+ */
+export const _isLegalDeclaration = (props: {
+  name: string;
+  parameters: string[];
+}): boolean => {
+  const parameters: string = props.parameters.join(", ");
+  return compiles(
+    `"use strict"; async function ${props.name}(${parameters}) { return [${parameters}]; }`,
+  );
+};

--- a/tests/test-utils/src/internal/_isLegalDeclaration.ts
+++ b/tests/test-utils/src/internal/_isLegalDeclaration.ts
@@ -1,0 +1,35 @@
+import vm from "node:vm";
+
+/**
+ * Ask the JavaScript engine whether a generated SDK function declaration
+ * compiles.
+ *
+ * This is the contract `IHttpMigrateRoute` actually has to satisfy: the
+ * accessor becomes the function name and each parameter key becomes one of its
+ * parameters. Compiling the whole declaration — rather than each name in
+ * isolation — additionally proves the parameter keys neither collide with each
+ * other nor with `connection`, since strict mode rejects duplicate parameter
+ * names.
+ *
+ * The `"use strict"` + `async` context reproduces the module goal generated SDK
+ * artifacts are emitted into; see `_isLegalBinding` for why `vm.Script` is used
+ * rather than `vm.SourceTextModule`.
+ *
+ * @param props.name Function name taken from the route accessor
+ * @param props.parameters Parameter names taken from the route parameter keys
+ * @returns True when the engine accepts the declaration
+ */
+export const _isLegalDeclaration = (props: {
+  name: string;
+  parameters: string[];
+}): boolean => {
+  const parameters: string = props.parameters.join(", ");
+  try {
+    new vm.Script(
+      `"use strict"; async function ${props.name}(${parameters}) { return [${parameters}]; }`,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Intent

Resolves #2111.

`NamingConvention.variable()` is documented as *"Check if string is valid JavaScript variable name"* but was implemented as `reserved(str) === false && /^[a-zA-Z_$][a-zA-Z_$0-9]*$/g.test(str)` — "not in my word list, and looks like an identifier". Those are different predicates, and the gap returned `true` for eight strings that cannot be binding identifiers in an ES module.

**The abstraction was wrong, not just the data.** `eval` and `arguments` are not reserved words at all — they are illegal only as *BoundNames* in strict code — so no reserved-word set can ever classify them. Adding eight strings to `RESERVED` would have left the same category error in place.

This branch models the three restriction classes the grammar actually defines and derives each public predicate from the ones that apply to it:

| Class | Contents | Feeds |
| --- | --- | --- |
| `RESERVED_WORDS` | ECMAScript `ReservedWord` (38, now including `await`/`yield`) | `reserved()`, `variable()` |
| `STRICT_RESERVED_WORDS` | strict future reserved (`implements`, `interface`, `let`, `package`, `private`, `protected`, `public`, `static`) | `reserved()`, `variable()` |
| `POLICY_RESERVED_WORDS` | `module` — typia policy, not grammar | `reserved()`, `variable()` |
| `STRICT_RESTRICTED_BINDINGS` | `eval`, `arguments` — restricted BoundNames | `variable()` only |

- `reserved()` = `ReservedWord` ∪ strict future reserved ∪ policy. This completes a class that already shipped `package`/`private`/`protected`/`public` while omitting `implements`/`interface`/`let`/`static`.
- `variable()` = identifier shape ∧ not `reserved()` ∧ not a restricted binding. It is no longer derivable from a word list alone.

## Deliberate public-API decisions

These are behavior changes to exported surface, stated explicitly rather than slipped in:

1. **`reserved()` gains 6 words** (`await`, `yield`, `implements`, `interface`, `let`, `static`). It previously returned `false` for words that *are* reserved in the strict dialect typia generates.
2. **`reserved()` still excludes `eval`/`arguments`** — deliberately. They are not reserved words; saying otherwise to make `variable()` work would re-introduce the category error. `variable()` rejects them separately.
3. **`module` stays reserved.** It is a legal identifier (`function f(module) {}` parses), so this is typia policy, not a grammar claim: shadowing it would break `module.exports` in CommonJS output. It is now documented and asserted as policy instead of sitting unexplained in a word list.
4. **The identifier pattern loses its `g` flag** and is hoisted to a module constant. A global regex carries `lastIndex` across `test()` calls; hoisting it *with* `/g` would have made the predicate alternate between answers for the same input. A stability assertion pins this.
5. **ASCII-only identifier shape is preserved** and now documented as a deliberate conservative bias — it can only cause a legal Unicode name to be escaped, never let an illegal binding through. Unicode support remains a separate policy decision, per the issue.

## Consequence surface

- **`EndpointUtil.normalize`** keeps gating on `reserved()`, so the 6 added words now escape there (`let` becomes `_let`), exactly as `package` already did. `eval`/`arguments` are not reserved and are caught downstream by the `variable()` gate, so both paths converge on a single `_` escape with no double-escaping.
- **`EndpointUtil.pascal`** consequently derives `_Let` where it derived `Let`, matching the existing `_Package` treatment. This is a generated *type-name* change for paths containing those 6 words.
- **Diagnostic consumers** (`stringifyValidationFailure`, `OpenApiObjectValidator`, `JsonDescriptor`) are intentionally untouched. They ask "can I use dot notation?", where a keyword is legal (`x.let`), so they were never defective. They now emit bracket notation instead of dot notation for these words — more verbose, still correct. Their call sites were left alone rather than quoting every consumer, per the issue's consumer split.
- **Compatibility:** accessors and parameter keys for the eight words change (`let` becomes `_let`), which is a generated-name change for anyone depending on today's broken output.
- **Scope:** `@typia/utils` only. No native Go change, so **no `typia` version bump** (development skill, Change Integrity).

### A latent divergence this does *not* fix

`packages/typia/src/internal/_accessExpressionAsString.ts` carries its own private copy of this predicate with a *different* 36-word set (no `module`/`package`/`public`/`private`/`protected`). The two already disagreed before this change; it widens that gap from 5 words to 13. It is a diagnostic property-access path, so it is not a defect, and `packages/typia` is outside this issue's scope. `test-typia-automated` predicts typia's generated paths through `@typia/utils`'s `variable()`, so the two are coupled — but no `@typia/template` structure uses a restricted word as a key, and the suite passes. **Flagged for the lead as a possible follow-up issue**, not addressed here.

## Verification

Tests were written first and observed failing against the original implementation, then passing — the final test forms were re-confirmed against a stashed revert:

| Test | Fails before on |
| --- | --- |
| `test_naming_convention_variable` | `variable("await")` returns `true`, engine says `false` |
| `test_naming_convention_reserved` | `reserved("await")` returns `false`, expected `true` |
| `test_http_migrate_route_accessor_identifier` | accessor segment `"await"` of `/await/{await}` is not a legal binding |

Expectations come from Node's own parser, not from typia's output. Because this suite does not run with `--experimental-vm-modules`, `vm.SourceTextModule` is unavailable; the helper uses `vm.Script` with `"use strict"` plus an `async` context, which was verified to reproduce module-goal binding legality **exactly across 69 probed words** (strict mode supplies the future-reserved words and the `eval`/`arguments` restriction; the async context supplies the `await` reservation).

Commands run locally (campaign CI is suspended):

| Command | Result |
| --- | --- |
| `pnpm --filter ./tests/test-utils start` | **pass** (full suite) |
| `pnpm --filter ./packages/utils build` | **pass** |
| `pnpm --filter ./tests/test-utils-automated start` | **pass** |
| `pnpm --filter ./tests/test-typia-automated start` | **pass** (the `variable()`-coupled suite) |

### Real `HttpMigration.application()` probe

Before — 8 of 11 routes emit a declaration that does not parse:

| route | accessor | param key | declaration compiles |
| --- | --- | --- | --- |
| `/let/{let}` | `["let","getByLet"]` | `let` | **NO — SyntaxError** |
| `/static/{static}` | `["static","getByStatic"]` | `static` | **NO — SyntaxError** |
| `/implements/{implements}` | `["implements","getByImplements"]` | `implements` | **NO — SyntaxError** |
| `/interface/{interface}` | `["interface","getByInterface"]` | `interface` | **NO — SyntaxError** |
| `/yield/{yield}` | `["yield","getByYield"]` | `yield` | **NO — SyntaxError** |
| `/await/{await}` | `["await","getByAwait"]` | `await` | **NO — SyntaxError** |
| `/eval/{eval}` | `["eval","getByEval"]` | `eval` | **NO — SyntaxError** |
| `/arguments/{arguments}` | `["arguments","getByArguments"]` | `arguments` | **NO — SyntaxError** |
| `/package/{package}` | `["_package","getBy_package"]` | `_package` | yes |
| `/module/{module}` | `["_module","getBy_module"]` | `_module` | yes |
| `/foo/{foo}` | `["foo","getByFoo"]` | `foo` | yes |

After — 0 of 11:

| route | accessor | param key | declaration compiles |
| --- | --- | --- | --- |
| `/let/{let}` | `["_let","getBy_let"]` | `_let` | yes |
| `/static/{static}` | `["_static","getBy_static"]` | `_static` | yes |
| `/implements/{implements}` | `["_implements","getBy_implements"]` | `_implements` | yes |
| `/interface/{interface}` | `["_interface","getBy_interface"]` | `_interface` | yes |
| `/yield/{yield}` | `["_yield","getBy_yield"]` | `_yield` | yes |
| `/await/{await}` | `["_await","getBy_await"]` | `_await` | yes |
| `/eval/{eval}` | `["_eval","getBy_eval"]` | `_eval` | yes |
| `/arguments/{arguments}` | `["_arguments","getBy_arguments"]` | `_arguments` | yes |
| `/package/{package}` | `["_package","getBy_package"]` | `_package` | yes (unchanged) |
| `/module/{module}` | `["_module","getBy_module"]` | `_module` | yes (unchanged) |
| `/foo/{foo}` | `["foo","getByFoo"]` | `foo` | yes (unchanged) |

`getBy_let` rather than `getByLet` follows the existing `getBy_package` shape, since `getName` capitalizes the already-escaped key.

## Documentation

No `website/src/content/docs/**` page documents `NamingConvention`, `HttpMigration`, or route accessors (verified by grep), so the JSDoc is the public documentation surface for this API and was rewritten to state the contract, the `module` policy, the `eval`/`arguments` split, the property-access caveat, and the ASCII bias. `experiments/esm` exercises only `camel`/`snake` and is unaffected.

## Campaign CI

Automatic CI for this branch is deliberately suspended under the issue campaign's per-push exact-SHA cancellation gate; every pushed SHA had its runs enumerated and cancelled. Local verification above is the gate. See `.agents/skills/issue-campaign/development.md`.

`pnpm format` was deliberately **not** run, per the campaign's no-format rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
