### PR TITLE
fix(utils): honour additionalProperties in OpenApiObjectValidator

### DIFF
--- a/packages/utils/src/utils/LlmJson.ts
+++ b/packages/utils/src/utils/LlmJson.ts
@@ -118,8 +118,10 @@ export namespace LlmJson {
    * auto-correction feedback.
    *
    * @param parameters LLM function parameters schema
-   * @param equals If `true`, reject extraneous properties not defined in the
-   *   schema. Otherwise, extra properties are ignored.
+   * @param equals If `true`, reject extraneous properties on a closed object.
+   *   Otherwise, extra properties are ignored. An object whose
+   *   `additionalProperties` opens it declares undeclared keys to be legitimate
+   *   members, so this flag does not close it.
    * @returns Validator function that checks data against the schema
    */
   export function validate(
@@ -187,8 +189,10 @@ export namespace LlmJson {
    *
    * @template T The expected output type
    * @param parameters LLM parameters schema
-   * @param equals If `true`, reject extraneous properties not defined in the
-   *   schema during validation. Otherwise, extra properties are ignored.
+   * @param equals If `true`, reject extraneous properties on a closed object
+   *   during validation. Otherwise, extra properties are ignored. An object
+   *   whose `additionalProperties` opens it declares undeclared keys to be
+   *   legitimate members, so this flag does not close it.
    * @returns Structured output interface with parse, coerce, and validate
    */
   export function structuredOutput<T>(

--- a/packages/utils/src/validators/OpenApiValidator.ts
+++ b/packages/utils/src/validators/OpenApiValidator.ts
@@ -18,7 +18,10 @@ import { OpenApiStationValidator } from "./internal/OpenApiStationValidator";
  * - {@link create}: Create reusable validator function from schema
  * - {@link validate}: One-shot validation with inline schema
  *
- * Set `equals: true` to reject objects with extra properties (strict mode).
+ * Set `equals: true` to reject extra properties on a closed object (strict
+ * mode). An object whose `additionalProperties` opens it — `true`, or a schema
+ * constraining the extra values — declares undeclared keys to be legitimate
+ * members, so `equals` does not close it.
  *
  * @author Jeongho Nam - https://github.com/samchon
  */

--- a/packages/utils/src/validators/internal/OpenApiObjectValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiObjectValidator.ts
@@ -32,11 +32,16 @@ export namespace OpenApiObjectValidator {
       ),
       ...(typeof ctx.schema.additionalProperties === "object" &&
       ctx.schema.additionalProperties !== null
-        ? Object.entries(ctx.value)
+        ? // A key whose value is `undefined` has no JSON form, so it is not an
+          // additional property to constrain. Validating it as a required value
+          // would reject what `typia.is` and `typia.equals` both accept on an
+          // index-signature type.
+          Object.entries(ctx.value)
             .filter(
-              ([key]) =>
+              ([key, value]) =>
+                value !== undefined &&
                 Object.keys(ctx.schema.properties ?? {}).includes(key) ===
-                false,
+                  false,
             )
             .map(([key, value]) =>
               OpenApiStationValidator.validate({

--- a/packages/utils/src/validators/internal/OpenApiObjectValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiObjectValidator.ts
@@ -52,8 +52,19 @@ export namespace OpenApiObjectValidator {
               }),
             )
         : []),
-      ...(ctx.equals === true &&
-      typeof ctx.schema.additionalProperties !== "object"
+      // Whether a stray property is superfluous is asked only of a closed
+      // object. An `additionalProperties` that opens the object — `true` for
+      // any value, or a schema constraining it — declares that undeclared keys
+      // are legitimate members, so they are never superfluous and `equals` has
+      // nothing to decide. `typia.equals` agrees: it accepts an extra key on a
+      // type carrying an index signature and rejects one on a type without.
+      //
+      // The previous `typeof !== "object"` test read only whether the keyword
+      // was a schema, so it excluded `{ ... }` but not `true`, and closed an
+      // object that had explicitly declared itself open. Reading the boolean is
+      // what lets one document mix an open and a closed object under a single
+      // `equals`, which no option value could otherwise satisfy.
+      ...(ctx.equals === true && !ctx.schema.additionalProperties
         ? [validateEquals(ctx)]
         : []),
     ].every((v) => v);
@@ -76,6 +87,12 @@ export namespace OpenApiObjectValidator {
     return Object.entries(ctx.value as object)
       .map(([key, value]) => {
         if (regular.has(key) === true) return true;
+        // A key whose value is `undefined` has no JSON form — `JSON.stringify`
+        // erases it — so the value does not carry it as a property and it
+        // cannot be superfluous. `typia.equals` agrees, and typia's own emitter
+        // erases `undefined` and `never` members from the schema while the
+        // generated value still spells the keys out.
+        if (value === undefined) return true;
         return ctx.report({
           ...ctx,
           path:

--- a/tests/test-utils-automated/src/TestAutomation.ts
+++ b/tests/test-utils-automated/src/TestAutomation.ts
@@ -78,16 +78,20 @@ export namespace TestAutomation {
    * Eight entries fail today if admitted. Failing is not by itself a validator
    * gap, and for `DynamicNever`, `DynamicUndefined`, and `ObjectUndefined` the
    * reasons below used to say it was — under three different causes, none of
-   * them the real one (#2145). All three fail for one shared reason, and it is
-   * the emitter's: a member or index-signature value typed `never` or
-   * `undefined` has no JSON form, so typia erases it and emits a plain closed
-   * object. `OpenApiValidator` sees only that schema. `DynamicNever`'s spoiler
-   * is a type error against the erased `[key: string]: never` signature, and
-   * `ObjectUndefined`'s spoilers are type errors against its erased `nothing`
-   * and `never` members; the emitted schema states neither, so the non-equals
-   * matrix cannot detect either and no schema-driven validator could. This is
-   * the same emitter over-approximation the other index-signature entries hit,
-   * not an index-signature gap and not a validator gap.
+   * them the real one (#2145). All three share one cause, and it is a schema
+   * collision, not a validator gap.
+   *
+   * A member or index-signature value typed `never` or `undefined` has no JSON
+   * form, so typia erases it. What is left is byte-identical to the schema of a
+   * type that never declared it: `DynamicNever` and an empty interface both
+   * emit `{properties: {}, required: [], additionalProperties: false}`. Their
+   * spoilers do not agree, though — `typia.validate<DynamicNever>` reports a
+   * stray key as a type error against `[key: string]: never`, while the same
+   * key against the empty interface is simply extra, and non-equals validation
+   * ignores extras by design. Two types, one schema, two answers: no
+   * schema-driven validator can give both, whatever it does with
+   * `additionalProperties`. `ObjectUndefined` collides the same way, through
+   * its erased `nothing` and `never` members.
    *
    * `ObjectUndefined` did also carry a real validator defect — an
    * `undefined`-valued key was reported as superfluous, which `typia.equals`
@@ -107,14 +111,14 @@ export namespace TestAutomation {
     // `additionalProperties` from an index signature
     DynamicArray: "index signature; passes today",
     DynamicComposite: "index signature",
-    DynamicNever: "index signature erased; no `never` in schema",
+    DynamicNever: "index signature erased; schema collides with `{}`",
     DynamicSimple: "index signature; passes today",
     DynamicTemplate: "index signature",
-    DynamicUndefined: "index signature erased; no `undefined` in schema",
+    DynamicUndefined: "index signature erased; schema collides with `{}`",
     DynamicUnion: "index signature",
     ObjectDynamic: "index signature; passes today",
-    // members erased from the emitted schema, so the validate matrix cannot see
-    // their spoilers; the equality matrix passes since #2145
+    // erased members, so the validate matrix cannot see their spoilers; the
+    // equality matrix passes since #2145
     ObjectUndefined: "`undefined` and `never` members erased",
     // integer format tags the validator does not enforce
     ConstantAtomicTagged: "uint32 tag; passes today",

--- a/tests/test-utils-automated/src/TestAutomation.ts
+++ b/tests/test-utils-automated/src/TestAutomation.ts
@@ -107,10 +107,10 @@ export namespace TestAutomation {
     // `additionalProperties` from an index signature
     DynamicArray: "index signature; passes today",
     DynamicComposite: "index signature",
-    DynamicNever: "index signature erased; schema states no `never` value",
+    DynamicNever: "index signature erased; no `never` in schema",
     DynamicSimple: "index signature; passes today",
     DynamicTemplate: "index signature",
-    DynamicUndefined: "index signature erased; schema states no `undefined` value",
+    DynamicUndefined: "index signature erased; no `undefined` in schema",
     DynamicUnion: "index signature",
     ObjectDynamic: "index signature; passes today",
     // members erased from the emitted schema, so the validate matrix cannot see

--- a/tests/test-utils-automated/src/TestAutomation.ts
+++ b/tests/test-utils-automated/src/TestAutomation.ts
@@ -75,7 +75,29 @@ export namespace TestAutomation {
    * `DynamicSimple` makes it unfit to be a fixture, only what the validator
    * does with the `additionalProperties` schema its type produces.
    *
-   * Eight entries fail today if admitted, so they are genuine validator gaps.
+   * Eight entries fail today if admitted. Failing is not by itself a validator
+   * gap, and for `DynamicNever`, `DynamicUndefined`, and `ObjectUndefined` the
+   * reasons below used to say it was — under three different causes, none of
+   * them the real one (#2145). All three fail for one shared reason, and it is
+   * the emitter's: a member or index-signature value typed `never` or
+   * `undefined` has no JSON form, so typia erases it and emits a plain closed
+   * object. `OpenApiValidator` sees only that schema. `DynamicNever`'s spoiler
+   * is a type error against the erased `[key: string]: never` signature, and
+   * `ObjectUndefined`'s spoilers are type errors against its erased `nothing`
+   * and `never` members; the emitted schema states neither, so the non-equals
+   * matrix cannot detect either and no schema-driven validator could. This is
+   * the same emitter over-approximation the other index-signature entries hit,
+   * not an index-signature gap and not a validator gap.
+   *
+   * `ObjectUndefined` did also carry a real validator defect — an
+   * `undefined`-valued key was reported as superfluous, which `typia.equals`
+   * accepts — and #2145 fixed it, so it now passes the equality matrix. It
+   * stays held out only because this one set feeds both matrices and it still
+   * fails the validate matrix above. Splitting the set per matrix is #2136's
+   * follow-up, which would also admit `TemplateInterpolationTagged` and
+   * `TypeTagType`; both pass the equality matrix and are held out for a
+   * validate-matrix reason.
+   *
    * The four marked `passes today` are measured to validate cleanly against
    * their own spoilers, and are held out only because admitting them changes
    * *which* structures the matrix covers — a separate decision from *how* they
@@ -85,14 +107,15 @@ export namespace TestAutomation {
     // `additionalProperties` from an index signature
     DynamicArray: "index signature; passes today",
     DynamicComposite: "index signature",
-    DynamicNever: "index signature over a `never` member",
+    DynamicNever: "index signature erased; schema states no `never` value",
     DynamicSimple: "index signature; passes today",
     DynamicTemplate: "index signature",
-    DynamicUndefined: "index signature",
+    DynamicUndefined: "index signature erased; schema states no `undefined` value",
     DynamicUnion: "index signature",
     ObjectDynamic: "index signature; passes today",
-    // a `never` member erased from the emitted schema
-    ObjectUndefined: "`never` member",
+    // members erased from the emitted schema, so the validate matrix cannot see
+    // their spoilers; the equality matrix passes since #2145
+    ObjectUndefined: "`undefined` and `never` members erased",
     // integer format tags the validator does not enforce
     ConstantAtomicTagged: "uint32 tag; passes today",
     TemplateInterpolationTagged: "uint32 tag",

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_object_additional_properties.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_object_additional_properties.ts
@@ -1,0 +1,147 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiValidator } from "@typia/utils";
+
+/**
+ * Verifies `additionalProperties: true` opens an object against `equals`.
+ *
+ * Whether a stray property is superfluous is a question only a closed object
+ * answers. An `additionalProperties` that opens the object — `true` for any
+ * value, or a schema constraining it — declares undeclared keys to be
+ * legitimate members, so `equals` has nothing left to decide. The validator
+ * tested `typeof additionalProperties !== "object"`, which reads whether the
+ * keyword is a schema but never reads the boolean, so `true` was indistinguish-
+ * able from `false` and from an absent keyword, and `equals: true` closed an
+ * object that had explicitly declared itself open.
+ *
+ * The case that pins this is a document mixing an open and a closed object: no
+ * value of a single global option can answer both halves, so the keyword must
+ * be read per schema. Expectations come from `ILlmSchema.IObject`'s published
+ * three-way contract and from `typia.equals`, which accepts an extra key on a
+ * type with an index signature and rejects one on a type without.
+ *
+ * 1. Cross every `additionalProperties` form with both `equals` values.
+ * 2. Require a mixed document to answer both objects correctly at once.
+ * 3. Pin the reported path so a rejection stays diagnosable.
+ */
+export const test_openapi_validator_object_additional_properties = (): void => {
+  const build = (
+    additionalProperties?: OpenApi.IJsonSchema.IObject["additionalProperties"],
+  ): OpenApi.IJsonSchema.IObject => ({
+    type: "object",
+    properties: { a: { type: "string" } },
+    required: ["a"],
+    ...(additionalProperties === undefined ? {} : { additionalProperties }),
+  });
+
+  const clean = { a: "value" };
+  const extra = { a: "value", b: 1 };
+
+  for (const equals of [false, true]) {
+    const label = (text: string): string => `equals: ${equals} - ${text}`;
+
+    // An open object never has a superfluous property. This is the row the
+    // unread boolean got wrong: `true` closed under `equals: true`.
+    expect(label("open accepts a clean value"), build(true), clean, equals, true);
+    expect(label("open accepts an extra property"), build(true), extra, equals, true);
+
+    // A schema value opens the object too, and constrains what may enter it.
+    expect(
+      label("constrained accepts a matching extra property"),
+      build({ type: "number" }),
+      extra,
+      equals,
+      true,
+    );
+    expect(
+      label("constrained rejects a mismatched extra property"),
+      build({ type: "number" }),
+      { a: "value", b: "not a number" },
+      equals,
+      false,
+    );
+
+    // A closed object is the only one `equals` speaks for, and an absent
+    // keyword is closed for this purpose.
+    expect(label("closed accepts a clean value"), build(false), clean, equals, true);
+    expect(
+      label("closed leaves an extra property to equals"),
+      build(false),
+      extra,
+      equals,
+      equals === false,
+    );
+    expect(label("absent accepts a clean value"), build(), clean, equals, true);
+    expect(
+      label("absent leaves an extra property to equals"),
+      build(),
+      extra,
+      equals,
+      equals === false,
+    );
+  }
+
+  // The mixed document. One schema carries an open and a closed object, so a
+  // global option cannot answer both: under `equals: true` the open object must
+  // still accept while the closed one rejects.
+  const mixed: OpenApi.IJsonSchema.IObject = {
+    type: "object",
+    properties: { open: build(true), closed: build(false) },
+    required: ["open", "closed"],
+    additionalProperties: false,
+  };
+  expect(
+    "mixed document allows an extra property on its open object",
+    mixed,
+    { open: extra, closed: clean },
+    true,
+    true,
+  );
+  expect(
+    "mixed document rejects an extra property on its closed object",
+    mixed,
+    { open: clean, closed: extra },
+    true,
+    false,
+  );
+  expect(
+    "mixed document separates its two objects at once",
+    mixed,
+    { open: extra, closed: extra },
+    true,
+    false,
+  );
+
+  // The rejection names the offending property, not the object holding it.
+  const validation = OpenApiValidator.validate({
+    components: {},
+    schema: mixed,
+    value: { open: extra, closed: extra },
+    required: true,
+    equals: true,
+  });
+  TestValidator.equals(
+    "the mixed document reports only the closed object's property",
+    validation.success === false ? validation.errors.map((e) => e.path) : [],
+    ["$input.closed.b"],
+  );
+};
+
+const expect = (
+  label: string,
+  schema: OpenApi.IJsonSchema,
+  value: unknown,
+  equals: boolean,
+  success: boolean,
+): void =>
+  TestValidator.equals(
+    label,
+    OpenApiValidator.validate({
+      components: {},
+      schema,
+      value,
+      required: true,
+      equals,
+    }).success,
+    success,
+  );

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_object_additional_properties.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_object_additional_properties.ts
@@ -10,9 +10,9 @@ import { OpenApiValidator } from "@typia/utils";
  * value, or a schema constraining it — declares undeclared keys to be
  * legitimate members, so `equals` has nothing left to decide. The validator
  * tested `typeof additionalProperties !== "object"`, which reads whether the
- * keyword is a schema but never reads the boolean, so `true` was indistinguish-
- * able from `false` and from an absent keyword, and `equals: true` closed an
- * object that had explicitly declared itself open.
+ * keyword is a schema but never reads the boolean. `true` was therefore no
+ * different from `false` or from an absent keyword, and `equals: true` closed
+ * an object that had explicitly declared itself open.
  *
  * The case that pins this is a document mixing an open and a closed object: no
  * value of a single global option can answer both halves, so the keyword must

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_object_additional_properties.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_object_additional_properties.ts
@@ -42,8 +42,20 @@ export const test_openapi_validator_object_additional_properties = (): void => {
 
     // An open object never has a superfluous property. This is the row the
     // unread boolean got wrong: `true` closed under `equals: true`.
-    expect(label("open accepts a clean value"), build(true), clean, equals, true);
-    expect(label("open accepts an extra property"), build(true), extra, equals, true);
+    expect(
+      label("open accepts a clean value"),
+      build(true),
+      clean,
+      equals,
+      true,
+    );
+    expect(
+      label("open accepts an extra property"),
+      build(true),
+      extra,
+      equals,
+      true,
+    );
 
     // A schema value opens the object too, and constrains what may enter it.
     expect(
@@ -63,7 +75,13 @@ export const test_openapi_validator_object_additional_properties = (): void => {
 
     // A closed object is the only one `equals` speaks for, and an absent
     // keyword is closed for this purpose.
-    expect(label("closed accepts a clean value"), build(false), clean, equals, true);
+    expect(
+      label("closed accepts a clean value"),
+      build(false),
+      clean,
+      equals,
+      true,
+    );
     expect(
       label("closed leaves an extra property to equals"),
       build(false),
@@ -111,6 +129,14 @@ export const test_openapi_validator_object_additional_properties = (): void => {
     true,
     false,
   );
+
+  // `null` sits outside the published `boolean | IJsonSchema` type, but this
+  // validator guards against it, so pin it: it constrains nothing and so cannot
+  // open the object. `OpenApiTypeCheckerBase.coverObject` reads it the same way.
+  const nulled = build(null as unknown as false);
+  expect("a null keyword accepts a clean value", nulled, clean, true, true);
+  expect("a null keyword does not open the object", nulled, extra, true, false);
+  expect("a null keyword is still lenient", nulled, extra, false, true);
 
   // The rejection names the offending property, not the object holding it.
   const validation = OpenApiValidator.validate({

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_object_undefined_property.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_object_undefined_property.ts
@@ -20,9 +20,15 @@ interface IUndefined {
  * `typia.equals` is an independent code generator, which makes it the oracle
  * here rather than the validator's own output.
  *
+ * Both branches that walk `Object.entries` must agree on this: the closure
+ * check, and the one constraining extras against an `additionalProperties`
+ * schema, which would otherwise validate the key as a required value.
+ *
  * 1. Confirm an `undefined`-valued key is not superfluous under `equals: true`,
  *    and that a defined extra key still is.
- * 2. Round-trip a type whose members erase from the emitted schema and require
+ * 2. Confirm an `additionalProperties` schema does not constrain a key with no
+ *    JSON form, under either `equals` value.
+ * 3. Round-trip a type whose members erase from the emitted schema and require
  *    the emitter's own schema to accept the emitter's own value.
  */
 export const test_openapi_validator_object_undefined_property = (): void => {
@@ -68,6 +74,44 @@ export const test_openapi_validator_object_undefined_property = (): void => {
     "typia.equals rejects a defined extra key",
     typia.equals<{ a: string }>({ a: "value", b: 1 }),
     false,
+  );
+
+  // The sibling branch: an `additionalProperties` schema constrains the extra
+  // values, but a key with no JSON form is not one of them. `typia` accepts it
+  // on an index-signature type under both `is` and `equals`.
+  const constrained: OpenApi.IJsonSchema.IObject = {
+    type: "object",
+    properties: { a: { type: "string" } },
+    required: ["a"],
+    additionalProperties: { type: "string" },
+  };
+  const constrains = (value: unknown, equals: boolean): boolean =>
+    OpenApiValidator.validate({
+      components: {},
+      schema: constrained,
+      value,
+      required: true,
+      equals,
+    }).success;
+  for (const equals of [false, true]) {
+    TestValidator.equals(
+      `equals: ${equals} - a constrained object ignores an undefined-valued key`,
+      constrains({ a: "value", b: undefined }, equals),
+      true,
+    );
+    TestValidator.equals(
+      `equals: ${equals} - a constrained object still checks a defined extra key`,
+      constrains({ a: "value", b: 1 }, equals),
+      false,
+    );
+  }
+  TestValidator.equals(
+    "typia accepts an undefined-valued key on an index-signature type",
+    typia.equals<{ a: string; [key: string]: string }>({
+      a: "value",
+      b: undefined,
+    } as any),
+    true,
   );
 
   // The emitter's own round trip. `nothing` and an `undefined` union member

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_object_undefined_property.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_object_undefined_property.ts
@@ -1,0 +1,109 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiValidator } from "@typia/utils";
+import typia from "typia";
+
+interface IUndefined {
+  name: string;
+  nothing: undefined;
+  grade: number | undefined;
+}
+
+/**
+ * Verifies `equals: true` agrees with `typia.equals` on `undefined` values.
+ *
+ * A key whose value is `undefined` has no JSON form — `JSON.stringify` erases
+ * it — so the value does not carry it as a property and it cannot be
+ * superfluous. The closure check walked `Object.entries` and reported it
+ * anyway, so a value typia generates was rejected against the schema typia
+ * emits from the same type. `equals` mode exists to mirror `typia.equals`, and
+ * `typia.equals` is an independent code generator, which makes it the oracle
+ * here rather than the validator's own output.
+ *
+ * 1. Confirm an `undefined`-valued key is not superfluous under `equals: true`,
+ *    and that a defined extra key still is.
+ * 2. Round-trip a type whose members erase from the emitted schema and require
+ *    the emitter's own schema to accept the emitter's own value.
+ */
+export const test_openapi_validator_object_undefined_property = (): void => {
+  const schema: OpenApi.IJsonSchema.IObject = {
+    type: "object",
+    properties: { a: { type: "string" } },
+    required: ["a"],
+    additionalProperties: false,
+  };
+  const accepts = (value: unknown): boolean =>
+    OpenApiValidator.validate({
+      components: {},
+      schema,
+      value,
+      required: true,
+      equals: true,
+    }).success;
+
+  TestValidator.equals(
+    "an undefined-valued key is not a property",
+    accepts({ a: "value", b: undefined }),
+    true,
+  );
+  TestValidator.equals(
+    "a defined extra key is still superfluous",
+    accepts({ a: "value", b: 1 }),
+    false,
+  );
+  TestValidator.equals(
+    "an undefined-valued key does not excuse its siblings",
+    accepts({ a: "value", b: undefined, c: 1 }),
+    false,
+  );
+
+  // `typia.equals` is the oracle, and it accepts what the closure check used to
+  // reject.
+  TestValidator.equals(
+    "typia.equals accepts an undefined-valued key",
+    typia.equals<{ a: string }>({ a: "value", b: undefined }),
+    true,
+  );
+  TestValidator.equals(
+    "typia.equals rejects a defined extra key",
+    typia.equals<{ a: string }>({ a: "value", b: 1 }),
+    false,
+  );
+
+  // The emitter's own round trip. `nothing` and an `undefined` union member
+  // have no JSON form, so typia erases them from the schema while the value
+  // still spells the keys out.
+  const collection = typia.json.schema<IUndefined>();
+  const value: IUndefined = {
+    name: "someone",
+    nothing: undefined,
+    grade: undefined,
+  };
+  TestValidator.equals(
+    "typia.equals accepts its own erased-member value",
+    typia.equals<IUndefined>(value),
+    true,
+  );
+  TestValidator.equals(
+    "the emitted schema accepts its own erased-member value",
+    OpenApiValidator.validate({
+      components: collection.components,
+      schema: collection.schema,
+      value,
+      required: true,
+      equals: true,
+    }).success,
+    true,
+  );
+  TestValidator.equals(
+    "the emitted schema still rejects a stray property",
+    OpenApiValidator.validate({
+      components: collection.components,
+      schema: collection.schema,
+      value: { ...value, stray: "extra" },
+      required: true,
+      equals: true,
+    }).success,
+    false,
+  );
+};


### PR DESCRIPTION
Fixes #2145.

## Intent

`OpenApiObjectValidator` gated its superfluous-property check on `typeof ctx.schema.additionalProperties !== "object"` — a test of whether the keyword is a *schema*, which never reads the boolean. `true`, `false`, and an absent keyword were indistinguishable, so `equals: true` closed an object that had explicitly declared itself open.

**The invariant:** whether a stray property is superfluous is a question only a *closed* object answers. An `additionalProperties` that opens the object — `true` for any value, or a schema constraining it — declares undeclared keys to be legitimate members, so `equals` has nothing to decide. Only a closed object leaves the question to `equals`.

`typia.equals` is the oracle and already agrees:

| type | typia emits | `typia.is` | `typia.equals` |
| --- | --- | --- | --- |
| `{a: string}` | `additionalProperties: false` | ignores extra | **rejects** extra |
| `{a: string; [k: string]: any}` | `additionalProperties: {}` | ignores extra | **accepts** extra |

The old code was reaching for exactly this with `typeof !== "object"`; it just forgot that `true` is as open as `{}`.

**The case no option value could answer** — a document mixing an open and a closed object. Before: `equals: false` accepted extras on both, `equals: true` rejected them on both. After: one `equals: true` accepts on the open object and rejects on the closed one.

**Second half:** `equals: true` reported a key whose value is `undefined` as superfluous, while `typia.equals` accepts it — so a value typia generates was rejected against the schema typia emits from the same type. Both branches that walk `Object.entries` now skip keys with no JSON form.

## Scope

- `packages/utils` only. No native Go. No version bump.
- `OpenApiTupleValidator` and `OpenApiTypeChecker.covers` are **not** touched — they already read their keyword.
- `OpenApiIntegerValidator` and the docblock's other five structures belong to #2146/#2148 and are untouched.
- At the default `equals: false`, the only behaviour change is the `undefined` skip; closure still runs solely under `equals: true`.

## Two things the issue asserts that did not survive verification

Both are recorded in the thread with measurements.

1. **"`additionalProperties: false` → reject regardless of `equals`" is wrong.** typia emits `additionalProperties: false` on *every* closed object, and `typia.is` ignores extras on those. Implementing that reading broke **14 structures** in `test-utils-automated` and contradicts `website/src/content/docs/llm/application.mdx:438`. Reverted.
2. **The 3 held-out structures cannot return to the validate matrix.** `DynamicNever`'s schema is byte-identical to a plain empty interface's, yet their `typia.validate` oracles disagree — two types, one schema, two required answers. No schema-driven validator can give both. D2A's "no regression" claim came from probing only the 12 held-out entries, never the full matrix.

`ObjectUndefined` *did* carry a real validator defect — the `undefined`-valued key — and now passes the equality matrix. It stays held out only because one `HELD_OUT` set feeds both matrices (#2136's follow-up). The docblock's attribution is corrected in place; counts stay 83/80.

## Verification

Local only; campaign CI is cancelled per the exact-SHA gate. On `origin/master` = `16f574af02`:

| suite | cases | result |
| --- | --- | --- |
| `./tests/test-utils` | 296 | Success |
| `./tests/test-utils-automated` | 163 | Success |
| `./tests/test-mcp` | 19 | Success |
| `./tests/test-vercel` | 22 | Success |
| `./tests/test-langchain` | 13 | Success |
| `./tests/test-feature-identity` | 6 | Success |

Three mutations each independently caught; none is caught by the automated matrix, since typia never emits `additionalProperties: true` and `ObjectUndefined` is held out.

Self-Review: 5 rounds, last two clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
