### PR TITLE
fix(typia): make ttsc-typia single-file transform honor typia diagnostics

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/non_trailing_rest_tuple_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/non_trailing_rest_tuple_transform_test.go
@@ -18,20 +18,22 @@ import (
 // addresses tuples by fixed leading positions, so the honest resolution is
 // a compile-time rejection, mirroring the json.schemas bigint precedent.
 //
-//  1. Require leading-rest and middle-rest tuples to be rejected: the call
-//     stays untransformed and a transform diagnostic is recorded (the same
-//     convention the duplicate-Sequence protobuf fixture pins; in build and
-//     project modes these diagnostics fail the compilation).
+//  1. Require leading-rest and middle-rest tuples to be rejected: the transform
+//     records a diagnostic naming the offending tuple, which every host --
+//     single-file included since samchon/typia#2117 -- reports while refusing to
+//     publish an artifact.
 //  2. Require trailing-rest tuples to keep compiling and validating
 //     correctly at every length.
 func TestNonTrailingRestTupleTransform(t *testing.T) {
   t.Run("leading rest rejected", func(t *testing.T) {
     nonTrailingRestExpectRejection(t, "leading-",
-      "export const validate = typia.createValidate<[...unknown[], string]>();")
+      "export const validate = typia.createValidate<[...unknown[], string]>();",
+      "[...unknown[], string]")
   })
   t.Run("middle rest rejected", func(t *testing.T) {
     nonTrailingRestExpectRejection(t, "middle-",
-      "export const validate = typia.createValidate<[number, ...boolean[], string]>();")
+      "export const validate = typia.createValidate<[number, ...boolean[], string]>();",
+      "[number, ...boolean[], string]")
   })
   t.Run("trailing rest keeps working", func(t *testing.T) {
     nonTrailingRestTrailingControl(t)
@@ -66,7 +68,12 @@ func nonTrailingRestProject(t *testing.T, prefix string, body string) string {
   return dir
 }
 
-func nonTrailingRestExpectRejection(t *testing.T, prefix string, body string) {
+// nonTrailingRestExpectRejection requires the rejection to reach the caller as a
+// diagnostic naming `tuple`, with no artifact published. This previously asserted
+// code 0 and inspected the untransformed call in stdout; that success code was
+// the samchon/typia#2117 defect, and in `js` mode the surviving `.createValidate()`
+// was only type erasure, so the diagnostic is the load-bearing evidence anyway.
+func nonTrailingRestExpectRejection(t *testing.T, prefix string, body string, tuple string) {
   t.Helper()
   project := nonTrailingRestProject(t, prefix, body)
   out, errText, code := ttscTypiaTestCapture(func() int {
@@ -77,11 +84,16 @@ func nonTrailingRestExpectRejection(t *testing.T, prefix string, body string) {
       "--output", "js",
     })
   })
-  if code != 0 {
-    t.Fatalf("single-file transform should stay inspectable: code=%d stderr=\n%s", code, errText)
+  if code != 3 {
+    t.Fatalf("non-trailing rest tuple should be rejected with code 3: code=%d stdout=\n%s\nstderr=\n%s", code, out, errText)
   }
-  if !strings.Contains(out, ".createValidate()") {
-    t.Fatalf("non-trailing rest tuple call should stay untransformed:\n%s", out)
+  if !strings.Contains(errText, "error TS(typia.createValidate):") ||
+    !strings.Contains(errText, tuple) ||
+    !strings.Contains(errText, "non-trailing rest element in tuple type is not supported.") {
+    t.Fatalf("rejection diagnostic did not name the tuple and cause:\n%s", errText)
+  }
+  if out != "" {
+    t.Fatalf("rejected transform published an artifact:\n%s", out)
   }
 }
 

--- a/packages/typia/native/cmd/ttsc-typia/protobuf_sequence_field_numbers_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/protobuf_sequence_field_numbers_transform_test.go
@@ -14,22 +14,18 @@ import (
 // explicit protobuf field numbers were silently replaced by auto-numbering and
 // duplicate-sequence validation never fired.
 //
+// The two messages live in separate fixtures because a duplicate-sequence
+// diagnostic now withholds the whole file's artifact (samchon/typia#2117), so one
+// combined source could no longer show the valid message's emitted numbers.
+//
 //  1. Transform a message fixture carrying explicit `Sequence<5>` / `Sequence<7>`
 //     field numbers plus an untagged property (auto-numbered after the highest
-//     explicit number).
-//  2. Require the emitted proto message to carry the explicit numbers.
-//  3. Require a message whose two properties share `Sequence<1>` to fail the
-//     transform, leaving the call untransformed.
+//     explicit number), and require the emitted proto message to carry them.
+//  2. Require a message whose two properties share `Sequence<1>` to fail the
+//     transform with a diagnostic naming the duplicate.
+//  3. Require that rejected transform to publish no artifact.
 func TestProtobufSequenceFieldNumbersTransform(t *testing.T) {
-  project := protobufSequenceFieldNumbersProject(t)
-  out, errText, code := ttscTypiaTestCapture(func() int {
-    return runTransform([]string{
-      "--cwd", project,
-      "--tsconfig", "tsconfig.json",
-      "--file", "src/main.ts",
-      "--output", "js",
-    })
-  })
+  out, errText, code := protobufSequenceFieldNumbersTransform(t, "sequenced-", protobufSequenceFieldNumbersSource)
   if code != 0 {
     t.Fatalf("protobuf sequence transform failed: code=%d stderr=\n%s", code, errText)
   }
@@ -42,19 +38,41 @@ func TestProtobufSequenceFieldNumbersTransform(t *testing.T) {
       t.Fatalf("emitted proto message should contain %q:\n%s", line, out)
     }
   }
-  if !strings.Contains(out, ".protobuf.message()") {
-    t.Fatalf("duplicated sequence message should stay untransformed:\n%s", out)
+
+  dupOut, dupErr, dupCode := protobufSequenceFieldNumbersTransform(t, "duplicated-", protobufSequenceDuplicatedSource)
+  if dupCode != 3 {
+    t.Fatalf("duplicated sequence message should be rejected with code 3: code=%d stdout=\n%s\nstderr=\n%s", dupCode, dupOut, dupErr)
+  }
+  if !strings.Contains(dupErr, "error TS(typia.protobuf.message):") ||
+    !strings.Contains(dupErr, `The Sequence<1> tag is duplicated in two properties ("id" and "age")`) {
+    t.Fatalf("duplicated sequence diagnostic did not name the collision:\n%s", dupErr)
+  }
+  if dupOut != "" {
+    t.Fatalf("duplicated sequence message published an artifact:\n%s", dupOut)
   }
 }
 
-func protobufSequenceFieldNumbersProject(t *testing.T) string {
+func protobufSequenceFieldNumbersTransform(t *testing.T, prefix string, source string) (string, string, int) {
+  t.Helper()
+  project := protobufSequenceFieldNumbersProject(t, prefix, source)
+  return ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+}
+
+func protobufSequenceFieldNumbersProject(t *testing.T, prefix string, source string) string {
   t.Helper()
   root := ttscTypiaTestRepoRoot(t)
   base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
   if err := os.MkdirAll(base, 0o755); err != nil {
     t.Fatalf("mkdir temp base: %v", err)
   }
-  dir, err := os.MkdirTemp(base, "protobuf-sequence-")
+  dir, err := os.MkdirTemp(base, "protobuf-sequence-"+prefix)
   if err != nil {
     t.Fatalf("create temp fixture: %v", err)
   }
@@ -68,7 +86,7 @@ func protobufSequenceFieldNumbersProject(t *testing.T) string {
   if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(protobufSequenceFieldNumbersTSConfig), 0o644); err != nil {
     t.Fatalf("write tsconfig: %v", err)
   }
-  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(protobufSequenceFieldNumbersSource), 0o644); err != nil {
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
     t.Fatalf("write source: %v", err)
   }
   return dir
@@ -97,11 +115,18 @@ interface Sequenced {
   flag: boolean;
 }
 
+export const sequenced = typia.protobuf.message<Sequenced>();
+`
+
+// protobufSequenceDuplicatedSource is the negative twin: the same message shape
+// whose two properties claim one `Sequence<1>` number, which typia must reject
+// rather than auto-renumber.
+const protobufSequenceDuplicatedSource = `import typia, { tags } from "typia";
+
 interface Duplicated {
   id: string & tags.Sequence<1>;
   age: number & tags.Sequence<1>;
 }
 
-export const sequenced = typia.protobuf.message<Sequenced>();
 export const duplicated = typia.protobuf.message<Duplicated>();
 `

--- a/packages/typia/native/cmd/ttsc-typia/transform.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform.go
@@ -26,6 +26,10 @@ import (
 // transformers), so injected namespace imports stay as ES imports the caller
 // can type-strip per file. With no --file it emits a JSON envelope of every
 // project source keyed by its cwd-relative path; with --file it prints one file.
+//
+// Every host here consults the same transformDiags before choosing its exit code
+// and before publishing anything: runTransformProject encodes them and returns 3,
+// runTransformSingle reports them and withholds the artifact.
 func runTransform(args []string) int {
   fs := flag.NewFlagSet("transform", flag.ContinueOnError)
   fs.SetOutput(stderr)
@@ -104,11 +108,39 @@ func runTransform(args []string) int {
     fmt.Fprintf(stderr, "ttsc-typia transform: source file is not in program: %s\n", absFile)
     return 2
   }
-  if *output == "js" {
-    return runTransformSingleJS(prog, typiaTransform, target, absFile, *out)
+  return runTransformSingle(cwd, *out, &transformDiags, func() (string, int) {
+    if *output == "js" {
+      return transformSingleToJavaScript(prog, typiaTransform, absFile)
+    }
+    return transformFileToTypeScript(prog, typiaTransform, target), 0
+  })
+}
+
+// runTransformSingle is the single-file counterpart of runTransformProject's
+// diagnostic decision: produce the artifact into memory, then publish it only
+// when typia's analysis reported nothing. Every single-file output mode routes
+// through this one commit point, so a mode cannot exit 0 over a diagnostic and
+// publish an untransformed `typia.is<T>(input)` call by forgetting its own check
+// (samchon/typia#2117).
+//
+// Diagnostics outrank the producer's own failure code: when typia could not
+// lower a call, that diagnostic is the cause a caller needs, not the "no output
+// produced" symptom it leaves behind.
+func runTransformSingle(
+  cwd string,
+  outPath string,
+  transformDiags *[]typiaTransformDiagnostic,
+  produce func() (string, int),
+) int {
+  text, code := produce()
+  if len(*transformDiags) > 0 {
+    writeTypiaTransformDiagnostics(stderr, *transformDiags, cwd)
+    return 3
   }
-  text := transformFileToTypeScript(prog, typiaTransform, target)
-  return writeSingleOutput(text, *out)
+  if code != 0 {
+    return code
+  }
+  return writeSingleOutput(text, outPath)
 }
 
 // runTransformProject prints every non-declaration project source as transformed
@@ -179,15 +211,14 @@ func transformFileToTypeScript(
   return writer.String()
 }
 
-// runTransformSingleJS emits a single file's JS through the full node-path emit
-// pipeline and writes it to stdout or --out.
-func runTransformSingleJS(
+// transformSingleToJavaScript emits a single file's JS through the full node-path
+// emit pipeline and returns the captured text. It only produces; publishing is
+// runTransformSingle's decision, so a diagnostic can withhold the artifact.
+func transformSingleToJavaScript(
   prog *driver.Program,
   typiaTransform driver.PluginTransform,
-  target *shimast.SourceFile,
   absFile string,
-  outPath string,
-) int {
+) (string, int) {
   var captured string
   found := false
   targetKey := filepath.ToSlash(absFile)
@@ -201,13 +232,13 @@ func runTransformSingleJS(
   })
   if _, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{typiaTransform}, writeFile); err != nil {
     fmt.Fprintf(stderr, "ttsc-typia transform: emit: %v\n", err)
-    return 3
+    return "", 3
   }
   if !found {
     fmt.Fprintf(stderr, "ttsc-typia transform: no output produced for %s\n", absFile)
-    return 3
+    return "", 3
   }
-  return writeSingleOutput(captured, outPath)
+  return captured, 0
 }
 
 // sameSourceStem reports whether an emitted .js path corresponds to a .ts source

--- a/packages/typia/native/cmd/ttsc-typia/transform.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform.go
@@ -214,6 +214,13 @@ func transformFileToTypeScript(
 // transformSingleToJavaScript emits a single file's JS through the full node-path
 // emit pipeline and returns the captured text. It only produces; publishing is
 // runTransformSingle's decision, so a diagnostic can withhold the artifact.
+//
+// The emit pass covers every file in the program, so unlike the `ts` mode -- which
+// transforms only the target -- a diagnostic raised by any project source reaches
+// runTransformSingle and withholds this file's artifact. That is deliberate and
+// matches the build host, which fails the whole build on any transform diagnostic:
+// the emit that produced this text is the same one that could not lower the other
+// call, so its success is not independently trustworthy.
 func transformSingleToJavaScript(
   prog *driver.Program,
   typiaTransform driver.PluginTransform,

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_atomicity_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_atomicity_test.go
@@ -28,7 +28,7 @@ func TestTransformSingleFileFailurePreservesArtifacts(t *testing.T) {
       dist := filepath.Join(project, "dist")
       outPath := filepath.Join(dist, "main."+output)
       seeds := map[string]string{
-        outPath:                          "previous artifact\n",
+        outPath:                         "previous artifact\n",
         filepath.Join(dist, "keep.txt"): "unrelated output\n",
       }
       for path, body := range seeds {

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_atomicity_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_atomicity_test.go
@@ -19,6 +19,8 @@ import (
 //  1. Seed `--out` with a byte-sensitive prior artifact beside an unrelated file.
 //  2. Run the single-file transform over a typia-invalid source in `ts` and `js`.
 //  3. Require exit 3, the diagnostic on stderr, and a byte-identical output tree.
+//  4. Require a fresh `--out` parent to stay uncreated, since publishing nothing
+//     must also mean creating no directory for it.
 func TestTransformSingleFileFailurePreservesArtifacts(t *testing.T) {
   for _, output := range []string{"ts", "js"} {
     t.Run(output, func(t *testing.T) {
@@ -58,6 +60,25 @@ func TestTransformSingleFileFailurePreservesArtifacts(t *testing.T) {
       }
       if after := buildReadTree(t, dist); !reflect.DeepEqual(after, before) {
         t.Fatalf("failed single-file transform mutated output tree:\nbefore=%q\nafter=%q", before, after)
+      }
+
+      // writeSingleOutput mkdirs its parent, so a guard placed after publication
+      // would leave the directory behind even with no artifact in it.
+      fresh := filepath.Join(project, "fresh", "nested")
+      _, _, code = ttscTypiaTestCapture(func() int {
+        return runTransform([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--file", filepath.Join("src", "main.ts"),
+          "--output", output,
+          "--out", filepath.Join(fresh, "main."+output),
+        })
+      })
+      if code != 3 {
+        t.Fatalf("invalid single-file transform should fail with code 3, got %d", code)
+      }
+      if _, err := os.Stat(filepath.Join(project, "fresh")); !os.IsNotExist(err) {
+        t.Fatalf("failed single-file transform created the --out directory: %v", err)
       }
     })
   }

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_atomicity_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_atomicity_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "reflect"
+  "strings"
+  "testing"
+)
+
+// TestTransformSingleFileFailurePreservesArtifacts verifies single-file atomicity.
+//
+// The project host returns 3 when typia's analysis produced diagnostics, but both
+// single-file hosts used to publish `--out` and exit 0 regardless, shipping the
+// untransformed `typia.is<T>(input)` call behind a success code. Publication must
+// follow the same decision as the exit code in both output modes, and a failed
+// transform must not destroy an artifact a previous run left behind.
+//
+//  1. Seed `--out` with a byte-sensitive prior artifact beside an unrelated file.
+//  2. Run the single-file transform over a typia-invalid source in `ts` and `js`.
+//  3. Require exit 3, the diagnostic on stderr, and a byte-identical output tree.
+func TestTransformSingleFileFailurePreservesArtifacts(t *testing.T) {
+  for _, output := range []string{"ts", "js"} {
+    t.Run(output, func(t *testing.T) {
+      project := transformSingleFileProject(t, transformDiagnosticSource)
+      dist := filepath.Join(project, "dist")
+      outPath := filepath.Join(dist, "main."+output)
+      seeds := map[string]string{
+        outPath:                          "previous artifact\n",
+        filepath.Join(dist, "keep.txt"): "unrelated output\n",
+      }
+      for path, body := range seeds {
+        if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+          t.Fatalf("mkdir seed parent: %v", err)
+        }
+        if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+          t.Fatalf("write seed %s: %v", path, err)
+        }
+      }
+      before := buildReadTree(t, dist)
+
+      _, errText, code := ttscTypiaTestCapture(func() int {
+        return runTransform([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--file", filepath.Join("src", "main.ts"),
+          "--output", output,
+          "--out", outPath,
+        })
+      })
+      if code != 3 {
+        t.Fatalf("invalid single-file transform should fail with code 3, got %d\nstderr=%s", code, errText)
+      }
+      normalized := filepath.ToSlash(errText)
+      if !strings.Contains(normalized, "src/main.ts:3:9 - error TS(typia.is):") ||
+        !strings.Contains(normalized, "non-specified generic argument") {
+        t.Fatalf("single-file diagnostic did not preserve location/code/message:\n%s", errText)
+      }
+      if after := buildReadTree(t, dist); !reflect.DeepEqual(after, before) {
+        t.Fatalf("failed single-file transform mutated output tree:\nbefore=%q\nafter=%q", before, after)
+      }
+    })
+  }
+}
+
+// transformSingleFileProject writes a one-source project whose `src/main.ts`
+// carries the given body, sharing the typia stub the other transform diagnostic
+// fixtures use.
+//
+// It deliberately omits `outDir`/`rootDir`. `--output js` locates its result
+// through `sameSourceStem`, which compares whole path stems, so an emitted
+// `dist/main.js` never matches its `src/main.ts` and the mode reports "no output
+// produced" instead of an artifact. Emitting beside the source keeps `js` mode
+// genuinely exercisable here rather than passing for the wrong reason.
+func transformSingleFileProject(t *testing.T, source string) string {
+  t.Helper()
+  project := t.TempDir()
+  src := filepath.Join(project, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(transformSingleFileTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  transformDiagnosticWriteTypiaStub(t, project)
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return project
+}
+
+// transformSingleFileValidSource is the negative twin of
+// transformDiagnosticSource: the same call shape with a resolved generic
+// argument, which typia can lower without a diagnostic.
+const transformSingleFileValidSource = `import typia from "typia";
+export function check(input: unknown): boolean {
+  return typia.is<{ value: number }>(input);
+}
+`
+
+// transformSingleFileTSConfig mirrors transformDiagnosticTSConfig without the
+// `rootDir`/`outDir` redirection, so `--output js` emits beside the source.
+const transformSingleFileTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_writes_no_stdout_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_writes_no_stdout_test.go
@@ -31,14 +31,12 @@ func TestTransformSingleFileFailureWritesNoStdout(t *testing.T) {
       if code != 3 {
         t.Fatalf("invalid single-file transform should fail with code 3, got %d\nstdout=%s\nstderr=%s", code, outText, errText)
       }
-      if !strings.Contains(filepath.ToSlash(errText), "error TS(typia.is):") {
+      if !strings.Contains(errText, "error TS(typia.is):") {
         t.Fatalf("single-file diagnostic missing from stderr:\n%s", errText)
       }
+      // Before the fix this carried the untransformed `typia.is<T>(input)` call.
       if outText != "" {
         t.Fatalf("failed single-file transform published an artifact on stdout:\n%s", outText)
-      }
-      if strings.Contains(outText, "typia.is<") {
-        t.Fatalf("failed single-file transform leaked the untransformed call:\n%s", outText)
       }
     })
   }

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_writes_no_stdout_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_writes_no_stdout_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestTransformSingleFileFailureWritesNoStdout verifies the stdout publication path.
+//
+// Without `--out` the artifact is stdout, so withholding a file is not enough:
+// the untransformed source must not reach the stream a caller pipes into a file.
+// This is also the shape the wasm host reaches through `jsTransform`, whose
+// `{ code, stdout, stderr }` response is exactly these three values.
+//
+//  1. Transform a typia-invalid source in `ts` and `js` with no `--out`.
+//  2. Require exit 3 and the diagnostic on stderr.
+//  3. Require stdout to be empty rather than carrying the untransformed call.
+func TestTransformSingleFileFailureWritesNoStdout(t *testing.T) {
+  for _, output := range []string{"ts", "js"} {
+    t.Run(output, func(t *testing.T) {
+      project := transformSingleFileProject(t, transformDiagnosticSource)
+      outText, errText, code := ttscTypiaTestCapture(func() int {
+        return runTransform([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--file", filepath.Join("src", "main.ts"),
+          "--output", output,
+        })
+      })
+      if code != 3 {
+        t.Fatalf("invalid single-file transform should fail with code 3, got %d\nstdout=%s\nstderr=%s", code, outText, errText)
+      }
+      if !strings.Contains(filepath.ToSlash(errText), "error TS(typia.is):") {
+        t.Fatalf("single-file diagnostic missing from stderr:\n%s", errText)
+      }
+      if outText != "" {
+        t.Fatalf("failed single-file transform published an artifact on stdout:\n%s", outText)
+      }
+      if strings.Contains(outText, "typia.is<") {
+        t.Fatalf("failed single-file transform leaked the untransformed call:\n%s", outText)
+      }
+    })
+  }
+}

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_success_publishes_artifact_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_success_publishes_artifact_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestTransformSingleFileSuccessPublishesArtifact verifies the positive twin.
+//
+// Consulting the diagnostics before publishing must not make a clean transform
+// withhold its artifact: the guard has to key on a reported diagnostic, not on
+// merely having run. This pins the success side of the same decision in both
+// output modes, including that the call was actually rewritten rather than
+// copied through as an untransformed stub.
+//
+//  1. Transform a typia-valid source with `--out` in `ts` and `js`.
+//  2. Require exit 0 and a silent stderr.
+//  3. Require the published artifact to exist and carry the lowered validator.
+func TestTransformSingleFileSuccessPublishesArtifact(t *testing.T) {
+  for _, output := range []string{"ts", "js"} {
+    t.Run(output, func(t *testing.T) {
+      project := transformSingleFileProject(t, transformSingleFileValidSource)
+      outPath := filepath.Join(project, "dist", "main."+output)
+      _, errText, code := ttscTypiaTestCapture(func() int {
+        return runTransform([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--file", filepath.Join("src", "main.ts"),
+          "--output", output,
+          "--out", outPath,
+        })
+      })
+      if code != 0 {
+        t.Fatalf("valid single-file transform should succeed, got %d\nstderr=%s", code, errText)
+      }
+      if errText != "" {
+        t.Fatalf("valid single-file transform reported diagnostics:\n%s", errText)
+      }
+      data, err := os.ReadFile(outPath)
+      if err != nil {
+        t.Fatalf("valid single-file transform published no artifact: %v", err)
+      }
+      text := string(data)
+      if strings.Contains(text, "typia.is<") {
+        t.Fatalf("published artifact still carries the untransformed call:\n%s", text)
+      }
+      if !strings.Contains(text, `"number"`) {
+        t.Fatalf("published artifact does not carry the lowered validator:\n%s", text)
+      }
+    })
+  }
+}

--- a/packages/typia/native/cmd/ttsc-typia/transform_wasm_host_argv_reports_diagnostics_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_wasm_host_argv_reports_diagnostics_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestTransformWasmHostArgvReportsDiagnostics verifies the wasm host contract.
+//
+// `main_wasm.go` is `js && wasm` only, so its `jsTransform` cannot be called
+// here. It carries no decision of its own: it renders the JS options object into
+// argv via `transformArgs`, hands that to this same `runTransform`, and returns
+// the resulting `{ code, stdout, stderr }`. Driving the exact argv it builds --
+// `--cwd=`/`--tsconfig=`/`--file=` with its `--output=ts` default -- therefore
+// pins what a playground caller observes: the typia error, not a stub.
+//
+//  1. Build the argv `transformArgs` produces for a single-file request.
+//  2. Run it against a typia-invalid source.
+//  3. Require code 3, the diagnostic in stderr, and no stub in stdout.
+func TestTransformWasmHostArgvReportsDiagnostics(t *testing.T) {
+  project := transformSingleFileProject(t, transformDiagnosticSource)
+  argv := []string{
+    "--cwd=" + project,
+    "--tsconfig=tsconfig.json",
+    "--file=" + filepath.Join(project, "src", "main.ts"),
+    "--output=ts",
+  }
+  outText, errText, code := ttscTypiaTestCapture(func() int { return runTransform(argv) })
+  if code != 3 {
+    t.Fatalf("wasm host argv should surface code 3, got %d\nstdout=%s\nstderr=%s", code, outText, errText)
+  }
+  if !strings.Contains(errText, "non-specified generic argument") {
+    t.Fatalf("wasm host argv did not surface the typia diagnostic:\n%s", errText)
+  }
+  if outText != "" {
+    t.Fatalf("wasm host argv returned an untransformed stub as stdout:\n%s", outText)
+  }
+}

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.14",
+  "version": "13.1.15",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
Implements #2117.

## Intent

`ttsc-typia transform` has two hosts. The project host (no `--file`) collects typia's transform diagnostics and returns exit `3`. Both single-file hosts — `--output ts` (the **default**, per `defaultTransformOutput()`) and `--output js` — never read `transformDiags` at all. They exit `0` and publish an artifact containing the **untransformed** `typia.is<T>(input)` call, so a caller that trusts exit `0` ships a file that cannot work at runtime, with no signal that anything failed.

This is the sibling of #2079 / PR #2096 (`40cfb302f3`), which repaired the identical root cause on the **build** host: collect outputs into `pending`, check `len(transformDiags) > 0` **before** draining them to disk, and withhold the artifact on failure. This PR tells the same story for the single-file transform hosts.

## Approach

The invariant: **every transform host consults the same `transformDiags` before deciding its exit code and before publishing any artifact.**

Rather than duplicate the check into two branches — which is exactly how the divergence arose — both single-file modes are routed through one shared commit decision. Producing the artifact text and publishing it become separate steps, so a future output mode cannot reintroduce the bug by forgetting a check.

## Public CLI contract change

**This deliberately flips `ttsc-typia transform --file` from exit `0` to exit `3`** for inputs that currently "succeed" while emitting an untransformed stub. Per #2117 this is a correction, not a regression: the previous `0` asserted a successful transform that did not happen. Consumers checked:

- `packages/typia/src/executable/generate/ttsc.ts` — propagates the child status verbatim (`process.exitCode = result.status ?? 1`), so `typia generate` now fails loudly instead of writing a stub.
- the ttsc transform stage — drives the project host (JSON envelope), which already returned `3`; unchanged.
- `packages/typia/native/cmd/ttsc-typia/main_wasm.go` -> `jsTransform` -> `runTransform` — inherits the fix; its `{ code, stdout, stderr }` response now carries `3` and the diagnostic.

## Verification

Pending; recorded on this thread as it completes. Campaign CI is suspended per `.agents/skills/issue-campaign/development.md`; verification is local.

## Deferred / coordination

- **The `typia` version bump is pending lead assignment.** This changes native Go under `packages/typia/native`, so Change Integrity requires a bump; the campaign lead serializes the version across the chain, so this branch deliberately does not pick one and is not rebased onto master.
- Serialized after PR #2096 (#2079); branched from `40cfb302f3`, which already contains it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
