### PR TITLE
fix(native): report barrel and index-signature-alias dependency edges

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/project_dependencies_barrel_reexport_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_dependencies_barrel_reexport_transform_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestProjectDependenciesBarrelReexportTransform verifies every barrel a type
+// is reached through registers, and no sibling the barrel merely also exports.
+//
+// A barrel re-export is an intermediate whose CONTENTS select which declaration
+// the reference reaches: re-pointing `export { Alpha } from "./alpha"` at
+// another module changes the generated validator. Resolving the alias straight
+// to its terminus reported only the concrete module, so a bundler cache had no
+// edge to invalidate and served a stale validator (samchon/typia#2126). The
+// negative twin pins the other direction — the chain must report the modules it
+// walked, not everything the barrels export.
+//
+//  1. Build a project where `a.ts` validates `Alpha` imported from `barrel.ts`,
+//     which re-exports it from `inner.ts`, which re-exports it from `alpha.ts`;
+//     `barrel.ts` also re-exports an unconsumed `Beta` from `beta.ts`.
+//  2. Run project transform mode and decode the JSON envelope.
+//  3. Assert `dependencies["src/a.ts"]` contains both barrels (`barrel.ts`,
+//     `inner.ts`) and the concrete module `alpha.ts`.
+//  4. Assert it does NOT contain `beta.ts`, which no consulted type reaches.
+func TestProjectDependenciesBarrelReexportTransform(t *testing.T) {
+  project := projectDependenciesBarrelReexportProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--output", "ts",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("project transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  var envelope struct {
+    Dependencies map[string][]string `json:"dependencies"`
+  }
+  if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+    t.Fatalf("decode envelope: %v\n%s", err, out)
+  }
+  entries := envelope.Dependencies["src/a.ts"]
+  found := map[string]bool{}
+  for _, entry := range entries {
+    found[entry] = true
+  }
+  if !found["src/barrel.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the barrel src/barrel.ts: %v", entries)
+  }
+  if !found["src/inner.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the chained barrel src/inner.ts: %v", entries)
+  }
+  if !found["src/alpha.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the concrete module src/alpha.ts: %v", entries)
+  }
+  if found["src/beta.ts"] {
+    t.Fatalf("dependencies of src/a.ts must not contain src/beta.ts, which the barrel exports but no consulted type reaches: %v", entries)
+  }
+}
+
+func projectDependenciesBarrelReexportProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "project-dependencies-barrel-reexport-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(projectDependenciesEnvelopeTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  for name, body := range map[string]string{
+    "a.ts":      projectDependenciesBarrelReexportSourceA,
+    "barrel.ts": projectDependenciesBarrelReexportSourceBarrel,
+    "inner.ts":  projectDependenciesBarrelReexportSourceInner,
+    "alpha.ts":  projectDependenciesBarrelReexportSourceAlpha,
+    "beta.ts":   projectDependenciesBarrelReexportSourceBeta,
+  } {
+    if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  return dir
+}
+
+const projectDependenciesBarrelReexportSourceA = `import typia from "typia";
+
+import { Alpha } from "./barrel";
+
+export const validateAlpha = (input: unknown) => typia.validate<Alpha>(input);
+`
+
+const projectDependenciesBarrelReexportSourceBarrel = `export { Alpha } from "./inner";
+export { Beta } from "./beta";
+`
+
+const projectDependenciesBarrelReexportSourceInner = `export { Alpha } from "./alpha";
+`
+
+const projectDependenciesBarrelReexportSourceAlpha = `export interface Alpha {
+  id: string;
+}
+`
+
+const projectDependenciesBarrelReexportSourceBeta = `export interface Beta {
+  flag: boolean;
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/project_dependencies_default_barrel_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_dependencies_default_barrel_transform_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestProjectDependenciesDefaultBarrelTransform verifies a default-export
+// barrel reports the module it forwards to, and never a same-named sibling.
+//
+// A default import binds `default`, not its own local name, so an alias walk
+// that stepped through the local name would look up whatever the barrel happens
+// to export under it — reporting a module the reference never consults and
+// invalidating consumers on edits that cannot reach them. `dependencies` names
+// every file whose edit can change the generated output and ONLY those, so this
+// pins both halves of that invariant on one fixture (samchon/typia#2126).
+//
+//  1. Build a project where `a.ts` validates the default import `Alpha` from
+//     `barrel.ts`, which forwards `default` from `real.ts` while separately
+//     exporting an unrelated NAMED `Alpha` from `unrelated.ts`.
+//  2. Run project transform mode and decode the JSON envelope.
+//  3. Assert `dependencies["src/a.ts"]` contains `barrel.ts` and `real.ts`.
+//  4. Assert it does NOT contain `unrelated.ts`, whose only tie to the walk is
+//     sharing the local name of the default import.
+func TestProjectDependenciesDefaultBarrelTransform(t *testing.T) {
+  project := projectDependenciesDefaultBarrelProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--output", "ts",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("project transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  var envelope struct {
+    Dependencies map[string][]string `json:"dependencies"`
+  }
+  if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+    t.Fatalf("decode envelope: %v\n%s", err, out)
+  }
+  entries := envelope.Dependencies["src/a.ts"]
+  found := map[string]bool{}
+  for _, entry := range entries {
+    found[entry] = true
+  }
+  if !found["src/barrel.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the default barrel src/barrel.ts: %v", entries)
+  }
+  if !found["src/real.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the forwarded module src/real.ts: %v", entries)
+  }
+  if found["src/unrelated.ts"] {
+    t.Fatalf("dependencies of src/a.ts must not contain src/unrelated.ts: the default import never consults the barrel's same-named export: %v", entries)
+  }
+}
+
+func projectDependenciesDefaultBarrelProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "project-dependencies-default-barrel-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(projectDependenciesEnvelopeTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  for name, body := range map[string]string{
+    "a.ts":         projectDependenciesDefaultBarrelSourceA,
+    "barrel.ts":    projectDependenciesDefaultBarrelSourceBarrel,
+    "real.ts":      projectDependenciesDefaultBarrelSourceReal,
+    "unrelated.ts": projectDependenciesDefaultBarrelSourceUnrelated,
+  } {
+    if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  return dir
+}
+
+const projectDependenciesDefaultBarrelSourceA = `import typia from "typia";
+
+import Alpha from "./barrel";
+
+export const validateAlpha = (input: unknown) => typia.validate<Alpha>(input);
+`
+
+const projectDependenciesDefaultBarrelSourceBarrel = `export { default } from "./real";
+export { Alpha } from "./unrelated";
+`
+
+const projectDependenciesDefaultBarrelSourceReal = `interface Real {
+  id: string;
+}
+
+export default Real;
+`
+
+const projectDependenciesDefaultBarrelSourceUnrelated = `export interface Alpha {
+  nope: boolean;
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/project_dependencies_index_signature_alias_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_dependencies_index_signature_alias_transform_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestProjectDependenciesIndexSignatureAliasTransform verifies an index
+// signature's written key and value aliases register their declaring files.
+//
+// Index signatures carry no property symbol, so the apparent-property walk that
+// registers every ordinary member never sees them; their aliases-of-intrinsics
+// are then collapsed by the checker and leave no trace on the type graph
+// either. Both `[k: string]: Value` and `[k: Key]: string` therefore changed the
+// generated validator with no reported edge to invalidate
+// (samchon/typia#2126). The negative twin pins the boundary: a file reached only
+// from a member the index signature does not consult must stay out.
+//
+//  1. Build a project where `a.ts` validates `Target` from `model.ts`, whose
+//     index signature uses the key alias `Key` (`key.ts`) and the value alias
+//     `Value` (`value.ts`), and whose unrelated property references `Kept`
+//     (`kept.ts`) while a method body alone references `BodyOnly` (`body.ts`).
+//  2. Run project transform mode and decode the JSON envelope.
+//  3. Assert `dependencies["src/a.ts"]` contains `key.ts`, `value.ts`, and
+//     `kept.ts`.
+//  4. Assert it does NOT contain the body-only `body.ts`.
+func TestProjectDependenciesIndexSignatureAliasTransform(t *testing.T) {
+  project := projectDependenciesIndexSignatureAliasProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--output", "ts",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("project transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  var envelope struct {
+    Dependencies map[string][]string `json:"dependencies"`
+  }
+  if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+    t.Fatalf("decode envelope: %v\n%s", err, out)
+  }
+  entries := envelope.Dependencies["src/a.ts"]
+  found := map[string]bool{}
+  for _, entry := range entries {
+    found[entry] = true
+  }
+  if !found["src/value.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the index-signature value alias file src/value.ts: %v", entries)
+  }
+  if !found["src/key.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the index-signature key alias file src/key.ts: %v", entries)
+  }
+  if !found["src/kept.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the property alias file src/kept.ts: %v", entries)
+  }
+  if found["src/body.ts"] {
+    t.Fatalf("dependencies of src/a.ts must not contain the body-only reference file src/body.ts: %v", entries)
+  }
+}
+
+func projectDependenciesIndexSignatureAliasProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "project-dependencies-index-signature-alias-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(projectDependenciesEnvelopeTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  for name, body := range map[string]string{
+    "a.ts":     projectDependenciesIndexSignatureAliasSourceA,
+    "model.ts": projectDependenciesIndexSignatureAliasSourceModel,
+    "key.ts":   projectDependenciesIndexSignatureAliasSourceKey,
+    "value.ts": projectDependenciesIndexSignatureAliasSourceValue,
+    "kept.ts":  projectDependenciesIndexSignatureAliasSourceKept,
+    "body.ts":  projectDependenciesIndexSignatureAliasSourceBody,
+  } {
+    if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  return dir
+}
+
+const projectDependenciesIndexSignatureAliasSourceA = `import typia from "typia";
+
+import { Holder, Target } from "./model";
+
+export const validateTarget = (input: unknown) => typia.validate<Target>(input);
+export const validateHolder = (input: unknown) => typia.validate<Holder>(input);
+`
+
+const projectDependenciesIndexSignatureAliasSourceModel = `import { BodyOnly } from "./body";
+import { Kept } from "./kept";
+import { Key } from "./key";
+import { Value } from "./value";
+
+export interface Target {
+  [key: Key]: Value;
+}
+
+export class Holder {
+  public kept!: Kept;
+
+  public describe(): string {
+    const helper: BodyOnly = { tag: "x" };
+    return helper.tag;
+  }
+}
+`
+
+const projectDependenciesIndexSignatureAliasSourceKey = `export type Key = string;
+`
+
+const projectDependenciesIndexSignatureAliasSourceValue = `export type Value = string;
+`
+
+const projectDependenciesIndexSignatureAliasSourceKept = `export type Kept = number;
+`
+
+const projectDependenciesIndexSignatureAliasSourceBody = `export interface BodyOnly {
+  tag: string;
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/project_dependencies_local_reexport_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_dependencies_local_reexport_transform_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestProjectDependenciesLocalReexportTransform verifies a barrel that imports
+// a name before re-exporting it still reports the module it imported from.
+//
+// `export { Alpha } from "./mid"` carries its module on the export declaration,
+// but the equivalent `import { Alpha } from "./mid"; export { Alpha };` carries
+// none: the export specifier re-publishes a LOCAL binding. A walk that reads
+// only export declarations therefore loses `mid.ts` — while re-pointing that
+// import still changes the generated validator, which is the same missing-edge
+// defect in a second syntactic form (samchon/typia#2126).
+//
+//  1. Build a project where `a.ts` validates `Alpha` from `barrel.ts`, which
+//     imports it from `mid.ts` and re-exports the local binding; `mid.ts` in
+//     turn re-exports it from `real.ts`.
+//  2. Run project transform mode and decode the JSON envelope.
+//  3. Assert `dependencies["src/a.ts"]` contains `barrel.ts`, the intermediate
+//     `mid.ts`, and the concrete `real.ts`.
+//  4. Assert it does NOT contain `beta.ts`, which `barrel.ts` also imports but
+//     no consulted type reaches.
+func TestProjectDependenciesLocalReexportTransform(t *testing.T) {
+  project := projectDependenciesLocalReexportProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--output", "ts",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("project transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  var envelope struct {
+    Dependencies map[string][]string `json:"dependencies"`
+  }
+  if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+    t.Fatalf("decode envelope: %v\n%s", err, out)
+  }
+  entries := envelope.Dependencies["src/a.ts"]
+  found := map[string]bool{}
+  for _, entry := range entries {
+    found[entry] = true
+  }
+  if !found["src/barrel.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the barrel src/barrel.ts: %v", entries)
+  }
+  if !found["src/mid.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the locally re-exported module src/mid.ts: %v", entries)
+  }
+  if !found["src/real.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the concrete module src/real.ts: %v", entries)
+  }
+  if found["src/beta.ts"] {
+    t.Fatalf("dependencies of src/a.ts must not contain src/beta.ts, which the barrel imports but no consulted type reaches: %v", entries)
+  }
+}
+
+func projectDependenciesLocalReexportProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "project-dependencies-local-reexport-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(projectDependenciesEnvelopeTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  for name, body := range map[string]string{
+    "a.ts":      projectDependenciesLocalReexportSourceA,
+    "barrel.ts": projectDependenciesLocalReexportSourceBarrel,
+    "mid.ts":    projectDependenciesLocalReexportSourceMid,
+    "real.ts":   projectDependenciesLocalReexportSourceReal,
+    "beta.ts":   projectDependenciesLocalReexportSourceBeta,
+  } {
+    if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  return dir
+}
+
+const projectDependenciesLocalReexportSourceA = `import typia from "typia";
+
+import { Alpha } from "./barrel";
+
+export const validateAlpha = (input: unknown) => typia.validate<Alpha>(input);
+`
+
+const projectDependenciesLocalReexportSourceBarrel = `import { Alpha } from "./mid";
+import { Beta } from "./beta";
+
+export { Alpha, Beta };
+`
+
+const projectDependenciesLocalReexportSourceMid = `export { Alpha } from "./real";
+`
+
+const projectDependenciesLocalReexportSourceReal = `export interface Alpha {
+  id: string;
+}
+`
+
+const projectDependenciesLocalReexportSourceBeta = `export interface Beta {
+  flag: boolean;
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/project_dependencies_signature_alias_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_dependencies_signature_alias_transform_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestProjectDependenciesSignatureAliasTransform verifies call- and
+// construct-signature types stay OUT of the reported dependencies.
+//
+// `dependencies` must name every file whose edit can change the generated
+// output — and only those. Typia validates a callable as `typeof x ===
+// "function"` and never inspects its parameter or return types, so editing
+// them provably cannot change the emitted validator; reporting them would
+// invalidate consumers on edits that cannot affect them. This is the negative
+// half of samchon/typia#2126, whose positive half adds the barrel and
+// index-signature edges: the two were confirmed by the same probe, which showed
+// the generated output is unchanged across these edits.
+//
+//  1. Build a project where `a.ts` validates `Target` from `model.ts`, whose
+//     call signature returns `CallRet` (`callret.ts`) and whose construct
+//     signature returns `NewRet` (`newret.ts`), while an ordinary property
+//     references `Kept` (`kept.ts`).
+//  2. Run project transform mode and decode the JSON envelope.
+//  3. Assert `dependencies["src/a.ts"]` contains `model.ts` and `kept.ts`, so
+//     the fixture is genuinely analyzed.
+//  4. Assert it contains neither `callret.ts` nor `newret.ts`.
+func TestProjectDependenciesSignatureAliasTransform(t *testing.T) {
+  project := projectDependenciesSignatureAliasProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--output", "ts",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("project transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  var envelope struct {
+    Dependencies map[string][]string `json:"dependencies"`
+  }
+  if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+    t.Fatalf("decode envelope: %v\n%s", err, out)
+  }
+  entries := envelope.Dependencies["src/a.ts"]
+  found := map[string]bool{}
+  for _, entry := range entries {
+    found[entry] = true
+  }
+  if !found["src/model.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the declaring file src/model.ts: %v", entries)
+  }
+  if !found["src/kept.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the consulted property alias file src/kept.ts: %v", entries)
+  }
+  if found["src/callret.ts"] {
+    t.Fatalf("dependencies of src/a.ts must not contain src/callret.ts: a call signature's return type cannot change the generated validator: %v", entries)
+  }
+  if found["src/newret.ts"] {
+    t.Fatalf("dependencies of src/a.ts must not contain src/newret.ts: a construct signature's return type cannot change the generated validator: %v", entries)
+  }
+}
+
+func projectDependenciesSignatureAliasProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "project-dependencies-signature-alias-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(projectDependenciesEnvelopeTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  for name, body := range map[string]string{
+    "a.ts":       projectDependenciesSignatureAliasSourceA,
+    "model.ts":   projectDependenciesSignatureAliasSourceModel,
+    "callret.ts": projectDependenciesSignatureAliasSourceCallRet,
+    "newret.ts":  projectDependenciesSignatureAliasSourceNewRet,
+    "kept.ts":    projectDependenciesSignatureAliasSourceKept,
+  } {
+    if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  return dir
+}
+
+const projectDependenciesSignatureAliasSourceA = `import typia from "typia";
+
+import { Target } from "./model";
+
+export const validateTarget = (input: unknown) => typia.validate<Target>(input);
+`
+
+const projectDependenciesSignatureAliasSourceModel = `import { CallRet } from "./callret";
+import { Kept } from "./kept";
+import { NewRet } from "./newret";
+
+export interface Target {
+  kept: Kept;
+  (arg: string): CallRet;
+  new (arg: string): NewRet;
+}
+`
+
+const projectDependenciesSignatureAliasSourceCallRet = `export type CallRet = string;
+`
+
+const projectDependenciesSignatureAliasSourceNewRet = `export type NewRet = string;
+`
+
+const projectDependenciesSignatureAliasSourceKept = `export type Kept = number;
+`

--- a/packages/typia/native/cmd/ttsc-typia/project_dependencies_star_barrel_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_dependencies_star_barrel_transform_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestProjectDependenciesStarBarrelTransform verifies a barrel reached through
+// `export *` registers, even though no local specifier names the type.
+//
+// A named re-export publishes an export specifier the alias walk can step
+// through hop by hop; `export * from "./alpha"` publishes none, so that walk
+// has nothing to follow and would stop before reporting the barrel — while
+// re-pointing the star at another module still changes the generated validator
+// (samchon/typia#2126). The walk therefore reports each module specifier's
+// resolved file directly, which is what keeps this shape covered.
+//
+//  1. Build a project where `a.ts` validates `Alpha` imported from `barrel.ts`,
+//     which reaches it only through `export * from "./alpha"`.
+//  2. Run project transform mode and decode the JSON envelope.
+//  3. Assert `dependencies["src/a.ts"]` contains the star barrel `barrel.ts`
+//     and the concrete module `alpha.ts`.
+//  4. Assert it does NOT contain `beta.ts`, a module the same barrel also stars
+//     in but no consulted type reaches.
+func TestProjectDependenciesStarBarrelTransform(t *testing.T) {
+  project := projectDependenciesStarBarrelProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--output", "ts",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("project transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  var envelope struct {
+    Dependencies map[string][]string `json:"dependencies"`
+  }
+  if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+    t.Fatalf("decode envelope: %v\n%s", err, out)
+  }
+  entries := envelope.Dependencies["src/a.ts"]
+  found := map[string]bool{}
+  for _, entry := range entries {
+    found[entry] = true
+  }
+  if !found["src/barrel.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the star barrel src/barrel.ts: %v", entries)
+  }
+  if !found["src/alpha.ts"] {
+    t.Fatalf("dependencies of src/a.ts must contain the concrete module src/alpha.ts: %v", entries)
+  }
+  if found["src/beta.ts"] {
+    t.Fatalf("dependencies of src/a.ts must not contain src/beta.ts, which the barrel stars in but no consulted type reaches: %v", entries)
+  }
+}
+
+func projectDependenciesStarBarrelProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "project-dependencies-star-barrel-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(projectDependenciesEnvelopeTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  for name, body := range map[string]string{
+    "a.ts":      projectDependenciesStarBarrelSourceA,
+    "barrel.ts": projectDependenciesStarBarrelSourceBarrel,
+    "alpha.ts":  projectDependenciesStarBarrelSourceAlpha,
+    "beta.ts":   projectDependenciesStarBarrelSourceBeta,
+  } {
+    if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  return dir
+}
+
+const projectDependenciesStarBarrelSourceA = `import typia from "typia";
+
+import { Alpha } from "./barrel";
+
+export const validateAlpha = (input: unknown) => typia.validate<Alpha>(input);
+`
+
+const projectDependenciesStarBarrelSourceBarrel = `export * from "./alpha";
+export * from "./beta";
+`
+
+const projectDependenciesStarBarrelSourceAlpha = `export interface Alpha {
+  id: string;
+}
+`
+
+const projectDependenciesStarBarrelSourceBeta = `export interface Beta {
+  flag: boolean;
+}
+`

--- a/packages/typia/native/core/schemas/metadata/MetadataDependency.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataDependency.go
@@ -291,7 +291,12 @@ func metadataDependency_touchPath(
     }
     specifier := metadataDependency_moduleSpecifier(declaration)
     if specifier == nil {
-      return
+      // A `from`-less `export { Alpha }` re-publishes a LOCAL binding, which is
+      // itself an alias when the file imported the name first (`import { Alpha }
+      // from "./mid"; export { Alpha };`). Continuing from that local keeps the
+      // module it reads (`./mid`) on the path instead of ending the walk here.
+      symbol = metadataDependency_local(declaration)
+      continue
     }
     // A module specifier's symbol is its resolved module, whose declaration is
     // the target source file. Reporting it keeps the next module registered
@@ -310,23 +315,59 @@ func metadataDependency_touchPath(
   }
 }
 
-// metadataDependency_exported steps one alias hop: the member `module` exports
-// under the name the alias declaration reads (`propertyName` when the hop
-// renames, e.g. `export { Beta as Alpha }`). Returns nil when the export cannot
-// be named locally, which stops the walk at an already-reported module.
+// metadataDependency_exported steps one alias hop to the member `module`
+// publishes under the name this declaration reads: `default` for an import
+// clause, and for a named import / export specifier its property name when the
+// hop renames (`export { Beta as Alpha }`) or its own name otherwise.
+//
+// Only those kinds are stepped. Any other alias binds the whole module rather
+// than one export — a namespace import above all — so its local name is not an
+// export name at all; looking one up would land on whatever member happens to
+// share that name and report files the reference never consults. Returning nil
+// stops the walk at the module already reported, which loses no edge: the
+// terminus is resolved separately by the checker.
 func metadataDependency_exported(module *nativeast.Symbol, declaration *nativeast.Node) *nativeast.Symbol {
   if module.Exports == nil {
     return nil
   }
-  name := declaration.PropertyNameOrName()
-  if name == nil {
-    return nil
-  }
-  switch name.Kind {
-  case nativeast.KindIdentifier, nativeast.KindStringLiteral:
-    return module.Exports[name.Text()]
+  switch declaration.Kind {
+  case nativeast.KindImportClause:
+    // ast.InternalSymbolNameDefault, which the shim does not re-export.
+    return module.Exports["default"]
+  case nativeast.KindImportSpecifier, nativeast.KindExportSpecifier:
+    name := declaration.PropertyNameOrName()
+    if name == nil {
+      return nil
+    }
+    switch name.Kind {
+    case nativeast.KindIdentifier, nativeast.KindStringLiteral:
+      return module.Exports[name.Text()]
+    }
   }
   return nil
+}
+
+// metadataDependency_local returns the local binding a `from`-less export
+// specifier re-publishes, so a walk that reaches one can continue through the
+// import that bound the name. Other declaration kinds have no such local to
+// resume from.
+func metadataDependency_local(declaration *nativeast.Node) *nativeast.Symbol {
+  if declaration.Kind != nativeast.KindExportSpecifier {
+    return nil
+  }
+  name := declaration.PropertyNameOrName()
+  if name == nil || name.Kind != nativeast.KindIdentifier {
+    return nil
+  }
+  source := nativeast.GetSourceFileOfNode(declaration)
+  if source == nil {
+    return nil
+  }
+  locals := source.AsNode().LocalsContainerData()
+  if locals == nil {
+    return nil
+  }
+  return locals.Locals[name.Text()]
 }
 
 // metadataDependency_moduleSpecifier returns the module specifier of the

--- a/packages/typia/native/core/schemas/metadata/MetadataDependency.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataDependency.go
@@ -135,12 +135,34 @@ func metadataDependency_touchVisited(
 // type), the annotation for properties and parameters, and parameter types +
 // return type for methods, accessors, and index signatures. Bodies and
 // initializers are excluded — a reference appearing only there is not part of
-// the type the analysis consulted. Interface and class declarations return
-// nothing: their members surface individually through property enumeration.
+// the type the analysis consulted. Interface, class, and type-literal
+// declarations contribute only their index signatures: every other member
+// surfaces individually through property enumeration.
 func metadataDependency_typeSurface(declaration *nativeast.Node) []*nativeast.Node {
   switch declaration.Kind {
   case nativeast.KindTypeAliasDeclaration:
     return []*nativeast.Node{declaration}
+  case nativeast.KindInterfaceDeclaration,
+    nativeast.KindClassDeclaration,
+    nativeast.KindClassExpression,
+    nativeast.KindTypeLiteral:
+    // An index signature has no property symbol, so — unlike every other
+    // member — it never reaches the apparent-property walk that registers a
+    // member's declaring files. Its written key and value types are consulted
+    // (the analysis reads both off each index info), so an alias used there
+    // must register its file like any other consulted alias; without this the
+    // aliased file changed the generated validator with no reported edge for a
+    // bundler cache to invalidate (samchon/typia#2126). Members are surfaced
+    // through this same selector, which keeps an index signature's own body-
+    // free key/value contract as the boundary.
+    output := []*nativeast.Node{}
+    for _, member := range declaration.Members() {
+      if member == nil || member.Kind != nativeast.KindIndexSignature {
+        continue
+      }
+      output = append(output, metadataDependency_typeSurface(member)...)
+    }
+    return output
   case nativeast.KindPropertySignature,
     nativeast.KindPropertyDeclaration,
     nativeast.KindParameter:
@@ -204,7 +226,7 @@ func metadataDependency_walkNode(
     }
   }
   if name != nil {
-    metadataDependency_touchVisited(checker, listener, metadataDependency_resolve(checker, name), visited)
+    metadataDependency_touchVisited(checker, listener, metadataDependency_resolve(checker, listener, name), visited)
   }
   node.ForEachChild(func(child *nativeast.Node) bool {
     metadataDependency_walkNode(checker, listener, child, visited)
@@ -214,8 +236,14 @@ func metadataDependency_walkNode(
 
 // metadataDependency_resolve resolves a written reference name to its final
 // symbol, following import aliases so the touched declarations are the real
-// declaring files rather than the local import specifier.
-func metadataDependency_resolve(checker *nativechecker.Checker, name *nativeast.Node) *nativeast.Symbol {
+// declaring files rather than the local import specifier. Every module the
+// alias path traverses is reported on the way, because those intermediates
+// SELECT which declaration the terminus is (see metadataDependency_touchPath).
+func metadataDependency_resolve(
+  checker *nativechecker.Checker,
+  listener func(fileName string),
+  name *nativeast.Node,
+) *nativeast.Symbol {
   if checker == nil || name == nil {
     return nil
   }
@@ -224,9 +252,96 @@ func metadataDependency_resolve(checker *nativechecker.Checker, name *nativeast.
     return nil
   }
   if symbol.Flags&nativeast.SymbolFlagsAlias != 0 {
+    metadataDependency_touchPath(checker, listener, symbol)
     if resolved := nativechecker.Checker_getAliasedSymbol(checker, symbol); resolved != nil {
       symbol = resolved
     }
   }
   return symbol
+}
+
+// metadataDependency_touchPath reports every module an alias path traverses on
+// its way to the declaration it finally names.
+//
+// Resolving an alias straight to its terminus reports where the type is
+// declared, not what was consulted to find it. A barrel (`export { Alpha } from
+// "./alpha"`) never holds the declaration, yet re-pointing that line at another
+// module changes the generated validator — so a consumer that watches only the
+// terminus has no edge to invalidate and serves a stale validator
+// (samchon/typia#2126). Walking the path hop by hop reports each intermediate.
+//
+// Only the modules actually traversed for THIS reference are reported: the walk
+// steps through the single named export it followed, never the rest of a
+// barrel's exports, keeping unrelated siblings out of the envelope.
+func metadataDependency_touchPath(
+  checker *nativechecker.Checker,
+  listener func(fileName string),
+  symbol *nativeast.Symbol,
+) {
+  visited := map[*nativeast.Symbol]bool{}
+  for symbol != nil && symbol.Flags&nativeast.SymbolFlagsAlias != 0 && visited[symbol] == false {
+    visited[symbol] = true
+    declaration := nativechecker.Checker_getDeclarationOfAliasSymbol(checker, symbol)
+    if declaration == nil {
+      return
+    }
+    // The file that WRITES this hop (the barrel's own `export ... from` line).
+    if src := nativeast.GetSourceFileOfNode(declaration); src != nil {
+      listener(src.FileName())
+    }
+    specifier := metadataDependency_moduleSpecifier(declaration)
+    if specifier == nil {
+      return
+    }
+    // A module specifier's symbol is its resolved module, whose declaration is
+    // the target source file. Reporting it keeps the next module registered
+    // even when the hop cannot be stepped through below (`export *` publishes
+    // no local specifier symbol to follow).
+    module := checker.GetSymbolAtLocation(specifier)
+    if module == nil {
+      return
+    }
+    for _, moduleDeclaration := range module.Declarations {
+      if src := nativeast.GetSourceFileOfNode(moduleDeclaration); src != nil {
+        listener(src.FileName())
+      }
+    }
+    symbol = metadataDependency_exported(module, declaration)
+  }
+}
+
+// metadataDependency_exported steps one alias hop: the member `module` exports
+// under the name the alias declaration reads (`propertyName` when the hop
+// renames, e.g. `export { Beta as Alpha }`). Returns nil when the export cannot
+// be named locally, which stops the walk at an already-reported module.
+func metadataDependency_exported(module *nativeast.Symbol, declaration *nativeast.Node) *nativeast.Symbol {
+  if module.Exports == nil {
+    return nil
+  }
+  name := declaration.PropertyNameOrName()
+  if name == nil {
+    return nil
+  }
+  switch name.Kind {
+  case nativeast.KindIdentifier, nativeast.KindStringLiteral:
+    return module.Exports[name.Text()]
+  }
+  return nil
+}
+
+// metadataDependency_moduleSpecifier returns the module specifier of the
+// import / export declaration an alias declaration belongs to, or nil when the
+// alias has no module specifier to traverse (a local `import X = Y`, an
+// `export =`, or an export clause with no `from`). Node.ModuleSpecifier panics
+// on other kinds, so every kind is matched explicitly.
+func metadataDependency_moduleSpecifier(declaration *nativeast.Node) *nativeast.Node {
+  for node := declaration; node != nil; node = node.Parent {
+    switch node.Kind {
+    case nativeast.KindImportDeclaration, nativeast.KindExportDeclaration:
+      return node.ModuleSpecifier()
+    case nativeast.KindSourceFile:
+      return nil
+    }
+  }
+  return nil
 }

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "13.1.16",
+  "version": "13.1.17",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
+++ b/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
@@ -204,24 +204,79 @@ const writeFixture = (project: string): void => {
     path.join(project, "src", "lib.custom.d.ts"),
     fixtureAmbientV1,
   );
+  fs.writeFileSync(path.join(project, "src", "barrel.ts"), fixtureBarrelV1);
+  fs.writeFileSync(path.join(project, "src", "nested.ts"), fixtureNested);
+  fs.writeFileSync(path.join(project, "src", "alt.ts"), fixtureAlt);
+  fs.writeFileSync(path.join(project, "src", "dynamic.ts"), fixtureDynamic);
+  fs.writeFileSync(path.join(project, "src", "cell.ts"), fixtureCellV1);
 };
 
 const fixtureTypeV1: string = [
+  `import { Nested } from "./barrel";`,
+  `import { Dynamic } from "./dynamic";`,
+  ``,
   `export interface MyType {`,
   `  id: string;`,
   `  ambient: CustomLabel;`,
+  `  nested: Nested;`,
+  `  dynamic: Dynamic;`,
   `}`,
   ``,
 ].join("\n");
 
 const fixtureTypeV2: string = [
+  `import { Nested } from "./barrel";`,
+  `import { Dynamic } from "./dynamic";`,
+  ``,
   `export interface MyType {`,
   `  id: string;`,
   `  age: number;`,
   `  ambient: CustomLabel;`,
+  `  nested: Nested;`,
+  `  dynamic: Dynamic;`,
   `}`,
   ``,
 ].join("\n");
+
+// The barrel holds no declaration: it only SELECTS which module `Nested`
+// resolves to, so re-pointing it must invalidate the consumer (#2126).
+const fixtureBarrelV1: string = [`export { Nested } from "./nested";`, ``].join(
+  "\n",
+);
+
+const fixtureBarrelV2: string = [`export { Nested } from "./alt";`, ``].join(
+  "\n",
+);
+
+const fixtureNested: string = [
+  `export interface Nested {`,
+  `  code: string;`,
+  `}`,
+  ``,
+].join("\n");
+
+const fixtureAlt: string = [
+  `export interface Nested {`,
+  `  code: string;`,
+  `  extra: boolean;`,
+  `}`,
+  ``,
+].join("\n");
+
+// `Cell` is reached only through the index signature, which carries no property
+// symbol for the member walk to register (#2126).
+const fixtureDynamic: string = [
+  `import { Cell } from "./cell";`,
+  ``,
+  `export interface Dynamic {`,
+  `  [key: string]: Cell;`,
+  `}`,
+  ``,
+].join("\n");
+
+const fixtureCellV1: string = [`export type Cell = string;`, ``].join("\n");
+
+const fixtureCellV2: string = [`export type Cell = number;`, ``].join("\n");
 
 const fixtureAmbientV1: string = [
   `declare interface CustomLabel {`,
@@ -251,15 +306,28 @@ const fixtureAmbientV2: string = [
  * participate in invalidation instead of being dropped as a default library by
  * its basename.
  *
+ * The barrel and index-signature steps pin samchon/typia#2126. Both files are
+ * intermediates that hold no declaration of their own but SELECT which one the
+ * analysis reaches, and both were omitted from the reported dependencies while
+ * demonstrably changing the generated validator — the defect survived #2100 and
+ * #2109 precisely because no end-to-end pin covered these two shapes.
+ *
  * 1. Bundle a fixture where `index.ts` calls `typia.validate<MyType>()`,
- *    `mytype.ts` declares `MyType`, and the ambient `lib.custom.d.ts` declares
- *    a consumed `CustomLabel`; assert the validator accepts a valid input and
- *    rejects a broken one.
+ *    `mytype.ts` declares `MyType`, the ambient `lib.custom.d.ts` declares a
+ *    consumed `CustomLabel`, `barrel.ts` re-exports `Nested` from `nested.ts`,
+ *    and `dynamic.ts` reaches `Cell` (`cell.ts`) through an index signature;
+ *    assert the validator accepts a valid input and rejects a broken one.
  * 2. Add a required `age` property to `MyType` and rebuild with the cache kept;
  *    assert the previously valid input now fails at `$input.age`.
  * 3. Add a required `flag` property to `CustomLabel` inside `lib.custom.d.ts` and
  *    rebuild with the cache kept; assert the previous input now fails at
  *    `$input.ambient.flag` and a fully updated input succeeds.
+ * 4. Re-point `barrel.ts` at `alt.ts`, whose `Nested` adds a required `extra`,
+ *    and rebuild with the cache kept; assert the previous input now fails at
+ *    `$input.nested.extra`.
+ * 5. Retype `Cell` from `string` to `number` in `cell.ts` and rebuild with the
+ *    cache kept; assert the previous string-valued dynamic entry now fails and a
+ *    numeric one succeeds.
  */
 export const test_webpack_filesystem_cache_invalidation =
   async (): Promise<void> => {
@@ -273,11 +341,20 @@ export const test_webpack_filesystem_cache_invalidation =
       build(project, "on the cold run");
       assertSuccess(
         "cold build with a valid input",
-        validate(project, { id: "a", ambient: { tag: "t" } }),
+        validate(project, {
+          id: "a",
+          ambient: { tag: "t" },
+          nested: { code: "c" },
+          dynamic: { k: "v" },
+        }),
       );
       assertErrorPath(
         "cold build with a broken input",
-        validate(project, { ambient: { tag: "t" } }),
+        validate(project, {
+          ambient: { tag: "t" },
+          nested: { code: "c" },
+          dynamic: { k: "v" },
+        }),
         "$input.id",
       );
 
@@ -286,12 +363,23 @@ export const test_webpack_filesystem_cache_invalidation =
       build(project, "after changing mytype.ts");
       assertErrorPath(
         "cached rebuild after adding MyType.age",
-        validate(project, { id: "a", ambient: { tag: "t" } }),
+        validate(project, {
+          id: "a",
+          ambient: { tag: "t" },
+          nested: { code: "c" },
+          dynamic: { k: "v" },
+        }),
         "$input.age",
       );
       assertSuccess(
         "cached rebuild with the updated input",
-        validate(project, { id: "a", age: 1, ambient: { tag: "t" } }),
+        validate(project, {
+          id: "a",
+          age: 1,
+          ambient: { tag: "t" },
+          nested: { code: "c" },
+          dynamic: { k: "v" },
+        }),
       );
 
       // 3. type-only change in the project-owned lib.custom.d.ts (#2108).
@@ -302,7 +390,13 @@ export const test_webpack_filesystem_cache_invalidation =
       build(project, "after changing lib.custom.d.ts");
       assertErrorPath(
         "cached rebuild after adding CustomLabel.flag",
-        validate(project, { id: "a", age: 1, ambient: { tag: "t" } }),
+        validate(project, {
+          id: "a",
+          age: 1,
+          ambient: { tag: "t" },
+          nested: { code: "c" },
+          dynamic: { k: "v" },
+        }),
         "$input.ambient.flag",
       );
       assertSuccess(
@@ -311,6 +405,62 @@ export const test_webpack_filesystem_cache_invalidation =
           id: "a",
           age: 1,
           ambient: { tag: "t", flag: true },
+          nested: { code: "c" },
+          dynamic: { k: "v" },
+        }),
+      );
+
+      // 4. re-point the barrel at a different module (#2126). Only barrel.ts
+      // changes; it declares nothing, so an envelope without the barrel edge
+      // leaves the cache serving the old Nested validator.
+      await mutate(path.join(project, "src", "barrel.ts"), fixtureBarrelV2);
+      build(project, "after re-pointing barrel.ts");
+      assertErrorPath(
+        "cached rebuild after re-pointing the barrel at alt.ts",
+        validate(project, {
+          id: "a",
+          age: 1,
+          ambient: { tag: "t", flag: true },
+          nested: { code: "c" },
+          dynamic: { k: "v" },
+        }),
+        "$input.nested.extra",
+      );
+      assertSuccess(
+        "cached rebuild with the re-pointed input",
+        validate(project, {
+          id: "a",
+          age: 1,
+          ambient: { tag: "t", flag: true },
+          nested: { code: "c", extra: true },
+          dynamic: { k: "v" },
+        }),
+      );
+
+      // 5. retype the index signature's value alias (#2126). `cell.ts` is
+      // reached only through `Dynamic`'s index signature, which carries no
+      // property symbol for the member walk to register.
+      await mutate(path.join(project, "src", "cell.ts"), fixtureCellV2);
+      build(project, "after retyping cell.ts");
+      assertErrorPath(
+        "cached rebuild after retyping the index-signature value alias",
+        validate(project, {
+          id: "a",
+          age: 1,
+          ambient: { tag: "t", flag: true },
+          nested: { code: "c", extra: true },
+          dynamic: { k: "v" },
+        }),
+        "$input.dynamic.k",
+      );
+      assertSuccess(
+        "cached rebuild with the retyped input",
+        validate(project, {
+          id: "a",
+          age: 1,
+          ambient: { tag: "t", flag: true },
+          nested: { code: "c", extra: true },
+          dynamic: { k: 1 },
         }),
       );
     } finally {


### PR DESCRIPTION
## Intent

Closes #2126.

The native transform's reported `dependencies` must name every file whose edit can change the generated output. Two edges are currently missing: a type reached through a **barrel** re-export, and a type reached through an **index-signature alias**. The resolver follows a type to its declaration site and reports the terminus, discarding the intermediate files it consulted to reach it — yet those intermediates *select* which declaration is reached, so editing one changes the emitted validator with no edge for a bundler to invalidate.

This is the live residue of #2095. #2100 (per-file consulted declarations) and #2109 (default-library classification + committed e2e pin) both landed and both still hold; these two shapes survive them.

## Scope

- `packages/typia/native/.../MetadataDependency.go` — `_resolve` / `_typeSurface`.
- Regression matrix extending the committed e2e bundler-cache pin from #2109, covering both omitted shapes plus call/construct-signature aliases.

Both directions are proven: the omitted files are reported, and files that genuinely cannot affect the output stay out. Over-reporting the whole program would destroy the envelope's value just as surely as under-reporting.

## Verification

Local only — campaign CI is deliberately suspended and exact-SHA runs are cancelled per `.agents/skills/issue-campaign/development.md`. Commands and results are recorded in the thread.

## Deferred / pending

- **Version bump pending lead assignment.** This changes Go source under `packages/typia/native`, so the development skill's Change Integrity rule requires a coordinated `typia` version bump. Rebase, version, and merge are lead-owned for this campaign.
- #2107 remains a correct deferral for the defence-in-depth host-`graph` union it actually covers; it is blocked on an upstream `ttsc` release that does not yet exist and is not a substitute for these edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
