### PR TITLE
fix(website): migrate the playground host to ttsc 0.19.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,14 +11,14 @@ catalogs:
       version: 1.1.5
   typescript:
     '@ttsc/playground':
-      specifier: ^0.18.4
-      version: 0.18.4
+      specifier: ^0.19.2
+      version: 0.19.2
     '@ttsc/unplugin':
       specifier: ^0.19.2
       version: 0.19.2
     '@ttsc/wasm':
-      specifier: ^0.18.4
-      version: 0.18.4
+      specifier: ^0.19.2
+      version: 0.19.2
     ttsc:
       specifier: ^0.19.2
       version: 0.19.2
@@ -805,10 +805,10 @@ importers:
         version: 4.3.0
       '@ttsc/playground':
         specifier: catalog:typescript
-        version: 0.18.4(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.18.4)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)
+        version: 0.19.2(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.19.2)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)
       '@ttsc/wasm':
         specifier: catalog:typescript
-        version: 0.18.4
+        version: 0.19.2
       '@typia/interface':
         specifier: workspace:^
         version: link:../packages/interface
@@ -2687,11 +2687,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@ttsc/playground@0.18.4':
-    resolution: {integrity: sha512-hyhVzAml/ENAw/Dgj60Vu0gdcrdPRcKZpBDSMt6GpQn5we7AMLr/1scJtS94yDwXwwXMaNH6ieY2iAmIBYDN+A==}
+  '@ttsc/playground@0.19.2':
+    resolution: {integrity: sha512-QYzQCTWOpXfMgj+hHqSjbaU2WHbcy2NvjCXpCZPG1TzefnPoDy+TvJgdm1wp3tmh1HtYpSZhegjJLXJE8NkTkQ==}
     peerDependencies:
       '@monaco-editor/react': ^4.6.0
-      '@ttsc/wasm': ^0.18.4
+      '@ttsc/wasm': ^0.19.2
       monaco-editor: ^0.52.0
       react: ^18.0.0
       react-dom: ^18.0.0
@@ -2702,8 +2702,8 @@ packages:
     peerDependencies:
       ttsc: 0.19.2
 
-  '@ttsc/wasm@0.18.4':
-    resolution: {integrity: sha512-WVyaZBpjd1tC3Xj7AEcSUqhjqWipyhSgxQyzgvzVG8rzmEl2rZLxQmQ1MC7mgh8izyk+LAmrgSpghZo94nLicQ==}
+  '@ttsc/wasm@0.19.2':
+    resolution: {integrity: sha512-eW7orjOOVkIg71C0CcDoV9ayUD5mblihXM83VDGCundsjCCjRAoI5/yMHC6924NdMnJN6Tvou7TfYBpXu0K8Xw==}
 
   '@ttsc/win32-arm64@0.19.2':
     resolution: {integrity: sha512-SEkMh77Jx4RtThidhZi46GMoFePxoUuaybTo0Es2vKDMId6ntQTXrfgx7lhxEHs5HK6Q+O1Mzmq4rdY8YJsezg==}
@@ -9084,10 +9084,10 @@ snapshots:
   '@ttsc/linux-x64@0.19.2':
     optional: true
 
-  '@ttsc/playground@0.18.4(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.18.4)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)':
+  '@ttsc/playground@0.19.2(@monaco-editor/react@4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@ttsc/wasm@0.19.2)(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tgrid@1.2.1)':
     dependencies:
       '@monaco-editor/react': 4.7.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@ttsc/wasm': 0.18.4
+      '@ttsc/wasm': 0.19.2
       lz-string: 1.5.0
       monaco-editor: 0.50.0
       react: 18.3.1
@@ -9099,7 +9099,7 @@ snapshots:
       ttsc: 0.19.2
       unplugin: 2.3.11
 
-  '@ttsc/wasm@0.18.4': {}
+  '@ttsc/wasm@0.19.2': {}
 
   '@ttsc/win32-arm64@0.19.2':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,11 +21,11 @@ catalogs:
     # @ttsc/wasm / @ttsc/playground drive only the website's in-browser
     # playground, which links ttsc's wasm host Go API — unrelated to the graph
     # SDK. website.yml clones the ttsc sibling at the installed @ttsc/wasm
-    # version to build that host, so bumping wasm here would force the
-    # playground onto ttsc 0.19.2's reworked host.Plugin contract. Keep them on
-    # 0.18.4 until that host migration lands on its own.
-    '@ttsc/playground': ^0.18.4
-    '@ttsc/wasm': ^0.18.4
+    # version to build that host, so these two pin the Go host API the
+    # playground compiles against: they move only together with
+    # website/compiler/cmd/playground, which implements host.Plugin.
+    '@ttsc/playground': ^0.19.2
+    '@ttsc/wasm': ^0.19.2
     ts-node: ^10.9.2
     typescript: ^7.0.2
   rolldown:

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -3,6 +3,12 @@ _pagefind/
 node_modules/
 out/
 packages/
+
+# `go build ./cmd/playground` drops its binary beside the module; only
+# `go run` / `go test` and the wasm output in public/compiler/ are wanted.
+compiler/playground
+compiler/playground.exe
+
 public/api/
 public/blog/rss.xml
 public/compiler/

--- a/website/compiler/cmd/playground/main.go
+++ b/website/compiler/cmd/playground/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -25,7 +26,14 @@ func main() {
 		name, command := args[0], args[1]
 		for _, p := range plugins {
 			if p.Name() == name {
-				os.Exit(p.Run(command, args[2:]))
+				// InvokePlugin owns the invocation's streams and waits for any
+				// child goroutine it registered. Here — and only here, at the
+				// process boundary — the capture is replayed onto the real
+				// process stdout / stderr.
+				result := host.InvokePlugin(context.Background(), p, command, args[2:])
+				fmt.Fprint(os.Stdout, result.Stdout)
+				fmt.Fprint(os.Stderr, result.Stderr)
+				os.Exit(result.Code)
 			}
 		}
 	}

--- a/website/compiler/cmd/playground/typia_plugin.go
+++ b/website/compiler/cmd/playground/typia_plugin.go
@@ -2,9 +2,12 @@
 //
 // Mirrors the dispatch flow of typia's `cmd/ttsc-typia/{build,transform}.go`,
 // but reframes it as a host.Plugin so the playground wasm can run typia's
-// real transform inline. Whereas the standalone `ttsc-typia` binary owns
-// its own package-level stdout/stderr, here we rely on host.runWithCapturedIO
-// to redirect `os.Stdout` / `os.Stderr` for us — the Plugin contract.
+// real transform inline. Whereas the standalone `ttsc-typia` binary owns its
+// own package-level stdout/stderr, the Plugin contract hands every run the
+// invocation-owned `Stdout` / `Stderr` writers: `Run` threads that pair down
+// through each helper, and nothing here ever touches `os.Stdout` /
+// `os.Stderr`. Concurrent invocations therefore never share output state.
+// Filesystem access (`os.Getwd`, `os.ReadFile`, …) is unaffected.
 //
 // Public surface this delegates into (all live under `packages/typia/native/`):
 //
@@ -35,6 +38,7 @@ import (
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 
   "github.com/samchon/ttsc/packages/ttsc/driver"
+  "github.com/samchon/ttsc/packages/wasm/host"
   typiaadapter "github.com/samchon/typia/packages/typia/native/adapter"
   nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
   nativetransform "github.com/samchon/typia/packages/typia/native/transform"
@@ -60,26 +64,29 @@ func newTypiaPlugin() typiaPlugin { return typiaPlugin{} }
 
 func (typiaPlugin) Name() string { return "typia" }
 
-// Run dispatches the typia subcommands. The verb defaults to `transform` —
-// the playground's TypeScript view is what users see, so an unspecified
-// command should return the rewritten TS rather than spawn an emit pass.
-func (typiaPlugin) Run(command string, args []string) int {
+// Run dispatches the typia subcommands over the invocation's own streams. The
+// verb defaults to `transform` — the playground's TypeScript view is what users
+// see, so an unspecified command should return the rewritten TS rather than
+// spawn an emit pass.
+func (typiaPlugin) Run(invocation *host.PluginInvocation) int {
+  stdout, stderr := invocation.Stdout, invocation.Stderr
+  command, args := invocation.Command, invocation.Args
   if command == "" {
     command = "transform"
   }
   switch command {
   case "build":
-    return runTypiaBuild(args)
+    return runTypiaBuild(args, stdout, stderr)
   case "check":
     // `check` is `build --noEmit` in typia's CLI; mirror that here.
-    return runTypiaBuild(append([]string{"--noEmit"}, args...))
+    return runTypiaBuild(append([]string{"--noEmit"}, args...), stdout, stderr)
   case "transform":
-    return runTypiaTransform(args)
+    return runTypiaTransform(args, stdout, stderr)
   case "-v", "--version", "version":
-    fmt.Fprintln(os.Stdout, "typia (playground-wasm bundled)")
+    fmt.Fprintln(stdout, "typia (playground-wasm bundled)")
     return 0
   default:
-    fmt.Fprintf(os.Stderr, "typia: unknown command %q\n", command)
+    fmt.Fprintf(stderr, "typia: unknown command %q\n", command)
     return 2
   }
 }
@@ -87,11 +94,12 @@ func (typiaPlugin) Run(command string, args []string) int {
 // runTypiaBuild is a stripped-down port of typia's `cmd/ttsc-typia/build.go`
 // runBuild. Differences from the upstream:
 //
-//   - writes via os.Stdout / os.Stderr (no package-level writer indirection)
+//   - writes to the invocation's stdout / stderr rather than a package-level
+//     writer pair
 //   - omits the manifest output (the playground has no use for it)
-func runTypiaBuild(args []string) int {
+func runTypiaBuild(args []string, stdout io.Writer, stderr io.Writer) int {
   fs := flag.NewFlagSet("build", flag.ContinueOnError)
-  fs.SetOutput(os.Stderr)
+  fs.SetOutput(stderr)
   tsconfigPath := fs.String("tsconfig", "tsconfig.json", "path to tsconfig.json")
   cwdOverride := fs.String("cwd", "", "override the working directory")
   quiet := fs.Bool("quiet", true, "suppress the per-call diagnostic summary")
@@ -104,7 +112,7 @@ func runTypiaBuild(args []string) int {
     return 2
   }
   if *emit && *noEmit {
-    fmt.Fprintln(os.Stderr, "typia build: --emit and --noEmit are mutually exclusive")
+    fmt.Fprintln(stderr, "typia build: --emit and --noEmit are mutually exclusive")
     return 2
   }
   if *verbose {
@@ -116,7 +124,7 @@ func runTypiaBuild(args []string) int {
     var err error
     cwd, err = os.Getwd()
     if err != nil {
-      fmt.Fprintf(os.Stderr, "typia build: cwd: %v\n", err)
+      fmt.Fprintf(stderr, "typia build: cwd: %v\n", err)
       return 2
     }
   }
@@ -126,16 +134,16 @@ func runTypiaBuild(args []string) int {
     OutDir:      *outDir,
   })
   if err != nil {
-    fmt.Fprintf(os.Stderr, "typia build: %v\n", err)
+    fmt.Fprintf(stderr, "typia build: %v\n", err)
     return 2
   }
   if len(diags) > 0 {
-    driver.WritePrettyDiagnostics(os.Stderr, diags, cwd)
+    driver.WritePrettyDiagnostics(stderr, diags, cwd)
     return 2
   }
   defer prog.Close()
   if pdiags := prog.Diagnostics(); len(pdiags) > 0 {
-    driver.WritePrettyDiagnostics(os.Stderr, pdiags, cwd)
+    driver.WritePrettyDiagnostics(stderr, pdiags, cwd)
     return 2
   }
 
@@ -143,7 +151,7 @@ func runTypiaBuild(args []string) int {
   transformDiags := []typiaPlaygroundDiag{}
   typiaTransform := newTypiaTransform(prog, cwd, *tsconfigPath, &transformDiags)
   if !*quiet {
-    fmt.Fprintf(os.Stdout, "// typia build: tsconfig=%s cwd=%s emit=%v\n", *tsconfigPath, cwd, shouldEmit)
+    fmt.Fprintf(stdout, "// typia build: tsconfig=%s cwd=%s emit=%v\n", *tsconfigPath, cwd, shouldEmit)
   }
   if shouldEmit {
     emitted := []string{}
@@ -153,18 +161,18 @@ func runTypiaBuild(args []string) int {
     })
     eDiags, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{typiaTransform}, writeFile)
     if err != nil {
-      fmt.Fprintf(os.Stderr, "typia build: emit failed: %v\n", err)
+      fmt.Fprintf(stderr, "typia build: emit failed: %v\n", err)
       return 3
     }
     for _, d := range eDiags {
-      fmt.Fprintln(os.Stderr, "  -", d.String())
+      fmt.Fprintln(stderr, "  -", d.String())
     }
     if !*quiet {
-      fmt.Fprintf(os.Stdout, "// typia build: emitted=%d files\n", len(emitted))
+      fmt.Fprintf(stdout, "// typia build: emitted=%d files\n", len(emitted))
     }
   }
   if len(transformDiags) > 0 {
-    writeTypiaPlaygroundDiagnostics(transformDiags, cwd)
+    writeTypiaPlaygroundDiagnostics(stderr, transformDiags, cwd)
     return 3
   }
   return 0
@@ -174,9 +182,9 @@ func runTypiaBuild(args []string) int {
 // runTransform. The playground only needs the project-wide TS rewrite mode
 // (the JSON-shaped output that maps file path → rewritten source); we keep
 // the single-file branch so command-line smoke tests stay close to the CLI.
-func runTypiaTransform(args []string) int {
+func runTypiaTransform(args []string, stdout io.Writer, stderr io.Writer) int {
   fs := flag.NewFlagSet("transform", flag.ContinueOnError)
-  fs.SetOutput(os.Stderr)
+  fs.SetOutput(stderr)
   file := fs.String("file", "", "absolute or cwd-relative path of the .ts file to transform")
   tsconfigPath := fs.String("tsconfig", "tsconfig.json", "tsconfig.json owning --file")
   cwdOverride := fs.String("cwd", "", "override the working directory")
@@ -187,7 +195,7 @@ func runTypiaTransform(args []string) int {
     return 2
   }
   if *output != "js" && *output != "ts" {
-    fmt.Fprintf(os.Stderr, "typia transform: unknown --output value %q\n", *output)
+    fmt.Fprintf(stderr, "typia transform: unknown --output value %q\n", *output)
     return 2
   }
   cwd := *cwdOverride
@@ -195,7 +203,7 @@ func runTypiaTransform(args []string) int {
     var err error
     cwd, err = os.Getwd()
     if err != nil {
-      fmt.Fprintf(os.Stderr, "typia transform: cwd: %v\n", err)
+      fmt.Fprintf(stderr, "typia transform: cwd: %v\n", err)
       return 2
     }
   }
@@ -204,11 +212,11 @@ func runTypiaTransform(args []string) int {
     ForceEmit: true,
   })
   if err != nil {
-    fmt.Fprintf(os.Stderr, "typia transform: %v\n", err)
+    fmt.Fprintf(stderr, "typia transform: %v\n", err)
     return 2
   }
   if len(diags) > 0 {
-    driver.WritePrettyDiagnostics(os.Stderr, diags, cwd)
+    driver.WritePrettyDiagnostics(stderr, diags, cwd)
     return 2
   }
   defer prog.Close()
@@ -218,10 +226,10 @@ func runTypiaTransform(args []string) int {
 
   if *file == "" {
     if *out != "" {
-      fmt.Fprintln(os.Stderr, "typia transform: --out requires --file")
+      fmt.Fprintln(stderr, "typia transform: --out requires --file")
       return 2
     }
-    return runTypiaTransformProject(prog, cwd, typiaTransform, &transformDiags)
+    return runTypiaTransformProject(prog, cwd, typiaTransform, &transformDiags, stdout, stderr)
   }
 
   absFile := *file
@@ -231,17 +239,17 @@ func runTypiaTransform(args []string) int {
   absFile = filepath.ToSlash(absFile)
   target := prog.SourceFile(absFile)
   if target == nil {
-    fmt.Fprintf(os.Stderr, "typia transform: source file is not in program: %s\n", absFile)
+    fmt.Fprintf(stderr, "typia transform: source file is not in program: %s\n", absFile)
     return 2
   }
 
   if *output == "ts" {
     text := transformFileToTypeScript(prog, typiaTransform, target)
     if len(transformDiags) > 0 {
-      writeTypiaPlaygroundDiagnostics(transformDiags, cwd)
+      writeTypiaPlaygroundDiagnostics(stderr, transformDiags, cwd)
       return 3
     }
-    return writeTypiaSingleOutput(text, *out)
+    return writeTypiaSingleOutput(text, *out, stdout, stderr)
   }
 
   // output == "js": run the emit pipeline so typia's rewrite lands in the
@@ -256,18 +264,18 @@ func runTypiaTransform(args []string) int {
     return nil
   })
   if _, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{typiaTransform}, writeFile); err != nil {
-    fmt.Fprintf(os.Stderr, "typia transform: emit: %v\n", err)
+    fmt.Fprintf(stderr, "typia transform: emit: %v\n", err)
     return 3
   }
   if len(transformDiags) > 0 {
-    writeTypiaPlaygroundDiagnostics(transformDiags, cwd)
+    writeTypiaPlaygroundDiagnostics(stderr, transformDiags, cwd)
     return 3
   }
   if !found {
-    fmt.Fprintf(os.Stderr, "typia transform: no output produced for %s\n", absFile)
+    fmt.Fprintf(stderr, "typia transform: no output produced for %s\n", absFile)
     return 3
   }
-  return writeTypiaSingleOutput(captured, *out)
+  return writeTypiaSingleOutput(captured, *out, stdout, stderr)
 }
 
 // runTypiaTransformProject walks every non-declaration source file and writes a
@@ -278,6 +286,8 @@ func runTypiaTransformProject(
   cwd string,
   typiaTransform driver.PluginTransform,
   transformDiags *[]typiaPlaygroundDiag,
+  stdout io.Writer,
+  stderr io.Writer,
 ) int {
   typescript := map[string]string{}
   for _, sf := range prog.SourceFiles() {
@@ -290,7 +300,7 @@ func runTypiaTransformProject(
     }
     typescript[key] = transformFileToTypeScript(prog, typiaTransform, sf)
   }
-  return writeTypiaTransformProjectOutput(os.Stdout, os.Stderr, typescript, *transformDiags)
+  return writeTypiaTransformProjectOutput(stdout, stderr, typescript, *transformDiags)
 }
 
 func writeTypiaTransformProjectOutput(
@@ -368,19 +378,19 @@ func transformFileToTypeScript(
   return writer.String()
 }
 
-func writeTypiaSingleOutput(text, outPath string) int {
+func writeTypiaSingleOutput(text, outPath string, stdout io.Writer, stderr io.Writer) int {
   if outPath == "" {
-    fmt.Fprint(os.Stdout, text)
+    fmt.Fprint(stdout, text)
     return 0
   }
   if dir := filepath.Dir(outPath); dir != "" {
     if err := os.MkdirAll(dir, 0o755); err != nil {
-      fmt.Fprintf(os.Stderr, "typia transform: mkdir: %v\n", err)
+      fmt.Fprintf(stderr, "typia transform: mkdir: %v\n", err)
       return 3
     }
   }
   if err := os.WriteFile(outPath, []byte(text), 0o644); err != nil {
-    fmt.Fprintf(os.Stderr, "typia transform: write %s: %v\n", outPath, err)
+    fmt.Fprintf(stderr, "typia transform: write %s: %v\n", outPath, err)
     return 3
   }
   return 0
@@ -444,9 +454,9 @@ func (d typiaPlaygroundDiag) String(cwd string) string {
   return fmt.Sprintf("%s - error TS(%s): %s", file, code, d.Message)
 }
 
-func writeTypiaPlaygroundDiagnostics(diagnostics []typiaPlaygroundDiag, cwd string) {
+func writeTypiaPlaygroundDiagnostics(stderr io.Writer, diagnostics []typiaPlaygroundDiag, cwd string) {
   for _, diag := range diagnostics {
-    fmt.Fprintln(os.Stderr, diag.String(cwd))
+    fmt.Fprintln(stderr, diag.String(cwd))
   }
 }
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -156,4 +156,5 @@ If typia saves you time, please consider [donating to the project](https://openc
 
 - Inspired by [`typescript-is`](https://github.com/woutervh-/typescript-is)
 - Source code: [github.com/samchon/typia](https://github.com/samchon/typia)
+- Playground: [typia.io/playground](https://typia.io/playground)
 - Benchmarks: [benchmark/results](https://github.com/samchon/typia/tree/master/benchmark/results/AMD%20Ryzen%209%207940HS%20w%20Radeon%20780M%20Graphics)


### PR DESCRIPTION
Moves the website onto ttsc 0.19.2. The playground wasm still implemented 0.18.4's `host.Plugin`, so every ttsc bump failed the website build:

```
cmd/playground/main.go:23:27: typiaPlugin does not implement host.Plugin
    have Run(string, []string) int
    want Run(*host.PluginInvocation) int
```

## The contract that changed

0.18.4 let the host redirect process stdout/stderr around each call (`runWithCapturedIO`). 0.19.2 drops that and hands every run its own streams, so independent invocations never share output state. Its doc comment is explicit, and it is the whole point of the change:

> Every run receives invocation-owned streams; a plugin must write only to those streams, **never `os.Stdout` or `os.Stderr`**.

So this is not a signature swap. `Run` now takes `*host.PluginInvocation` and threads the invocation's writers down through every helper — all **28** `os.Stdout` / `os.Stderr` uses in `typia_plugin.go` are gone, including the flag sets' `SetOutput` and the `driver.WritePrettyDiagnostics` calls. Filesystem access (`os.Getwd`, `os.ReadFile`, …) is untouched; only the streams were ever the contract.

- **Plumbing** is an explicit `stdout, stderr io.Writer` pair rather than a carried struct — `writeTypiaTransformProjectOutput` already had exactly that signature, so this extends the file's own precedent instead of adding a competing convention, and it keeps `host` imported by `Run` alone.
- **`main.go`**, the native smoke entry, now goes through `host.InvokePlugin` — it builds the invocation, owns the streams, and waits for any registered child work — then replays the capture onto the real process streams at the process boundary, where that is correct.
- **`main_wasm.go`** needed nothing; it only builds `host.Config{Plugins: …}`.
- The stale header comment describing `runWithCapturedIO` is rewritten to the new contract.

## The catalog pin moves with it

`@ttsc/wasm` and `@ttsc/playground` are what `website.yml` clones the ttsc sibling at in order to build this host, so those pins and this package are one unit. The old comment said to keep them at 0.18.4 *"until that host migration lands on its own"* — this is that migration, so the pins go to `^0.19.2` and the comment now says what actually binds them.

## Also

Ignores `compiler/playground[.exe]`. `go build ./cmd/playground` drops its binary beside the module and nothing ignored it, so the repo was one stray build away from committing it. (I hit this.)

## Verification

- `go build` / `go vet` / `go test ./cmd/playground` — pass.
- `GOOS=js GOARCH=wasm go build` — clean. This is the target the website actually compiles, so it is the one that matters.
- `pnpm run test:compiler` — 14/14.
- `npx tsc --noEmit` on both `tsconfig.json` and `tsconfig.rspack.json` — clean. The JS side needed no changes; the break was Go-only.
- **`pnpm build` in `website/` now completes end to end** — wasm (38.89 MiB), 74 pages prerendered, pagefind, sitemap, 346 files in `out/`. That is the step that has been failing, and it is what CI's `website` job runs.

Verified against a real ttsc v0.19.2 checkout, not against assumptions about the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pq8sozdFV7CKziiApEbPjq
