### PR TITLE
fix(utils): gate description-constraint inversion on the mode that wrote the tags

### DIFF
--- a/packages/mcp/src/internal/McpControllerRegistrar.ts
+++ b/packages/mcp/src/internal/McpControllerRegistrar.ts
@@ -42,6 +42,14 @@ export namespace McpControllerRegistrar {
               // schema. A `strict` application carries its constraints as
               // description tags instead of keywords, and only that config
               // tells the inverter to read them back.
+              //
+              // An HttpLlm application reports the config it was composed with,
+              // so this is exact for it. A typia.llm.controller reports
+              // `strict: false` whatever its Config generic said — a transform
+              // defect, not a reason to guess here: guessing is what erased the
+              // non-strict constraints in the first place. This reads the
+              // declared config and becomes exact for class controllers too the
+              // moment the transform reports it truthfully.
               LlmJson.validate(
                 func.output,
                 true,

--- a/packages/mcp/src/internal/McpControllerRegistrar.ts
+++ b/packages/mcp/src/internal/McpControllerRegistrar.ts
@@ -38,7 +38,11 @@ export namespace McpControllerRegistrar {
         validateOutput:
           func.output === undefined
             ? undefined
-            : LlmJson.validate(func.output, true),
+            : // Validate the output against the config that produced its
+              // schema. A `strict` application carries its constraints as
+              // description tags instead of keywords, and only that config
+              // tells the inverter to read them back.
+              LlmJson.validate(func.output, true, controller.application.config),
       });
     }
 

--- a/packages/mcp/src/internal/McpControllerRegistrar.ts
+++ b/packages/mcp/src/internal/McpControllerRegistrar.ts
@@ -42,7 +42,11 @@ export namespace McpControllerRegistrar {
               // schema. A `strict` application carries its constraints as
               // description tags instead of keywords, and only that config
               // tells the inverter to read them back.
-              LlmJson.validate(func.output, true, controller.application.config),
+              LlmJson.validate(
+                func.output,
+                true,
+                controller.application.config,
+              ),
       });
     }
 

--- a/packages/utils/src/converters/LlmSchemaConverter.ts
+++ b/packages/utils/src/converters/LlmSchemaConverter.ts
@@ -504,18 +504,27 @@ export namespace LlmSchemaConverter {
    * Restores constraint information from description tags and converts `$defs`
    * references to `#/components/schemas`.
    *
+   * Only `strict` conversions move constraints into the description, so only a
+   * `strict` inversion reads them back. Pass the same `config` the schema was
+   * converted with; the default is the same non-strict default {@link getConfig}
+   * applies, under which the constraint keywords are still on the schema and a
+   * description is only ever prose.
+   *
+   * @param props.config Configuration the schema was converted with
    * @param props.components Target components (mutated with definitions)
    * @param props.schema LLM schema to invert
    * @param props.$defs LLM schema definitions
    * @returns OpenAPI JSON schema
    */
   export const invert = (props: {
+    config?: Partial<ILlmSchema.IConfig>;
     components: OpenApi.IComponents;
     schema: ILlmSchema;
     $defs: Record<string, ILlmSchema>;
   }): OpenApi.IJsonSchema =>
     invertInternal({
       ...props,
+      config: getConfig(props.config),
       // One allocation per conversion, seeded with the component names the
       // caller already owns. Recursive inversion reuses it instead of
       // recomputing, so a reference and its stored component never disagree.
@@ -532,6 +541,7 @@ export namespace LlmSchemaConverter {
     });
 
   const invertInternal = (props: {
+    config: ILlmSchema.IConfig;
     components: OpenApi.IComponents;
     schema: ILlmSchema;
     $defs: Record<string, ILlmSchema>;
@@ -556,6 +566,7 @@ export namespace LlmSchemaConverter {
 
     const next = (schema: ILlmSchema): OpenApi.IJsonSchema =>
       invertInternal({
+        config: props.config,
         components: props.components,
         $defs: props.$defs,
         schema,
@@ -566,7 +577,10 @@ export namespace LlmSchemaConverter {
       if (LlmTypeChecker.isArray(schema))
         union.push({
           ...schema,
-          ...LlmDescriptionInverter.array(schema.description),
+          ...LlmDescriptionInverter.array({
+            config: props.config,
+            description: schema.description,
+          }),
           items: next(schema.items),
         });
       else if (LlmTypeChecker.isObject(schema))
@@ -640,7 +654,10 @@ export namespace LlmSchemaConverter {
         else
           union.push({
             ...schema,
-            ...LlmDescriptionInverter.numeric(schema.description),
+            ...LlmDescriptionInverter.numeric({
+              config: props.config,
+              description: schema.description,
+            }),
             ...{ enum: undefined },
           });
       else if (LlmTypeChecker.isString(schema))
@@ -653,7 +670,10 @@ export namespace LlmSchemaConverter {
         else
           union.push({
             ...schema,
-            ...LlmDescriptionInverter.string(schema.description),
+            ...LlmDescriptionInverter.string({
+              config: props.config,
+              description: schema.description,
+            }),
             ...{ enum: undefined },
           });
       else

--- a/packages/utils/src/converters/internal/LlmDescriptionInverter.ts
+++ b/packages/utils/src/converters/internal/LlmDescriptionInverter.ts
@@ -7,10 +7,9 @@ import { OpenApiExclusiveEmender } from "./OpenApiExclusiveEmender";
  * description.
  *
  * The shifter and this reader are one pair, so they share one gate. The shifter
- * only runs under `strict` — the mode whose schema may not carry the constraint
- * keywords itself — and therefore this reader only runs under `strict` too:
- * every function here takes the config that produced the schema and reports
- * nothing outside that mode.
+ * moves constraints into the description only under `strict`, so this reader
+ * reads them back only under `strict` too: every function here takes the config
+ * that produced the schema and reports nothing outside that mode.
  *
  * Without that gate an `@minimum 3` written by a documentation author would be
  * promoted to a constraint the type never declared, and, because these results

--- a/packages/utils/src/converters/internal/LlmDescriptionInverter.ts
+++ b/packages/utils/src/converters/internal/LlmDescriptionInverter.ts
@@ -1,11 +1,27 @@
-import { OpenApi } from "@typia/interface";
+import { ILlmSchema, OpenApi } from "@typia/interface";
 
 import { OpenApiExclusiveEmender } from "./OpenApiExclusiveEmender";
 
+/**
+ * Reader for the constraints `OpenApiConstraintShifter` moved into a
+ * description.
+ *
+ * The shifter and this reader are one pair, so they share one gate. The shifter
+ * only runs under `strict` — the mode whose schema may not carry the constraint
+ * keywords itself — and therefore this reader only runs under `strict` too:
+ * every function here takes the config that produced the schema and reports
+ * nothing outside that mode.
+ *
+ * Without that gate an `@minimum 3` written by a documentation author would be
+ * promoted to a constraint the type never declared, and, because these results
+ * are spread over the live schema, the lookups that found nothing would delete
+ * the real keywords a non-strict schema still carries.
+ */
 export namespace LlmDescriptionInverter {
-  export const numeric = (
-    description: string | undefined,
-  ): Pick<
+  export const numeric = (props: {
+    config: ILlmSchema.IConfig;
+    description: string | undefined;
+  }): Pick<
     OpenApi.IJsonSchema.INumber,
     | "minimum"
     | "maximum"
@@ -14,35 +30,40 @@ export namespace LlmDescriptionInverter {
     | "multipleOf"
     | "description"
   > => {
+    const description: string | undefined = read(props);
     if (description === undefined) return {};
 
     const lines: string[] = description.split("\n");
-    return OpenApiExclusiveEmender.emend({
-      minimum: find({
-        type: "number",
-        name: "minimum",
-        lines,
-      }),
-      maximum: find({
-        type: "number",
-        name: "maximum",
-        lines,
-      }),
-      exclusiveMinimum: find({
-        type: "number",
-        name: "exclusiveMinimum",
-        lines,
-      }),
-      exclusiveMaximum: find({
-        type: "number",
-        name: "exclusiveMaximum",
-        lines,
-      }),
-      multipleOf: find({
-        type: "number",
-        name: "multipleOf",
-        lines,
-      }),
+    return {
+      ...compact(
+        OpenApiExclusiveEmender.emend({
+          minimum: find({
+            type: "number",
+            name: "minimum",
+            lines,
+          }),
+          maximum: find({
+            type: "number",
+            name: "maximum",
+            lines,
+          }),
+          exclusiveMinimum: find({
+            type: "number",
+            name: "exclusiveMinimum",
+            lines,
+          }),
+          exclusiveMaximum: find({
+            type: "number",
+            name: "exclusiveMaximum",
+            lines,
+          }),
+          multipleOf: find({
+            type: "number",
+            name: "multipleOf",
+            lines,
+          }),
+        }),
+      ),
       description: describe(lines, [
         "minimum",
         "maximum",
@@ -50,12 +71,13 @@ export namespace LlmDescriptionInverter {
         "exclusiveMaximum",
         "multipleOf",
       ]),
-    });
+    };
   };
 
-  export const string = (
-    description: string | undefined,
-  ): Pick<
+  export const string = (props: {
+    config: ILlmSchema.IConfig;
+    description: string | undefined;
+  }): Pick<
     OpenApi.IJsonSchema.IString,
     | "format"
     | "pattern"
@@ -64,34 +86,37 @@ export namespace LlmDescriptionInverter {
     | "maxLength"
     | "description"
   > => {
+    const description: string | undefined = read(props);
     if (description === undefined) return {};
 
     const lines: string[] = description.split("\n");
     return {
-      format: find({
-        type: "string",
-        name: "format",
-        lines,
-      }),
-      pattern: find({
-        type: "string",
-        name: "pattern",
-        lines,
-      }),
-      contentMediaType: find({
-        type: "string",
-        name: "contentMediaType",
-        lines,
-      }),
-      minLength: find({
-        type: "number",
-        name: "minLength",
-        lines,
-      }),
-      maxLength: find({
-        type: "number",
-        name: "maxLength",
-        lines,
+      ...compact({
+        format: find({
+          type: "string",
+          name: "format",
+          lines,
+        }),
+        pattern: find({
+          type: "string",
+          name: "pattern",
+          lines,
+        }),
+        contentMediaType: find({
+          type: "string",
+          name: "contentMediaType",
+          lines,
+        }),
+        minLength: find({
+          type: "number",
+          name: "minLength",
+          lines,
+        }),
+        maxLength: find({
+          type: "number",
+          name: "maxLength",
+          lines,
+        }),
       }),
       description: describe(lines, [
         "format",
@@ -103,34 +128,66 @@ export namespace LlmDescriptionInverter {
     };
   };
 
-  export const array = (
-    description: string | undefined,
-  ): Pick<
+  export const array = (props: {
+    config: ILlmSchema.IConfig;
+    description: string | undefined;
+  }): Pick<
     OpenApi.IJsonSchema.IArray,
     "minItems" | "maxItems" | "uniqueItems" | "description"
   > => {
+    const description: string | undefined = read(props);
     if (description === undefined) return {};
 
     const lines: string[] = description.split("\n");
     return {
-      minItems: find({
-        type: "number",
-        name: "minItems",
-        lines,
-      }),
-      maxItems: find({
-        type: "number",
-        name: "maxItems",
-        lines,
-      }),
-      uniqueItems: find({
-        type: "boolean",
-        name: "uniqueItems",
-        lines,
+      ...compact({
+        minItems: find({
+          type: "number",
+          name: "minItems",
+          lines,
+        }),
+        maxItems: find({
+          type: "number",
+          name: "maxItems",
+          lines,
+        }),
+        uniqueItems: find({
+          type: "boolean",
+          name: "uniqueItems",
+          lines,
+        }),
       }),
       description: describe(lines, ["minItems", "maxItems", "uniqueItems"]),
     };
   };
+
+  /**
+   * Yield the description to read, or nothing when this mode wrote no tags.
+   *
+   * Only a `strict` conversion shifts constraints into the description. Under
+   * any other config there is nothing to read back, whatever the description
+   * happens to say.
+   */
+  const read = (props: {
+    config: ILlmSchema.IConfig;
+    description: string | undefined;
+  }): string | undefined =>
+    props.config.strict === true ? props.description : undefined;
+
+  /**
+   * Drop the keys whose tag lookup found nothing.
+   *
+   * Every value returned from here is spread over a real schema, so a key
+   * present with an `undefined` value does not mean "no constraint" — it is an
+   * instruction to delete the schema's own constraint. Only a tag that was
+   * actually found may reach that spread. `description` is exempt and stays on
+   * the result even when `undefined`, because rewriting it to drop the consumed
+   * tag lines is the point rather than an accident of a failed lookup.
+   */
+  const compact = <T extends object>(record: T): Partial<T> =>
+    Object.fromEntries(
+      Object.entries(record).filter(([, value]) => value !== undefined),
+    ) as Partial<T>;
 
   const find = <Type extends "boolean" | "number" | "string">(props: {
     type: Type;

--- a/packages/utils/src/utils/LlmJson.ts
+++ b/packages/utils/src/utils/LlmJson.ts
@@ -122,11 +122,14 @@ export namespace LlmJson {
    *   Otherwise, extra properties are ignored. An object whose
    *   `additionalProperties` opens it declares undeclared keys to be legitimate
    *   members, so this flag does not close it.
-   * @param config Configuration `parameters` was generated with, e.g.
-   *   `application.config` from `typia.llm.application`. Only `strict` schemas
-   *   carry their constraints as `@minimum 3` description tags rather than as
-   *   keywords, so only a `strict` inversion reads them back. Defaults to
-   *   non-strict, matching `ILlmSchema.IConfig.strict`.
+   * @param config Configuration `parameters` was generated with. Only a
+   *   `strict` schema carries its constraints as `@minimum 3` description tags
+   *   rather than as keywords, so only a `strict` inversion reads them back.
+   *   Defaults to non-strict, matching {@link ILlmSchema.IConfig.strict}. An
+   *   `HttpLlm.application` reports its own config, so pass that; for
+   *   `typia.llm.application` and `typia.llm.controller` pass the same value
+   *   their `Config` generic was given, because their emitted `config.strict`
+   *   is `false` even when the schema was generated in `strict` mode.
    * @returns Validator function that checks data against the schema
    */
   export function validate(

--- a/packages/utils/src/utils/LlmJson.ts
+++ b/packages/utils/src/utils/LlmJson.ts
@@ -122,16 +122,23 @@ export namespace LlmJson {
    *   Otherwise, extra properties are ignored. An object whose
    *   `additionalProperties` opens it declares undeclared keys to be legitimate
    *   members, so this flag does not close it.
+   * @param config Configuration `parameters` was generated with, e.g.
+   *   `application.config` from `typia.llm.application`. Only `strict` schemas
+   *   carry their constraints as `@minimum 3` description tags rather than as
+   *   keywords, so only a `strict` inversion reads them back. Defaults to
+   *   non-strict, matching `ILlmSchema.IConfig.strict`.
    * @returns Validator function that checks data against the schema
    */
   export function validate(
     parameters: ILlmSchema.IParameters,
     equals?: boolean | undefined,
+    config?: Partial<ILlmSchema.IConfig> | undefined,
   ): (input: unknown) => IValidation<unknown> {
     const components: OpenApi.IComponents = {
       schemas: {},
     };
     const schema: OpenApi.IJsonSchema = LlmSchemaConverter.invert({
+      config,
       components,
       schema: parameters,
       $defs: parameters.$defs,
@@ -193,13 +200,16 @@ export namespace LlmJson {
    *   during validation. Otherwise, extra properties are ignored. An object
    *   whose `additionalProperties` opens it declares undeclared keys to be
    *   legitimate members, so this flag does not close it.
+   * @param config Configuration `parameters` was generated with. See
+   *   {@link validate}.
    * @returns Structured output interface with parse, coerce, and validate
    */
   export function structuredOutput<T>(
     parameters: ILlmSchema.IParameters,
     equals?: boolean | undefined,
+    config?: Partial<ILlmSchema.IConfig> | undefined,
   ): ILlmStructuredOutput<T> {
-    const validator = validate(parameters, equals);
+    const validator = validate(parameters, equals, config);
     return {
       parameters,
       parse: (str: string): IJsonParseResult<T> => parse(str, parameters),

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -143,6 +143,14 @@ export namespace VercelToolsRegistrar {
           // `strict` application carries its constraints as description tags
           // instead of keywords, and only that config tells the inverter to
           // read them back.
+          //
+          // An HttpLlm application reports the config it was composed with, so
+          // this is exact for it. A typia.llm.controller reports
+          // `strict: false` whatever its Config generic said — a transform
+          // defect, not a reason to guess here: guessing is what erased the
+          // non-strict constraints in the first place. This reads the declared
+          // config and becomes exact for class controllers too the moment the
+          // transform reports it truthfully.
           LlmJson.validate(func.output, true, props.config);
 
     return tool({

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -3,6 +3,7 @@ import {
   IHttpLlmFunction,
   ILlmController,
   ILlmFunction,
+  ILlmSchema,
   IValidation,
 } from "@typia/interface";
 import { HttpLlm, LlmJson } from "@typia/utils";
@@ -83,6 +84,7 @@ export namespace VercelToolsRegistrar {
       tools[toolName] = createTool({
         name: toolName,
         func,
+        config: controller.application.config,
         execute: async (args: unknown) => method.call(execute, args),
       });
     }
@@ -103,6 +105,7 @@ export namespace VercelToolsRegistrar {
       tools[toolName] = createTool({
         name: toolName,
         func,
+        config: application.config,
         execute: async (args: unknown) => {
           if (controller.execute !== undefined) {
             const response = await controller.execute({
@@ -127,6 +130,7 @@ export namespace VercelToolsRegistrar {
   const createTool = (props: {
     name: string;
     func: ILlmFunction | IHttpLlmFunction;
+    config: ILlmSchema.IConfig;
     execute: (args: unknown) => Promise<unknown>;
   }): Tool => {
     const { name, func, execute } = props;
@@ -135,7 +139,11 @@ export namespace VercelToolsRegistrar {
       | undefined =
       func.output === undefined
         ? undefined
-        : LlmJson.validate(func.output, true);
+        : // Validate the output against the config that produced its schema. A
+          // `strict` application carries its constraints as description tags
+          // instead of keywords, and only that config tells the inverter to
+          // read them back.
+          LlmJson.validate(func.output, true, props.config);
 
     return tool({
       description: func.description ?? "",

--- a/tests/test-mcp/src/features/test_mcp_tool_output_constraint_enforcement.ts
+++ b/tests/test-mcp/src/features/test_mcp_tool_output_constraint_enforcement.ts
@@ -1,0 +1,144 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { createMcpServer } from "@typia/mcp";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies tool output constraints are enforced in both schema modes.
+ *
+ * `createMcpServer` validates a declared result by inverting its LLM schema,
+ * and the two modes keep constraints in different places: a non-strict schema
+ * keeps `minimum` and `format` as keywords, while a strict one moves them into
+ * the description as `@minimum 0` tags. The inverter only reads those tags back
+ * when told the schema is strict, so the registrar has to hand it the
+ * application's own config — and every property here is documented, because a
+ * description is exactly what used to make the non-strict keywords disappear.
+ *
+ * The strict controller's `config.strict` is corrected before it is served.
+ * `typia.llm.application`/`controller` emit `config: { strict: false }`
+ * whatever the `Config` generic says, even while shifting the constraints into
+ * the description — the emitted config contradicts the schema beside it,
+ * against `ILlmApplication.config`'s own contract. That is a separate transform
+ * defect; this case pins the registrar's plumbing against the config the
+ * contract promises rather than the one typia currently emits.
+ *
+ * 1. Serve the same documented controller twice, once non-strict and once strict.
+ * 2. Assert a conforming result is accepted and shipped as structured content.
+ * 3. Assert a result violating `Minimum` is reported as a tool error in both
+ *    modes.
+ * 4. Assert the same for a result violating `Format<"email">`.
+ */
+export const test_mcp_tool_output_constraint_enforcement =
+  async (): Promise<void> => {
+    const strict: ILlmController = typia.llm.controller<
+      ConstraintController,
+      { strict: true }
+    >("constraint", new ConstraintController());
+    strict.application.config.strict = true;
+
+    const controllers: [string, ILlmController][] = [
+      [
+        "non-strict",
+        typia.llm.controller<ConstraintController>(
+          "constraint",
+          new ConstraintController(),
+        ),
+      ],
+      ["strict", strict],
+    ];
+    for (const [mode, controller] of controllers) {
+      const server: McpServer = createMcpServer(controller);
+      const client: Client = new Client({
+        name: "constraint-test",
+        version: "1.0",
+      });
+      const [clientTransport, serverTransport] =
+        InMemoryTransport.createLinkedPair();
+
+      try {
+        await server.connect(serverTransport);
+        await client.connect(clientTransport);
+
+        const valid: CallToolResult = (await client.callTool({
+          name: "read",
+          arguments: { variant: "valid" },
+        })) as CallToolResult;
+        TestValidator.predicate(
+          `${mode} conforming output accepted`,
+          valid.isError !== true,
+        );
+        TestValidator.equals(
+          `${mode} conforming structured content`,
+          valid.structuredContent,
+          {
+            id: "u1",
+            age: 20,
+            email: "member@typia.io",
+          },
+        );
+
+        for (const [variant, path] of [
+          ["minimum", "$input.age"],
+          ["format", "$input.email"],
+        ] as const) {
+          const result: CallToolResult = (await client.callTool({
+            name: "read",
+            arguments: { variant },
+          })) as CallToolResult;
+          TestValidator.predicate(
+            `${mode} ${variant} violation is a tool error`,
+            result.isError === true && result.structuredContent === undefined,
+          );
+          TestValidator.predicate(
+            `${mode} ${variant} violation reports its path`,
+            getText(result).includes(path),
+          );
+        }
+      } finally {
+        await Promise.allSettled([client.close(), server.close()]);
+      }
+    }
+  };
+
+class ConstraintController {
+  /** Return a member selected by the test variant. */
+  read(input: ConstraintController.IInput): ConstraintController.IMember {
+    const valid: ConstraintController.IMember = {
+      id: "u1",
+      age: 20,
+      email: "member@typia.io",
+    };
+    switch (input.variant) {
+      case "valid":
+        return valid;
+      case "minimum":
+        return { ...valid, age: -5 };
+      case "format":
+        return { ...valid, email: "not-an-email" };
+    }
+  }
+}
+
+namespace ConstraintController {
+  export interface IInput {
+    /** Which member to return. */
+    variant: "valid" | "minimum" | "format";
+  }
+  export interface IMember {
+    /** How the member is identified. */
+    id: string;
+    /** How old the member is. */
+    age: number & tags.Minimum<0>;
+    /** Where to reach the member. */
+    email: string & tags.Format<"email">;
+  }
+}
+
+const getText = (result: CallToolResult): string => {
+  const content = result.content[0];
+  return content?.type === "text" ? content.text : "";
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_parity_invert.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_parity_invert.ts
@@ -65,6 +65,7 @@ export const test_llm_schema_parity_invert = (): void => {
     { strict: true }
   >({});
   const strictInverted = LlmSchemaConverter.invert({
+    config: { strict: true },
     components: {},
     schema: strict,
     $defs: {},

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_description_tag_prose_not_promoted.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_description_tag_prose_not_promoted.ts
@@ -9,8 +9,8 @@ import { LlmSchemaConverter } from "@typia/utils";
  * put it there. Without `strict`, nothing shifted, so the same text is the
  * author's prose: promoting it to a real keyword would invent a constraint the
  * type never declared, and stripping the line would silently edit the doc the
- * model reads. This is the inverse witness of the erasure defect — the read must
- * do nothing at all when the write did nothing.
+ * model reads. This is the inverse witness of the erasure defect — the read
+ * must do nothing at all when the write did nothing.
  *
  * The inverted leaf is the first argument here, unlike the sibling cases that
  * assert a keyword is present: `TestValidator.equals` walks its first argument

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_description_tag_prose_not_promoted.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_description_tag_prose_not_promoted.ts
@@ -1,0 +1,61 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema, OpenApi } from "@typia/interface";
+import { LlmSchemaConverter } from "@typia/utils";
+
+/**
+ * Verifies non-strict inversion never reads constraints out of a description.
+ *
+ * `@minimum 3` in a description is a constraint only because the strict shifter
+ * put it there. Without `strict`, nothing shifted, so the same text is the
+ * author's prose: promoting it to a real keyword would invent a constraint the
+ * type never declared, and stripping the line would silently edit the doc the
+ * model reads. This is the inverse witness of the erasure defect — the read must
+ * do nothing at all when the write did nothing.
+ *
+ * The inverted leaf is the first argument here, unlike the sibling cases that
+ * assert a keyword is present: `TestValidator.equals` walks its first argument
+ * and skips the keys holding `undefined`, so passing the leaf first is what
+ * makes an invented keyword — present and defined — the thing it compares.
+ *
+ * 1. Hand-build a non-strict leaf whose prose happens to contain tag-like text.
+ * 2. Invert it without `config.strict`.
+ * 3. Assert no constraint keyword is invented.
+ * 4. Assert the description survives verbatim.
+ */
+export const test_llm_invert_description_tag_prose_not_promoted = (): void => {
+  const description: string = [
+    "Write @minimum 3 in the doc to require three characters.",
+    "@maxLength 7",
+  ].join("\n");
+  const inverted = LlmSchemaConverter.invert({
+    components: {},
+    $defs: {},
+    schema: {
+      type: "string",
+      description,
+    } satisfies ILlmSchema.IString,
+  }) as OpenApi.IJsonSchema.IString;
+
+  TestValidator.equals(
+    "prose not promoted to constraints",
+    {
+      minLength: inverted.minLength,
+      maxLength: inverted.maxLength,
+      format: inverted.format,
+      pattern: inverted.pattern,
+      contentMediaType: inverted.contentMediaType,
+    },
+    {
+      minLength: undefined,
+      maxLength: undefined,
+      format: undefined,
+      pattern: undefined,
+      contentMediaType: undefined,
+    },
+  );
+  TestValidator.equals(
+    "prose preserved verbatim",
+    inverted.description,
+    description,
+  );
+};

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_constraints_survive.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_constraints_survive.ts
@@ -1,0 +1,116 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { LlmSchemaConverter } from "@typia/utils";
+import typia, { ILlmSchema, tags } from "typia";
+
+/**
+ * Verifies a JSDoc comment does not erase a non-strict leaf's constraints.
+ *
+ * `invert` restores constraints that `OpenApiConstraintShifter` moved into the
+ * description, but the shift only happens under `strict`. Reading the tags back
+ * unconditionally made `LlmDescriptionInverter` return an all-`undefined` object
+ * for every non-strict leaf, and spreading it over the schema erased the real
+ * keywords. Only a leaf carrying a `description` reached that spread, so
+ * documenting a property silently disabled its validation. This pins all
+ * thirteen keywords across the numeric, string, and array inverters.
+ *
+ * Each keyword is asserted on its own rather than as one object, because
+ * `TestValidator.equals` walks the keys of its first argument and skips the ones
+ * holding `undefined`: a wholly erased leaf compared as an object matches
+ * anything and passes vacuously.
+ *
+ * 1. Declare two identical interfaces whose only difference is property JSDoc.
+ * 2. Convert both to non-strict LLM parameters and invert them back to OpenAPI.
+ * 3. Assert each of the thirteen constraint keywords survives on the documented
+ *    leaves.
+ * 4. Assert the documented and undocumented inversions agree in both directions
+ *    apart from `description`.
+ */
+export const test_llm_invert_documented_constraints_survive = (): void => {
+  interface IDocumented {
+    /** How old the member is. */
+    age: number & tags.Minimum<0> & tags.Maximum<100> & tags.MultipleOf<5>;
+    /** How much the member scored. */
+    score: number & tags.ExclusiveMinimum<0> & tags.ExclusiveMaximum<100>;
+    /** Where to reach the member. */
+    thumbnail: string &
+      tags.Format<"uri"> &
+      tags.ContentMediaType<"image/png"> &
+      tags.Pattern<"^https://"> &
+      tags.MinLength<8> &
+      tags.MaxLength<255>;
+    /** What the member likes. */
+    hobbies: Array<string> &
+      tags.MinItems<1> &
+      tags.MaxItems<10> &
+      tags.UniqueItems;
+  }
+  interface IUndocumented {
+    age: number & tags.Minimum<0> & tags.Maximum<100> & tags.MultipleOf<5>;
+    score: number & tags.ExclusiveMinimum<0> & tags.ExclusiveMaximum<100>;
+    thumbnail: string &
+      tags.Format<"uri"> &
+      tags.ContentMediaType<"image/png"> &
+      tags.Pattern<"^https://"> &
+      tags.MinLength<8> &
+      tags.MaxLength<255>;
+    hobbies: Array<string> &
+      tags.MinItems<1> &
+      tags.MaxItems<10> &
+      tags.UniqueItems;
+  }
+
+  const invert = (parameters: ILlmSchema.IParameters): OpenApi.IJsonSchema =>
+    LlmSchemaConverter.invert({
+      components: {},
+      schema: parameters,
+      $defs: parameters.$defs,
+    });
+  const documented = invert(
+    typia.llm.parameters<IDocumented>(),
+  ) as OpenApi.IJsonSchema.IObject;
+  const undocumented = invert(
+    typia.llm.parameters<IUndocumented>(),
+  ) as OpenApi.IJsonSchema.IObject;
+
+  const properties = documented.properties!;
+  const age = properties.age as OpenApi.IJsonSchema.INumber;
+  const score = properties.score as OpenApi.IJsonSchema.INumber;
+  const thumbnail = properties.thumbnail as OpenApi.IJsonSchema.IString;
+  const hobbies = properties.hobbies as OpenApi.IJsonSchema.IArray;
+
+  TestValidator.equals("documented minimum", 0, age.minimum);
+  TestValidator.equals("documented maximum", 100, age.maximum);
+  TestValidator.equals("documented multipleOf", 5, age.multipleOf);
+  TestValidator.equals("documented exclusiveMinimum", 0, score.exclusiveMinimum);
+  TestValidator.equals(
+    "documented exclusiveMaximum",
+    100,
+    score.exclusiveMaximum,
+  );
+  TestValidator.equals("documented format", "uri", thumbnail.format);
+  TestValidator.equals(
+    "documented contentMediaType",
+    "image/png",
+    thumbnail.contentMediaType,
+  );
+  TestValidator.equals("documented pattern", "^https://", thumbnail.pattern);
+  TestValidator.equals("documented minLength", 8, thumbnail.minLength);
+  TestValidator.equals("documented maxLength", 255, thumbnail.maxLength);
+  TestValidator.equals("documented minItems", 1, hobbies.minItems);
+  TestValidator.equals("documented maxItems", 10, hobbies.maxItems);
+  TestValidator.equals("documented uniqueItems", true, hobbies.uniqueItems);
+
+  TestValidator.equals(
+    "undocumented shape reaches documented",
+    undocumented,
+    documented,
+    (key) => key !== "description",
+  );
+  TestValidator.equals(
+    "documented shape reaches undocumented",
+    documented,
+    undocumented,
+    (key) => key !== "description",
+  );
+};

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_constraints_survive.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_constraints_survive.ts
@@ -8,15 +8,15 @@ import typia, { ILlmSchema, tags } from "typia";
  *
  * `invert` restores constraints that `OpenApiConstraintShifter` moved into the
  * description, but the shift only happens under `strict`. Reading the tags back
- * unconditionally made `LlmDescriptionInverter` return an all-`undefined` object
- * for every non-strict leaf, and spreading it over the schema erased the real
- * keywords. Only a leaf carrying a `description` reached that spread, so
+ * unconditionally made `LlmDescriptionInverter` return an all-`undefined`
+ * object for every non-strict leaf, and spreading it over the schema erased the
+ * real keywords. Only a leaf carrying a `description` reached that spread, so
  * documenting a property silently disabled its validation. This pins all
  * thirteen keywords across the numeric, string, and array inverters.
  *
  * Each keyword is asserted on its own rather than as one object, because
- * `TestValidator.equals` walks the keys of its first argument and skips the ones
- * holding `undefined`: a wholly erased leaf compared as an object matches
+ * `TestValidator.equals` walks the keys of its first argument and skips the
+ * ones holding `undefined`: a wholly erased leaf compared as an object matches
  * anything and passes vacuously.
  *
  * 1. Declare two identical interfaces whose only difference is property JSDoc.
@@ -82,7 +82,11 @@ export const test_llm_invert_documented_constraints_survive = (): void => {
   TestValidator.equals("documented minimum", 0, age.minimum);
   TestValidator.equals("documented maximum", 100, age.maximum);
   TestValidator.equals("documented multipleOf", 5, age.multipleOf);
-  TestValidator.equals("documented exclusiveMinimum", 0, score.exclusiveMinimum);
+  TestValidator.equals(
+    "documented exclusiveMinimum",
+    0,
+    score.exclusiveMinimum,
+  );
   TestValidator.equals(
     "documented exclusiveMaximum",
     100,

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_validation_verdict.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_validation_verdict.ts
@@ -12,12 +12,12 @@ import typia, { tags } from "typia";
  * comment must produce the same verdict — the model is told about both
  * constraints, so both must be checked.
  *
- * 1. Declare a member type whose documented and undocumented properties carry
- *    the same tags.
+ * 1. Declare a member type whose documented and undocumented properties carry the
+ *    same tags.
  * 2. Build the non-strict validator from its LLM parameters.
  * 3. Assert a value violating only the documented property is rejected.
- * 4. Assert the undocumented twin's violation is rejected identically, and that
- *    a conforming value still passes.
+ * 4. Assert the undocumented twin's violation is rejected identically, and that a
+ *    conforming value still passes.
  */
 export const test_llm_invert_documented_validation_verdict = (): void => {
   interface IMember {
@@ -36,7 +36,11 @@ export const test_llm_invert_documented_validation_verdict = (): void => {
     undocumentedEmail: "member@typia.io",
   };
 
-  TestValidator.equals("conforming value accepted", validate(valid).success, true);
+  TestValidator.equals(
+    "conforming value accepted",
+    validate(valid).success,
+    true,
+  );
   TestValidator.equals(
     "documented minimum enforced",
     validate({ ...valid, documentedAge: -5 }).success,

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_validation_verdict.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_validation_verdict.ts
@@ -1,0 +1,60 @@
+import { TestValidator } from "@nestia/e2e";
+import { LlmJson } from "@typia/utils";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies documenting a property does not change `LlmJson.validate`'s verdict.
+ *
+ * This is the soundness half of the `invert` constraint-erasure defect: invalid
+ * data was reported valid, not merely described badly. `LlmJson.validate`
+ * inverts the LLM schema before validating, so every constraint the inverter
+ * erased stopped being enforced. Two properties that differ only by a JSDoc
+ * comment must produce the same verdict — the model is told about both
+ * constraints, so both must be checked.
+ *
+ * 1. Declare a member type whose documented and undocumented properties carry
+ *    the same tags.
+ * 2. Build the non-strict validator from its LLM parameters.
+ * 3. Assert a value violating only the documented property is rejected.
+ * 4. Assert the undocumented twin's violation is rejected identically, and that
+ *    a conforming value still passes.
+ */
+export const test_llm_invert_documented_validation_verdict = (): void => {
+  interface IMember {
+    /** How old the member is. */
+    documentedAge: number & tags.Minimum<0>;
+    undocumentedAge: number & tags.Minimum<0>;
+    /** Where to reach the member. */
+    documentedEmail: string & tags.Format<"email">;
+    undocumentedEmail: string & tags.Format<"email">;
+  }
+  const validate = LlmJson.validate(typia.llm.parameters<IMember>());
+  const valid = {
+    documentedAge: 5,
+    undocumentedAge: 5,
+    documentedEmail: "member@typia.io",
+    undocumentedEmail: "member@typia.io",
+  };
+
+  TestValidator.equals("conforming value accepted", validate(valid).success, true);
+  TestValidator.equals(
+    "documented minimum enforced",
+    validate({ ...valid, documentedAge: -5 }).success,
+    false,
+  );
+  TestValidator.equals(
+    "undocumented minimum enforced",
+    validate({ ...valid, undocumentedAge: -5 }).success,
+    false,
+  );
+  TestValidator.equals(
+    "documented format enforced",
+    validate({ ...valid, documentedEmail: "not-an-email" }).success,
+    false,
+  );
+  TestValidator.equals(
+    "undocumented format enforced",
+    validate({ ...valid, undocumentedEmail: "not-an-email" }).success,
+    false,
+  );
+};

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_strict_constraints_restored.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_strict_constraints_restored.ts
@@ -1,0 +1,98 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { LlmSchemaConverter } from "@typia/utils";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies strict inversion still restores every shifted constraint keyword.
+ *
+ * Under `strict`, `OpenApiConstraintShifter` deletes the constraint keywords and
+ * writes them into the description as `@minimum 3` tags, so the inverter is the
+ * only thing that can put them back. Gating the read on `strict` — the same gate
+ * the write uses — must not weaken that half: all thirteen keywords have to
+ * survive the round trip, and the consumed tags must leave the description
+ * behind as plain prose.
+ *
+ * Each keyword is asserted on its own rather than as one object, because
+ * `TestValidator.equals` walks the keys of its first argument and skips the ones
+ * holding `undefined`: an unrestored leaf compared as an object matches anything
+ * and passes vacuously.
+ *
+ * 1. Convert a fully tagged interface to strict LLM parameters.
+ * 2. Invert it back with `config.strict` set, matching the conversion.
+ * 3. Assert each of the thirteen numeric, string, and array keywords is
+ *    restored.
+ * 4. Assert each leaf's description keeps its prose and drops its tags.
+ */
+export const test_llm_invert_strict_constraints_restored = (): void => {
+  interface IMember {
+    /** How old the member is. */
+    age: number & tags.Minimum<0> & tags.Maximum<100> & tags.MultipleOf<5>;
+    /** How much the member scored. */
+    score: number & tags.ExclusiveMinimum<0> & tags.ExclusiveMaximum<100>;
+    /** Where to reach the member. */
+    thumbnail: string &
+      tags.Format<"uri"> &
+      tags.ContentMediaType<"image/png"> &
+      tags.Pattern<"^https://"> &
+      tags.MinLength<8> &
+      tags.MaxLength<255>;
+    /** What the member likes. */
+    hobbies: Array<string> &
+      tags.MinItems<1> &
+      tags.MaxItems<10> &
+      tags.UniqueItems;
+  }
+  const parameters = typia.llm.parameters<IMember, { strict: true }>();
+  const inverted = LlmSchemaConverter.invert({
+    config: { strict: true },
+    components: {},
+    schema: parameters,
+    $defs: parameters.$defs,
+  }) as OpenApi.IJsonSchema.IObject;
+
+  const properties = inverted.properties!;
+  const age = properties.age as OpenApi.IJsonSchema.INumber;
+  const score = properties.score as OpenApi.IJsonSchema.INumber;
+  const thumbnail = properties.thumbnail as OpenApi.IJsonSchema.IString;
+  const hobbies = properties.hobbies as OpenApi.IJsonSchema.IArray;
+
+  TestValidator.equals("strict minimum", 0, age.minimum);
+  TestValidator.equals("strict maximum", 100, age.maximum);
+  TestValidator.equals("strict multipleOf", 5, age.multipleOf);
+  TestValidator.equals("strict exclusiveMinimum", 0, score.exclusiveMinimum);
+  TestValidator.equals("strict exclusiveMaximum", 100, score.exclusiveMaximum);
+  TestValidator.equals("strict format", "uri", thumbnail.format);
+  TestValidator.equals(
+    "strict contentMediaType",
+    "image/png",
+    thumbnail.contentMediaType,
+  );
+  TestValidator.equals("strict pattern", "^https://", thumbnail.pattern);
+  TestValidator.equals("strict minLength", 8, thumbnail.minLength);
+  TestValidator.equals("strict maxLength", 255, thumbnail.maxLength);
+  TestValidator.equals("strict minItems", 1, hobbies.minItems);
+  TestValidator.equals("strict maxItems", 10, hobbies.maxItems);
+  TestValidator.equals("strict uniqueItems", true, hobbies.uniqueItems);
+
+  TestValidator.equals(
+    "strict age description",
+    "How old the member is.",
+    age.description,
+  );
+  TestValidator.equals(
+    "strict score description",
+    "How much the member scored.",
+    score.description,
+  );
+  TestValidator.equals(
+    "strict thumbnail description",
+    "Where to reach the member.",
+    thumbnail.description,
+  );
+  TestValidator.equals(
+    "strict hobbies description",
+    "What the member likes.",
+    hobbies.description,
+  );
+};

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_strict_constraints_restored.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_strict_constraints_restored.ts
@@ -6,22 +6,21 @@ import typia, { tags } from "typia";
 /**
  * Verifies strict inversion still restores every shifted constraint keyword.
  *
- * Under `strict`, `OpenApiConstraintShifter` deletes the constraint keywords and
- * writes them into the description as `@minimum 3` tags, so the inverter is the
- * only thing that can put them back. Gating the read on `strict` — the same gate
- * the write uses — must not weaken that half: all thirteen keywords have to
- * survive the round trip, and the consumed tags must leave the description
+ * Under `strict`, `OpenApiConstraintShifter` deletes the constraint keywords
+ * and writes them into the description as `@minimum 3` tags, so the inverter is
+ * the only thing that can put them back. Gating the read on `strict` — the same
+ * gate the write uses — must not weaken that half: all thirteen keywords have
+ * to survive the round trip, and the consumed tags must leave the description
  * behind as plain prose.
  *
  * Each keyword is asserted on its own rather than as one object, because
- * `TestValidator.equals` walks the keys of its first argument and skips the ones
- * holding `undefined`: an unrestored leaf compared as an object matches anything
- * and passes vacuously.
+ * `TestValidator.equals` walks the keys of its first argument and skips the
+ * ones holding `undefined`: an unrestored leaf compared as an object matches
+ * anything and passes vacuously.
  *
  * 1. Convert a fully tagged interface to strict LLM parameters.
  * 2. Invert it back with `config.strict` set, matching the conversion.
- * 3. Assert each of the thirteen numeric, string, and array keywords is
- *    restored.
+ * 3. Assert each of the thirteen numeric, string, and array keywords is restored.
  * 4. Assert each leaf's description keeps its prose and drops its tags.
  */
 export const test_llm_invert_strict_constraints_restored = (): void => {

--- a/tests/test-vercel/src/features/test_vercel_tool_output_constraint_enforcement.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_output_constraint_enforcement.ts
@@ -1,0 +1,124 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies tool output constraints are enforced in both schema modes.
+ *
+ * `toVercelTools` validates a declared result by inverting its LLM schema, and
+ * the two modes keep constraints in different places: a non-strict schema keeps
+ * `minimum` and `format` as keywords, while a strict one moves them into the
+ * description as `@minimum 0` tags. The inverter only reads those tags back
+ * when told the schema is strict, so the registrar has to hand it the
+ * application's own config — and every property here is documented, because a
+ * description is exactly what used to make the non-strict keywords disappear.
+ *
+ * The strict controller's `config.strict` is corrected before it is converted.
+ * `typia.llm.application`/`controller` emit `config: { strict: false }`
+ * whatever the `Config` generic says, even while shifting the constraints into
+ * the description — the emitted config contradicts the schema beside it,
+ * against `ILlmApplication.config`'s own contract. That is a separate transform
+ * defect; this case pins the registrar's plumbing against the config the
+ * contract promises rather than the one typia currently emits.
+ *
+ * 1. Convert the same documented controller twice, once non-strict and once
+ *    strict.
+ * 2. Assert a conforming result uses the typed success branch.
+ * 3. Assert a result violating `Minimum` uses the failure branch in both modes.
+ * 4. Assert the same for a result violating `Format<"email">`.
+ */
+export const test_vercel_tool_output_constraint_enforcement =
+  async (): Promise<void> => {
+    const strict: ILlmController = typia.llm.controller<
+      ConstraintController,
+      { strict: true }
+    >("constraint", new ConstraintController());
+    strict.application.config.strict = true;
+
+    const controllers: [string, ILlmController][] = [
+      [
+        "non-strict",
+        typia.llm.controller<ConstraintController>(
+          "constraint",
+          new ConstraintController(),
+        ),
+      ],
+      ["strict", strict],
+    ];
+    for (const [mode, controller] of controllers) {
+      const tools: Record<string, Tool> = toVercelTools(controller);
+      const read: Tool = tools["read"]!;
+
+      const valid: unknown = await execute(read, "valid");
+      TestValidator.equals(`${mode} conforming output accepted`, valid, {
+        success: true,
+        data: {
+          id: "u1",
+          age: 20,
+          email: "member@typia.io",
+        },
+      });
+
+      for (const [variant, path] of [
+        ["minimum", '"path":"$input.age"'],
+        ["format", '"path":"$input.email"'],
+      ] as const) {
+        const result = (await execute(read, variant)) as {
+          success?: boolean;
+          error?: string;
+        };
+        TestValidator.predicate(
+          `${mode} ${variant} violation uses the failure branch`,
+          result.success === false &&
+            typeof result.error === "string" &&
+            result.error.includes(path),
+        );
+      }
+    }
+  };
+
+const execute = (tool: Tool, variant: string): Promise<unknown> =>
+  tool.execute!(
+    { variant },
+    {
+      toolCallId: `test-constraint-${variant}`,
+      messages: [],
+      abortSignal: undefined as any,
+    },
+  );
+
+class ConstraintController {
+  /** Return a member selected by the test variant. */
+  read(input: ConstraintController.IInput): ConstraintController.IMember {
+    const valid: ConstraintController.IMember = {
+      id: "u1",
+      age: 20,
+      email: "member@typia.io",
+    };
+    switch (input.variant) {
+      case "valid":
+        return valid;
+      case "minimum":
+        return { ...valid, age: -5 };
+      case "format":
+        return { ...valid, email: "not-an-email" };
+    }
+  }
+}
+
+namespace ConstraintController {
+  export interface IInput {
+    /** Which member to return. */
+    variant: "valid" | "minimum" | "format";
+  }
+  export interface IMember {
+    /** How the member is identified. */
+    id: string;
+    /** How old the member is. */
+    age: number & tags.Minimum<0>;
+    /** Where to reach the member. */
+    email: string & tags.Format<"email">;
+  }
+}

--- a/website/src/content/docs/llm/json.mdx
+++ b/website/src/content/docs/llm/json.mdx
@@ -46,6 +46,7 @@ export namespace LlmJson {
   function validate(
     parameters: ILlmSchema.IParameters,
     equals?: boolean,
+    config?: Partial<ILlmSchema.IConfig>,
   ): (value: unknown) => IValidation<unknown>;
 
   // Coerce one function's raw arguments, then validate them. Returns IValidation<T>.
@@ -72,6 +73,7 @@ export namespace LlmJson {
   export function validate(
     parameters: ILlmSchema.IParameters,
     equals?: boolean,
+    config?: Partial<ILlmSchema.IConfig>,
   ): (value: unknown) => IValidation<unknown>;
   export function validateArguments<T>(
     func: Pick<ILlmFunction, "parameters" | "validate">,
@@ -260,8 +262,11 @@ A reference that is malformed or points at a missing definition is an error, not
 ## `LlmJson.validate`
 
 ```typescript copy
-LlmJson.validate(parameters: ILlmSchema.IParameters, equals?: boolean)
-  : (value: unknown) => IValidation<unknown>
+LlmJson.validate(
+  parameters: ILlmSchema.IParameters,
+  equals?: boolean,
+  config?: Partial<ILlmSchema.IConfig>,
+): (value: unknown) => IValidation<unknown>
 ```
 
 ```typescript filename="@typia/utils - LlmJson.validate" showLineNumbers {10-17}
@@ -306,6 +311,23 @@ lenient({ name: "John", age: 25, extra: "ignored" }); // success: true
 const strict = LlmJson.validate(parameters, true);
 strict({ name: "John", age: 25, extra: "ignored" });  // success: false
 ```
+
+### Constraint tags in `strict` schemas
+
+`config` is a different flag from `equals` above. Pass the same config the schema was generated with:
+
+```typescript copy
+const application = typia.llm.application<IBbsArticleController, { strict: true }>();
+const validate = LlmJson.validate(
+  application.functions[0].output!,
+  true,
+  application.config,
+);
+```
+
+A `strict` schema cannot carry the constraint keywords itself, so `typia.llm.*` moves them into the description as `@minimum 3` tags. `config` is what tells the validator to read them back; without it, a `strict` schema's constraints go unchecked. Schemas built without `strict` — the default — keep their keywords and need no config.
+
+`createMcpServer` and the Vercel AI SDK adapter pass the controller's own config for you.
 
 <Callout type="info">
 **Prefer the compile-time validator when you can.**

--- a/website/src/content/docs/llm/json.mdx
+++ b/website/src/content/docs/llm/json.mdx
@@ -321,16 +321,16 @@ const parameters = typia.llm.parameters<IMember, { strict: true }>();
 const validate = LlmJson.validate(parameters, false, { strict: true });
 ```
 
-A `strict` schema may not carry the constraint keywords itself, so `typia.llm.*` moves them into the description as `@minimum 3` tags. `config` is what tells the validator to read them back; without it, a `strict` schema's constraints go unchecked. Schemas built without `strict` — the default — keep their keywords and need no config.
+In `strict` mode `typia.llm.*` moves the constraint keywords into the description as `@minimum 3` tags instead of leaving them on the schema. `config` is what tells the validator to read them back; without it, a `strict` schema's constraints go unchecked. Schemas built without `strict` — the default — keep their keywords and need no config.
 
-When the schema came from an application, pass its own config rather than a literal:
+An application generated from an OpenAPI document carries its own config, so pass that:
 
 ```typescript copy
-const app = typia.llm.application<IMemberController, { strict: true }>();
+const app = HttpLlm.application({ document, config: { strict: true } });
 const validate = LlmJson.validate(app.functions[0].output!, true, app.config);
 ```
 
-`createMcpServer` and the Vercel AI SDK adapter do this for you.
+For `typia.llm.application` and `typia.llm.controller`, pass the same value you wrote in the generic instead — their `config.strict` currently reports `false` even when the application was generated in `strict` mode.
 
 <Callout type="info">
 **Prefer the compile-time validator when you can.**

--- a/website/src/content/docs/llm/json.mdx
+++ b/website/src/content/docs/llm/json.mdx
@@ -317,17 +317,20 @@ strict({ name: "John", age: 25, extra: "ignored" });  // success: false
 `config` is a different flag from `equals` above. Pass the same config the schema was generated with:
 
 ```typescript copy
-const application = typia.llm.application<IBbsArticleController, { strict: true }>();
-const validate = LlmJson.validate(
-  application.functions[0].output!,
-  true,
-  application.config,
-);
+const parameters = typia.llm.parameters<IMember, { strict: true }>();
+const validate = LlmJson.validate(parameters, false, { strict: true });
 ```
 
-A `strict` schema cannot carry the constraint keywords itself, so `typia.llm.*` moves them into the description as `@minimum 3` tags. `config` is what tells the validator to read them back; without it, a `strict` schema's constraints go unchecked. Schemas built without `strict` — the default — keep their keywords and need no config.
+A `strict` schema may not carry the constraint keywords itself, so `typia.llm.*` moves them into the description as `@minimum 3` tags. `config` is what tells the validator to read them back; without it, a `strict` schema's constraints go unchecked. Schemas built without `strict` — the default — keep their keywords and need no config.
 
-`createMcpServer` and the Vercel AI SDK adapter pass the controller's own config for you.
+When the schema came from an application, pass its own config rather than a literal:
+
+```typescript copy
+const app = typia.llm.application<IMemberController, { strict: true }>();
+const validate = LlmJson.validate(app.functions[0].output!, true, app.config);
+```
+
+`createMcpServer` and the Vercel AI SDK adapter do this for you.
 
 <Callout type="info">
 **Prefer the compile-time validator when you can.**


### PR DESCRIPTION
Fixes #2150.

## Documenting a property disabled its validation

`LlmSchemaConverter.invert` erased 13 constraint keywords from any integer / number / string / array leaf carrying a `description`, and `LlmJson.validate` then accepted data violating the constraints typia had advertised to the model. This is a soundness defect on the **non-strict default path**. Reproduced exactly as filed:

```
typia.llm.parameters<{ /** How old the member is. */ age: number & Minimum<0> & Maximum<100> & MultipleOf<5> }>()
  →  { type: "number", minimum: 0, maximum: 100, multipleOf: 5, description: "How old the member is." }
  →  invert
  →  { description: "How old the member is.", type: "number" }
```

All three keywords gone. The undocumented twin keeps every one. Same for string and array leaves.

## The mechanism, and the invariant

The design is a pair: under `strict`, `OpenApiConstraintShifter` *moves* constraints out of the schema into the description as `@minimum 3` tags, and `LlmDescriptionInverter` reads them back. **The write was gated on `config.strict === true`; the read was not.** `invert` took no config, so it sniffed `description === undefined` instead. Outside `strict` nothing was ever shifted, every `find()` returned `undefined`, and the returned `{ minimum: undefined, ... }` was spread over the live schema — which is why the defect was guarded by the *absence* of a doc comment.

The invariant: **a constraint is restored from a description only when it was moved there.**

The gate now lives **inside** `LlmDescriptionInverter`, which takes the config that produced the schema. `LlmSchemaConverter` is its only consumer, so no call site — including one added later — can read tags the write half never wrote. `invert` gains an optional `config` defaulting through the existing `getConfig` (non-strict), and `LlmJson` threads it.

The all-`undefined` return is gone independently of the gate: the three readers drop the keys whose lookup found nothing, so a failed lookup can never delete a caller's constraint. `description` stays exempt — rewriting it to drop consumed tag lines is the point, not an accident.

## Two things that did not survive verification, both recorded because they were measured

### `typia.llm.application`'s `config.strict` is always `false`

The natural caller-side source of truth is `application.config`. **It is not one for `typia.llm.*`.**

```
typia.llm.application<T, { strict: true }>().config   →  {"strict":false,"validate":null}
  age description                                     →  "How old the member is.\n\n\n@minimum 0"
```

The schema *was* generated in strict mode — the constraints are shifted — while the config beside it says `strict: false`. `strict` is read in exactly two places in the Go tree, both in `LlmSchemaProgrammer`, and nothing writes it into the emitted config. `ILlmApplication.config` is declared to hold "the settings that were applied during schema generation, **including strict mode**", so the runtime contradicts its own declaration. Unfiled; **needs a follow-up issue** the maintainer owns. `HttpLlm.application` composes its config in TypeScript and reports it honestly, so the adapters are exact for HTTP controllers today.

**Consequence:** a `strict` **class** controller in MCP/Vercel does not enforce its declared output constraints, because the config it hands over is false. Shipping anyway: what is fixed is unsound behaviour on the default path with nothing else checking it; what regresses is a server-side self-check on a nearly-dead mode where the shape is already enforced at compile time. Sniffing the schema is the heuristic this issue exists to remove, `{ strict: true }` is a lie in the other direction, and fixing the emission is native Go — excluded here. Threading `application.config` is inert for class controllers today and becomes exact the moment the transform reports truthfully.

### #2157's fix is not sufficient on its own

`shift_numeric` does `delete(output, "default")` with no tag — that is #2157. But `shift_string` **does** write `@default`, and the round trip still loses it:

```
typia.llm.schema<string & Default<"abc"> & MinLength<2>, { strict: true }>
  →  { type: "string", description: "@minLength 2\n@default abc" }
  →  invert  →  { description: "@default abc", type: "string", minLength: 2 }
```

`minLength` restored; `default` lost; the tag leaked into the description as prose. The inverter restores no `default` for either type and `describe()` does not filter it. Fixing #2157 alone gives numeric this same outcome — it needs a read-side counterpart. Out of #2150's 13-keyword scope and overlapping #2157's owner, so not done here, and **no test locks the current behaviour** since that would snapshot the bug.

## Tests

Fail-then-pass on the pre-fix code for every new `test-utils` case, re-verified on the current rebased tree. The decisive pair — two properties differing only by a doc comment — and all 13 keywords across all three readers. With the fix reverted, the documented leaves invert to bare `{description, type}` (age −3, score −2, thumbnail −5, hobbies −3 = 13) and the tests Error; with the fix they pass.

One trap worth recording: **`TestValidator.equals` walks `Object.keys(x)` and skips the keys holding `undefined`.** A first draft passed the erased leaf as `x` and compared nothing at all — green against the fully-present defect. The presence cases now assert one scalar per keyword, expectation first; the prose case deliberately keeps the leaf first, because there the invented keyword is the *present* value.

`test-mcp` and `test-vercel` had zero `strict` coverage, so dropping `controller.application.config` broke nothing. Both new adapter cases are independently caught by that mutation:

| mutation | caught by |
| --- | --- |
| `LlmJson.validate(func.output, true)` in `McpControllerRegistrar` | `strict minimum violation is a tool error` |
| `LlmJson.validate(func.output, true)` in `VercelToolsRegistrar` | `strict minimum violation uses the failure branch` |

## Design note for the maintainer

`LlmJson.validate` now has three optional positionals (`parameters, equals?, config?`) — the optional-positional chain you have objected to before. Kept because converting these two to options bags is a public break outside this issue's scope. Yours to call.

## Scope

`@typia/utils`, `@typia/mcp`, `@typia/vercel`, their tests, and `website/src/content/docs/llm/json.mdx`. No native Go. No version bump. `ILlmSchema.ts` untouched (#2160). No provider behaviour claims in comments, code, or tests (#2165). No repository-wide `pnpm format`.

## Verification

Rebased onto current master `df10f34bae` (#2163 native, #2167 langchain/vercel). Executed case counts, all Success, 0 bugs:

| suite | cases |
| --- | --- |
| test-utils | 301 |
| test-mcp | 20 |
| test-vercel | 24 |
| test-langchain | 17 |
| test-typia-schema | 160 |
| test-utils-automated | 163 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
