### PR TITLE
ci(website): watch release.yml so the deploy can reach gh-pages

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,6 +16,7 @@ on:
       - 'pnpm-workspace.yaml'
   pull_request:
     paths:
+      - .github/workflows/release.yml
       - .github/workflows/website.yml
       - 'config/**'
       - 'examples/**'

--- a/website/build/deploy.js
+++ b/website/build/deploy.js
@@ -13,6 +13,6 @@ deploy.publish(
     if (err) {
       console.log(err);
       process.exit(-1);
-    } else clear();
+    } else deploy.clean();
   },
 );


### PR DESCRIPTION
## Cause

`154f074a99` — *"fix(website): restore the master push deploy to gh-pages"* — deleted `- .github/workflows/release.yml` from `pull_request.paths` while restructuring the `on:` block. The deletion is unmentioned in its commit message and is not part of restoring the push trigger; `2d927f0f3d` had added the entry deliberately.

**A commit whose purpose was to restore the deploy is the one that broke it.**

## Consequence

`workflowPathFilters.test.mjs` names the omission, so the `Test Playground Compiler` step fails and the job dies **before** the `Deploy` step ever runs.

The live site has been stale since 2026-07-15 — `gh-pages` tip `a2a182ccdf`, built from `37377717ad` (v13.1.1). **21 merged PRs have not published**, including the #2118 deep-blue retheme and 23 changed docs pages.

## Why the test is right and the filter is the bug

This is a soundness property, not over-specification:

- `workflowPathFilters.test.mjs` **physically reads `release.yml`** (lines 152-177) to assert the website job's ttsc provenance: tagged clone, non-empty `TTSC_VERSION`, and step order.
- `website.yml` is the **only** workflow that runs `test:compiler`.
- `release.yml` does **not** validate its own website job, and triggers only on `v*.*.*` tags and `workflow_dispatch` — so it never runs on a pull request that edits it.

Without the path filter, **nothing** validates release.yml's provenance contracts. A bad edit merges silently and surfaces only once a release has already published — precisely what the test's own doc comment warns about. Removing the filter makes the guard **pass stale**.

A job must watch every input it consumes, which is literally what the test is named: *"workflow contracts match consumed inputs and compiler provenance"*.

Contrast #2141 explicitly: that was an accident pinned as a contract. This is the opposite — a real, causal dependency where the guard becomes unsound without the filter.

## Why `pull_request.paths` only

A release.yml edit changes no site content. The push trigger exists to publish, so it must not rebuild and redeploy for it. This restores exactly what was accidentally deleted, and nothing more.

## The `clean()` commit

`deploy.js` has called a bare `clear()` on the publish success path since `18b67334c9` (2023). `clear` is defined nowhere in the repository and is not a Node global — it is a REPL-only affordance. The `gh-pages` module the file already imports as `deploy` exports `clean()`, so `clear()` is a typo for `deploy.clean()`.

**Honest consequence model — it never broke a deploy.** gh-pages invokes the callback through an internal `done()` that wraps it in try/catch and reports a throw only through `util.debuglog("gh-pages")`, which is silent unless `NODE_DEBUG=gh-pages`. The publish itself completes and the process exits 0. That is why a three-year-old `ReferenceError` left no trace.

This corrects a claim made during review that the bug would bite the manual deploy path — it does not. That was checked empirically, and the claim was wrong. The one real consequence is that the intended cache cleanup never ran, evidenced by a leftover `node_modules/.cache/gh-pages` directory found on a working checkout.

This path is manual-deploy only; CI publishes through `JamesIves/github-pages-deploy-action` and never loads this file.

## Verification

The full CI prerequisite chain was reproduced locally on Windows, with the ttsc sibling cloned at the exact tag `v0.19.2` matching the installed `@ttsc/wasm`:

| step | result |
| --- | --- |
| `pnpm install` (root) | ok |
| ttsc sibling @ `v0.19.2` | ok |
| `pnpm run build` | ok |
| `pnpm run package:tgz` | ok |
| `pnpm run test:compiler` | **14/14, `# fail 0`** (fails without this fix) |
| `go -C compiler test ./cmd/playground` | **ok** |
| website `pnpm run build` | **exit 0** |

`out/` was inspected before drawing any conclusion:

| check | result |
| --- | --- |
| top-level entry set | **identical** to the live site |
| file count | 346 vs live 339 (+7, new docs pages) |
| `CNAME` | `typia.io` present — custom domain safe |
| `compiler/ttsc-typia.wasm` | 40,778,115 B vs live 40,616,686 B (+0.4%) |
| `compiler/wasm_exec.js` | 16,992 B — byte-identical to live |
| #2118 retheme | present (`--nextra-primary-hue: 214deg`) |
| Windows absolute-path leakage | none |
| zero-byte files | none |
| `robots.txt` / sitemap URLs | correct `https://typia.io` |

Both commits touch only CI configuration and the `deploy` script — neither is read by `pnpm run build` — so `out/` equals what master builds and this verification transfers to CI.

## Scope

- `packages/typia/package.json` untouched.
- No `pnpm format` run.
- No manual publish. The site publishes from ubuntu through CI once this lands, which keeps `gh-pages` provenance traceable. Publishing manually would have refreshed the site while leaving the CI deploy broken, masking the very symptom that reveals it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
