### PR TITLE
feat(native): adopt the ttsc driver reference-graph SDK in the transform envelope

### DIFF
--- a/experiments/esm/package.json
+++ b/experiments/esm/package.json
@@ -18,7 +18,7 @@
     "@typia/utils": "file:../tarballs/utils.tgz",
     "@typia/vercel": "file:../tarballs/vercel.tgz",
     "ai": "^6.0.116",
-    "ttsc": "^0.17.3",
+    "ttsc": "^0.19.2",
     "typescript": "^7.0.2",
     "typia": "file:../tarballs/typia.tgz"
   }

--- a/experiments/mcp/package.json
+++ b/experiments/mcp/package.json
@@ -14,7 +14,7 @@
     "@typia/interface": "file:../tarballs/interface.tgz",
     "@typia/mcp": "file:../tarballs/mcp.tgz",
     "@typia/utils": "file:../tarballs/utils.tgz",
-    "ttsc": "^0.17.3",
+    "ttsc": "^0.19.2",
     "typescript": "7.0.1-rc",
     "typia": "file:../tarballs/typia.tgz"
   }

--- a/experiments/smoke/package.json
+++ b/experiments/smoke/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "7.0.1-rc",
-    "ttsc": "^0.17.3"
+    "ttsc": "^0.19.2"
   }
 }

--- a/packages/typia/native/cmd/ttsc-typia/project_reference_graph_envelope_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_reference_graph_envelope_transform_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestProjectReferenceGraphEnvelopeTransform verifies the project transform
+// envelope carries the ttsc driver SDK's host-owned reference `graph` section
+// alongside typia's precise `dependencies`.
+//
+// `graph` is the plugin-agnostic sound invalidation baseline: the ttsc consumer
+// registers reach(edges, F) ∪ globals ∪ configs ∪ dependencies[F], so a
+// consulted file the precise `dependencies` collection might not attribute is
+// still guarded by the host baseline (samchon/typia#2107). This pins that
+// typia's hand-rolled envelope now routes through driver.NewTransformGraph:
+// direct reference edges (type-only included), ambient global-scope files, and
+// the tsconfig `extends` chain, all keyed by the same driver.TransformOutputKey
+// convention as the `typescript`/`dependencies` sections so a consumer joins
+// them by key.
+//
+//  1. Build a project where `a.ts` imports `Bee` from `b.ts` (and calls
+//     `typia.validate<Bee>()`), `b.ts` imports type-only `Cee` from `c.ts`, an
+//     ambient `globals.d.ts` contributes a global augmentation, and
+//     `tsconfig.json` extends `tsconfig.base.json`.
+//  2. Run project transform mode and decode the JSON envelope's `graph`.
+//  3. Assert the `a.ts -> b.ts` and the type-only `b.ts -> c.ts` edges, the
+//     `globals.d.ts` global entry, and the `tsconfig.json` + `tsconfig.base.json`
+//     configs chain, all under keys that join with the `typescript` section.
+//  4. Assert `dependencies` is still emitted next to `graph`, and that a
+//     non-global source is not misreported as a global.
+func TestProjectReferenceGraphEnvelopeTransform(t *testing.T) {
+  project := projectReferenceGraphEnvelopeProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--output", "ts",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("project transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  var envelope struct {
+    TypeScript map[string]string `json:"typescript"`
+    Graph      *struct {
+      Edges   map[string][]string `json:"edges"`
+      Globals []string            `json:"globals"`
+      Configs []string            `json:"configs"`
+    } `json:"graph"`
+    Dependencies map[string][]string `json:"dependencies"`
+  }
+  if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+    t.Fatalf("decode envelope: %v\n%s", err, out)
+  }
+  if envelope.Graph == nil {
+    t.Fatalf("envelope must carry a graph section:\n%s", out)
+  }
+  if _, ok := envelope.TypeScript["src/a.ts"]; !ok {
+    t.Fatalf("typescript map must contain src/a.ts (graph keys join with it):\n%s", out)
+  }
+
+  contains := func(values []string, want string) bool {
+    for _, value := range values {
+      if value == want {
+        return true
+      }
+    }
+    return false
+  }
+
+  // Direct resolved edge from the transformed file to its import.
+  if !contains(envelope.Graph.Edges["src/a.ts"], "src/b.ts") {
+    t.Fatalf("graph edges of src/a.ts must contain src/b.ts: %v", envelope.Graph.Edges["src/a.ts"])
+  }
+  // Type-only edges must be included: b.ts imports Cee with `import type`.
+  if !contains(envelope.Graph.Edges["src/b.ts"], "src/c.ts") {
+    t.Fatalf("graph edges of src/b.ts must contain the type-only edge src/c.ts: %v", envelope.Graph.Edges["src/b.ts"])
+  }
+  // Ambient global-scope file appears in globals.
+  if !contains(envelope.Graph.Globals, "src/globals.d.ts") {
+    t.Fatalf("graph globals must contain src/globals.d.ts: %v", envelope.Graph.Globals)
+  }
+  // A plain module source is not a global-scope contributor.
+  if contains(envelope.Graph.Globals, "src/c.ts") {
+    t.Fatalf("graph globals must not contain the module source src/c.ts: %v", envelope.Graph.Globals)
+  }
+  // tsconfig extends chain: project config followed by its base.
+  if !contains(envelope.Graph.Configs, "tsconfig.json") {
+    t.Fatalf("graph configs must contain tsconfig.json: %v", envelope.Graph.Configs)
+  }
+  if !contains(envelope.Graph.Configs, "tsconfig.base.json") {
+    t.Fatalf("graph configs must contain the extended tsconfig.base.json: %v", envelope.Graph.Configs)
+  }
+
+  // The precise dependencies channel remains emitted alongside graph.
+  if !contains(envelope.Dependencies["src/a.ts"], "src/b.ts") {
+    t.Fatalf("dependencies of src/a.ts must still be emitted alongside graph: %v", envelope.Dependencies["src/a.ts"])
+  }
+}
+
+func projectReferenceGraphEnvelopeProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "project-reference-graph-envelope-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  files := map[string]string{
+    "tsconfig.json":      projectReferenceGraphEnvelopeTSConfig,
+    "tsconfig.base.json": projectReferenceGraphEnvelopeTSConfigBase,
+  }
+  for name, body := range files {
+    if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  for name, body := range map[string]string{
+    "a.ts":         projectReferenceGraphEnvelopeSourceA,
+    "b.ts":         projectReferenceGraphEnvelopeSourceB,
+    "c.ts":         projectReferenceGraphEnvelopeSourceC,
+    "globals.d.ts": projectReferenceGraphEnvelopeGlobals,
+  } {
+    if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  return dir
+}
+
+const projectReferenceGraphEnvelopeTSConfig = `{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}
+`
+
+const projectReferenceGraphEnvelopeTSConfigBase = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}
+`
+
+const projectReferenceGraphEnvelopeSourceA = `import typia from "typia";
+
+import { Bee } from "./b";
+
+export const validateBee = (input: unknown) => typia.validate<Bee>(input);
+`
+
+const projectReferenceGraphEnvelopeSourceB = `import type { Cee } from "./c";
+
+export interface Bee {
+  id: string;
+  nested: Cee;
+}
+`
+
+const projectReferenceGraphEnvelopeSourceC = `export interface Cee {
+  value: number;
+}
+`
+
+// A pure ambient declaration file (no import/export) is a script file, so it
+// contributes to the global scope and must appear in graph.globals.
+const projectReferenceGraphEnvelopeGlobals = `declare interface TypiaGraphGlobal {
+  tag: string;
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/transform.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform.go
@@ -145,10 +145,22 @@ func runTransformSingle(
 
 // runTransformProject prints every non-declaration project source as transformed
 // TypeScript and encodes the JSON envelope the ttsc host expects. Alongside the
-// transformed sources it reports, per file, the source files owning the
-// declarations the typia analysis consulted (`dependencies`), which the ttsc
-// consumer registers with the bundler so persistent caches and watch mode
-// invalidate generated validators when a consulted type's file changes.
+// transformed sources it reports two invalidation channels the ttsc consumer
+// registers with the bundler so persistent caches and watch mode invalidate
+// generated validators soundly:
+//
+//   - `graph`, the host-owned reference graph of the loaded program (direct
+//     resolved edges, ambient globals, tsconfig extends chain) computed by the
+//     ttsc driver SDK. It is the plugin-agnostic sound baseline under `tsc
+//     --incremental` semantics; the consumer registers, per file F,
+//     reach(edges, F) ∪ globals ∪ configs.
+//   - `dependencies`, typia's precise per-file list of the source files owning
+//     the declarations the typia analysis consulted for each transformed file.
+//
+// The consumer unions the two (reach(edges, F) ∪ globals ∪ configs ∪
+// dependencies[F]), so graph is added alongside dependencies, not a replacement.
+// Every section keys through driver.TransformOutputKey, so the consumer joins
+// them by key.
 func runTransformProject(
   prog *driver.Program,
   cwd string,
@@ -159,6 +171,11 @@ func runTransformProject(
     Diagnostics: []transformCompilerDiagnostic{},
     TypeScript:  map[string]string{},
   }
+  // Compute the reference graph from the loaded program before the transform
+  // loop runs typia's per-file node transformer: the graph must describe the
+  // original source's resolved references (the transform's inputs), matching
+  // ttsc's own `api-transform` host.
+  out.Graph = driver.NewTransformGraph(prog, cwd)
   collector := newTransformDependencyCollector(cwd, func(fileName string) bool {
     sf := prog.SourceFile(fileName)
     return sf != nil && prog.TSProgram.IsLibFile(sf)
@@ -169,7 +186,7 @@ func runTransformProject(
     if sf.IsDeclarationFile {
       continue
     }
-    key := sourceFileKey(cwd, filepath.ToSlash(sf.FileName()))
+    key := driver.TransformOutputKey(cwd, sf.FileName())
     if filepath.IsAbs(key) || key == ".." || strings.HasPrefix(key, "../") {
       continue
     }
@@ -286,6 +303,14 @@ func defaultTransformOutput() string {
 type transformProjectOutput struct {
   Diagnostics []transformCompilerDiagnostic `json:"diagnostics,omitempty"`
   TypeScript  map[string]string             `json:"typescript"`
+  // Graph is the host-owned reference graph of the loaded program produced by
+  // the ttsc driver SDK (driver.NewTransformGraph): direct resolved reference
+  // edges, ambient global-scope files, and the tsconfig extends chain, keyed
+  // like TypeScript through driver.TransformOutputKey. It is the plugin-agnostic
+  // sound invalidation baseline; the consumer unions it with Dependencies.
+  // Omitted only when the program is nil (never here — a nil program returns
+  // earlier).
+  Graph *driver.TransformGraph `json:"graph,omitempty"`
   // Dependencies maps each transformed file (same project-relative keys as
   // TypeScript) to the source files owning the declarations typia's analysis
   // consulted for it. Values are project-relative when the file lives under the
@@ -364,7 +389,7 @@ func (collector *transformDependencyCollector) value(fileName string) string {
   if strings.Contains(fileName, "://") || collector.isLibraryFile(fileName) {
     return ""
   }
-  return sourceFileKey(collector.cwd, filepath.ToSlash(fileName))
+  return driver.TransformOutputKey(collector.cwd, fileName)
 }
 
 // ToJSON renders the collected sets as the envelope's `dependencies` map with
@@ -398,14 +423,6 @@ type transformCompilerDiagnostic struct {
   Line        int     `json:"line,omitempty"`
   Character   int     `json:"character,omitempty"`
   MessageText string  `json:"messageText"`
-}
-
-func sourceFileKey(cwd string, file string) string {
-  rel, err := filepath.Rel(cwd, filepath.FromSlash(file))
-  if err != nil {
-    return filepath.ToSlash(file)
-  }
-  return filepath.ToSlash(rel)
 }
 
 func transformDiagnosticToCompilerDiagnostic(diag typiaTransformDiagnostic) transformCompilerDiagnostic {

--- a/packages/typia/native/go.mod
+++ b/packages/typia/native/go.mod
@@ -2,6 +2,14 @@ module github.com/samchon/typia/packages/typia/native
 
 go 1.26
 
+// Build-time floor: the driver reference-graph SDK
+// (driver.NewTransformGraph / driver.TransformGraph / driver.TransformOutputKey)
+// this plugin consumes exists only in ttsc >= 0.19.2. That floor is enforced
+// through typia's package.json peerDependencies (ttsc / @ttsc/unplugin), not
+// here: ttsc builds this plugin from source on the user's machine and its
+// buildSourcePlugin generates `replace github.com/samchon/ttsc/packages/ttsc
+// v0.0.0 => <installed ttsc root>`, so the require below must stay v0.0.0 or the
+// generated replace no longer matches and the plugin build fails to resolve.
 require (
 	github.com/microsoft/typescript-go/shim/ast v0.0.0
 	github.com/microsoft/typescript-go/shim/checker v0.0.0

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -42,6 +42,18 @@
     "randexp": "^0.5.3",
     "tinyglobby": "^0.2.12"
   },
+  "peerDependencies": {
+    "@ttsc/unplugin": ">=0.19.2",
+    "ttsc": ">=0.19.2"
+  },
+  "peerDependenciesMeta": {
+    "@ttsc/unplugin": {
+      "optional": true
+    },
+    "ttsc": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/inquirer": "^8.2.5",
     "@types/node": "catalog:utils",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,14 +11,14 @@ catalogs:
       version: 1.1.5
   typescript:
     '@ttsc/playground':
-      specifier: ^0.19.2
-      version: 0.19.2
+      specifier: ^0.18.4
+      version: 0.18.4
     '@ttsc/unplugin':
       specifier: ^0.19.2
       version: 0.19.2
     '@ttsc/wasm':
-      specifier: ^0.19.2
-      version: 0.19.2
+      specifier: ^0.18.4
+      version: 0.18.4
     ttsc:
       specifier: ^0.19.2
       version: 0.19.2
@@ -820,10 +820,10 @@ importers:
         version: 4.3.0
       '@ttsc/playground':
         specifier: catalog:typescript
-        version: 0.19.2(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.19.2)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)
+        version: 0.18.4(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.18.4)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)
       '@ttsc/wasm':
         specifier: catalog:typescript
-        version: 0.19.2
+        version: 0.18.4
       '@typia/interface':
         specifier: workspace:^
         version: link:../packages/interface
@@ -2851,11 +2851,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@ttsc/playground@0.19.2':
-    resolution: {integrity: sha512-QYzQCTWOpXfMgj+hHqSjbaU2WHbcy2NvjCXpCZPG1TzefnPoDy+TvJgdm1wp3tmh1HtYpSZhegjJLXJE8NkTkQ==}
+  '@ttsc/playground@0.18.4':
+    resolution: {integrity: sha512-hyhVzAml/ENAw/Dgj60Vu0gdcrdPRcKZpBDSMt6GpQn5we7AMLr/1scJtS94yDwXwwXMaNH6ieY2iAmIBYDN+A==}
     peerDependencies:
       '@monaco-editor/react': ^4.6.0
-      '@ttsc/wasm': ^0.19.2
+      '@ttsc/wasm': ^0.18.4
       monaco-editor: ^0.52.0
       react: ^18.0.0
       react-dom: ^18.0.0
@@ -2866,8 +2866,8 @@ packages:
     peerDependencies:
       ttsc: 0.19.2
 
-  '@ttsc/wasm@0.19.2':
-    resolution: {integrity: sha512-eW7orjOOVkIg71C0CcDoV9ayUD5mblihXM83VDGCundsjCCjRAoI5/yMHC6924NdMnJN6Tvou7TfYBpXu0K8Xw==}
+  '@ttsc/wasm@0.18.4':
+    resolution: {integrity: sha512-WVyaZBpjd1tC3Xj7AEcSUqhjqWipyhSgxQyzgvzVG8rzmEl2rZLxQmQ1MC7mgh8izyk+LAmrgSpghZo94nLicQ==}
 
   '@ttsc/win32-arm64@0.19.2':
     resolution: {integrity: sha512-SEkMh77Jx4RtThidhZi46GMoFePxoUuaybTo0Es2vKDMId6ntQTXrfgx7lhxEHs5HK6Q+O1Mzmq4rdY8YJsezg==}
@@ -9518,10 +9518,10 @@ snapshots:
   '@ttsc/linux-x64@0.19.2':
     optional: true
 
-  '@ttsc/playground@0.19.2(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.19.2)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)':
+  '@ttsc/playground@0.18.4(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.18.4)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)':
     dependencies:
       '@monaco-editor/react': 4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@ttsc/wasm': 0.19.2
+      '@ttsc/wasm': 0.18.4
       lz-string: 1.5.0
       monaco-editor: 0.50.0
       react: 18.3.1
@@ -9533,7 +9533,7 @@ snapshots:
       ttsc: 0.19.2
       unplugin: 2.3.11
 
-  '@ttsc/wasm@0.19.2': {}
+  '@ttsc/wasm@0.18.4': {}
 
   '@ttsc/win32-arm64@0.19.2':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,9 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
+      '@ttsc/unplugin':
+        specifier: '>=0.19.2'
+        version: 0.19.2(ttsc@0.19.2)
       '@typia/interface':
         specifier: workspace:^
         version: link:../interface

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,17 +11,17 @@ catalogs:
       version: 1.1.5
   typescript:
     '@ttsc/playground':
-      specifier: ^0.18.4
-      version: 0.18.4
+      specifier: ^0.19.2
+      version: 0.19.2
     '@ttsc/unplugin':
-      specifier: ^0.18.4
-      version: 0.18.4
+      specifier: ^0.19.2
+      version: 0.19.2
     '@ttsc/wasm':
-      specifier: ^0.18.4
-      version: 0.18.4
+      specifier: ^0.19.2
+      version: 0.19.2
     ttsc:
-      specifier: ^0.18.4
-      version: 0.18.4
+      specifier: ^0.19.2
+      version: 0.19.2
     typescript:
       specifier: ^7.0.2
       version: 7.0.2
@@ -72,7 +72,7 @@ importers:
         version: 1.8.0(prettier@3.8.3)
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
 
   benchmark:
     dependencies:
@@ -190,7 +190,7 @@ importers:
         version: 0.10.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -202,7 +202,7 @@ importers:
     devDependencies:
       '@ttsc/unplugin':
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2(ttsc@0.19.2)
       tinyglobby:
         specifier: ^0.2.12
         version: 0.2.16
@@ -233,7 +233,7 @@ importers:
         version: 6.1.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
 
   packages/interface:
     devDependencies:
@@ -242,7 +242,7 @@ importers:
         version: 6.1.3
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -270,7 +270,7 @@ importers:
         version: 0.2.16
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -298,7 +298,7 @@ importers:
         version: 0.2.16
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -347,7 +347,7 @@ importers:
         version: 1.0.2
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -369,7 +369,7 @@ importers:
         version: 0.2.16
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -400,7 +400,7 @@ importers:
         version: 0.2.16
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -489,7 +489,7 @@ importers:
     devDependencies:
       ttsc:
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -610,7 +610,7 @@ importers:
     devDependencies:
       '@ttsc/unplugin':
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2(ttsc@0.19.2)
       '@types/node':
         specifier: catalog:utils
         version: 25.6.0
@@ -817,10 +817,10 @@ importers:
         version: 4.3.0
       '@ttsc/playground':
         specifier: catalog:typescript
-        version: 0.18.4(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.18.4)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)
+        version: 0.19.2(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.19.2)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)
       '@ttsc/wasm':
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       '@typia/interface':
         specifier: workspace:^
         version: link:../packages/interface
@@ -2823,54 +2823,56 @@ packages:
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
-  '@ttsc/darwin-arm64@0.18.4':
-    resolution: {integrity: sha512-XhUPqcmx1w83fUSQfYA91zoD5dQzDlTxi6fGtmDPzXz839hbI21iZ80rQtKIr0FjLqbCHWuTmz5PAbquTZ1wXA==}
+  '@ttsc/darwin-arm64@0.19.2':
+    resolution: {integrity: sha512-DYCm+wXpLtZHzlJmTFY+NsVNiqw3irmD4Cx1kyH34xgfudHsPn7ItWPlYoZTWWANH1xPRoH05CP+akDEsNX80Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ttsc/darwin-x64@0.18.4':
-    resolution: {integrity: sha512-oDfrHVsHGgmbhEwNtVUmArzB4XnkfqhtjEN1h95eZWfJpTZGKhWIXwucX3ODOaJpxZFjRczvrvlpm5c5Sksw0g==}
+  '@ttsc/darwin-x64@0.19.2':
+    resolution: {integrity: sha512-0FoaF4YVhItnRWXf4oMJEwe1XQvOmaGH/M0PxO2HTiVI7cMCGTy555gOZ2svYgBmliqkLBVGoez29IWVlgZF5Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@ttsc/linux-arm64@0.18.4':
-    resolution: {integrity: sha512-y7j9rhYGxiYosDsnP2ZzTVGLo8CRm6CyK+2ex16bhdO1idkmRCvCYMN6PdtYTjFfldDROI+bqouikqwftEKylQ==}
+  '@ttsc/linux-arm64@0.19.2':
+    resolution: {integrity: sha512-/m7xTO5dJHzJpv9A7m4H5PBl8txFBGEMoM7k8L8Iod5ZrnUlF3mZSb5v6lUAZfJA5SkFBa6oHJ1fgafCmBInjg==}
     cpu: [arm64]
     os: [linux]
 
-  '@ttsc/linux-arm@0.18.4':
-    resolution: {integrity: sha512-B5P6a65jXh4mDYbmbSgdnGMUsZ0/gvld5KcVbQMb1Am0tl3yQ9F588zgGQm4PYAWcoqsvZ+qtNoBMQkvg93WFw==}
+  '@ttsc/linux-arm@0.19.2':
+    resolution: {integrity: sha512-fAuf9Kk+Jask/GAmIS54tCzYBj4MQY4LAjj+RFfBh3N5zGN3hXNXFKRa1i5ZDmRKQwTy8NYYaBXJDHYMvM2+Rw==}
     cpu: [arm]
     os: [linux]
 
-  '@ttsc/linux-x64@0.18.4':
-    resolution: {integrity: sha512-nq6Tzm1yJf2XQ+68Sg8MIf5GoLyDFuwW0Pw+6TQCKz8mFpexiIkztoiptGYgzNJmrEqTNeiK/gs4IMIO1pkb/g==}
+  '@ttsc/linux-x64@0.19.2':
+    resolution: {integrity: sha512-9X8a1IgxgYaRbeY4v0uQk+B7116/xsqDR8SznoyXbLrWoJqynKLfe3XZWo5kbpTaXNQN6vlXFgVRlvis9+LOIA==}
     cpu: [x64]
     os: [linux]
 
-  '@ttsc/playground@0.18.4':
-    resolution: {integrity: sha512-hyhVzAml/ENAw/Dgj60Vu0gdcrdPRcKZpBDSMt6GpQn5we7AMLr/1scJtS94yDwXwwXMaNH6ieY2iAmIBYDN+A==}
+  '@ttsc/playground@0.19.2':
+    resolution: {integrity: sha512-QYzQCTWOpXfMgj+hHqSjbaU2WHbcy2NvjCXpCZPG1TzefnPoDy+TvJgdm1wp3tmh1HtYpSZhegjJLXJE8NkTkQ==}
     peerDependencies:
       '@monaco-editor/react': ^4.6.0
-      '@ttsc/wasm': ^0.18.4
+      '@ttsc/wasm': ^0.19.2
       monaco-editor: ^0.52.0
       react: ^18.0.0
       react-dom: ^18.0.0
       tgrid: ^1.0.3
 
-  '@ttsc/unplugin@0.18.4':
-    resolution: {integrity: sha512-lbizSMFePL+dzJZIw8N/ethvsHKwqsa741H301EefMvG7u4sOEyJHiorN1H2Zp58sYb8HJYBxCtDavtHJjf9IQ==}
+  '@ttsc/unplugin@0.19.2':
+    resolution: {integrity: sha512-027L/hHBleyFq9OJdglGmiL2dmLeA23nIKKC6TcwC/NlMa+ZVvTccXsL8FQyESR6u9ntGxCPr1N1heeMPNRcXg==}
+    peerDependencies:
+      ttsc: 0.19.2
 
-  '@ttsc/wasm@0.18.4':
-    resolution: {integrity: sha512-WVyaZBpjd1tC3Xj7AEcSUqhjqWipyhSgxQyzgvzVG8rzmEl2rZLxQmQ1MC7mgh8izyk+LAmrgSpghZo94nLicQ==}
+  '@ttsc/wasm@0.19.2':
+    resolution: {integrity: sha512-eW7orjOOVkIg71C0CcDoV9ayUD5mblihXM83VDGCundsjCCjRAoI5/yMHC6924NdMnJN6Tvou7TfYBpXu0K8Xw==}
 
-  '@ttsc/win32-arm64@0.18.4':
-    resolution: {integrity: sha512-YmEoUVZg2OAQcoWeYQw0c9aBgoz8kBvFEvbI+uAFn0+bFX1uGryD/5f6bUhS/c3Cdx7xoISumEF3KSJpkjmT9g==}
+  '@ttsc/win32-arm64@0.19.2':
+    resolution: {integrity: sha512-SEkMh77Jx4RtThidhZi46GMoFePxoUuaybTo0Es2vKDMId6ntQTXrfgx7lhxEHs5HK6Q+O1Mzmq4rdY8YJsezg==}
     cpu: [arm64]
     os: [win32]
 
-  '@ttsc/win32-x64@0.18.4':
-    resolution: {integrity: sha512-dp+h7XLLYSw4FHSiZF+EgQs0Fu2RtPcO4lpZfA6NwtmXuTuf64kh4NSsYTDeaEv5qquTcZpFxmA9I4HMNxXWkA==}
+  '@ttsc/win32-x64@0.19.2':
+    resolution: {integrity: sha512-6aimNDbf6ASRZTEiUDwOWajLRo0t678hWW3UpiKLTmUDWa7aI3x8LXvAYlQlChJvsgNgiNaZ8cXc9p3R+EfPrQ==}
     cpu: [x64]
     os: [win32]
 
@@ -6816,8 +6818,9 @@ packages:
   tstl@3.0.0:
     resolution: {integrity: sha512-pR83y6/tbJx6jeGRqGJXk2t/eCUynaHEE6zsOLB0Zga8ej61LXtPfoeiROdhezpoCT15+1QMbqKB1Um5kasSKg==}
 
-  ttsc@0.18.4:
-    resolution: {integrity: sha512-RKsPOGP0D4EpH3yMNOiDw2Ona7e2CeEX6YwybDcVu+2dN6oToHrF43rlYC9srZ6zyvEbT/4wT39QiYQNj4d9JQ==}
+  ttsc@0.19.2:
+    resolution: {integrity: sha512-By0MZNSTg75rURwyDgCdFnjRsQe5eA0w9jdfgmRUsfS5z0cRxvj292eb6bAPBBnsDgIh82HN+D1c9wHIR+/T3g==}
+    engines: {node: '>=22.15.0'}
     hasBin: true
 
   twoslash-protocol@0.3.8:
@@ -9497,41 +9500,42 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.16
 
-  '@ttsc/darwin-arm64@0.18.4':
+  '@ttsc/darwin-arm64@0.19.2':
     optional: true
 
-  '@ttsc/darwin-x64@0.18.4':
+  '@ttsc/darwin-x64@0.19.2':
     optional: true
 
-  '@ttsc/linux-arm64@0.18.4':
+  '@ttsc/linux-arm64@0.19.2':
     optional: true
 
-  '@ttsc/linux-arm@0.18.4':
+  '@ttsc/linux-arm@0.19.2':
     optional: true
 
-  '@ttsc/linux-x64@0.18.4':
+  '@ttsc/linux-x64@0.19.2':
     optional: true
 
-  '@ttsc/playground@0.18.4(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.18.4)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)':
+  '@ttsc/playground@0.19.2(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.19.2)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)':
     dependencies:
       '@monaco-editor/react': 4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@ttsc/wasm': 0.18.4
+      '@ttsc/wasm': 0.19.2
       lz-string: 1.5.0
       monaco-editor: 0.50.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tgrid: 1.2.1
 
-  '@ttsc/unplugin@0.18.4':
+  '@ttsc/unplugin@0.19.2(ttsc@0.19.2)':
     dependencies:
+      ttsc: 0.19.2
       unplugin: 2.3.11
 
-  '@ttsc/wasm@0.18.4': {}
+  '@ttsc/wasm@0.19.2': {}
 
-  '@ttsc/win32-arm64@0.18.4':
+  '@ttsc/win32-arm64@0.19.2':
     optional: true
 
-  '@ttsc/win32-x64@0.18.4':
+  '@ttsc/win32-x64@0.19.2':
     optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -14286,15 +14290,15 @@ snapshots:
 
   tstl@3.0.0: {}
 
-  ttsc@0.18.4:
+  ttsc@0.19.2:
     optionalDependencies:
-      '@ttsc/darwin-arm64': 0.18.4
-      '@ttsc/darwin-x64': 0.18.4
-      '@ttsc/linux-arm': 0.18.4
-      '@ttsc/linux-arm64': 0.18.4
-      '@ttsc/linux-x64': 0.18.4
-      '@ttsc/win32-arm64': 0.18.4
-      '@ttsc/win32-x64': 0.18.4
+      '@ttsc/darwin-arm64': 0.19.2
+      '@ttsc/darwin-x64': 0.19.2
+      '@ttsc/linux-arm': 0.19.2
+      '@ttsc/linux-arm64': 0.19.2
+      '@ttsc/linux-x64': 0.19.2
+      '@ttsc/win32-arm64': 0.19.2
+      '@ttsc/win32-x64': 0.19.2
 
   twoslash-protocol@0.3.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,10 +13,19 @@ overrides:
   zod@4: 4.1.12
 catalogs:
   typescript:
-    ttsc: &ttsc ^0.19.2
-    '@ttsc/playground': *ttsc
-    '@ttsc/unplugin': *ttsc
-    '@ttsc/wasm': *ttsc
+    # typia's native transform consults ttsc's reference-graph SDK (ttsc >=
+    # 0.19.2), and @ttsc/unplugin reads the resulting `graph` envelope, so both
+    # move to 0.19.2 together (@ttsc/unplugin 0.19.2 peers on ttsc 0.19.2).
+    ttsc: ^0.19.2
+    '@ttsc/unplugin': ^0.19.2
+    # @ttsc/wasm / @ttsc/playground drive only the website's in-browser
+    # playground, which links ttsc's wasm host Go API — unrelated to the graph
+    # SDK. website.yml clones the ttsc sibling at the installed @ttsc/wasm
+    # version to build that host, so bumping wasm here would force the
+    # playground onto ttsc 0.19.2's reworked host.Plugin contract. Keep them on
+    # 0.18.4 until that host migration lands on its own.
+    '@ttsc/playground': ^0.18.4
+    '@ttsc/wasm': ^0.18.4
     ts-node: ^10.9.2
     typescript: ^7.0.2
   rolldown:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ overrides:
   zod@4: 4.1.12
 catalogs:
   typescript:
-    ttsc: &ttsc ^0.18.4
+    ttsc: &ttsc ^0.19.2
     '@ttsc/playground': *ttsc
     '@ttsc/unplugin': *ttsc
     '@ttsc/wasm': *ttsc

--- a/website/src/content/docs/setup/index.mdx
+++ b/website/src/content/docs/setup/index.mdx
@@ -12,6 +12,10 @@ typia is a compile-time transformer, so your build has to run through the TypeSc
 >
 > Projects pinned to typia 12 and TypeScript below 7 use the [legacy TypeScript setup](/docs/setup/legacy). The rest of this page is the current typia 13 and TypeScript 7 setup.
 
+> [!IMPORTANT]
+>
+> typia's native transform requires [`ttsc`](https://github.com/samchon/ttsc) **0.19.2 or newer**. ttsc builds typia's plugin from source against your installed ttsc, and the plugin consults ttsc's host-owned reference-graph SDK (added in ttsc 0.19.2) so bundler caches and watch mode invalidate generated validators soundly. On an older ttsc the plugin build fails to compile. This floor is declared through typia's optional `peerDependencies`, so an older `ttsc` (or `@ttsc/unplugin`) already in your project surfaces an npm version-mismatch warning; type-only consumers that install neither are unaffected.
+
 ## Install
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>


### PR DESCRIPTION
## Scope

Adopts the ttsc host-owned reference-graph SDK (shipped in ttsc 0.19.2 by
samchon/ttsc#718) into typia's native transform envelope, so a typia project's
`ttsc-typia transform` output carries the plugin-agnostic `graph` baseline
alongside typia's precise `dependencies` (from #2100). The `@ttsc/unplugin`
consumer registers `reach(edges, F) ∪ globals ∪ configs ∪ dependencies[F]`, so
graph is added, not a replacement.

Closes #2107.

### Changes

1. **Native envelope graph emission** — `runTransformProject` now computes
   `driver.NewTransformGraph(prog, cwd)` (before the transform loop, matching
   ttsc's `api-transform` host, so the graph describes the original resolved
   references, not mutated ASTs) and stamps it into the envelope's optional
   `graph` field. All envelope sections key through `driver.TransformOutputKey`
   so `graph` / `typescript` / `dependencies` join by key. typia's precise
   `dependencies` emission is untouched.
2. **go.mod floor** — `packages/typia/native/go.mod` bumps
   `github.com/samchon/ttsc/packages/ttsc` `v0.0.0 -> v0.19.2` (documentary
   floor; the module is workspace-provided by go.work `use`, so resolution is
   unaffected).
3. **peerDependencies floor** — see the decision note below.
4. **Catalog + lockfile** — `pnpm-workspace.yaml` catalog anchor
   `ttsc ^0.18.4 -> ^0.19.2` (moves `ttsc`/`@ttsc/unplugin`/`@ttsc/wasm`/
   `@ttsc/playground` in lockstep) with `pnpm-lock.yaml` regenerated. Required:
   CI resolves `node_modules/ttsc` for `pnpm test:go:native`, and the graph SDK
   symbols only exist at >= 0.19.2. This is a dependency-range change, not a
   package `version` field change.
5. **Docs** — `website/src/content/docs/setup/index.mdx` states the ttsc
   >= 0.19.2 requirement.

### peerDependencies floor decision (owner-chosen)

typia's plugin is built from bundled Go source against the USER's installed ttsc,
and `driver.NewTransformGraph` exists only in ttsc >= 0.19.2. There is no build
tag to gate on, so referencing the SDK is a hard minimum-ttsc floor raise. The
owner chose to declare it via `peerDependencies` (npm signal), not a preflight
guard:

```jsonc
"peerDependencies": {
  "ttsc": ">=0.19.2",
  "@ttsc/unplugin": ">=0.19.2"
},
"peerDependenciesMeta": {
  "ttsc": { "optional": true },
  "@ttsc/unplugin": { "optional": true }
}
```

`optional: true` on every peer is load-bearing: an ABSENT optional peer triggers
no install/warning/error, so type-only consumers (who install neither ttsc nor
`@ttsc/unplugin`) stay completely clean; a peer PRESENT below the floor gets the
advisory version-mismatch warning. Honest tradeoff: this is a warning, not a hard
failure — a forced install on old ttsc still hits the Go compile error. Both
install topologies are covered (CLI users install `ttsc`; bundler users install
`@ttsc/unplugin`, which carries ttsc transitively).

### Deferred

Narrowing below the host baseline (declaring typia's per-file lists complete) is
NOT in scope — it waits for the completeness contract on the ttsc side (per #2107).

### Verification

Local verification (commands + results) and the empirical peer-warning check
(clean install with no ttsc; warning with old ttsc) are recorded as a thread
comment. CI runs normally on this PR.
