### PR TITLE
fix(typia): hold every Protobuf reader fault to one prefix and one varint limit

### DIFF
--- a/packages/typia/src/internal/_ProtobufReader.ts
+++ b/packages/typia/src/internal/_ProtobufReader.ts
@@ -82,9 +82,7 @@ export class _ProtobufReader {
     try {
       return decoder.decode(bytes);
     } catch {
-      throw new Error(
-        "Error on typia.protobuf.decode(): invalid UTF-8 string.",
-      );
+      throw error("invalid UTF-8 string.");
     }
   }
 
@@ -99,8 +97,7 @@ export class _ProtobufReader {
   }
 
   public close(previous: number): void {
-    if (this.ptr !== this.end)
-      throw new Error("Error on typia.protobuf.decode(): buffer overflow.");
+    if (this.ptr !== this.end) throw error("buffer overflow.");
     this.end = previous;
   }
 
@@ -109,10 +106,19 @@ export class _ProtobufReader {
     this.take(length);
   }
 
-  /** Advance by exactly one varint, which carries no length prefix. */
+  /**
+   * Advance by exactly one varint, which carries no length prefix.
+   *
+   * A varint terminates at its first byte without the continuation bit, and may
+   * occupy no more than {@link VARINT_MAX_BYTES}. Reading past that limit would
+   * accept a varint that `varint32` and `varint64` could not, making the limit
+   * depend on which method happens to consume the value.
+   */
   public skipVarint(): void {
     this.atomic(() => {
-      while (this.u8() & 0x80);
+      for (let i: number = 0; i < VARINT_MAX_BYTES; ++i)
+        if ((this.u8() & 0x80) === 0) return;
+      throw error(`varint exceeds ${VARINT_MAX_BYTES} bytes.`);
     });
   }
 
@@ -136,9 +142,7 @@ export class _ProtobufReader {
           this.skip(4);
           break;
         default:
-          throw new Error(
-            `Invalid wire type ${wireType} at offset ${this.ptr}.`,
-          );
+          throw error(`invalid wire type ${wireType} at offset ${this.ptr}.`);
       }
     });
   }
@@ -227,10 +231,10 @@ export class _ProtobufReader {
     const end: number = this.end;
     try {
       return closure();
-    } catch (error) {
+    } catch (thrown) {
       this.ptr = index;
       this.end = end;
-      throw error;
+      throw thrown;
     }
   }
 
@@ -240,9 +244,28 @@ export class _ProtobufReader {
       length < 0 ||
       length > this.size() - this.ptr
     )
-      throw new Error("Error on typia.protobuf.decode(): buffer overflow.");
+      throw error("buffer overflow.");
   }
 }
+
+/**
+ * Builds every fault this reader raises, so each one names typia as its source.
+ *
+ * Every decode error a caller can see must be attributable, and the prefix is
+ * what attributes it. Composing it here rather than at each throw keeps a new
+ * fault from silently shipping without it.
+ */
+const error = (message: string): Error =>
+  new Error(`Error on typia.protobuf.decode(): ${message}`);
+
+/**
+ * The most bytes a varint may occupy: a 64-bit value in seven-bit groups.
+ *
+ * `varint32` and `varint64` hold this same limit structurally, by reading no
+ * further than their tenth byte. This constant is what a loop-driven consumer
+ * holds it by.
+ */
+const VARINT_MAX_BYTES = 10;
 
 const utf8 = new Singleton(
   () => new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }),

--- a/packages/typia/src/internal/_ProtobufReader.ts
+++ b/packages/typia/src/internal/_ProtobufReader.ts
@@ -166,7 +166,8 @@ export class _ProtobufReader {
     value |= ((loaded = this.u8()) & 0xf) << 28;
     if (loaded < 0x80) return value;
 
-    // increment position until there is no continuation bit or until we read 10 bytes
+    // increment position until there is no continuation bit, or until this read
+    // reaches VARINT_MAX_BYTES and the value can hold no further bits
     if (this.u8() < 0x80) return value;
     if (this.u8() < 0x80) return value;
     if (this.u8() < 0x80) return value;

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_unknown_field_faults.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_unknown_field_faults.ts
@@ -2,22 +2,22 @@ import typia from "typia";
 
 /**
  * Verifies generated Protobuf decoders attribute every unknown-field fault to
- * typia and bound an unknown varint at ten bytes.
+ * typia and bind an unknown varint to ten bytes.
  *
  * A generated decoder routes every field it does not know to the reader's
  * `skipType` with `tag & 0x07`, so a payload author reaches wire types 6 and 7
- * and a bare END_GROUP, none of which are skippable, and reaches the varint skip
- * with as many continuation bytes as they like. The first case must not surface
- * an anonymous error that no user can trace back to typia, and the second must
- * not accept a varint longer than a 64-bit value can occupy while `uint32` on
- * the very same buffer stops at ten.
+ * and a bare END_GROUP, none of which are skippable, and reaches the varint
+ * skip with as many continuation bytes as they like. The first case must not
+ * surface an anonymous error that no user can trace back to typia, and the
+ * second must not accept a varint longer than a 64-bit value can occupy while
+ * `uint32` on the very same buffer stops at ten.
  *
- * 1. Decode payloads whose unknown field declares each non-skippable wire type
- *    and assert the error names typia and the wire type.
+ * 1. Decode payloads whose unknown field declares each non-skippable wire type and
+ *    assert the error names typia and the wire type.
  * 2. Decode an unknown varint field of ten bytes and of eleven, asserting the
  *    first skips and the second is rejected.
- * 3. Assert every known field still survives an unknown field, and that the
- *    prefixed error reaches each throwing decoder factory alike.
+ * 3. Assert both faults surface identically from every decoder variant, and that a
+ *    known field, a valid payload, and the merged contracts are untouched.
  */
 export const test_protobuf_decode_unknown_field_faults = (): void => {
   // IValue field 1 = "a", then an unknown field 2 with the given wire type

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_unknown_field_faults.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_unknown_field_faults.ts
@@ -1,0 +1,121 @@
+import typia from "typia";
+
+/**
+ * Verifies generated Protobuf decoders attribute every unknown-field fault to
+ * typia and bound an unknown varint at ten bytes.
+ *
+ * A generated decoder routes every field it does not know to the reader's
+ * `skipType` with `tag & 0x07`, so a payload author reaches wire types 6 and 7
+ * and a bare END_GROUP, none of which are skippable, and reaches the varint skip
+ * with as many continuation bytes as they like. The first case must not surface
+ * an anonymous error that no user can trace back to typia, and the second must
+ * not accept a varint longer than a 64-bit value can occupy while `uint32` on
+ * the very same buffer stops at ten.
+ *
+ * 1. Decode payloads whose unknown field declares each non-skippable wire type
+ *    and assert the error names typia and the wire type.
+ * 2. Decode an unknown varint field of ten bytes and of eleven, asserting the
+ *    first skips and the second is rejected.
+ * 3. Assert every known field still survives an unknown field, and that the
+ *    prefixed error reaches each throwing decoder factory alike.
+ */
+export const test_protobuf_decode_unknown_field_faults = (): void => {
+  // IValue field 1 = "a", then an unknown field 2 with the given wire type
+  const unknown = (wire: number, ...payload: number[]): Uint8Array =>
+    Uint8Array.from([0x0a, 1, 0x61, (2 << 3) | wire, ...payload]);
+
+  //----
+  // NON-SKIPPABLE WIRE TYPES ARE ATTRIBUTED TO TYPIA
+  //----
+  for (const wire of [4, 6, 7])
+    assertMessage(
+      `unknown field with wire type ${wire}`,
+      `${PREFIX}invalid wire type ${wire} at offset 4.`,
+      () => typia.protobuf.decode<IValue>(unknown(wire)),
+    );
+
+  // A reader fault is a wire-framing failure rather than a validation failure,
+  // so it is raised rather than reported, and every decoder surfaces it alike.
+  // `isDecode` and `validateDecode` report a *type* mismatch by null or by a
+  // failure result; a payload that never decoded has no value to report on.
+  const decoders: Array<readonly [string, (input: Uint8Array) => unknown]> = [
+    ["decode", (input) => typia.protobuf.decode<IValue>(input)],
+    ["createDecode", typia.protobuf.createDecode<IValue>()],
+    ["assertDecode", (input) => typia.protobuf.assertDecode<IValue>(input)],
+    ["createAssertDecode", typia.protobuf.createAssertDecode<IValue>()],
+    ["isDecode", (input) => typia.protobuf.isDecode<IValue>(input)],
+    ["createIsDecode", typia.protobuf.createIsDecode<IValue>()],
+    ["validateDecode", (input) => typia.protobuf.validateDecode<IValue>(input)],
+    ["createValidateDecode", typia.protobuf.createValidateDecode<IValue>()],
+  ];
+  for (const [label, decode] of decoders) {
+    assertMessage(label, `${PREFIX}invalid wire type 6 at offset 4.`, () =>
+      decode(unknown(6)),
+    );
+    assertMessage(`${label} with an over-long varint`, OVERLONG, () =>
+      decode(unknown(0, ...continuations(10), 0x01)),
+    );
+  }
+
+  //----
+  // AN UNKNOWN VARINT IS BOUND TO TEN BYTES
+  //----
+  // ten bytes is legal and skips, leaving the known field intact
+  const ten: Uint8Array = unknown(0, ...continuations(9), 0x01);
+  if (typia.protobuf.decode<IValue>(ten).value !== "a")
+    throw new Error("a legal ten-byte unknown varint broke a known field.");
+
+  // the eleventh byte is one past the limit and is rejected rather than skipped
+  assertMessage("eleven-byte unknown varint", OVERLONG, () =>
+    typia.protobuf.decode<IValue>(unknown(0, ...continuations(10), 0x01)),
+  );
+  // a runaway of continuation bytes is a length fault, decided at byte ten
+  assertMessage("runaway unknown varint", OVERLONG, () =>
+    typia.protobuf.decode<IValue>(unknown(0, ...continuations(64))),
+  );
+
+  //----
+  // WHAT MUST NOT CHANGE
+  //----
+  // #2083: a varint the buffer truncates before the limit stays a framing fault
+  assertMessage("truncated unknown varint", OVERFLOW, () =>
+    typia.protobuf.decode<IValue>(unknown(0, ...continuations(5))),
+  );
+  // #2116: a zero-length unknown record still advances exactly its two bytes
+  if (typia.protobuf.decode<IValue>(unknown(2, 0)).value !== "a")
+    throw new Error("a zero-length unknown record broke a known field.");
+  // a valid payload round-trips untouched
+  const encoded: Uint8Array = typia.protobuf.encode<IValue>({ value: "a" });
+  if (typia.protobuf.decode<IValue>(encoded).value !== "a")
+    throw new Error("a valid payload no longer round-trips.");
+  if (typia.protobuf.isDecode<IValue>(encoded)?.value !== "a")
+    throw new Error("isDecode rejected a valid payload.");
+};
+
+interface IValue {
+  value: string;
+}
+
+/** Bytes carrying only the continuation bit, so a varint never terminates. */
+const continuations = (count: number): number[] =>
+  new Array(count).fill(0x80) as number[];
+
+const assertMessage = (
+  label: string,
+  expected: string,
+  closure: () => unknown,
+): void => {
+  try {
+    closure();
+  } catch (error) {
+    if (error instanceof Error && error.message === expected) return;
+    throw new Error(
+      `${label} reported ${String(error)} instead of ${JSON.stringify(expected)}.`,
+    );
+  }
+  throw new Error(`${label} was accepted by a generated Protobuf decoder.`);
+};
+
+const PREFIX = "Error on typia.protobuf.decode(): ";
+const OVERFLOW = `${PREFIX}buffer overflow.`;
+const OVERLONG = `${PREFIX}varint exceeds 10 bytes.`;

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_unknown_field_faults.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_unknown_field_faults.ts
@@ -1,0 +1,191 @@
+import { ProtobufWire } from "@typia/interface";
+import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
+
+/**
+ * Verifies every fault the runtime Protobuf reader raises while skipping an
+ * unknown field identifies typia and bounds its varint.
+ *
+ * Skipping unknown fields is the one reader surface a payload author fully
+ * controls, so both of these faults are reachable from `typia.protobuf.decode`.
+ * A reserved wire type must not report an anonymous error that leaves the caller
+ * unable to attribute the failure, and a varint must not be consumed past the
+ * ten bytes a 64-bit value can legally occupy merely because the skip path
+ * discards the bytes it reads. `varint32` and `varint64` are already
+ * structurally bounded at ten, so a skip that is not makes the limit depend on
+ * which method happens to consume the varint.
+ *
+ * 1. Reject every wire type that carries no skip semantics, including the
+ *    reserved 6 and 7 and a bare END_GROUP, directly, from a non-zero offset,
+ *    and nested inside a group.
+ * 2. Skip varints up to the ten-byte limit and reject the eleventh byte, while a
+ *    varint the buffer truncates before that limit still reports overflow.
+ * 3. Assert every fault carries the standard prefix and restores the reader,
+ *    and that the legal wire types and `uint32` are left untouched.
+ */
+export const test_protobuf_reader_unknown_field_faults = (): void => {
+  //----
+  // RESERVED AND NON-SKIPPABLE WIRE TYPES
+  //----
+  // the generated decoder passes `tag & 0x07`, so every one of these is reachable
+  assertMessage("reserved wire type 6", [], `${PREFIX}invalid wire type 6 at offset 0.`, (r) =>
+    r.skipType(6 as ProtobufWire),
+  );
+  assertMessage("reserved wire type 7", [], `${PREFIX}invalid wire type 7 at offset 0.`, (r) =>
+    r.skipType(7 as ProtobufWire),
+  );
+  // END_GROUP closes a group and carries no payload, so it is not skippable
+  assertMessage("bare END_GROUP", [], `${PREFIX}invalid wire type 4 at offset 0.`, (r) =>
+    r.skipType(ProtobufWire.END_GROUP),
+  );
+  // a group member may itself declare a reserved wire type: field 6, wire type 6
+  assertMessage("reserved wire type inside a group", [0x36], `${PREFIX}invalid wire type 6 at offset 1.`, (r) =>
+    r.skipType(ProtobufWire.START_GROUP),
+  );
+
+  // the reported offset is the reader's own position rather than always zero,
+  // and the failed skip restores that position instead of the buffer start
+  const advanced: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.of(0x00, 0x00),
+  );
+  advanced.skipType(ProtobufWire.VARIANT);
+  advanced.skipType(ProtobufWire.VARIANT);
+  const raised: Error = expect("a reserved wire type at a non-zero offset", () =>
+    advanced.skipType(6 as ProtobufWire),
+  );
+  if (raised.message !== `${PREFIX}invalid wire type 6 at offset 2.`)
+    throw new Error(
+      `a reserved wire type at a non-zero offset reported ${JSON.stringify(raised.message)}.`,
+    );
+  if (advanced.index() !== 2)
+    throw new Error(
+      `a failed skip left index ${advanced.index()} instead of restoring 2.`,
+    );
+
+  //----
+  // THE TEN-BYTE VARINT LIMIT
+  //----
+  // ten bytes is the maximum a 64-bit value occupies in seven-bit groups
+  assertSkip("single-byte varint", [0x00, 0x0a], 1);
+  assertSkip("two-byte varint", [0x80, 0x01, 0x0a], 2);
+  assertSkip("nine-byte varint", [...continuations(8), 0x01, 0x0a], 9);
+  assertSkip("ten-byte varint", [...continuations(9), 0x01, 0x0a], 10);
+
+  // the eleventh byte is one past the limit and must be rejected, not skipped
+  assertMessage("eleven-byte varint", [...continuations(10), 0x01, 0x0a], OVERLONG, (r) =>
+    r.skipVarint(),
+  );
+  // the issue's witness: a thirteen-byte varint was accepted, leaving ptr at 13
+  assertMessage("thirteen-byte varint", [...continuations(12), 0x01], OVERLONG, (r) =>
+    r.skipVarint(),
+  );
+  // a runaway of continuation bytes is a length fault, decided at byte ten
+  assertMessage("runaway varint", continuations(64), OVERLONG, (r) =>
+    r.skipVarint(),
+  );
+  // the limit falls exactly on the buffer end: still an over-long varint,
+  // because no eleventh byte could make these ten continuation bytes legal
+  assertMessage("ten continuation bytes", continuations(10), OVERLONG, (r) =>
+    r.skipVarint(),
+  );
+
+  // #2083: a varint the buffer truncates before the limit stays a framing fault
+  assertMessage("truncated varint", [0x80], OVERFLOW, (r) => r.skipVarint());
+  assertMessage("truncated five-byte varint", continuations(5), OVERFLOW, (r) =>
+    r.skipVarint(),
+  );
+
+  // the same limit applies through the public unknown-field entry point
+  assertSkip("ten-byte varint through skipType", [...continuations(9), 0x01], 10, (r) =>
+    r.skipType(ProtobufWire.VARIANT),
+  );
+  assertMessage("eleven-byte varint through skipType", [...continuations(10), 0x01], OVERLONG, (r) =>
+    r.skipType(ProtobufWire.VARIANT),
+  );
+
+  //----
+  // WHAT MUST NOT CHANGE
+  //----
+  // every legal wire type still skips by its exact width (#2116)
+  assertSkip("zero-length LEN", [0x00, 0x0a], 1, (r) =>
+    r.skipType(ProtobufWire.LEN),
+  );
+  assertSkip("non-zero LEN", [0x02, 0x61, 0x62, 0x0a], 3, (r) =>
+    r.skipType(ProtobufWire.LEN),
+  );
+  assertSkip("I64", [0, 0, 0, 0, 0, 0, 0, 0, 0x0a], 8, (r) =>
+    r.skipType(ProtobufWire.I64),
+  );
+  assertSkip("I32", [0, 0, 0, 0, 0x0a], 4, (r) => r.skipType(ProtobufWire.I32));
+  assertSkip("group", [0x0a, 0x00, 0x1c], 3, (r) =>
+    r.skipType(ProtobufWire.START_GROUP),
+  );
+
+  // `varint32` keeps capping at ten bytes rather than throwing: the reader's
+  // value paths are unchanged, and only the skip path gained the limit it lacked
+  const capped: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.from([...continuations(10), 0x01]),
+  );
+  if (capped.uint32() !== 0 || capped.index() !== 10)
+    throw new Error(
+      `uint32 stopped at index ${capped.index()} instead of its ten-byte cap.`,
+    );
+};
+
+/** Bytes carrying only the continuation bit, so a varint never terminates. */
+const continuations = (count: number): number[] =>
+  new Array(count).fill(0x80) as number[];
+
+const assertSkip = (
+  label: string,
+  bytes: number[],
+  expected: number,
+  closure: (reader: _ProtobufReader) => void = (r) => r.skipVarint(),
+): void => {
+  const reader: _ProtobufReader = new _ProtobufReader(Uint8Array.from(bytes));
+  closure(reader);
+  if (reader.index() !== expected)
+    throw new Error(
+      `${label} left index ${reader.index()} instead of ${expected}.`,
+    );
+};
+
+/** Requires the closure to reject, and hands its error back for inspection. */
+const expect = (label: string, closure: () => void): Error => {
+  try {
+    closure();
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw new Error(`${label} raised ${String(error)} instead of an Error.`);
+  }
+  throw new Error(`${label} was accepted by the Protobuf reader.`);
+};
+
+/**
+ * Requires an exact error message and an atomically restored reader.
+ *
+ * The message is compared whole rather than by prefix. The prefix is the point
+ * of the contract, but a fault that keeps the prefix while losing the wire type
+ * or the limit it names would still leave the caller without a diagnosis.
+ */
+const assertMessage = (
+  label: string,
+  bytes: number[],
+  expected: string,
+  closure: (reader: _ProtobufReader) => void,
+): void => {
+  const reader: _ProtobufReader = new _ProtobufReader(Uint8Array.from(bytes));
+  const size: number = reader.size();
+  const error: Error = expect(label, () => closure(reader));
+  if (error.message !== expected)
+    throw new Error(
+      `${label} reported ${JSON.stringify(error.message)} instead of ${JSON.stringify(expected)}.`,
+    );
+  if (reader.index() !== 0 || reader.size() !== size)
+    throw new Error(
+      `${label} left index ${reader.index()} and size ${reader.size()} instead of restoring the reader.`,
+    );
+};
+
+const PREFIX = "Error on typia.protobuf.decode(): ";
+const OVERFLOW = `${PREFIX}buffer overflow.`;
+const OVERLONG = `${PREFIX}varint exceeds 10 bytes.`;

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_unknown_field_faults.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_unknown_field_faults.ts
@@ -7,39 +7,51 @@ import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
  *
  * Skipping unknown fields is the one reader surface a payload author fully
  * controls, so both of these faults are reachable from `typia.protobuf.decode`.
- * A reserved wire type must not report an anonymous error that leaves the caller
- * unable to attribute the failure, and a varint must not be consumed past the
- * ten bytes a 64-bit value can legally occupy merely because the skip path
- * discards the bytes it reads. `varint32` and `varint64` are already
+ * A reserved wire type must not report an anonymous error that leaves the
+ * caller unable to attribute the failure, and a varint must not be consumed
+ * past the ten bytes a 64-bit value can legally occupy merely because the skip
+ * path discards the bytes it reads. `varint32` and `varint64` are already
  * structurally bounded at ten, so a skip that is not makes the limit depend on
  * which method happens to consume the varint.
  *
- * 1. Reject every wire type that carries no skip semantics, including the
- *    reserved 6 and 7 and a bare END_GROUP, directly, from a non-zero offset,
- *    and nested inside a group.
+ * 1. Reject every wire type that carries no skip semantics, including the reserved
+ *    6 and 7 and a bare END_GROUP, directly, from a non-zero offset, and nested
+ *    inside a group.
  * 2. Skip varints up to the ten-byte limit and reject the eleventh byte, while a
  *    varint the buffer truncates before that limit still reports overflow.
- * 3. Assert every fault carries the standard prefix and restores the reader,
- *    and that the legal wire types and `uint32` are left untouched.
+ * 3. Assert every fault carries the standard prefix and restores the reader, and
+ *    that the legal wire types and `uint32` are left untouched.
  */
 export const test_protobuf_reader_unknown_field_faults = (): void => {
   //----
   // RESERVED AND NON-SKIPPABLE WIRE TYPES
   //----
   // the generated decoder passes `tag & 0x07`, so every one of these is reachable
-  assertMessage("reserved wire type 6", [], `${PREFIX}invalid wire type 6 at offset 0.`, (r) =>
-    r.skipType(6 as ProtobufWire),
+  assertMessage(
+    "reserved wire type 6",
+    [],
+    `${PREFIX}invalid wire type 6 at offset 0.`,
+    (r) => r.skipType(6 as ProtobufWire),
   );
-  assertMessage("reserved wire type 7", [], `${PREFIX}invalid wire type 7 at offset 0.`, (r) =>
-    r.skipType(7 as ProtobufWire),
+  assertMessage(
+    "reserved wire type 7",
+    [],
+    `${PREFIX}invalid wire type 7 at offset 0.`,
+    (r) => r.skipType(7 as ProtobufWire),
   );
   // END_GROUP closes a group and carries no payload, so it is not skippable
-  assertMessage("bare END_GROUP", [], `${PREFIX}invalid wire type 4 at offset 0.`, (r) =>
-    r.skipType(ProtobufWire.END_GROUP),
+  assertMessage(
+    "bare END_GROUP",
+    [],
+    `${PREFIX}invalid wire type 4 at offset 0.`,
+    (r) => r.skipType(ProtobufWire.END_GROUP),
   );
   // a group member may itself declare a reserved wire type: field 6, wire type 6
-  assertMessage("reserved wire type inside a group", [0x36], `${PREFIX}invalid wire type 6 at offset 1.`, (r) =>
-    r.skipType(ProtobufWire.START_GROUP),
+  assertMessage(
+    "reserved wire type inside a group",
+    [0x36],
+    `${PREFIX}invalid wire type 6 at offset 1.`,
+    (r) => r.skipType(ProtobufWire.START_GROUP),
   );
 
   // the reported offset is the reader's own position rather than always zero,
@@ -49,8 +61,9 @@ export const test_protobuf_reader_unknown_field_faults = (): void => {
   );
   advanced.skipType(ProtobufWire.VARIANT);
   advanced.skipType(ProtobufWire.VARIANT);
-  const raised: Error = expect("a reserved wire type at a non-zero offset", () =>
-    advanced.skipType(6 as ProtobufWire),
+  const raised: Error = rejection(
+    "a reserved wire type at a non-zero offset",
+    () => advanced.skipType(6 as ProtobufWire),
   );
   if (raised.message !== `${PREFIX}invalid wire type 6 at offset 2.`)
     throw new Error(
@@ -65,18 +78,28 @@ export const test_protobuf_reader_unknown_field_faults = (): void => {
   // THE TEN-BYTE VARINT LIMIT
   //----
   // ten bytes is the maximum a 64-bit value occupies in seven-bit groups
-  assertSkip("single-byte varint", [0x00, 0x0a], 1);
-  assertSkip("two-byte varint", [0x80, 0x01, 0x0a], 2);
-  assertSkip("nine-byte varint", [...continuations(8), 0x01, 0x0a], 9);
-  assertSkip("ten-byte varint", [...continuations(9), 0x01, 0x0a], 10);
-
-  // the eleventh byte is one past the limit and must be rejected, not skipped
-  assertMessage("eleven-byte varint", [...continuations(10), 0x01, 0x0a], OVERLONG, (r) =>
+  assertSkip("single-byte varint", [0x00, 0x0a], 1, (r) => r.skipVarint());
+  assertSkip("two-byte varint", [0x80, 0x01, 0x0a], 2, (r) => r.skipVarint());
+  assertSkip("nine-byte varint", [...continuations(8), 0x01, 0x0a], 9, (r) =>
     r.skipVarint(),
   );
-  // the issue's witness: a thirteen-byte varint was accepted, leaving ptr at 13
-  assertMessage("thirteen-byte varint", [...continuations(12), 0x01], OVERLONG, (r) =>
+  assertSkip("ten-byte varint", [...continuations(9), 0x01, 0x0a], 10, (r) =>
     r.skipVarint(),
+  );
+
+  // the eleventh byte is one past the limit and must be rejected, not skipped
+  assertMessage(
+    "eleven-byte varint",
+    [...continuations(10), 0x01, 0x0a],
+    OVERLONG,
+    (r) => r.skipVarint(),
+  );
+  // the issue's witness: a thirteen-byte varint was accepted, leaving ptr at 13
+  assertMessage(
+    "thirteen-byte varint",
+    [...continuations(12), 0x01],
+    OVERLONG,
+    (r) => r.skipVarint(),
   );
   // a runaway of continuation bytes is a length fault, decided at byte ten
   assertMessage("runaway varint", continuations(64), OVERLONG, (r) =>
@@ -95,11 +118,25 @@ export const test_protobuf_reader_unknown_field_faults = (): void => {
   );
 
   // the same limit applies through the public unknown-field entry point
-  assertSkip("ten-byte varint through skipType", [...continuations(9), 0x01], 10, (r) =>
-    r.skipType(ProtobufWire.VARIANT),
+  assertSkip(
+    "ten-byte varint through skipType",
+    [...continuations(9), 0x01],
+    10,
+    (r) => r.skipType(ProtobufWire.VARIANT),
   );
-  assertMessage("eleven-byte varint through skipType", [...continuations(10), 0x01], OVERLONG, (r) =>
-    r.skipType(ProtobufWire.VARIANT),
+  assertMessage(
+    "eleven-byte varint through skipType",
+    [...continuations(10), 0x01],
+    OVERLONG,
+    (r) => r.skipType(ProtobufWire.VARIANT),
+  );
+  // a group member's varint is bound alike, and unwinding two nested skips
+  // still restores the reader to where the outer skip began: field 1, wire 0
+  assertMessage(
+    "eleven-byte varint inside a group",
+    [0x08, ...continuations(10), 0x01],
+    OVERLONG,
+    (r) => r.skipType(ProtobufWire.START_GROUP),
   );
 
   //----
@@ -139,7 +176,7 @@ const assertSkip = (
   label: string,
   bytes: number[],
   expected: number,
-  closure: (reader: _ProtobufReader) => void = (r) => r.skipVarint(),
+  closure: (reader: _ProtobufReader) => void,
 ): void => {
   const reader: _ProtobufReader = new _ProtobufReader(Uint8Array.from(bytes));
   closure(reader);
@@ -150,7 +187,7 @@ const assertSkip = (
 };
 
 /** Requires the closure to reject, and hands its error back for inspection. */
-const expect = (label: string, closure: () => void): Error => {
+const rejection = (label: string, closure: () => void): Error => {
   try {
     closure();
   } catch (error) {
@@ -175,7 +212,7 @@ const assertMessage = (
 ): void => {
   const reader: _ProtobufReader = new _ProtobufReader(Uint8Array.from(bytes));
   const size: number = reader.size();
-  const error: Error = expect(label, () => closure(reader));
+  const error: Error = rejection(label, () => closure(reader));
   if (error.message !== expected)
     throw new Error(
       `${label} reported ${JSON.stringify(error.message)} instead of ${JSON.stringify(expected)}.`,


### PR DESCRIPTION
Closes #2135.

Two contract gaps in the Protocol Buffer reader, `packages/typia/src/internal/_ProtobufReader.ts`. Neither is a soundness defect: no valid payload decodes differently, and no invalid payload becomes accepted as data.

1. **`skipType`'s `default:` threw without the standard prefix.** Every other reader error is `Error on typia.protobuf.decode(): …`; this one was `Invalid wire type 6 at offset 0.`, so a user could not attribute the failure to typia. It is user-reachable: the generated decoder skips unknown fields with `skipType(tag & 0x07)`, and wire types 4, 6, and 7 all survive that mask and land on the `default:`.
2. **`skipVarint` enforced no length cap.** `varint32` and `varint64` are both structurally bounded at ten bytes, the maximum a 64-bit value can occupy. `skipVarint` consumed to the first terminator or the buffer end, so a malformed varint with excess continuation bytes was skipped rather than rejected. It was bounded by the buffer end, so nothing ran away, and the skipped bytes were discarded anyway — a leniency where its two siblings hold the line.

## Approach

Both gaps are one contract implemented in more than one place with one copy left behind, so both are fixed by removing the copy rather than adding another.

- **The prefix is now single-sourced.** A module-local `error(message)` builds every reader error, so the literal `Error on typia.protobuf.decode(): ` appears exactly once in the file instead of the three inline copies it had. The four throw sites route through it; the `buffer overflow.` and `invalid UTF-8 string.` texts are byte-for-byte unchanged.
- **The limit is now named once.** `VARINT_MAX_BYTES = 10` is the only occurrence of the literal in the file, and it feeds both `skipVarint`'s bound and its message. `varint32` and `varint64` encode the same limit structurally in their unrolled reads; they are left alone deliberately, because routing them through the constant would change what `uint32` does with a malformed varint, which #2135 explicitly holds fixed.

New messages: `Error on typia.protobuf.decode(): invalid wire type <n> at offset <m>.` and `Error on typia.protobuf.decode(): varint exceeds 10 bytes.`

An over-long varint is rejected rather than capped. Capping would leave the reader parked mid-varint on a continuation byte, which has no valid interpretation; a skip that silently stops there is worse than an error, and #2083 already set this file's posture of rejecting rather than clamping.

## Case matrix

| Case | Behavior |
| --- | --- |
| unknown field, wire type 4, 6, or 7 | rejected, prefixed, naming the wire type and offset |
| unknown varint, 10 bytes or fewer | skipped — unchanged |
| unknown varint, 11+ bytes | rejected with `varint exceeds 10 bytes.` |
| unknown varint truncated before byte 10 | `buffer overflow.` — #2083 unchanged |
| zero-length unknown `LEN` | advances exactly 2 bytes — #2116 unchanged |
| framing fault inside `string()` | `buffer overflow.`, not relabelled — #2090 unchanged |
| `uint32` on an 11-byte varint | still caps at 10 — unchanged |
| every valid payload | unchanged |

A varint whose tenth byte still carries the continuation bit is reported as over-long even when the buffer ends there, because no eleventh byte could make those ten bytes legal. Truncation before byte ten stays `buffer overflow`, since the length fault is not yet decided.

## Tests

Added first and observed failing against `master`, mirroring the reader-plus-decoder pair that #2084, #2090, and #2119 each established:

- `tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_unknown_field_faults.ts`
- `tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_unknown_field_faults.ts`

They cover the 10-vs-11-byte boundary, the reserved and bare-END_GROUP wire types directly and nested in a group, the reported offset from a non-zero position, atomic restoration, the legal wire types as negative twins, and the three merged contracts above.

## Verification

TypeScript runtime only. Per the #2066 precedent, no `packages/typia/package.json` version bump: the final diff touches no native Go.

- `pnpm --filter ./tests/test-typia-schema start`
- `pnpm --filter ./tests/test-typia-automated start`
- `go -C packages/typia/test test ./...`

Campaign CI is suspended; each pushed SHA passes the exact-SHA cancellation gate and verification is local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
