### PR TITLE
fix(utils): make NamingConvention.localize total and select automated structures by declaration

### DIFF
--- a/packages/utils/src/utils/NamingConvention.ts
+++ b/packages/utils/src/utils/NamingConvention.ts
@@ -136,7 +136,8 @@ export namespace NamingConvention {
    * @param str Input string
    * @returns Localized string
    */
-  export const localize = (str: string) => str[0]!.toLowerCase() + str.slice(1);
+  export const localize = (str: string): string =>
+    str.length !== 0 ? str[0]!.toLowerCase() + str.slice(1) : str;
 
   /**
    * Check if string is valid JavaScript variable name.

--- a/tests/template/src/structures/TypeTagRange.ts
+++ b/tests/template/src/structures/TypeTagRange.ts
@@ -61,6 +61,14 @@ export namespace TypeTagRange {
   export const MINIMUM = 3;
   export const MAXIMUM = 7;
 
+  /**
+   * Boundary spoilers, one step outside each tag's bound.
+   *
+   * Every spoiled value is the nearest integer a correct validator must never
+   * accept: `3` against `ExclusiveMinimum<3>`, `7` against `ExclusiveMaximum<7>`,
+   * and `9` against the `equal` pair. A validator that compares with the wrong
+   * strictness passes the ordinary generated value and fails only here.
+   */
   export const SPOILERS: Spoiler<TypeTagRange>[] = [
     (input) => {
       input.value[4]!.greater = 3;

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -4,7 +4,7 @@
   "version": "13.1.1",
   "description": "Automated test features of openapi.",
   "scripts": {
-    "prestart": "ttsx src/regressions/test_process_fatal_events.ts",
+    "prestart": "ttsx src/regressions/test_process_fatal_events.ts && ttsx src/regressions/test_structure_selection_ignores_prose.ts",
     "start": "ttsx src/index.ts"
   },
   "repository": {

--- a/tests/test-utils-automated/src/TestAutomation.ts
+++ b/tests/test-utils-automated/src/TestAutomation.ts
@@ -1,3 +1,4 @@
+import * as template from "@typia/template";
 import { dedent } from "@typia/utils";
 import fs from "fs";
 
@@ -58,10 +59,50 @@ export namespace TestAutomation {
     );
   };
 
-  const getStructures = async (equals: boolean): Promise<string[]> => {
+  /**
+   * Structures the OpenAPI validate matrix cannot cover yet.
+   *
+   * Each entry names a `typia.json.schema` output that `OpenApiValidator` does
+   * not round-trip faithfully, so the fixture is skipped rather than asserted.
+   * The reason is recorded per fixture because it is a property of the
+   * validator's coverage, not of the fixture: nothing about `DynamicSimple`
+   * makes it unfit to be a fixture, only the validator's handling of the
+   * `additionalProperties` schema its type produces.
+   *
+   * These replace the source-text scans (`"never"`, `"[key: "`, `'<"uint32">'`)
+   * this selector used to run over each fixture's raw file, where a doc comment
+   * that merely mentioned one of those words silently changed matrix membership
+   * (#2136). Membership is byte-identical to those scans.
+   *
+   * Four entries are marked `passes today`: they were excluded when the matrix
+   * was introduced (#1736) and now validate cleanly against their own spoilers.
+   * They stay listed because admitting them changes *which* structures the
+   * matrix covers, which is a separate decision from *how* they are selected.
+   */
+  const UNVALIDATABLE: Record<string, string> = {
+    // `additionalProperties` from an index signature
+    DynamicArray: "index signature; passes today",
+    DynamicComposite: "index signature",
+    DynamicNever: "index signature over a `never` member",
+    DynamicSimple: "index signature; passes today",
+    DynamicTemplate: "index signature",
+    DynamicUndefined: "index signature",
+    DynamicUnion: "index signature",
+    ObjectDynamic: "index signature; passes today",
+    // a `never` member erased from the emitted schema
+    ObjectUndefined: "`never` member",
+    // integer format tags the validator does not enforce
+    ConstantAtomicTagged: "uint32 tag; passes today",
+    TemplateInterpolationTagged: "uint32 tag",
+    TypeTagType: "uint32 and uint64 tags",
+  };
+
+  export const getStructures = async (equals: boolean): Promise<string[]> => {
     const directory: string[] = await fs.promises.readdir(
       `${TestGlobal.ROOT}/../template/src/structures`,
     );
+    const declarations: Record<string, IStructureDeclaration> =
+      template as unknown as Record<string, IStructureDeclaration>;
     const result: string[] = [];
     for (const file of directory) {
       if (
@@ -72,23 +113,43 @@ export namespace TestAutomation {
         file.startsWith("ToJson")
       )
         continue;
-      const content: string = await fs.promises.readFile(
-        `${TestGlobal.ROOT}/../template/src/structures/${file}`,
-        "utf-8",
-      );
-      if (
-        content.includes("JSONABLE = false") ||
-        content.includes("JSONABLE: boolean = false") ||
-        content.includes("[key: ") ||
-        content.includes("never") ||
-        content.includes("toJSON") ||
-        content.includes('<"uint32">') ||
-        content.includes('<"uint64">') ||
-        (equals === true && content.includes("ADDABLE = false"))
-      )
-        continue;
-      result.push(file.substring(0, file.length - 3));
+      const name: string = file.substring(0, file.length - 3);
+      const structure: IStructureDeclaration | undefined = declarations[name];
+      if (structure === undefined)
+        throw new Error(`@typia/template does not export ${name}`);
+      // Read what the fixture declares about itself, so that prose cannot
+      // decide the matrix. `JSONABLE === false` marks a type whose value has no
+      // faithful JSON form.
+      if (structure.JSONABLE === false) continue;
+      else if (UNVALIDATABLE[name] !== undefined) continue;
+      // `ADDABLE` is still read from source text, and deliberately so: four
+      // fixtures spell it `ADDABLE: boolean = false`, which this scan does not
+      // match, so they sit in the equality matrix despite declaring otherwise.
+      // Reading the declaration instead would drop them — and two of the four
+      // (ArrayRepeatedUnion, ArrayRepeatedUnionWithTuple) assert 270 superfluous
+      // paths each, so the "faithful" read silently deletes real coverage. That
+      // is a decision about *which* structures the matrix covers, so it is left
+      // to #2136's follow-up rather than smuggled in behind a refactor.
+      else if (equals === true) {
+        const content: string = await fs.promises.readFile(
+          `${TestGlobal.ROOT}/../template/src/structures/${file}`,
+          "utf-8",
+        );
+        if (content.includes("ADDABLE = false")) continue;
+      }
+      result.push(name);
     }
     return result;
   };
+}
+
+/**
+ * The part of a `@typia/template` structure this selector reads.
+ *
+ * Mirrors `TestAutomationMetadata` in `test-typia-automated`, which narrows the
+ * same namespaces to the flags its own matrix consumes. Only declared members
+ * belong here: a flag this selector does not read would be dead configuration.
+ */
+interface IStructureDeclaration {
+  JSONABLE?: boolean;
 }

--- a/tests/test-utils-automated/src/TestAutomation.ts
+++ b/tests/test-utils-automated/src/TestAutomation.ts
@@ -116,14 +116,17 @@ export namespace TestAutomation {
       )
         continue;
       const name: string = file.substring(0, file.length - 3);
-      const structure: IStructureDeclaration | undefined = declarations[name];
-      if (structure === undefined)
+      // `Object.hasOwn`, not a truthiness test: a fixture named after an
+      // `Object.prototype` member would otherwise resolve against the prototype
+      // and be held out silently — the very failure this selector is shedding.
+      if (Object.hasOwn(declarations, name) === false)
         throw new Error(`@typia/template does not export ${name}`);
+      const structure: IStructureDeclaration = declarations[name]!;
       // Read what the fixture declares about itself, so that prose cannot
       // decide the matrix. `JSONABLE === false` marks a type whose value has no
       // faithful JSON form.
       if (structure.JSONABLE === false) continue;
-      else if (HELD_OUT[name] !== undefined) continue;
+      else if (Object.hasOwn(HELD_OUT, name)) continue;
       // `ADDABLE` is still read from source text, and deliberately so: four
       // fixtures spell it `ADDABLE: boolean = false`, which this scan does not
       // match, so they sit in the equality matrix despite declaring otherwise.

--- a/tests/test-utils-automated/src/TestAutomation.ts
+++ b/tests/test-utils-automated/src/TestAutomation.ts
@@ -60,26 +60,28 @@ export namespace TestAutomation {
   };
 
   /**
-   * Structures the OpenAPI validate matrix cannot cover yet.
+   * Structures held out of the OpenAPI validate matrix, and the type feature
+   * each was held out for.
    *
-   * Each entry names a `typia.json.schema` output that `OpenApiValidator` does
-   * not round-trip faithfully, so the fixture is skipped rather than asserted.
-   * The reason is recorded per fixture because it is a property of the
-   * validator's coverage, not of the fixture: nothing about `DynamicSimple`
-   * makes it unfit to be a fixture, only the validator's handling of the
-   * `additionalProperties` schema its type produces.
+   * This replaces three source-text scans (`"never"`, `"[key: "`, `'<"uint32">'`)
+   * that the selector ran over each fixture's raw file. Matching source text
+   * means prose decides coverage: a doc comment that merely mentioned one of
+   * those words dropped a structure from the matrix silently, with nothing to
+   * observe (#2136). The set below reproduces those three scans exactly — the
+   * same 148 structures resolve to the same 83 validate and 80 equality cases.
    *
-   * These replace the source-text scans (`"never"`, `"[key: "`, `'<"uint32">'`)
-   * this selector used to run over each fixture's raw file, where a doc comment
-   * that merely mentioned one of those words silently changed matrix membership
-   * (#2136). Membership is byte-identical to those scans.
+   * The reason belongs here rather than on the fixture because it describes
+   * `OpenApiValidator`'s coverage, not the fixture: nothing about
+   * `DynamicSimple` makes it unfit to be a fixture, only what the validator
+   * does with the `additionalProperties` schema its type produces.
    *
-   * Four entries are marked `passes today`: they were excluded when the matrix
-   * was introduced (#1736) and now validate cleanly against their own spoilers.
-   * They stay listed because admitting them changes *which* structures the
-   * matrix covers, which is a separate decision from *how* they are selected.
+   * Eight entries fail today if admitted, so they are genuine validator gaps.
+   * The four marked `passes today` are measured to validate cleanly against
+   * their own spoilers, and are held out only because admitting them changes
+   * *which* structures the matrix covers — a separate decision from *how* they
+   * are selected, left to #2136's follow-up.
    */
-  const UNVALIDATABLE: Record<string, string> = {
+  const HELD_OUT: Record<string, string> = {
     // `additionalProperties` from an index signature
     DynamicArray: "index signature; passes today",
     DynamicComposite: "index signature",
@@ -121,7 +123,7 @@ export namespace TestAutomation {
       // decide the matrix. `JSONABLE === false` marks a type whose value has no
       // faithful JSON form.
       if (structure.JSONABLE === false) continue;
-      else if (UNVALIDATABLE[name] !== undefined) continue;
+      else if (HELD_OUT[name] !== undefined) continue;
       // `ADDABLE` is still read from source text, and deliberately so: four
       // fixtures spell it `ADDABLE: boolean = false`, which this scan does not
       // match, so they sit in the equality matrix despite declaring otherwise.

--- a/tests/test-utils-automated/src/regressions/test_structure_selection_ignores_prose.ts
+++ b/tests/test-utils-automated/src/regressions/test_structure_selection_ignores_prose.ts
@@ -21,26 +21,28 @@ import { TestGlobal } from "../TestGlobal";
  * 2. Resolve the validate and the equality matrices.
  * 3. Require the witness to remain in both.
  */
-export const test_structure_selection_ignores_prose = async (): Promise<void> => {
-  const WITNESS = "TypeTagRange";
-  const source: string = await fs.promises.readFile(
-    `${TestGlobal.ROOT}/../template/src/structures/${WITNESS}.ts`,
-    "utf-8",
-  );
-  // Exactly the condition the removed `content.includes("never")` scan tested,
-  // so the guard tracks the real trigger rather than a paraphrase of it.
-  TestValidator.equals(
-    `${WITNESS} still carries prose the old selector matched`,
-    source.includes("never") && WITNESS.includes("never") === false,
-    true,
-  );
-  for (const equals of [false, true])
+export const test_structure_selection_ignores_prose =
+  async (): Promise<void> => {
+    const WITNESS = "TypeTagRange";
+    const source: string = await fs.promises.readFile(
+      `${TestGlobal.ROOT}/../template/src/structures/${WITNESS}.ts`,
+      "utf-8",
+    );
+    // The witness word must come from the fixture's prose, not from its type:
+    // `must never` appears only in the doc comment, while the removed scan
+    // tested `includes("never")` and so matched that sentence.
     TestValidator.equals(
-      `${WITNESS} stays in the ${equals ? "equality" : "validate"} matrix`,
-      (await TestAutomation.getStructures(equals)).includes(WITNESS),
+      `${WITNESS} still carries prose the old selector matched`,
+      source.includes("must never"),
       true,
     );
-};
+    for (const equals of [false, true])
+      TestValidator.equals(
+        `${WITNESS} stays in the ${equals ? "equality" : "validate"} matrix`,
+        (await TestAutomation.getStructures(equals)).includes(WITNESS),
+        true,
+      );
+  };
 
 test_structure_selection_ignores_prose().catch((error) => {
   console.log(error);

--- a/tests/test-utils-automated/src/regressions/test_structure_selection_ignores_prose.ts
+++ b/tests/test-utils-automated/src/regressions/test_structure_selection_ignores_prose.ts
@@ -1,0 +1,48 @@
+import { TestValidator } from "@nestia/e2e";
+import fs from "fs";
+
+import { TestAutomation } from "../TestAutomation";
+import { TestGlobal } from "../TestGlobal";
+
+/**
+ * Verifies fixture prose cannot decide automated matrix membership.
+ *
+ * `getStructures` used to select fixtures by matching raw source text, so a
+ * structure whose comments merely mentioned `never`, `toJSON`, `[key: `, or a
+ * `uint32`/`uint64` tag silently left the validate matrix with no signal —
+ * coverage loss that no assertion could observe (#2136). `TypeTagRange` carries
+ * a doc comment that legitimately reads "must never accept", which the old
+ * `content.includes("never")` scan would match, dropping it from both matrices.
+ *
+ * The guard runs first on purpose: it fails if that prose ever disappears, so
+ * this case cannot quietly decay into an oracle that proves nothing.
+ *
+ * 1. Require the witness fixture to still carry a previously filtered word.
+ * 2. Resolve the validate and the equality matrices.
+ * 3. Require the witness to remain in both.
+ */
+export const test_structure_selection_ignores_prose = async (): Promise<void> => {
+  const WITNESS = "TypeTagRange";
+  const source: string = await fs.promises.readFile(
+    `${TestGlobal.ROOT}/../template/src/structures/${WITNESS}.ts`,
+    "utf-8",
+  );
+  // Exactly the condition the removed `content.includes("never")` scan tested,
+  // so the guard tracks the real trigger rather than a paraphrase of it.
+  TestValidator.equals(
+    `${WITNESS} still carries prose the old selector matched`,
+    source.includes("never") && WITNESS.includes("never") === false,
+    true,
+  );
+  for (const equals of [false, true])
+    TestValidator.equals(
+      `${WITNESS} stays in the ${equals ? "equality" : "validate"} matrix`,
+      (await TestAutomation.getStructures(equals)).includes(WITNESS),
+      true,
+    );
+};
+
+test_structure_selection_ignores_prose().catch((error) => {
+  console.log(error);
+  process.exit(-1);
+});

--- a/tests/test-utils/src/features/naming/test_naming_convention_empty.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_empty.ts
@@ -1,0 +1,29 @@
+import { TestValidator } from "@nestia/e2e";
+import { NamingConvention } from "@typia/utils";
+
+/**
+ * Verifies every NamingConvention string helper is total over the empty string.
+ *
+ * The helpers are siblings of one contract, so a caller that picks one by name
+ * must not discover that a single member throws where the rest return `""`.
+ * `localize` was exactly that outlier (#2136). Asserting the whole family in one
+ * place makes the shared boundary a property of the namespace rather than of
+ * whichever helper happened to be tested, so a future helper cannot quietly
+ * reintroduce a partial member.
+ *
+ * 1. Collect every helper that maps a string to a string.
+ * 2. Apply each to the empty string.
+ * 3. Require `""` from all of them, with no throw.
+ */
+export const test_naming_convention_empty = (): void => {
+  const helpers: [string, (str: string) => string][] = [
+    ["camel", NamingConvention.camel],
+    ["pascal", NamingConvention.pascal],
+    ["snake", NamingConvention.snake],
+    ["kebab", NamingConvention.kebab],
+    ["capitalize", NamingConvention.capitalize],
+    ["localize", NamingConvention.localize],
+  ];
+  for (const [name, convert] of helpers)
+    TestValidator.equals(`${name}("")`, convert(""), "");
+};

--- a/tests/test-utils/src/features/naming/test_naming_convention_localize.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_localize.ts
@@ -1,0 +1,37 @@
+import { TestValidator } from "@nestia/e2e";
+import { NamingConvention } from "@typia/utils";
+
+/**
+ * Verifies NamingConvention.localize lowercases the first character only.
+ *
+ * `localize` asserted `str[0]!` without ever checking for it, so the empty
+ * string raised a `TypeError` while all five sibling helpers returned `""`
+ * (#2136). No in-repo caller could reach that branch — every call site guards on
+ * `method.startsWith("create")` — but `@typia/utils` is published, and an
+ * external caller has no such guard. Pins the boundary alongside the ordinary
+ * conversions so the total contract cannot regress to a partial one.
+ *
+ * 1. Localize ordinary capitalized, already-lowercase, and single-character
+ *    inputs.
+ * 2. Localize inputs whose tail must survive untouched, including acronym runs.
+ * 3. Localize the empty string and require `""` rather than a throw.
+ */
+export const test_naming_convention_localize = (): void => {
+  const expectations: [string, string][] = [
+    ["Is", "is"],
+    ["Assert", "assert"],
+    ["ValidateEquals", "validateEquals"],
+    ["already", "already"],
+    ["A", "a"],
+    ["XMLParser", "xMLParser"],
+    ["_private", "_private"],
+    ["1st", "1st"],
+    ["", ""],
+  ];
+  for (const [input, expected] of expectations)
+    TestValidator.equals(
+      `localize(${JSON.stringify(input)})`,
+      NamingConvention.localize(input),
+      expected,
+    );
+};


### PR DESCRIPTION
## Intent

Close #2136. Two independent gaps, each kept at the size its evidence supports — neither is a live defect, and this body does not imply otherwise.

## Gap 1 — `NamingConvention.localize("")` threw

`str[0]!.toLowerCase()` asserted a character that is not there, while all five siblings (`capitalize`, `camel`, `snake`, `kebab`, `pascal`) already returned `""`. `localize` is now total in the same shape as `capitalize`, one line away in the same file.

**This is a public-API robustness and consistency gap, not a live in-repo defect.** No in-repo caller can reach it: `localize`'s only callers are the three in `write_common.ts`, each guarded by `p.method.startsWith("create")`, and `TestAutomationTemplate` builds methods as `` `create${capitalize(tpl.method)}` `` — so it always receives a non-empty capitalized remainder. It is worth fixing because `@typia/utils` is published and an external caller has no such guard, and because PR #2114 rewrote this exact file and left it.

Traced past the one witness rather than patching it: every other `[0]!` in `@typia/utils` is already length-guarded, so `localize` was the sole outlier and the class is closed, not the instance.

## Gap 2 — the automated selector matched raw source text

`getStructures` chose fixtures with `content.includes("never")`, `includes("toJSON")`, `includes('<"uint32">')`, and `includes("[key: ")` over each fixture's **raw file**, so prose decided coverage. It now reads each fixture's `JSONABLE` declaration — the same source `test-typia-automated` already reads — plus an explicit, per-fixture-reasoned held-out set. No scan for a word in a comment remains.

**Latent, not live.** Measured across all 148 structures: zero comment-only matches today, both `never` hits being genuine types. Nothing was being dropped; the mechanism was simply able to.

**This is a refactor of *how* structures are selected, not *which*.** Membership is byte-identical — `validate 83 = 83`, `validateEquals 80 = 80` — verified after every change.

### The dead predicates: three, not two

Measured marginally rather than assumed, and the issue's count moved in both directions. `toJSON` and `'<"uint64">'` excluded **zero** structures each and are removed; the annotated `JSONABLE: boolean = false` variant also excluded zero and is subsumed by reading the declaration. But `"JSONABLE = false"` excludes **41** structures and is very much alive — the issue's "JSONABLE drops zero" holds only for the annotated variant. It was kept. The per-predicate table is on the thread.

### What is deliberately not fixed here

`ADDABLE` still reads source text, and the comment at that line says why: four fixtures spell it `ADDABLE: boolean = false`, which the scan misses, so they sit in the equality matrix against their own declaration. Reading the declaration would drop them — and two assert **270 superfluous paths each**, so the "faithful" read silently deletes real coverage. That is a *which* decision, so it is reported on the thread, not smuggled in behind a refactor. Four held-out entries are likewise marked `passes today` rather than quietly admitted.

## Verification

Recorded on the thread: `test-utils`, `test-utils-automated`, `test-typia-automated`, `test-feature-identity`, and `packages/utils build` all pass. Both gaps have fail-then-pass evidence, and the gap-2 negative is proven to fail against the old selector rather than merely pass against the new one.

No product change beyond the `@typia/utils` fix, and no version bump: no Go source under `packages/typia/native` changed.

## Campaign CI

Campaign CI for each pushed SHA is cancelled at the exact-SHA gate; local verification is the gate.

Closes #2136
