### PR TITLE
fix(native): escape emitted accessor paths through one owner

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/escaped_property_key_path_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/escaped_property_key_path_transform_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestEscapedPropertyKeyPathTransform verifies emits with hostile keys parse.
+//
+// Sole-literal property keys are folded into the emit as accessor path text, and
+// no build step reads the file back, so a mis-escaped key shipped as a broken
+// artifact while ttsc still exited 0. A `"` in a key terminated the path string
+// early and the emitted module stopped being JavaScript; a control character
+// stayed raw and the reported path became unparseable. Only running node against
+// a real emit can catch that, which is why this asserts on the transform output
+// rather than on the factory in isolation.
+//
+//  1. Transform a fixture whose keys carry quotes, backslashes, and control
+//     characters.
+//  2. Assert node --check accepts the emitted module as JavaScript.
+//  3. Execute it and assert each reported path is the accessor JSON.stringify
+//     defines for that key, which is what the runtime helper produces for
+//     dynamic keys.
+func TestEscapedPropertyKeyPathTransform(t *testing.T) {
+  project := escapedPropertyKeyPathProject(t)
+  js := escapedPropertyKeyPathTransform(t, project)
+  escapedPropertyKeyPathCheckSyntax(t, project, js)
+  escapedPropertyKeyPathRunRuntimeCases(t, project, js)
+}
+
+func escapedPropertyKeyPathProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "escaped-property-key-path-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(escapedPropertyKeyPathTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(escapedPropertyKeyPathSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func escapedPropertyKeyPathTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("escaped property key transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+// escapedPropertyKeyPathCheckSyntax runs node against the emit exactly as it
+// would ship. node --check only parses, so the unresolved typia imports in the
+// untouched output do not matter, and that keeps this a check of the real
+// artifact rather than of a rewritten copy.
+func escapedPropertyKeyPathCheckSyntax(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  emitted := filepath.Join(project, "emitted.cjs")
+  if err := os.WriteFile(emitted, []byte(js), 0o644); err != nil {
+    t.Fatalf("write emitted module: %v", err)
+  }
+  if output, err := exec.Command(node, "--check", emitted).CombinedOutput(); err != nil {
+    t.Fatalf("emitted module is not valid JavaScript: %v\n%s\n--- emit ---\n%s", err, output, js)
+  }
+}
+
+func escapedPropertyKeyPathRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(escapedPropertyKeyPathRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = project
+  if output, err := cmd.CombinedOutput(); err != nil {
+    t.Fatalf("escaped property key runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const escapedPropertyKeyPathTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const escapedPropertyKeyPathSource = `import typia from "typia";
+
+interface IHostileKeys {
+  "quote\"key": number;
+  "back\\slash": number;
+  "line\nbreak": number;
+  "tab\tkey": number;
+  "bell\u0007key": number;
+  "nul\u0000key": number;
+  "sep\u2028key": number;
+  "plain-key": number;
+  plainIdentifier: number;
+}
+
+export const KEYS: string[] = [
+  "quote\"key",
+  "back\\slash",
+  "line\nbreak",
+  "tab\tkey",
+  "bell\u0007key",
+  "nul\u0000key",
+  "sep\u2028key",
+  "plain-key",
+];
+
+const validateHostile = typia.createValidate<IHostileKeys>();
+
+export const run = () => {
+  const input: Record<string, unknown> = { plainIdentifier: 1 };
+  for (const key of KEYS) input[key] = "not a number";
+  return validateHostile(input);
+};
+`
+
+// The expected path is rebuilt with JSON.stringify rather than written out
+// literally, because that is the contract _accessExpressionAsString implements
+// for dynamic keys and the compile-time fold must agree with it.
+const escapedPropertyKeyPathRuntimeRunner = `const mod = require("./main.cjs");
+const result = mod.run();
+
+if (result.success !== false) {
+  throw new Error("validate accepted non-number values");
+}
+for (const key of mod.KEYS) {
+  const expected = "$input[" + JSON.stringify(key) + "]";
+  const found = result.errors.find((error) => error.path === expected);
+  if (!found) {
+    throw new Error(
+      "missing path for key " + JSON.stringify(key) +
+        ": expected " + JSON.stringify(expected) +
+        ", got " + JSON.stringify(result.errors.map((error) => error.path)),
+    );
+  }
+}
+if (result.errors.some((error) => error.path === "$input.plainIdentifier")) {
+  throw new Error("identifier fast path reported an error for a valid value");
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/escaped_property_key_path_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/escaped_property_key_path_transform_test.go
@@ -10,12 +10,12 @@ import (
 // TestEscapedPropertyKeyPathTransform verifies emits with hostile keys parse.
 //
 // Sole-literal property keys are folded into the emit as accessor path text, and
-// no build step reads the file back, so a mis-escaped key shipped as a broken
-// artifact while ttsc still exited 0. A `"` in a key terminated the path string
-// early and the emitted module stopped being JavaScript; a control character
-// stayed raw and the reported path became unparseable. Only running node against
-// a real emit can catch that, which is why this asserts on the transform output
-// rather than on the factory in isolation.
+// no build step reads the file back, so a wrongly escaped key shipped as a
+// broken artifact while ttsc still exited 0. A `"` in a key terminated the path
+// string early and the emitted module stopped being JavaScript; a control
+// character stayed raw and the reported path could not be parsed. Only running
+// node against a real emit can catch that, which is why this asserts on the
+// transform output rather than on the factory in isolation.
 //
 //  1. Transform a fixture whose keys carry quotes, backslashes, and control
 //     characters.

--- a/packages/typia/native/core/factories/IdentifierFactory.go
+++ b/packages/typia/native/core/factories/IdentifierFactory.go
@@ -1,8 +1,9 @@
 package factories
 
 import (
-  "strconv"
+  "fmt"
   "strings"
+  "unicode/utf8"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimprinter "github.com/microsoft/typescript-go/shim/printer"
@@ -71,12 +72,124 @@ func (identifierFactoryNamespace) GetName(input *shimast.Expression) string {
   return "unknown"
 }
 
+// Postfix renders the accessor for `str` as JavaScript source for a string
+// literal, because callers splice the result straight into emitted text (see
+// AssertProgrammer and ValidateProgrammer building `_path + <postfix>`).
+//
+// The value of that literal must equal what the runtime helper
+// `typia/lib/internal/_accessExpressionAsString` computes for the same key,
+// since dynamic keys take that runtime path while sole-literal keys are folded
+// here at compile time. Both must produce one path grammar, which
+// `typia/lib/internal/_createStandardSchema` parses back with JSON.parse.
+//
+// So there are two nested levels of escaping: the key becomes a JSON literal,
+// and that literal is embedded in the JavaScript literal returned here. Both
+// levels go through identifierFactory_literal; a level that escapes only some
+// characters emits a file that does not parse.
 func (identifierFactoryNamespace) Postfix(str string) string {
   if identifierFactory_variable(str) {
-    return "\"." + str + "\""
+    return identifierFactory_literal("." + str)
   }
-  quoted := strings.ReplaceAll(strconv.Quote(str), "\"", "\\\"")
-  return "\"[" + quoted + "]\""
+  return identifierFactory_literal("[" + identifierFactory_literal(str) + "]")
+}
+
+// identifierFactory_literal renders `str` as JavaScript source for a string
+// literal whose value is exactly `str`.
+//
+// The escape set is JSON.stringify's, so that a literal built here reads back
+// through JSON.parse in _createStandardSchema and matches what
+// _accessExpressionAsString produces at runtime. JSON string syntax is a subset
+// of JavaScript string syntax, so one escaper satisfies both the JavaScript
+// parser that loads the emitted file and the JSON parser that reads a key out
+// of a reported path.
+//
+// strconv.Quote cannot serve this role: it escapes for Go, and Go and
+// JavaScript disagree. Quote renders U+0007 as `\a` and a non-printable astral
+// rune as `\U0001d173`; JavaScript has neither escape and decodes them as the
+// identity escapes `a` and `U`, silently corrupting the key, while JSON.parse
+// rejects both outright.
+func identifierFactory_literal(str string) string {
+  var builder strings.Builder
+  builder.Grow(len(str) + 2)
+  builder.WriteByte('"')
+  for i := 0; i < len(str); {
+    if char := str[i]; char < utf8.RuneSelf {
+      i++
+      switch char {
+      case '"':
+        builder.WriteString("\\\"")
+      case '\\':
+        builder.WriteString("\\\\")
+      case '\b':
+        builder.WriteString("\\b")
+      case '\f':
+        builder.WriteString("\\f")
+      case '\n':
+        builder.WriteString("\\n")
+      case '\r':
+        builder.WriteString("\\r")
+      case '\t':
+        builder.WriteString("\\t")
+      default:
+        // JSON forbids a raw control character in a string, and JSON.parse
+        // throws on one rather than reporting the validation issue that the
+        // path belongs to. Every other ASCII byte is safe verbatim.
+        if char < 0x20 {
+          builder.WriteString(identifierFactory_unicode_escape(rune(char)))
+        } else {
+          builder.WriteByte(char)
+        }
+      }
+      continue
+    }
+    if unit, size := identifierFactory_surrogate(str[i:]); size != 0 {
+      // A lone surrogate reaches here WTF-8 encoded and has no valid UTF-8
+      // form, so it survives only as an escape. JSON.stringify does the same.
+      builder.WriteString(identifierFactory_unicode_escape(unit))
+      i += size
+      continue
+    }
+    rune_, size := utf8.DecodeRuneInString(str[i:])
+    if rune_ == utf8.RuneError && size == 1 {
+      // Not UTF-8 at all. No escape can denote the byte, so spend the
+      // replacement character and keep the literal well-formed; the
+      // alternative is emitting a file that does not parse.
+      builder.WriteString(identifierFactory_unicode_escape(utf8.RuneError))
+      i++
+      continue
+    }
+    if rune_ == '\u2028' || rune_ == '\u2029' {
+      // Legal in a JavaScript string only since ES2019, and JSON.stringify
+      // leaves them raw. Escaping costs nothing and keeps the emit parseable
+      // on an older target.
+      builder.WriteString(identifierFactory_unicode_escape(rune_))
+      i += size
+      continue
+    }
+    builder.WriteString(str[i : i+size])
+    i += size
+  }
+  builder.WriteByte('"')
+  return builder.String()
+}
+
+// identifierFactory_unicode_escape writes the `\uXXXX` form, which denotes one
+// UTF-16 code unit and so only spans the Basic Multilingual Plane. Every caller
+// passes a control character, a surrogate, or the replacement character; an
+// astral rune needs no escape and must keep taking the verbatim path, because
+// four hex digits cannot spell it.
+func identifierFactory_unicode_escape(value rune) string {
+  return fmt.Sprintf("\\u%04x", value)
+}
+
+// identifierFactory_surrogate decodes a leading WTF-8 encoded surrogate code
+// unit, which utf8.DecodeRuneInString reports as an error because no valid
+// UTF-8 sequence denotes one.
+func identifierFactory_surrogate(str string) (rune, int) {
+  if len(str) < 3 || str[0] != 0xed || str[1] < 0xa0 || str[1] > 0xbf || str[2] < 0x80 || str[2] > 0xbf {
+    return 0, 0
+  }
+  return rune(str[0]&0x0f)<<12 | rune(str[1]&0x3f)<<6 | rune(str[2]&0x3f), 3
 }
 
 func (identifierFactoryNamespace) Parameter(name any, typeNode *shimast.TypeNode, init *shimast.Node, emit ...*shimprinter.EmitContext) *shimast.Node {

--- a/packages/typia/native/core/factories/IdentifierFactory.go
+++ b/packages/typia/native/core/factories/IdentifierFactory.go
@@ -82,33 +82,47 @@ func (identifierFactoryNamespace) GetName(input *shimast.Expression) string {
 // here at compile time. Both must produce one path grammar, which
 // `typia/lib/internal/_createStandardSchema` parses back with JSON.parse.
 //
-// So there are two nested levels of escaping: the key becomes a JSON literal,
-// and that literal is embedded in the JavaScript literal returned here. Both
-// levels go through identifierFactory_literal; a level that escapes only some
-// characters emits a file that does not parse.
+// So there are two nested levels, and they escape for different readers. The
+// key becomes JSON text, which is part of the path a user sees and JSON.parse
+// reads. That text is then embedded in JavaScript source. Escaping only one
+// level emits a file that does not parse; escaping both for the same reader
+// makes the reported path disagree with the runtime helper.
 func (identifierFactoryNamespace) Postfix(str string) string {
   if identifierFactory_variable(str) {
-    return identifierFactory_literal("." + str)
+    return identifierFactory_source("." + str)
   }
-  return identifierFactory_literal("[" + identifierFactory_literal(str) + "]")
+  return identifierFactory_source("[" + identifierFactory_json(str) + "]")
 }
 
-// identifierFactory_literal renders `str` as JavaScript source for a string
+// identifierFactory_json renders `str` as JSON text, matching JSON.stringify so
+// that the path this lands in is the one _accessExpressionAsString builds for
+// the same key at runtime, and so JSON.parse in _createStandardSchema reads the
+// key back out.
+func identifierFactory_json(str string) string {
+  return identifierFactory_quote(str, false)
+}
+
+// identifierFactory_source renders `str` as JavaScript source for a string
 // literal whose value is exactly `str`.
 //
-// The escape set is JSON.stringify's, so that a literal built here reads back
-// through JSON.parse in _createStandardSchema and matches what
-// _accessExpressionAsString produces at runtime. JSON string syntax is a subset
-// of JavaScript string syntax, so one escaper satisfies both the JavaScript
-// parser that loads the emitted file and the JSON parser that reads a key out
-// of a reported path.
+// This is JSON's escape set plus the line separators. JSON string syntax is
+// otherwise a subset of JavaScript's: both forbid a raw `"` and `\`, and JSON
+// already escapes every character below U+0020, which covers the CR and LF that
+// JavaScript also forbids raw. U+2028 and U+2029 are the whole difference, being
+// line terminators to JavaScript but ordinary characters to JSON.
+func identifierFactory_source(str string) string {
+  return identifierFactory_quote(str, true)
+}
+
+// identifierFactory_quote writes a quoted literal, escaping the line separators
+// only when the reader is a JavaScript parser.
 //
-// strconv.Quote cannot serve this role: it escapes for Go, and Go and
+// strconv.Quote cannot serve either role: it escapes for Go, and Go and
 // JavaScript disagree. Quote renders U+0007 as `\a` and a non-printable astral
 // rune as `\U0001d173`; JavaScript has neither escape and decodes them as the
 // identity escapes `a` and `U`, silently corrupting the key, while JSON.parse
 // rejects both outright.
-func identifierFactory_literal(str string) string {
+func identifierFactory_quote(str string, source bool) string {
   var builder strings.Builder
   builder.Grow(len(str) + 2)
   builder.WriteByte('"')
@@ -158,10 +172,10 @@ func identifierFactory_literal(str string) string {
       i++
       continue
     }
-    if rune_ == '\u2028' || rune_ == '\u2029' {
-      // Legal in a JavaScript string only since ES2019, and JSON.stringify
-      // leaves them raw. Escaping costs nothing and keeps the emit parseable
-      // on an older target.
+    if source && (rune_ == '\u2028' || rune_ == '\u2029') {
+      // A line terminator to JavaScript, so a raw one would end the literal on
+      // a target below ES2019. Escaping it in the source is invisible to the
+      // reader of the path, because JavaScript decodes it straight back.
       builder.WriteString(identifierFactory_unicode_escape(rune_))
       i += size
       continue

--- a/packages/typia/native/core/factories/identifier_factory_postfix_escapes_every_key_test.go
+++ b/packages/typia/native/core/factories/identifier_factory_postfix_escapes_every_key_test.go
@@ -1,0 +1,145 @@
+package factories
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+// TestIdentifierFactoryPostfixEscapesEveryKey verifies emitted accessor paths.
+//
+// Postfix returns JavaScript source that callers splice into the emit as
+// `_path + <postfix>`, so it carries two nested escaping levels: the key becomes
+// a JSON literal, and that literal sits inside the JavaScript literal returned.
+// Escaping one level and not the other emitted a file that does not parse for a
+// `"` key, and a path that JSON.parse rejects inside _createStandardSchema for a
+// control-character key. The expected strings below come from the contract that
+// typia's own runtime helper _accessExpressionAsString implements for dynamic
+// keys, `variable(str) ? ".{str}" : "[{JSON.stringify(str)}]"`, not from what
+// the emitter happens to produce.
+//
+//  1. Assert the exact source text Postfix returns for identifier keys, quoting
+//     keys, escape-sensitive keys, control characters, and non-ASCII keys.
+//  2. Decode every result as JSON twice and assert the original key survives.
+//  3. Assert the identifier fast path stays a dotted accessor, so ordinary keys
+//     and prototype-shadowing keys keep their existing output.
+func TestIdentifierFactoryPostfixEscapesEveryKey(t *testing.T) {
+  for _, item := range []struct {
+    name     string
+    key      string
+    expected string
+  }{
+    // Identifier fast path: no escaping is possible, so output is unchanged.
+    {"identifier", "field", `".field"`},
+    {"underscore", "_private", `"._private"`},
+    {"dollar", "$ref", `".$ref"`},
+    // A prototype-shadowing key is still a plain property access, because the
+    // emitted accessor reads the property and never the prototype.
+    {"proto", "__proto__", `".__proto__"`},
+    {"constructor", "constructor", `".constructor"`},
+    {"toString", "toString", `".toString"`},
+    // Ordinary quoted keys: byte-identical to the pre-fix output.
+    {"hyphen", "a-b", `"[\"a-b\"]"`},
+    {"space", "not valid", `"[\"not valid\"]"`},
+    {"empty", "", `"[\"\"]"`},
+    {"digit first", "0abc", `"[\"0abc\"]"`},
+    {"dotted", "a.b", `"[\"a.b\"]"`},
+    {"bracket", "a[0]", `"[\"a[0]\"]"`},
+    {"reserved", "for", `"[\"for\"]"`},
+    // Neither quote nor backslash, so no escape applies at either level.
+    {"single quote", "a'b", `"[\"a'b\"]"`},
+    {"backtick", "a`b", "\"[\\\"a`b\\\"]\""},
+    {"template hole", "a${b}c", `"[\"a${b}c\"]"`},
+    // The double quote is escaped once per level: `"` -> `\"` -> `\\\"`.
+    {"double quote", `a"b`, `"[\"a\\\"b\"]"`},
+    {"only double quote", `"`, `"[\"\\\"\"]"`},
+    // The backslash likewise. Escaping it once left the emitted path saying
+    // `["a\b"]`, which JSON.parse reads back as a backspace, not a backslash.
+    {"backslash", `a\b`, `"[\"a\\\\b\"]"`},
+    {"only backslash", `\`, `"[\"\\\\\"]"`},
+    {"quote and backslash", `a"\b`, `"[\"a\\\"\\\\b\"]"`},
+    // Control characters need a JSON escape; a raw one makes JSON.parse throw.
+    {"newline", "a\nb", `"[\"a\\nb\"]"`},
+    {"tab", "a\tb", `"[\"a\\tb\"]"`},
+    {"carriage return", "a\rb", `"[\"a\\rb\"]"`},
+    {"backspace", "a\bb", `"[\"a\\bb\"]"`},
+    {"form feed", "a\fb", `"[\"a\\fb\"]"`},
+    {"null", "a\x00b", `"[\"a\\u0000b\"]"`},
+    {"unit separator", "a\x1fb", `"[\"a\\u001fb\"]"`},
+    // strconv.Quote wrote `\a` and `\v` here. JavaScript has no `\a`, so it
+    // decoded to a plain "a" and silently changed the key.
+    {"bell", "a\x07b", `"[\"a\\u0007b\"]"`},
+    {"vertical tab", "a\x0bb", `"[\"a\\u000bb\"]"`},
+    // Line separators are only legal raw in a JavaScript string since ES2019.
+    {"line separator", "a\u2028b", `"[\"a\\u2028b\"]"`},
+    {"paragraph separator", "a\u2029b", `"[\"a\\u2029b\"]"`},
+    // Printable non-ASCII stays raw, exactly as JSON.stringify leaves it.
+    {"non ascii", "한글", `"[\"한글\"]"`},
+    {"emoji", "a\U0001F600b", "\"[\\\"a\U0001F600b\\\"]\""},
+    // strconv.Quote wrote `\U0001d173` for a non-printable astral rune, and
+    // JavaScript has no `\U` escape at all; it read back as "U0001d173".
+    {"astral format", "a\U0001D173b", "\"[\\\"a\U0001D173b\\\"]\""},
+    // A lone surrogate arrives WTF-8 encoded and has no valid UTF-8 form, so an
+    // escape is the only way to carry it.
+    {"lone surrogate", "a\xed\xa0\x80b", `"[\"a\\ud800b\"]"`},
+    // No escape denotes a byte that is not UTF-8 at all.
+    {"invalid utf8", "a\xffb", `"[\"a\\ufffdb\"]"`},
+  } {
+    t.Run(item.name, func(t *testing.T) {
+      output := IdentifierFactory.Postfix(item.key)
+      if output != item.expected {
+        t.Fatalf("Postfix(%q)\n got: %s\nwant: %s", item.key, output, item.expected)
+      }
+      identifierFactoryPostfixRoundTrip(t, item.key, output)
+    })
+  }
+}
+
+// identifierFactoryPostfixRoundTrip decodes the emitted source the way the
+// runtime does: JavaScript reads the outer literal, then _createStandardSchema
+// hands the bracketed key to JSON.parse. encoding/json stands in for both,
+// which makes this an independent check that the escaping is real rather than a
+// restatement of the emitter's own logic.
+func identifierFactoryPostfixRoundTrip(t *testing.T, key string, output string) {
+  t.Helper()
+  var path string
+  if err := json.Unmarshal([]byte(output), &path); err != nil {
+    t.Fatalf("Postfix(%q) is not a JavaScript string literal: %s (%v)", key, output, err)
+  }
+  if strings.HasPrefix(path, ".") {
+    if path[1:] != key {
+      t.Fatalf("Postfix(%q) dotted accessor lost the key: %q", key, path)
+    }
+    return
+  }
+  if !strings.HasPrefix(path, "[") || !strings.HasSuffix(path, "]") {
+    t.Fatalf("Postfix(%q) is neither a dotted nor a bracketed accessor: %q", key, path)
+  }
+  var decoded string
+  if err := json.Unmarshal([]byte(path[1:len(path)-1]), &decoded); err != nil {
+    t.Fatalf("Postfix(%q) bracketed key is not JSON: %q (%v)", key, path, err)
+  }
+  if want := identifierFactoryPostfixDecodable(key); decoded != want {
+    t.Fatalf("Postfix(%q) round-tripped to %q, want %q", key, decoded, want)
+  }
+}
+
+// identifierFactoryPostfixDecodable states what a JSON decoder can return for
+// `key`. encoding/json replaces an unpaired surrogate and never yields invalid
+// UTF-8, so those two inputs come back as the replacement character even though
+// the emitted escape itself is exact.
+func identifierFactoryPostfixDecodable(key string) string {
+  var builder strings.Builder
+  for i := 0; i < len(key); {
+    // Detect a WTF-8 surrogate here rather than calling the factory's own
+    // helper, so this expectation stays independent of the code under test.
+    if len(key)-i >= 3 && key[i] == 0xed && key[i+1] >= 0xa0 && key[i+1] <= 0xbf {
+      builder.WriteRune('�')
+      i += 3
+      continue
+    }
+    builder.WriteByte(key[i])
+    i++
+  }
+  return strings.ToValidUTF8(builder.String(), "�")
+}

--- a/packages/typia/native/core/factories/identifier_factory_postfix_escapes_every_key_test.go
+++ b/packages/typia/native/core/factories/identifier_factory_postfix_escapes_every_key_test.go
@@ -70,9 +70,11 @@ func TestIdentifierFactoryPostfixEscapesEveryKey(t *testing.T) {
     // decoded to a plain "a" and silently changed the key.
     {"bell", "a\x07b", `"[\"a\\u0007b\"]"`},
     {"vertical tab", "a\x0bb", `"[\"a\\u000bb\"]"`},
-    // Line separators are only legal raw in a JavaScript string since ES2019.
-    {"line separator", "a\u2028b", `"[\"a\\u2028b\"]"`},
-    {"paragraph separator", "a\u2029b", `"[\"a\\u2029b\"]"`},
+    // A line terminator to JavaScript but an ordinary character to JSON, so the
+    // escape belongs in the source and must not reach the path itself: the
+    // emitted `\u2028` decodes back to the raw character JSON.stringify writes.
+    {"line separator", "a\u2028b", `"[\"a\u2028b\"]"`},
+    {"paragraph separator", "a\u2029b", `"[\"a\u2029b\"]"`},
     // Printable non-ASCII stays raw, exactly as JSON.stringify leaves it.
     {"non ascii", "한글", `"[\"한글\"]"`},
     {"emoji", "a\U0001F600b", "\"[\\\"a\U0001F600b\\\"]\""},

--- a/packages/typia/native/core/factories/identifier_factory_postfix_survives_every_code_point_test.go
+++ b/packages/typia/native/core/factories/identifier_factory_postfix_survives_every_code_point_test.go
@@ -1,0 +1,86 @@
+package factories
+
+import (
+  "encoding/json"
+  "fmt"
+  "strings"
+  "testing"
+  "unicode/utf8"
+)
+
+// TestIdentifierFactoryPostfixSurvivesEveryCodePoint verifies total escaping.
+//
+// The emitted accessor is spliced into the emit as source text, and nothing
+// downstream parses the file, so a key the escaper mishandles ships as a broken
+// artifact behind a successful build. The table-driven case list pins the
+// characters that actually regressed; this one closes the class by sweeping the
+// whole input space, because the escape decision is per rune and a sampled
+// matrix cannot prove a per-rune rule. encoding/json decodes the result, which
+// is an implementation typia does not own and therefore a real oracle: JSON
+// string syntax is a subset of JavaScript string syntax, so a literal it accepts
+// also parses in the emitted file.
+//
+//  1. Sweep every scalar value and assert the key round-trips exactly.
+//  2. Sweep every surrogate code unit and assert the WTF-8 form survives as an
+//     escape rather than corrupting the literal.
+//  3. Sweep every single byte, including the ones that are not UTF-8, and assert
+//     the emitted literal still decodes.
+func TestIdentifierFactoryPostfixSurvivesEveryCodePoint(t *testing.T) {
+  for code := rune(0); code <= utf8.MaxRune; code++ {
+    if code >= 0xd800 && code <= 0xdfff {
+      continue // Not a scalar value; covered by the surrogate sweep below.
+    }
+    key := "a" + string(code) + "b"
+    if decoded := identifierFactoryPostfixDecode(t, key); decoded != key {
+      t.Fatalf("U+%04X: Postfix round-tripped to %q, want %q", code, decoded, key)
+    }
+  }
+
+  for unit := rune(0xd800); unit <= 0xdfff; unit++ {
+    key := "a" + string([]byte{
+      0xe0 | byte(unit>>12),
+      0x80 | byte((unit>>6)&0x3f),
+      0x80 | byte(unit&0x3f),
+    }) + "b"
+    output := IdentifierFactory.Postfix(key)
+    // The inner level writes `\ud800` and the outer level escapes that
+    // backslash, so the emitted source carries `\\ud800`.
+    if want := fmt.Sprintf(`\\u%04x`, unit); !strings.Contains(output, want) {
+      t.Fatalf("U+%04X: lone surrogate was not escaped as %s: %s", unit, want, output)
+    }
+    // The decoder replaces an unpaired surrogate, so assert the literal stays
+    // well formed rather than demanding the original bytes back.
+    identifierFactoryPostfixDecode(t, key)
+  }
+
+  for value := 0; value <= 0xff; value++ {
+    key := "a" + string([]byte{byte(value)}) + "b"
+    decoded := identifierFactoryPostfixDecode(t, key)
+    if utf8.ValidString(key) && decoded != key {
+      t.Fatalf("byte 0x%02X: Postfix round-tripped to %q, want %q", value, decoded, key)
+    }
+  }
+}
+
+// identifierFactoryPostfixDecode reads the emitted source the way the runtime
+// does and fails the test if any layer rejects it: JavaScript parses the outer
+// literal, then _createStandardSchema hands the bracketed key to JSON.parse.
+func identifierFactoryPostfixDecode(t *testing.T, key string) string {
+  t.Helper()
+  output := IdentifierFactory.Postfix(key)
+  var path string
+  if err := json.Unmarshal([]byte(output), &path); err != nil {
+    t.Fatalf("Postfix(%q) is not a string literal: %s (%v)", key, output, err)
+  }
+  if strings.HasPrefix(path, ".") {
+    return path[1:]
+  }
+  if !strings.HasPrefix(path, "[") || !strings.HasSuffix(path, "]") {
+    t.Fatalf("Postfix(%q) is not an accessor: %q", key, path)
+  }
+  var decoded string
+  if err := json.Unmarshal([]byte(path[1:len(path)-1]), &decoded); err != nil {
+    t.Fatalf("Postfix(%q) bracketed key is not JSON: %q (%v)", key, path, err)
+  }
+  return decoded
+}

--- a/tests/test-typia-schema/src/features/standardSchema/test_standard_schema_escaped_key_paths.ts
+++ b/tests/test-typia-schema/src/features/standardSchema/test_standard_schema_escaped_key_paths.ts
@@ -1,0 +1,69 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+interface IHostileKeys {
+  'quote"key': number;
+  "back\\slash": number;
+  "line\nbreak": number;
+  "tab\tkey": number;
+  "bell\u0007key": number;
+  "nul\u0000key": number;
+  "sep\u2028key": number;
+  "plain-key": number;
+  plainIdentifier: number;
+}
+
+const KEYS: readonly string[] = [
+  'quote"key',
+  "back\\slash",
+  "line\nbreak",
+  "tab\tkey",
+  "bell\u0007key",
+  "nul\u0000key",
+  "sep\u2028key",
+  "plain-key",
+];
+
+/**
+ * Verifies Standard Schema reports issues for keys that need escaping.
+ *
+ * The transform folds a sole-literal key into the emitted path as source text,
+ * and `~standard.validate()` parses that path back with JSON.parse. Escaping the
+ * key for Go rather than for JavaScript left a raw control character in the
+ * path, so JSON.parse threw and destroyed the whole result instead of reporting
+ * the one property that failed. A quote-only fix leaves that throw live, which
+ * is why the control characters are pinned here beside the quote.
+ *
+ * 1. Validate an object whose keys carry quotes, backslashes, and control
+ *    characters through the Standard Schema adapter.
+ * 2. Assert it returns issues rather than throwing.
+ * 3. Assert every issue path segment is the original key, unmangled.
+ */
+export const test_standard_schema_escaped_key_paths = (): void => {
+  const validator = typia.createValidate<IHostileKeys>();
+  const input: Record<string, unknown> = { plainIdentifier: 1 };
+  for (const key of KEYS) input[key] = "not a number";
+
+  const result = validator["~standard"].validate(input);
+  if (result instanceof Promise || result.issues === undefined)
+    throw new Error("Expected escaped keys to return Standard Schema issues.");
+
+  TestValidator.equals("issue count", KEYS.length, result.issues.length);
+  for (const key of KEYS)
+    TestValidator.predicate(
+      `issue path for ${JSON.stringify(key)}`,
+      () =>
+        result.issues!.some(
+          (issue) =>
+            issue.path?.length === 1 &&
+            segmentKey(issue.path[0]) === key,
+        ),
+    );
+};
+
+const segmentKey = (
+  segment: PropertyKey | { readonly key: PropertyKey } | undefined,
+): PropertyKey | undefined =>
+  segment !== null && typeof segment === "object" && "key" in segment
+    ? segment.key
+    : segment;


### PR DESCRIPTION
Closes #2158.

## Intent

`IdentifierFactory.Postfix` builds the emitted accessor path (`$input["a-b"]`) as **raw JavaScript source text**, spliced into the emit through `f.NewIdentifier("_path + " + explore.Postfix)`. That text needs **two** levels of escaping — the key becomes a JSON literal, and that literal is embedded in a JavaScript string literal in the emitted file. The current code applies `strconv.Quote` once and then a `strings.ReplaceAll(…, "\"", "\\\"")` pass that only knows about `"`.

That outer pass is not an escaper. It double-escapes the `"` that `Quote` already handled, and it ignores every other character that needs escaping at the outer level.

## What measurement changed about the above

Kept as written because it is the intent this branch started from, but two parts of it did not survive verification, and the thread records the evidence:

- **`strconv.Quote` is not a usable inner escaper either.** It escapes for Go. It writes `\a` for U+0007 and `\U0001d173` for a non-printable astral rune; JavaScript has neither escape and decodes them as the identity escapes `a` and `U`, silently corrupting the key.
- **The two levels escape for different readers.** The key becomes JSON text that a user sees and `JSON.parse` reads; that text is then embedded in JavaScript source. U+2028/U+2029 are the entire difference between the grammars, so they are escaped in the source level only.
- **19 of 39 keys in the character matrix were already broken on `master`, not 2**, including `\` (emits valid JavaScript, then decodes as a backspace — the wrong key) and every control character (makes `~standard.validate()` throw instead of returning issues).

The invariant that settles it: the value of what `Postfix` returns must equal what typia's own runtime helper `typia/lib/internal/_accessExpressionAsString` computes for the same key, since dynamic keys take that runtime path while sole-literal keys are folded at compile time. That helper is `variable(str) ? ".{str}" : "[{JSON.stringify(str)}]"` — the oracle was already in the repo.

## Scope

Native Go, one owner: `packages/typia/native/core/factories/IdentifierFactory.go`, plus three tests and one feature test.

## The emit is still not parsed by the pipeline — deliberate, and here is the residual risk

typia's transform hands ttsc an AST and never sees the emitted text, so "parse what you wrote" belongs to ttsc's emitter and to #2117, not here. It would also treat the symptom: invalid text is expressible because `f.NewIdentifier("<raw source text>")` is a deliberate raw-text hatch used across the native tree for path expressions, regex literals from `metadata_to_pattern`, IIFEs in the compare programmers, and WeakSet/WeakMap recursion slots.

This bug did not survive 21 months because nothing parses the emit. **42 of the 57 `*_transform_test.go` cases already execute their emitted module through node, which parses it.** The gap was fixture coverage: no fixture had a `"` in a property key. This branch adds one, plus an explicit `node --check` on an untouched emit.

**Residual risk, stated plainly:** this change seals the escaping class at its owner — `Postfix` is now total over every scalar value, every surrogate code unit, and every single byte, proven exhaustively rather than by sampling. It does **not** make an invalid emit impossible in general. **A different raw-text splice with no fixture covering it can still ship JavaScript that does not parse behind a green build; the regex-pattern splices are the most plausible next instance.** Closing that properly means removing the raw-text hatch and building real AST nodes — a refactor across the path-building subsystem, since `FeatureProgrammer.Index` and `postfix_of_tuple` splice these strings by stripping a trailing quote. That is out of scope here and is the same shape as #2117.

## Deferred

**No `packages/typia/package.json` version bump.** Native Go source normally owes one under the development skill, but the maintainer owns releases and version numbers, and this campaign's issues state that explicitly.

The Go reserved-word list carries five words the runtime helper lacks (`module`, `package`, `private`, `protected`, `public`), so a static key `module` reports `$input["module"]` where a dynamic one reports `$input.module`. Both parse back to the same key. Cosmetic, different cause, lead is filing it separately — not folded in here.

Campaign CI is suspended per `.agents/skills/issue-campaign/development.md`; every run for each pushed SHA is cancelled at the exact-SHA gate and verification is local. Verification, the character matrix, and the outstanding gates are recorded in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
