### PR TITLE
fix(typia): skip zero-length unknown length-delimited protobuf fields exactly

### DIFF
--- a/packages/typia/src/internal/_ProtobufReader.ts
+++ b/packages/typia/src/internal/_ProtobufReader.ts
@@ -104,10 +104,15 @@ export class _ProtobufReader {
     this.end = previous;
   }
 
+  /** Advance by exactly `length` bytes, for every length including zero. */
   public skip(length: number): void {
+    this.take(length);
+  }
+
+  /** Advance by exactly one varint, which carries no length prefix. */
+  public skipVarint(): void {
     this.atomic(() => {
-      if (length === 0) while (this.u8() & 0x80);
-      else this.take(length);
+      while (this.u8() & 0x80);
     });
   }
 
@@ -115,7 +120,7 @@ export class _ProtobufReader {
     this.atomic(() => {
       switch (wireType) {
         case ProtobufWire.VARIANT:
-          this.skip(0);
+          this.skipVarint();
           break;
         case ProtobufWire.I64:
           this.skip(8);

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_zero_length_unknown_field.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_zero_length_unknown_field.ts
@@ -1,0 +1,178 @@
+import typia from "typia";
+
+/**
+ * Verifies generated Protobuf decoders accept unknown zero-length
+ * length-delimited fields.
+ *
+ * An empty string, an empty bytes value, an empty embedded message, and an
+ * empty packed repeated field all serialize to the same length-delimited record
+ * with a declared length of zero. Skipping such a record must consume exactly
+ * its two bytes, otherwise a reader that does not know the field desynchronizes
+ * and rejects a well-formed payload, which is the forward compatibility that
+ * unknown-field skipping exists to provide.
+ *
+ * 1. Round-trip messages whose trailing field is an empty string, bytes value, or
+ *    embedded message, and decode them through a schema missing that field.
+ * 2. Decode hand-built payloads carrying the same record first, last, and between
+ *    two known fields, through every direct and factory decoder.
+ * 3. Assert the known fields survive, and that truncated records are still
+ *    rejected.
+ */
+export const test_protobuf_decode_zero_length_unknown_field = (): void => {
+  // an unknown zero-length record is what a newer schema's empty field emits
+  const evolved: Array<readonly [string, Uint8Array]> = [
+    ["empty string", typia.protobuf.encode<IString>({ value: "a", extra: "" })],
+    [
+      "empty bytes",
+      typia.protobuf.encode<IBytes>({ value: "a", extra: new Uint8Array(0) }),
+    ],
+    [
+      "empty embedded message",
+      typia.protobuf.encode<INested>({ value: "a", extra: {} }),
+    ],
+  ];
+  for (const [label, encoded] of evolved) {
+    if (encoded.join() !== "10,1,97,18,0")
+      throw new Error(
+        `${label} did not encode to a trailing zero-length record, but to ${encoded.join()}.`,
+      );
+    if (typia.protobuf.decode<IValue>(encoded).value !== "a")
+      throw new Error(`${label} did not survive a decoder missing the field.`);
+  }
+
+  // an empty packed repeated field encodes to the identical record, which
+  // typia's own writer never emits because it omits an empty repeated field
+  const packed: typia.Resolved<IPacked> = typia.protobuf.decode<IPacked>(
+    Uint8Array.of(0x0a, 2, 1, 2, 0x12, 0),
+  );
+  if (packed.values.join() !== "1,2")
+    throw new Error(
+      "a trailing empty packed record broke a known packed repeated field.",
+    );
+
+  const decoders: Array<
+    readonly [string, (input: Uint8Array) => typia.Resolved<IValue>]
+  > = [
+    ["decode", (input) => typia.protobuf.decode<IValue>(input)],
+    ["createDecode", typia.protobuf.createDecode<IValue>()],
+    ["assertDecode", (input) => typia.protobuf.assertDecode<IValue>(input)],
+    ["createAssertDecode", typia.protobuf.createAssertDecode<IValue>()],
+    [
+      "isDecode",
+      (input) => must("isDecode", typia.protobuf.isDecode<IValue>(input)),
+    ],
+    [
+      "createIsDecode",
+      (
+        (closure) => (input: Uint8Array) =>
+          must("createIsDecode", closure(input))
+      )(typia.protobuf.createIsDecode<IValue>()),
+    ],
+    [
+      "validateDecode",
+      (input) =>
+        unwrap("validateDecode", typia.protobuf.validateDecode<IValue>(input)),
+    ],
+    [
+      "createValidateDecode",
+      (
+        (closure) => (input: Uint8Array) =>
+          unwrap("createValidateDecode", closure(input))
+      )(typia.protobuf.createValidateDecode<IValue>()),
+    ],
+  ];
+  for (const [label, decode] of decoders) {
+    if (decode(Uint8Array.of(0x12, 0, 0x0a, 1, 0x61)).value !== "a")
+      throw new Error(
+        `${label} desynchronized on a leading zero-length record.`,
+      );
+    if (decode(Uint8Array.of(0x0a, 1, 0x61, 0x12, 0)).value !== "a")
+      throw new Error(
+        `${label} desynchronized on a trailing zero-length record.`,
+      );
+  }
+
+  // optional presence and a record standing between two known fields
+  if (
+    typia.protobuf.decode<IOptional>(Uint8Array.of(0x12, 0, 0x0a, 1, 0x61))
+      .value !== "a"
+  )
+    throw new Error(
+      "an optional field lost its value to a zero-length record.",
+    );
+  if (
+    typia.protobuf.decode<IOptional>(Uint8Array.of(0x12, 0)).value !== undefined
+  )
+    throw new Error("a lone zero-length record produced a phantom value.");
+  const pair: typia.Resolved<IPair> = typia.protobuf.decode<IPair>(
+    Uint8Array.of(0x0a, 1, 0x61, 0x1a, 0, 0x12, 1, 0x62),
+  );
+  if (pair.first !== "a" || pair.second !== "b")
+    throw new Error(
+      "a zero-length record between two known fields desynchronized.",
+    );
+
+  // #2083: a declared length beyond the buffer is still rejected
+  assertOverflow("truncated unknown record", () =>
+    typia.protobuf.decode<IValue>(Uint8Array.of(0x0a, 1, 0x61, 0x12, 2, 0x62)),
+  );
+};
+
+interface IValue {
+  value: string;
+}
+
+interface IOptional {
+  value?: string;
+}
+
+interface IString {
+  value: string;
+  extra: string;
+}
+
+interface IBytes {
+  value: string;
+  extra: Uint8Array;
+}
+
+interface INested {
+  value: string;
+  extra: {
+    text?: string;
+  };
+}
+
+interface IPacked {
+  values: Array<number & typia.tags.Type<"uint32">>;
+}
+
+interface IPair {
+  first: string;
+  second: string;
+}
+
+const must = <T>(label: string, value: T | null): T => {
+  if (value === null) throw new Error(`${label} rejected a valid payload.`);
+  return value;
+};
+
+const unwrap = <T>(label: string, result: typia.IValidation<T>): T => {
+  if (result.success === false)
+    throw new Error(`${label} rejected a valid payload.`);
+  return result.data;
+};
+
+const assertOverflow = (label: string, closure: () => unknown): void => {
+  try {
+    closure();
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Error on typia.protobuf.decode(): buffer overflow."
+    )
+      return;
+    throw new Error(`${label} reported ${String(error)} instead of overflow.`);
+  }
+  throw new Error(`${label} accepted a truncated Protobuf payload.`);
+};

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_zero_length_unknown_field.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_zero_length_unknown_field.ts
@@ -15,13 +15,13 @@ import typia from "typia";
  *    embedded message, and decode them through a schema missing that field.
  * 2. Decode the same record hand-built as the leading and the trailing field,
  *    through every direct and factory decoder.
- * 3. Assert the known fields survive that record, an optional one, a packed one,
- *    and one standing between two known fields, and that truncated records are
- *    still rejected.
+ * 3. Assert the record leaves a required, optional, packed, and surrounding known
+ *    field intact, and that a truncated record is still rejected.
  */
 export const test_protobuf_decode_zero_length_unknown_field = (): void => {
-  // field 1 = "a", then field 2 length-delimited declaring a length of zero
+  // field 2 length-delimited declaring a length of zero, around field 1 = "a"
   const trailing: Uint8Array = Uint8Array.of(0x0a, 1, 0x61, 0x12, 0);
+  const leading: Uint8Array = Uint8Array.of(0x12, 0, 0x0a, 1, 0x61);
 
   // an unknown zero-length record is what a newer schema's empty field emits
   const evolved: Array<readonly [string, Uint8Array]> = [
@@ -92,7 +92,7 @@ export const test_protobuf_decode_zero_length_unknown_field = (): void => {
     ],
   ];
   for (const [label, decode] of decoders) {
-    if (decode(Uint8Array.of(0x12, 0, 0x0a, 1, 0x61)).value !== "a")
+    if (decode(leading).value !== "a")
       throw new Error(
         `${label} desynchronized on a leading zero-length record.`,
       );
@@ -103,10 +103,7 @@ export const test_protobuf_decode_zero_length_unknown_field = (): void => {
   }
 
   // optional presence and a record standing between two known fields
-  if (
-    typia.protobuf.decode<IOptional>(Uint8Array.of(0x12, 0, 0x0a, 1, 0x61))
-      .value !== "a"
-  )
+  if (typia.protobuf.decode<IOptional>(leading).value !== "a")
     throw new Error(
       "an optional field lost its value to a zero-length record.",
     );

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_zero_length_unknown_field.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_zero_length_unknown_field.ts
@@ -13,28 +13,38 @@ import typia from "typia";
  *
  * 1. Round-trip messages whose trailing field is an empty string, bytes value, or
  *    embedded message, and decode them through a schema missing that field.
- * 2. Decode hand-built payloads carrying the same record first, last, and between
- *    two known fields, through every direct and factory decoder.
- * 3. Assert the known fields survive, and that truncated records are still
- *    rejected.
+ * 2. Decode the same record hand-built as the leading and the trailing field,
+ *    through every direct and factory decoder.
+ * 3. Assert the known fields survive that record, an optional one, a packed one,
+ *    and one standing between two known fields, and that truncated records are
+ *    still rejected.
  */
 export const test_protobuf_decode_zero_length_unknown_field = (): void => {
+  // field 1 = "a", then field 2 length-delimited declaring a length of zero
+  const trailing: Uint8Array = Uint8Array.of(0x0a, 1, 0x61, 0x12, 0);
+
   // an unknown zero-length record is what a newer schema's empty field emits
   const evolved: Array<readonly [string, Uint8Array]> = [
-    ["empty string", typia.protobuf.encode<IString>({ value: "a", extra: "" })],
+    [
+      "empty string",
+      typia.protobuf.encode<IEvolvedString>({ value: "a", extra: "" }),
+    ],
     [
       "empty bytes",
-      typia.protobuf.encode<IBytes>({ value: "a", extra: new Uint8Array(0) }),
+      typia.protobuf.encode<IEvolvedBytes>({
+        value: "a",
+        extra: new Uint8Array(0),
+      }),
     ],
     [
       "empty embedded message",
-      typia.protobuf.encode<INested>({ value: "a", extra: {} }),
+      typia.protobuf.encode<IEvolvedNested>({ value: "a", extra: {} }),
     ],
   ];
   for (const [label, encoded] of evolved) {
-    if (encoded.join() !== "10,1,97,18,0")
+    if (encoded.join() !== trailing.join())
       throw new Error(
-        `${label} did not encode to a trailing zero-length record, but to ${encoded.join()}.`,
+        `${label} encoded to ${encoded.join()} instead of ${trailing.join()}.`,
       );
     if (typia.protobuf.decode<IValue>(encoded).value !== "a")
       throw new Error(`${label} did not survive a decoder missing the field.`);
@@ -86,7 +96,7 @@ export const test_protobuf_decode_zero_length_unknown_field = (): void => {
       throw new Error(
         `${label} desynchronized on a leading zero-length record.`,
       );
-    if (decode(Uint8Array.of(0x0a, 1, 0x61, 0x12, 0)).value !== "a")
+    if (decode(trailing).value !== "a")
       throw new Error(
         `${label} desynchronized on a trailing zero-length record.`,
       );
@@ -126,17 +136,17 @@ interface IOptional {
   value?: string;
 }
 
-interface IString {
+interface IEvolvedString {
   value: string;
   extra: string;
 }
 
-interface IBytes {
+interface IEvolvedBytes {
   value: string;
   extra: Uint8Array;
 }
 
-interface INested {
+interface IEvolvedNested {
   value: string;
   extra: {
     text?: string;

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_zero_length_skip.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_zero_length_skip.ts
@@ -117,13 +117,15 @@ const assertOverflow = (
   closure: (reader: _ProtobufReader) => void,
 ): void => {
   const reader: _ProtobufReader = new _ProtobufReader(Uint8Array.from(bytes));
+  const size: number = reader.size();
   try {
     closure(reader);
   } catch (error) {
     if (
       error instanceof Error &&
       error.message === "Error on typia.protobuf.decode(): buffer overflow." &&
-      reader.index() === 0
+      reader.index() === 0 &&
+      reader.size() === size
     )
       return;
     throw new Error(

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_zero_length_skip.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_zero_length_skip.ts
@@ -1,0 +1,134 @@
+import { ProtobufWire } from "@typia/interface";
+import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
+
+/**
+ * Verifies the runtime Protobuf reader skips every unknown wire type by its
+ * exact width.
+ *
+ * A length-delimited field may legally declare a length of zero, so the skip
+ * operation must not read a length of zero as a request to consume a varint.
+ * That confusion swallows the following field's tag and desynchronizes the
+ * parser on well-formed input, while the varint wire type carries no length
+ * prefix and genuinely needs the varint-consuming skip.
+ *
+ * 1. Skip zero-length, non-zero, mid-buffer, and trailing length-delimited fields.
+ * 2. Skip single-byte and multi-byte varints, fixed-width fields, and a group
+ *    whose member declares a zero length.
+ * 3. Assert every skip lands on the exact following byte, that a zero-length skip
+ *    honors an enclosing `fork` boundary, and that truncated fields are still
+ *    rejected atomically.
+ */
+export const test_protobuf_reader_zero_length_skip = (): void => {
+  assertSkip("zero-length LEN before another field", [0x00, 0x0a], 1, (r) =>
+    r.skipType(ProtobufWire.LEN),
+  );
+  assertSkip("zero-length LEN as the last field", [0x00], 1, (r) =>
+    r.skipType(ProtobufWire.LEN),
+  );
+  assertSkip(
+    "non-zero LEN before another field",
+    [0x02, 0x61, 0x62, 0x0a],
+    3,
+    (r) => r.skipType(ProtobufWire.LEN),
+  );
+  assertSkip(
+    "multi-byte length LEN",
+    [0x80, 0x01, ...new Array(128).fill(0)],
+    130,
+    (r) => r.skipType(ProtobufWire.LEN),
+  );
+
+  assertSkip("single-byte VARIANT", [0x7f, 0x0a], 1, (r) =>
+    r.skipType(ProtobufWire.VARIANT),
+  );
+  assertSkip("multi-byte VARIANT", [0x80, 0x80, 0x01, 0x0a], 3, (r) =>
+    r.skipType(ProtobufWire.VARIANT),
+  );
+  assertSkip("zero VARIANT", [0x00, 0x0a], 1, (r) =>
+    r.skipType(ProtobufWire.VARIANT),
+  );
+
+  assertSkip("I64", [0, 0, 0, 0, 0, 0, 0, 0, 0x0a], 8, (r) =>
+    r.skipType(ProtobufWire.I64),
+  );
+  assertSkip("I32", [0, 0, 0, 0, 0x0a], 4, (r) => r.skipType(ProtobufWire.I32));
+
+  // group members: field 1 LEN length 0, then the field 3 END_GROUP tag
+  assertSkip(
+    "group with a zero-length LEN member",
+    [0x0a, 0x00, 0x1c],
+    3,
+    (r) => r.skipType(ProtobufWire.START_GROUP),
+  );
+  // nested group: field 2 START_GROUP, zero-length LEN member, both END_GROUPs
+  assertSkip(
+    "nested group with a zero-length LEN member",
+    [0x13, 0x0a, 0x00, 0x14, 0x1c],
+    5,
+    (r) => r.skipType(ProtobufWire.START_GROUP),
+  );
+
+  // a zero-length skip must consume nothing beyond an enclosing fork boundary
+  const framed: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.of(0x02, 0x12, 0x00, 0x0a),
+  );
+  const previous: number = framed.fork();
+  framed.skipType(framed.uint32() & 0x07);
+  if (framed.index() !== 3)
+    throw new Error(
+      `a trailing zero-length skip left index ${framed.index()} instead of its frame end.`,
+    );
+  framed.close(previous);
+  if (framed.uint32() !== 0x0a)
+    throw new Error("a zero-length skip consumed the enclosing message's tag.");
+
+  // #2083: a declared length beyond the buffer is still rejected atomically
+  assertOverflow("truncated LEN", [0x02, 0x61], (r) =>
+    r.skipType(ProtobufWire.LEN),
+  );
+  assertOverflow("LEN at the buffer end", [0x01], (r) =>
+    r.skipType(ProtobufWire.LEN),
+  );
+  assertOverflow("truncated VARIANT", [0x80], (r) =>
+    r.skipType(ProtobufWire.VARIANT),
+  );
+  assertOverflow("truncated group member", [0x0a, 0x02, 0x61], (r) =>
+    r.skipType(ProtobufWire.START_GROUP),
+  );
+};
+
+const assertSkip = (
+  label: string,
+  bytes: number[],
+  expected: number,
+  closure: (reader: _ProtobufReader) => void,
+): void => {
+  const reader: _ProtobufReader = new _ProtobufReader(Uint8Array.from(bytes));
+  closure(reader);
+  if (reader.index() !== expected)
+    throw new Error(
+      `${label} left index ${reader.index()} instead of ${expected}.`,
+    );
+};
+
+const assertOverflow = (
+  label: string,
+  bytes: number[],
+  closure: (reader: _ProtobufReader) => void,
+): void => {
+  const reader: _ProtobufReader = new _ProtobufReader(Uint8Array.from(bytes));
+  try {
+    closure(reader);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Error on typia.protobuf.decode(): buffer overflow." &&
+      reader.index() === 0
+    )
+      return;
+    throw new Error(
+      `${label} reported ${String(error)} at index ${reader.index()} instead of the stable atomic overflow.`,
+    );
+  }
+  throw new Error(`${label} accepted a truncated Protobuf payload.`);
+};


### PR DESCRIPTION
## Intent

Fixes #2116.

`typia.protobuf.decode` rejects **valid** Protocol Buffer messages containing an unknown length-delimited field of length zero. `_ProtobufReader.skip(0)` is overloaded: `0` is a sentinel meaning "skip one varint" (used by the `VARIANT` case), but `skipType` forwards the decoded length directly for `LEN`, where zero is a legal length. The sentinel branch then consumes a byte belonging to the *next* field and desynchronizes the parser, so a well-formed payload throws `buffer overflow`.

Unknown fields are the mechanism of Protobuf schema evolution, so this breaks the exact forward-compatibility property that unknown-field skipping exists to provide.

## Scope

The invariant: **`skipType` must advance the cursor by exactly the bytes the wire type occupies, for every legal length including zero.**

The fault is the overloaded parameter, not the arithmetic. Per the issue's Approach, the two intents are separated so a legal length of zero can never be read as a sentinel — rather than special-casing zero at the `LEN` call site, which would leave the trap for the next caller.

Sits on top of the `_ProtobufReader` design merged by PR #2084 (`end` boundary, `take()`, `validate()`, `atomic()`, `fork()`, `close()`) and does not disturb PR #2090's `string()` decoder boundary.

## Verification

Recorded on the thread once implementation lands. Campaign CI is deliberately suspended; the exact-SHA cancellation gate is passed after every push, and local verification is the gate.
