### PR TITLE
fix(typia): resolve the single-file js transform output path from the compiler

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/command_routes_and_diagnostics_coverage_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/command_routes_and_diagnostics_coverage_test.go
@@ -175,6 +175,8 @@ func TestCommandRoutesAndDiagnosticsCoverage(t *testing.T) {
 				"--rewrite-mode", "none",
 			})
 		}, 0},
+		// Publishes, rather than the 3 this expected while samchon/typia#2134
+		// made `--output js` miss its own artifact under the fixture's `outDir`.
 		{"transform_js_out", func(t *testing.T) int {
 			return runTransform([]string{
 				"--cwd", primitives,
@@ -184,7 +186,7 @@ func TestCommandRoutesAndDiagnosticsCoverage(t *testing.T) {
 				"--out", filepath.Join(t.TempDir(), "main.js"),
 				"--rewrite-mode", "none",
 			})
-		}, 3},
+		}, 0},
 		{"transform_ts_stdout_write_error", func(t *testing.T) int {
 			return commandRoutesWithFailingStdout(func() int {
 				return runTransform([]string{

--- a/packages/typia/native/cmd/ttsc-typia/transform.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform.go
@@ -110,7 +110,7 @@ func runTransform(args []string) int {
   }
   return runTransformSingle(cwd, *out, &transformDiags, func() (string, int) {
     if *output == "js" {
-      return transformSingleToJavaScript(prog, typiaTransform, absFile)
+      return transformSingleToJavaScript(prog, typiaTransform, target)
     }
     return transformFileToTypeScript(prog, typiaTransform, target), 0
   })
@@ -221,17 +221,35 @@ func transformFileToTypeScript(
 // matches the build host, which fails the whole build on any transform diagnostic:
 // the emit that produced this text is the same one that could not lower the other
 // call, so its success is not independently trustworthy.
+//
+// The emit writes every project output through one callback, so the target's own
+// artifact has to be identified among them. That identity comes from the
+// compiler's output-path resolution rather than from a resemblance between the
+// source and emitted paths, because the emit chooses its write path with that
+// same resolution: `outDir`, `rootDir`, and nested source directories may move
+// the artifact anywhere without the two disagreeing, and two sources sharing a
+// basename in different directories resolve to different artifacts instead of
+// collapsing onto one. Deriving the path instead of matching stems is what fixed
+// samchon/typia#2134, where a whole-path-stem match asked whether `dist/main`
+// equalled `src/main` and so reported "no output produced" for every project
+// with an `outDir`.
 func transformSingleToJavaScript(
   prog *driver.Program,
   typiaTransform driver.PluginTransform,
-  absFile string,
+  target *shimast.SourceFile,
 ) (string, int) {
+  // The resolution answers with an empty path for a source that has no
+  // JavaScript lane of its own -- a JSON module that would be emitted over
+  // itself. Nothing the emit writes is then this file's artifact, so guard the
+  // comparison rather than let an empty expectation match anything.
+  expected := ""
+  if paths := shimcompiler.GetOutputPathsFor(target, prog.TSProgram.Options(), prog.TSProgram, false); paths != nil {
+    expected = filepath.ToSlash(paths.JsFilePath())
+  }
   var captured string
   found := false
-  targetKey := filepath.ToSlash(absFile)
   writeFile := shimcompiler.WriteFile(func(fileName, text string, _ *shimcompiler.WriteFileData) error {
-    // The emitted .js maps back to its .ts; match on basename stem.
-    if sameSourceStem(targetKey, fileName) {
+    if expected != "" && filepath.ToSlash(fileName) == expected {
       captured = text
       found = true
     }
@@ -242,17 +260,10 @@ func transformSingleToJavaScript(
     return "", 3
   }
   if !found {
-    fmt.Fprintf(stderr, "ttsc-typia transform: no output produced for %s\n", absFile)
+    fmt.Fprintf(stderr, "ttsc-typia transform: no output produced for %s\n", target.FileName())
     return "", 3
   }
   return captured, 0
-}
-
-// sameSourceStem reports whether an emitted .js path corresponds to a .ts source
-// path by comparing their extension-stripped values.
-func sameSourceStem(tsPath, jsPath string) bool {
-  return strings.TrimSuffix(filepath.ToSlash(jsPath), filepath.Ext(jsPath)) ==
-    strings.TrimSuffix(tsPath, filepath.Ext(tsPath))
 }
 
 func writeSingleOutput(text, outPath string) int {

--- a/packages/typia/native/cmd/ttsc-typia/transform.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform.go
@@ -231,7 +231,7 @@ func transformFileToTypeScript(
 // basename in different directories resolve to different artifacts instead of
 // collapsing onto one. Deriving the path instead of matching stems is what fixed
 // samchon/typia#2134, where a whole-path-stem match asked whether `dist/main`
-// equalled `src/main` and so reported "no output produced" for every project
+// equaled `src/main` and so reported "no output produced" for every project
 // with an `outDir`.
 func transformSingleToJavaScript(
   prog *driver.Program,

--- a/packages/typia/native/cmd/ttsc-typia/transform_declaration_source_produces_no_javascript_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_declaration_source_produces_no_javascript_test.go
@@ -17,9 +17,12 @@ import (
 // of returning a successful but blank result.
 //
 // The file name deliberately spells out "javascript". Go reads a trailing `_js`
-// on a source file name as a `GOOS=js` build constraint, so this case sat in the
-// tree under the name `..._produces_no_js_test.go` and compiled on no platform
-// the suite ever runs -- the tag it carries was never the reason it did not run.
+// on a source file name as a `GOOS=js` build constraint, so under the earlier
+// name `..._produces_no_js_test.go` this case built only for `GOOS=js` -- where
+// `main.go` (`//go:build !js`) drops out and the test package does not compile
+// at all. It therefore ran on no platform whatsoever, and the tag it carries was
+// never the reason. Keep a `_js`, `_windows`, `_linux`, or `_darwin` ending off
+// a Go file name unless that constraint is meant.
 //
 // 1. Create a project that includes only a declaration source file.
 // 2. Run single-file transform with JavaScript output.

--- a/packages/typia/native/cmd/ttsc-typia/transform_declaration_source_produces_no_javascript_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_declaration_source_produces_no_javascript_test.go
@@ -10,17 +10,22 @@ import (
 	"testing"
 )
 
-// TestTransformDeclarationSourceProducesNoJS verifies JS transform reports empty emission.
+// TestTransformDeclarationSourceProducesNoJavaScript verifies JS transform reports empty emission.
 //
 // Declaration files can belong to the program while producing no JavaScript
 // output. The single-file transform path must detect that empty capture instead
 // of returning a successful but blank result.
 //
+// The file name deliberately spells out "javascript". Go reads a trailing `_js`
+// on a source file name as a `GOOS=js` build constraint, so this case sat in the
+// tree under the name `..._produces_no_js_test.go` and compiled on no platform
+// the suite ever runs -- the tag it carries was never the reason it did not run.
+//
 // 1. Create a project that includes only a declaration source file.
 // 2. Run single-file transform with JavaScript output.
 // 3. Capture the command diagnostics.
 // 4. Assert the command reports that no output was produced.
-func TestTransformDeclarationSourceProducesNoJS(t *testing.T) {
+func TestTransformDeclarationSourceProducesNoJavaScript(t *testing.T) {
 	root := transformCoverageRepoRoot(t)
 	base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
 	if err := os.MkdirAll(base, 0o755); err != nil {

--- a/packages/typia/native/cmd/ttsc-typia/transform_fixtures_emit_coverage_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_fixtures_emit_coverage_test.go
@@ -20,9 +20,19 @@ import (
 // directly, which makes transformer, adapter, and programmer code visible to
 // `-coverpkg`.
 //
+// The `_js` lane asserted the opposite of this until samchon/typia#2134 was
+// fixed: it required every fixture to report "no output produced". These
+// projects all set `rootDir`/`outDir`, and the old identity check compared whole
+// path stems, so it asked whether `dist/main` equalled `src/main` and never
+// found the artifact the emit had just written. Reading those exit 3s as the
+// specification turned this suite into the defect's own guard rail -- it would
+// have failed the repair -- and left the JS emit path it exists to cover
+// unreached, since the run stopped at the identity check.
+//
 // 1. Create isolated temporary TypeScript projects under the native package.
 // 2. Transform each project's `src/main.ts` to TypeScript output in memory.
-// 3. Exercise JavaScript single-file output error handling for synthetic projects.
+// 3. Transform each project's `src/main.ts` to JavaScript and require emitted
+//    CommonJS, which is what reaches the printer and the emit path.
 // 4. Cover reflect metadata, protobuf maps, and object-union emit paths.
 // 5. Run build/check/project-transform command paths against the same project.
 func TestTransformSyntheticEmitCoverage(t *testing.T) {
@@ -63,7 +73,7 @@ func TestTransformSyntheticEmitCoverage(t *testing.T) {
   for _, tc := range cases {
     tc := tc
     t.Run(tc.name+"_js", func(t *testing.T) {
-      _, errText, code := transformCoverageCapture(func() int {
+      out, errText, code := transformCoverageCapture(func() int {
         return runTransform([]string{
           "--cwd", projects[tc.name],
           "--tsconfig", "tsconfig.json",
@@ -71,8 +81,15 @@ func TestTransformSyntheticEmitCoverage(t *testing.T) {
           "--output", "js",
         })
       })
-      if code != 3 || !strings.Contains(errText, "no output produced") {
-        t.Fatalf("transform js should report no output for %s: code=%d stderr=\n%s", tc.name, code, errText)
+      if code != 0 {
+        t.Fatalf("transform js failed for %s: code=%d stderr=\n%s", tc.name, code, errText)
+      }
+      // These fixtures compile as `commonjs`, so a real emit is module-wrapped
+      // JavaScript. The lowering itself is pinned by the dedicated single-file
+      // `js` cases; what this lane adds is that every fixture's shape reaches
+      // the printer at all.
+      if !strings.Contains(out, `"use strict"`) || !strings.Contains(out, "exports.") {
+        t.Fatalf("transform js output for %s is not emitted CommonJS:\n%s", tc.name, out)
       }
     })
   }

--- a/packages/typia/native/cmd/ttsc-typia/transform_fixtures_emit_coverage_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_fixtures_emit_coverage_test.go
@@ -23,7 +23,7 @@ import (
 // The `_js` lane asserted the opposite of this until samchon/typia#2134 was
 // fixed: it required every fixture to report "no output produced". These
 // projects all set `rootDir`/`outDir`, and the old identity check compared whole
-// path stems, so it asked whether `dist/main` equalled `src/main` and never
+// path stems, so it asked whether `dist/main` equaled `src/main` and never
 // found the artifact the emit had just written. Reading those exit 3s as the
 // specification turned this suite into the defect's own guard rail -- it would
 // have failed the repair -- and left the JS emit path it exists to cover

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_atomicity_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_failure_atomicity_test.go
@@ -87,12 +87,6 @@ func TestTransformSingleFileFailurePreservesArtifacts(t *testing.T) {
 // transformSingleFileProject writes a one-source project whose `src/main.ts`
 // carries the given body, sharing the typia stub the other transform diagnostic
 // fixtures use.
-//
-// It deliberately omits `outDir`/`rootDir`. `--output js` locates its result
-// through `sameSourceStem`, which compares whole path stems, so an emitted
-// `dist/main.js` never matches its `src/main.ts` and the mode reports "no output
-// produced" instead of an artifact. Emitting beside the source keeps `js` mode
-// genuinely exercisable here rather than passing for the wrong reason.
 func transformSingleFileProject(t *testing.T, source string) string {
   t.Helper()
   project := t.TempDir()
@@ -100,7 +94,7 @@ func transformSingleFileProject(t *testing.T, source string) string {
   if err := os.MkdirAll(src, 0o755); err != nil {
     t.Fatalf("mkdir fixture src: %v", err)
   }
-  if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(transformSingleFileTSConfig), 0o644); err != nil {
+  if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(transformDiagnosticTSConfig), 0o644); err != nil {
     t.Fatalf("write tsconfig: %v", err)
   }
   transformDiagnosticWriteTypiaStub(t, project)
@@ -116,22 +110,5 @@ func transformSingleFileProject(t *testing.T, source string) string {
 const transformSingleFileValidSource = `import typia from "typia";
 export function check(input: unknown): boolean {
   return typia.is<{ value: number }>(input);
-}
-`
-
-// transformSingleFileTSConfig mirrors transformDiagnosticTSConfig without the
-// `rootDir`/`outDir` redirection, so `--output js` emits beside the source.
-const transformSingleFileTSConfig = `{
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "commonjs",
-    "moduleResolution": "bundler",
-    "ignoreDeprecations": "6.0",
-    "types": ["*"],
-    "esModuleInterop": true,
-    "strict": true,
-    "skipLibCheck": true
-  },
-  "include": ["src"]
 }
 `

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_distinguishes_same_basename_sources_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_distinguishes_same_basename_sources_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestTransformSingleFileJSDistinguishesSameBasenameSources verifies the
+// collision boundary of the `--output js` artifact match.
+//
+// The comment on the old whole-path-stem match named the intended repair --
+// "match on basename stem" -- and a basename match would indeed have unblocked
+// `outDir`. It would also have made `src/alpha/main.ts` and `src/beta/main.ts`
+// indistinguishable, so whichever emitted `main.js` arrived last would win and
+// the command would publish another file's validator under an exit 0. Resolving
+// the expected output path through the compiler keeps the two apart by
+// construction, since they resolve to different artifacts.
+//
+//  1. Give one project two sources that share a basename in different
+//     directories, each lowering a differently shaped validator.
+//  2. Transform each with `--output js --out` under a `rootDir`/`outDir` layout.
+//  3. Require each published artifact to carry its own validator and not its
+//     namesake's.
+func TestTransformSingleFileJSDistinguishesSameBasenameSources(t *testing.T) {
+  const alphaSource = `import typia from "typia";
+export function check(input: unknown): boolean {
+  return typia.is<{ alpha: number }>(input);
+}
+`
+  const betaSource = `import typia from "typia";
+export function check(input: unknown): boolean {
+  return typia.is<{ beta: string }>(input);
+}
+`
+  project := transformSingleFileLayoutProject(
+    t,
+    []string{`"rootDir": "src"`, `"outDir": "dist"`},
+    map[string]string{
+      "src/alpha/main.ts": alphaSource,
+      "src/beta/main.ts":  betaSource,
+    },
+  )
+  for _, probe := range []struct {
+    name    string
+    file    string
+    carries string
+    rejects string
+  }{
+    {name: "alpha", file: "src/alpha/main.ts", carries: "alpha", rejects: "beta"},
+    {name: "beta", file: "src/beta/main.ts", carries: "beta", rejects: "alpha"},
+  } {
+    t.Run(probe.name, func(t *testing.T) {
+      outPath := filepath.Join(project, "artifact", probe.name+".js")
+      _, errText, code := ttscTypiaTestCapture(func() int {
+        return runTransform([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--file", filepath.FromSlash(probe.file),
+          "--output", "js",
+          "--out", outPath,
+        })
+      })
+      if code != 0 {
+        t.Fatalf("`--output js` should publish %s, got %d\nstderr=%s", probe.file, code, errText)
+      }
+      data, err := os.ReadFile(outPath)
+      if err != nil {
+        t.Fatalf("`--output js` published no artifact for %s: %v", probe.file, err)
+      }
+      text := string(data)
+      if !strings.Contains(text, probe.carries) {
+        t.Fatalf("published artifact does not carry %s's validator:\n%s", probe.file, text)
+      }
+      if strings.Contains(text, probe.rejects) {
+        t.Fatalf("published artifact carries the same-basename sibling's validator:\n%s", text)
+      }
+    })
+  }
+}

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_empty_emit_reports_no_output_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_empty_emit_reports_no_output_test.go
@@ -14,7 +14,7 @@ import (
 // can belong to the program and still have no JavaScript of its own, and the
 // caller needs exit 3 rather than an empty file behind exit 0. Every probe puts
 // a real artifact for a sibling source through the same write callback, so a
-// check that stopped discriminating would capture that neighbour and report
+// check that stopped discriminating would capture that neighbor and report
 // success. The three probes reach the outcome by different routes -- an emit
 // that skips the file, an emit that withholds it, and a file the resolution
 // gives no output path at all -- so no one of them stands in for the others.

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_empty_emit_reports_no_output_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_empty_emit_reports_no_output_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+  "os"
   "path/filepath"
   "strings"
   "testing"
@@ -24,7 +25,8 @@ import (
 //     land outside `outDir` and is therefore withheld by the emit.
 //  3. Ask for the JavaScript of a JSON module that would be emitted over
 //     itself, which resolves to no JavaScript output path.
-//  4. Require exit 3 and the "no output produced" report in all three.
+//  4. Require exit 3, the "no output produced" report, and an unwritten `--out`
+//     in all three.
 func TestTransformSingleFileJSEmptyEmitReportsNoOutput(t *testing.T) {
   for _, probe := range []struct {
     name    string
@@ -86,6 +88,12 @@ func TestTransformSingleFileJSEmptyEmitReportsNoOutput(t *testing.T) {
       }
       if !strings.Contains(errText, "no output produced") {
         t.Fatalf("an empty emit must still report the cause:\n%s", errText)
+      }
+      // An empty emit leaves runTransformSingle through `if code != 0`, a
+      // different branch than the diagnostic route the atomicity case pins, so
+      // withholding the artifact needs its own check here.
+      if _, err := os.Stat(outPath); !os.IsNotExist(err) {
+        t.Fatalf("an empty emit must publish nothing, but --out exists: %v", err)
       }
     })
   }

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_empty_emit_reports_no_output_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_empty_emit_reports_no_output_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestTransformSingleFileJSEmptyEmitReportsNoOutput verifies the negative twin
+// of the `--output js` artifact match.
+//
+// Teaching the match where an `outDir` puts an artifact must not turn it into a
+// match that always succeeds. "No output produced" is a real outcome: a source
+// can belong to the program and still have no JavaScript of its own, and the
+// caller needs exit 3 rather than an empty file behind exit 0. Every probe puts
+// a real artifact for a sibling source through the same write callback, so a
+// check that stopped discriminating would capture that neighbour and report
+// success. The three probes reach the outcome by different routes -- an emit
+// that skips the file, an emit that withholds it, and a file the resolution
+// gives no output path at all -- so no one of them stands in for the others.
+//
+//  1. Ask for the JavaScript of a declaration source, which the emit skips.
+//  2. Ask for the JavaScript of a source outside `rootDir`, whose output would
+//     land outside `outDir` and is therefore withheld by the emit.
+//  3. Ask for the JavaScript of a JSON module that would be emitted over
+//     itself, which resolves to no JavaScript output path.
+//  4. Require exit 3 and the "no output produced" report in all three.
+func TestTransformSingleFileJSEmptyEmitReportsNoOutput(t *testing.T) {
+  for _, probe := range []struct {
+    name    string
+    extra   []string
+    sources map[string]string
+    file    string
+  }{
+    // A declaration source is in the program but never emitted, so no write
+    // ever arrives for the path it resolves to.
+    {
+      name:  "declaration_source",
+      extra: []string{`"rootDir": "src"`, `"outDir": "dist"`},
+      sources: map[string]string{
+        "src/types.d.ts": "export declare const value: string;\n",
+        "src/main.ts":    transformSingleFileValidSource,
+      },
+      file: "src/types.d.ts",
+    },
+    // A source outside `rootDir` resolves to an output outside `outDir`, which
+    // the emit refuses to write rather than escaping the output tree. The
+    // source is ordinary TypeScript that transforms fine, so only the absent
+    // write distinguishes it -- exactly the state the check exists to report.
+    {
+      name:  "output_escapes_out_dir",
+      extra: []string{`"rootDir": "src/deep"`, `"outDir": "dist"`},
+      sources: map[string]string{
+        "src/deep/main.ts": transformSingleFileValidSource,
+        "src/stray.ts":     transformSingleFileValidSource,
+      },
+      file: "src/stray.ts",
+    },
+    // A JSON module with no `outDir` would be emitted over its own source, so
+    // the compiler resolves it to no JavaScript output path at all. This is the
+    // one route that reaches the empty-path guard rather than an absent write.
+    {
+      name:  "json_module_emitted_over_itself",
+      extra: []string{`"resolveJsonModule": true`},
+      sources: map[string]string{
+        "src/data.json": "{ \"value\": 1 }\n",
+        "src/main.ts":   "import data from \"./data.json\";\nexport const value = data.value;\n",
+      },
+      file: "src/data.json",
+    },
+  } {
+    t.Run(probe.name, func(t *testing.T) {
+      project := transformSingleFileLayoutProject(t, probe.extra, probe.sources)
+      outPath := filepath.Join(project, "artifact", "main.js")
+      _, errText, code := ttscTypiaTestCapture(func() int {
+        return runTransform([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--file", filepath.FromSlash(probe.file),
+          "--output", "js",
+          "--out", outPath,
+        })
+      })
+      if code != 3 {
+        t.Fatalf("an empty emit must still fail with code 3, got %d\nstderr=%s", code, errText)
+      }
+      if !strings.Contains(errText, "no output produced") {
+        t.Fatalf("an empty emit must still report the cause:\n%s", errText)
+      }
+    })
+  }
+}

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_locates_output_across_layouts_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_locates_output_across_layouts_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestTransformSingleFileJSLocatesOutputAcrossLayouts verifies `--output js`
+// finds its artifact wherever the compiler places the emit.
+//
+// `transformSingleToJavaScript` captures the emit by matching the write callback
+// against the requested source. Comparing whole path stems made that match ask
+// whether `dist/main` equals `src/main`, so every project with an `outDir` --
+// which is every realistic layout -- reported "no output produced" and exited 3
+// over a transform that had in fact succeeded (samchon/typia#2134). `outDir` is
+// only one of the settings that reposition an emit, so this pins the whole class
+// rather than the reported witness: the match must come from the compiler's own
+// output-path resolution, the same one the emitter uses to choose where to
+// write, so no combination of `outDir`, `rootDir`, `rootDirs`, or source nesting
+// can desynchronize the two.
+//
+//  1. Build the same typia-valid source under each output-path layout.
+//  2. Transform it with `--output js --out`.
+//  3. Require exit 0, a silent stderr, and a published artifact carrying the
+//     lowered validator rather than the untransformed call.
+func TestTransformSingleFileJSLocatesOutputAcrossLayouts(t *testing.T) {
+  for _, layout := range []struct {
+    name  string
+    extra []string
+    file  string
+  }{
+    // The reported regression. With no `rootDir` the common source directory is
+    // the tsconfig's own directory, so the emit lands at `dist/src/main.js`.
+    {
+      name:  "out_dir",
+      extra: []string{`"outDir": "dist"`},
+      file:  "src/main.ts",
+    },
+    // `rootDir` re-bases the emit again, to `dist/main.js`, so a fix keyed on
+    // `outDir` alone would still put the artifact somewhere else than expected.
+    {
+      name:  "root_dir_and_out_dir",
+      extra: []string{`"rootDir": "src"`, `"outDir": "dist"`},
+      file:  "src/main.ts",
+    },
+    // Nesting below the root dir carries into the output as `dist/deep/nested/
+    // main.js`: the emitted path differs from the source path in more than its
+    // leading directory.
+    {
+      name:  "nested_source_directory",
+      extra: []string{`"rootDir": "src"`, `"outDir": "dist"`},
+      file:  "src/deep/nested/main.ts",
+    },
+    // `rootDirs` is a module-resolution feature and must not reposition the
+    // emit. Pin that the resolution agrees instead of assuming it.
+    {
+      name:  "root_dirs_and_out_dir",
+      extra: []string{`"rootDirs": ["src", "generated"]`, `"outDir": "dist"`},
+      file:  "src/main.ts",
+    },
+    // The one layout that already worked, because the emit lands beside its
+    // source. It must keep working.
+    {
+      name:  "no_out_dir",
+      extra: nil,
+      file:  "src/main.ts",
+    },
+  } {
+    t.Run(layout.name, func(t *testing.T) {
+      project := transformSingleFileLayoutProject(t, layout.extra, map[string]string{
+        layout.file: transformSingleFileValidSource,
+      })
+      outPath := filepath.Join(project, "artifact", "main.js")
+      _, errText, code := ttscTypiaTestCapture(func() int {
+        return runTransform([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--file", filepath.FromSlash(layout.file),
+          "--output", "js",
+          "--out", outPath,
+        })
+      })
+      if code != 0 {
+        t.Fatalf("`--output js` should publish under this layout, got %d\nstderr=%s", code, errText)
+      }
+      if errText != "" {
+        t.Fatalf("`--output js` reported diagnostics under this layout:\n%s", errText)
+      }
+      data, err := os.ReadFile(outPath)
+      if err != nil {
+        t.Fatalf("`--output js` published no artifact: %v", err)
+      }
+      text := string(data)
+      if strings.Contains(text, "typia.is<") {
+        t.Fatalf("published artifact still carries the untransformed call:\n%s", text)
+      }
+      if !strings.Contains(text, `"number"`) {
+        t.Fatalf("published artifact does not carry the lowered validator:\n%s", text)
+      }
+    })
+  }
+}
+
+// transformSingleFileLayoutProject writes a project whose tsconfig carries the
+// given extra `compilerOptions` entries and whose sources are the given
+// project-relative slash paths, sharing the typia stub the other transform
+// fixtures use. It exists so one fixture can vary only the output-path settings.
+func transformSingleFileLayoutProject(
+  t *testing.T,
+  extra []string,
+  sources map[string]string,
+) string {
+  t.Helper()
+  project := t.TempDir()
+  options := append([]string{
+    `"target": "ES2022"`,
+    `"module": "commonjs"`,
+    `"moduleResolution": "bundler"`,
+    `"ignoreDeprecations": "6.0"`,
+    `"types": ["*"]`,
+    `"esModuleInterop": true`,
+    `"strict": true`,
+    `"skipLibCheck": true`,
+  }, extra...)
+  tsconfig := "{\n  \"compilerOptions\": {\n    " +
+    strings.Join(options, ",\n    ") +
+    "\n  },\n  \"include\": [\"src\"]\n}\n"
+  if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(tsconfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  transformDiagnosticWriteTypiaStub(t, project)
+  for rel, body := range sources {
+    path := filepath.Join(project, filepath.FromSlash(rel))
+    if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+      t.Fatalf("mkdir %s: %v", rel, err)
+    }
+    if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", rel, err)
+    }
+  }
+  return project
+}

--- a/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_locates_output_across_layouts_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_single_file_js_locates_output_across_layouts_test.go
@@ -60,6 +60,22 @@ func TestTransformSingleFileJSLocatesOutputAcrossLayouts(t *testing.T) {
       extra: []string{`"rootDirs": ["src", "generated"]`, `"outDir": "dist"`},
       file:  "src/main.ts",
     },
+    // One source, three writes through the one callback: `dist/main.js`,
+    // `dist/main.js.map`, and `dist/main.d.ts`. Finding the artifact is not
+    // enough here -- the check has to tell it apart from its own siblings. The
+    // map is the trap, since its `sourcesContent` embeds the original
+    // TypeScript, so capturing it would publish text still carrying
+    // `typia.is<` behind exit 0.
+    {
+      name: "declaration_and_source_map",
+      extra: []string{
+        `"rootDir": "src"`,
+        `"outDir": "dist"`,
+        `"declaration": true`,
+        `"sourceMap": true`,
+      },
+      file: "src/main.ts",
+    },
     // The one layout that already worked, because the emit lands beside its
     // source. It must keep working.
     {


### PR DESCRIPTION
Implements #2134.

## Intent

`ttsc-typia transform --file <f> --output js` reports `no output produced` and exits `3` for **any project with an `outDir`**, even though the transform succeeded and the emit wrote the artifact. The mode is unusable for any realistic project layout.

The cause is entirely in the post-emit identity check. `sameSourceStem` compares **whole path stems**, so it asks whether `<p>/dist/main` equals `<p>/src/main` — which it never does once `outDir` redirects the emit. The check's own comment at `transform.go:233` says it matches "on basename stem", which is what would have worked.

Verified with a single-variable control — same source, only `outDir` differing:

| Project | Result on master |
| --- | --- |
| valid source **with** `outDir` | **exit 3, `no output produced`** |
| identical source **without** `outDir` | exit 0, 500 bytes emitted |

## Approach

The invariant: **the check identifies the emitted artifact that corresponds to the requested source file, regardless of where `outDir` places it.**

The fix does not stop at making the comment true. A bare basename comparison would still be wrong: `rootDir`, `rootDirs`, and nested source directories all reposition the emitted path independently of `outDir`, and two sources with the same basename in different directories would collide into one another under a basename match. Instead, `transformSingleToJavaScript` asks the **compiler's own output-path resolution** — the same `outputpaths` computation the emitter itself uses to choose where to write — for the JS path belonging to the target source, and matches the emit callback against that resolved path.

That makes the check exact rather than heuristic: it is right for every `outDir` / `rootDir` / `rootDirs` / nested-directory combination by construction, because it is the emitter's own answer, and two same-basename sources in different directories resolve to different output paths and cannot be confused.

The check keeps its real job. When the emit genuinely produces no artifact for the requested file — a declaration-only source, for instance — no write ever arrives for the resolved path, `found` stays false, and the host still exits `3` with `no output produced`.

## Scope

- `packages/typia/native/cmd/ttsc-typia/transform.go` — resolve the expected output path from the compiler; `sameSourceStem` is removed.
- Regression matrix pinning the issue's full case matrix, including the negative twin and the same-basename collision boundary.
- **Removes the workaround this unblocks.** #2120's `transform_single_file_*` fixture omitted `outDir` *because of this bug*, with a comment saying so. The fixture now carries an `outDir`, and the comment is gone — otherwise the coverage would stay shaped around the defect.

## Verification

Pending; recorded on this thread as it completes. Campaign CI is suspended per `.agents/skills/issue-campaign/development.md`; verification is local.

## Deferred / coordination

- **The `typia` version bump is pending lead assignment.** This changes native Go under `packages/typia/native`, so Change Integrity requires a bump; the campaign lead serializes the version across the chain, so this branch deliberately does not pick one and is not rebased onto master.
- #2117's diagnostic gate (PR #2120) is untouched: it is the check that runs *before* publishing; this is the identity check that runs after a successful transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
