### PR TITLE
fix(protobuf): emit a proto3-legal message document

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/protobuf_sequence_field_numbers_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/protobuf_sequence_field_numbers_transform_test.go
@@ -29,10 +29,15 @@ func TestProtobufSequenceFieldNumbersTransform(t *testing.T) {
   if code != 0 {
     t.Fatalf("protobuf sequence transform failed: code=%d stderr=\n%s", code, errText)
   }
+  // The subject is the explicit `Sequence<5>` / `Sequence<7>` field numbers and
+  // the auto-numbered `8` after them; the presence label is `optional` because
+  // proto3 has no `required`, and emitting it would make the document reject
+  // under a Protobuf compiler (samchon/typia#2155). Compiler legality itself is
+  // pinned by TestProtobufMessageDocumentCompiles.
   for _, line := range []string{
-    "required string id = 5;",
-    "required double age = 7;",
-    "required bool flag = 8;",
+    "optional string id = 5;",
+    "optional double age = 7;",
+    "optional bool flag = 8;",
   } {
     if !strings.Contains(out, line) {
       t.Fatalf("emitted proto message should contain %q:\n%s", line, out)

--- a/packages/typia/native/core/programmers/protobuf/ProtobufMessageProgrammer.go
+++ b/packages/typia/native/core/programmers/protobuf/ProtobufMessageProgrammer.go
@@ -40,19 +40,7 @@ func (protobufMessageProgrammerNamespace) Write(props ProtobufMessageProgrammer_
     Components: collection,
     Type:       props.Type,
   })
-  hierarchies := map[string]*protobufMessageProgrammer_Hierarchy{}
-  order := []string{}
-  for _, object := range collection.Objects() {
-    if protobufMessageProgrammer_is_dynamic_object(object) {
-      continue
-    }
-    order = protobufMessageProgrammer_emplace(hierarchies, order, object)
-  }
-  bodies := []string{}
-  for _, key := range order {
-    bodies = append(bodies, protobufMessageProgrammer_write_hierarchy(hierarchies[key]))
-  }
-  content := "syntax = \"proto3\";\n\n" + strings.Join(bodies, "\n\n")
+  content := ProtobufMessageProgrammer.Document(collection.Objects())
   lines := strings.Split(content, "\n")
   elements := make([]*shimast.Node, 0, len(lines))
   for _, line := range lines {
@@ -71,6 +59,28 @@ func (protobufMessageProgrammerNamespace) Write(props ProtobufMessageProgrammer_
     }),
     shimast.NodeFlagsNone,
   )
+}
+
+// Document renders the `.proto` text for the given protobuf metadata objects.
+//
+// The rendered text is the artifact `typia.protobuf.message<T>()` hands to
+// another language, so it is kept separate from the AST wrapping above: a
+// document is testable against a real Protobuf compiler, an emitted call
+// expression is not.
+func (protobufMessageProgrammerNamespace) Document(objects []*schemametadata.MetadataObjectType) string {
+  hierarchies := map[string]*protobufMessageProgrammer_Hierarchy{}
+  order := []string{}
+  for _, object := range objects {
+    if protobufMessageProgrammer_is_dynamic_object(object) {
+      continue
+    }
+    order = protobufMessageProgrammer_emplace(hierarchies, order, object)
+  }
+  bodies := []string{}
+  for _, key := range order {
+    bodies = append(bodies, protobufMessageProgrammer_write_hierarchy(hierarchies[key]))
+  }
+  return "syntax = \"proto3\";\n\n" + strings.Join(bodies, "\n\n")
 }
 
 func protobufMessageProgrammer_emplace(hierarchies map[string]*protobufMessageProgrammer_Hierarchy, order []string, object *schemametadata.MetadataObjectType) []string {
@@ -136,11 +146,9 @@ func protobufMessageProgrammer_write_object(obj *schemametadata.MetadataObjectTy
     }
     lines = append(lines, protobufMessageProgrammer_decodeProperty(struct {
       Key   string
-      Value *schemametadata.MetadataSchema
       Union []schemaprotobuf.IProtobufPropertyType
     }{
       Key:   key,
-      Value: p.Value,
       Union: p.Of_protobuf_.Union,
     }))
   }
@@ -149,18 +157,29 @@ func protobufMessageProgrammer_write_object(obj *schemametadata.MetadataObjectTy
 
 func protobufMessageProgrammer_decodeProperty(props struct {
   Key   string
-  Value *schemametadata.MetadataSchema
   Union []schemaprotobuf.IProtobufPropertyType
 }) string {
   if len(props.Union) == 1 {
     top := props.Union[0]
     words := []string{}
+    // Every singular field carries proto3 explicit presence.
+    //
+    // proto3 removed `required`, so a required non-nullable property cannot keep
+    // that label; a compiler rejects the whole document over it. `optional` is
+    // the label that matches what the codecs already do, rather than the merely
+    // legal one: ProtobufEncodeProgrammer writes a required non-nullable field
+    // unguarded, so it emits the field even when the value equals the scalar
+    // default, and ProtobufDecodeProgrammer defaults an absent required number
+    // or boolean to `undefined`. A bare field means implicit presence, which
+    // licenses a peer to drop default values from the wire and would decode back
+    // into a property the declared type says is always there. `optional` keeps
+    // that presence explicit on both sides.
+    //
+    // Requiredness itself is a TypeScript-level guarantee that proto3 has no
+    // label for; `protobuf.assertEncode` / `assertDecode` remain the place it is
+    // enforced.
     if protobufMessageProgrammer_schemaType(top) != "array" && protobufMessageProgrammer_schemaType(top) != "map" {
-      if props.Value.IsRequired() && props.Value.Nullable == false {
-        words = append(words, "required")
-      } else {
-        words = append(words, "optional")
-      }
+      words = append(words, "optional")
     }
     words = append(words, protobufMessageProgrammer_decodeSchema(top), props.Key, "=", protobufMessageProgrammer_index(top)+";")
     return strings.Join(words, " ")

--- a/packages/typia/test/contract/native/protobuf_message_document_compiles_test.go
+++ b/packages/typia/test/contract/native/protobuf_message_document_compiles_test.go
@@ -1,0 +1,137 @@
+package typia_test
+
+import (
+  "testing"
+
+  nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
+  nativeprotobufprogrammers "github.com/samchon/typia/packages/typia/native/core/programmers/protobuf"
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  protobuforacle "github.com/samchon/typia/packages/typia/test/internal/protobuforacle"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+)
+
+// TestProtobufMessageDocumentCompiles verifies every emitted document compiles.
+//
+// `typia.protobuf.message<T>()` exists to hand a schema to another language, so
+// the document must compile under the syntax it declares. It declared
+// `syntax = "proto3"` while labelling required non-nullable scalars `required`,
+// a label proto3 removed; because a Protobuf compiler rejects the whole file
+// rather than the field, one required scalar invalidated the entire document.
+// The substring assertions in the sibling suites cannot see this — a compiler
+// is the only oracle that can, so the document goes to one here.
+//
+// 1. Build objects covering required scalars, the all-optional boundary,
+//    nullable fields, arrays, maps, bytes, nested messages, and a `oneof`.
+// 2. Render each through the message programmer's document writer.
+// 3. Require a strict Protobuf compiler to accept every rendered document.
+func TestProtobufMessageDocumentCompiles(t *testing.T) {
+  for _, tuple := range []struct {
+    name    string
+    objects []*schemametadata.MetadataObjectType
+  }{
+    {
+      // The reported defect: one required scalar invalidated the whole file.
+      name: "required scalars",
+      objects: []*schemametadata.MetadataObjectType{
+        protobufMessageDocumentObject("IMember",
+          testutil.Property("id", protobufMessageDocumentTagged("number", "int32")),
+          testutil.Property("name", testutil.AtomicMetadata("string")),
+          testutil.Property("active", testutil.AtomicMetadata("boolean")),
+        ),
+      },
+    },
+    {
+      // The boundary: today's only passing shape must stay passing.
+      name: "no required scalars",
+      objects: []*schemametadata.MetadataObjectType{
+        protobufMessageDocumentObject("IConfig",
+          testutil.Property("timeout", protobufMessageDocumentOptional(protobufMessageDocumentTagged("number", "int32"))),
+          testutil.Property("debug", protobufMessageDocumentOptional(testutil.AtomicMetadata("boolean"))),
+        ),
+      },
+    },
+    {
+      name: "nullable scalars",
+      objects: []*schemametadata.MetadataObjectType{
+        protobufMessageDocumentObject("INullable",
+          testutil.Property("nickname", protobufMessageDocumentNullable(testutil.AtomicMetadata("string"))),
+          testutil.Property("score", protobufMessageDocumentNullable(protobufMessageDocumentTagged("number", "int32"))),
+        ),
+      },
+    },
+    {
+      name: "arrays and maps",
+      objects: []*schemametadata.MetadataObjectType{
+        protobufMessageDocumentObject("IContainer",
+          testutil.Property("tags", testutil.ArrayMetadata(testutil.AtomicMetadata("string"))),
+          testutil.Property("data", testutil.MapMetadata(testutil.AtomicMetadata("string"), testutil.AtomicMetadata("string"))),
+          testutil.Property("counts", testutil.MapMetadata(testutil.AtomicMetadata("string"), protobufMessageDocumentTagged("number", "int32"))),
+        ),
+      },
+    },
+    {
+      name: "bytes",
+      objects: []*schemametadata.MetadataObjectType{
+        protobufMessageDocumentObject("IBinary",
+          testutil.Property("payload", testutil.NativeMetadata("Uint8Array")),
+        ),
+      },
+    },
+    {
+      name: "oneof union",
+      objects: []*schemametadata.MetadataObjectType{
+        protobufMessageDocumentObject("IUnion",
+          testutil.Property("value", schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
+            Required: true,
+            Atomics: []*schemametadata.MetadataAtomic{
+              schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "string"}),
+              schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "boolean"}),
+            },
+          })),
+        ),
+      },
+    },
+  } {
+    document := protobufMessageDocumentRender(tuple.objects)
+    if err := protobuforacle.Compile(document); err != nil {
+      t.Errorf("emitted document for %s must compile: %v\n%s", tuple.name, err, document)
+    }
+  }
+}
+
+func protobufMessageDocumentRender(objects []*schemametadata.MetadataObjectType) string {
+  for _, object := range objects {
+    nativefactories.ProtobufFactory.EmplaceObject(object)
+  }
+  return nativeprotobufprogrammers.ProtobufMessageProgrammer.Document(objects)
+}
+
+func protobufMessageDocumentObject(name string, properties ...*schemametadata.MetadataProperty) *schemametadata.MetadataObjectType {
+  return schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{
+    Name:       name,
+    Properties: properties,
+  })
+}
+
+func protobufMessageDocumentTagged(kind string, tag string) *schemametadata.MetadataSchema {
+  return schemametadata.MetadataSchema_create(schemametadata.MetadataSchema{
+    Required: true,
+    Atomics: []*schemametadata.MetadataAtomic{
+      schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{
+        Type: kind,
+        Tags: [][]schemametadata.IMetadataTypeTag{{testutil.TypeTag(tag)}},
+      }),
+    },
+  })
+}
+
+func protobufMessageDocumentOptional(schema *schemametadata.MetadataSchema) *schemametadata.MetadataSchema {
+  schema.Required = false
+  schema.Optional = true
+  return schema
+}
+
+func protobufMessageDocumentNullable(schema *schemametadata.MetadataSchema) *schemametadata.MetadataSchema {
+  schema.Nullable = true
+  return schema
+}

--- a/packages/typia/test/contract/native/protobuf_message_document_explicit_presence_test.go
+++ b/packages/typia/test/contract/native/protobuf_message_document_explicit_presence_test.go
@@ -1,0 +1,50 @@
+package typia_test
+
+import (
+  "strings"
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+)
+
+// TestProtobufMessageDocumentExplicitPresence verifies singular fields stay labelled.
+//
+// A Protobuf compiler accepts both `optional int32 id = 1;` and a bare
+// `int32 id = 1;`, so the compiler oracle cannot tell the two apart — but the
+// codecs can. ProtobufEncodeProgrammer writes a required non-nullable field
+// unguarded, emitting it even at the scalar default, and ProtobufDecodeProgrammer
+// defaults an absent required number to `undefined`. A bare field is implicit
+// presence, which lets a peer drop default values from the wire and decode back
+// into a missing property, so dropping the label to satisfy proto3 would trade
+// an illegal document for a lossy one. This pins the choice the oracle cannot.
+//
+// 1. Render a document whose scalars are required, optional, and nullable.
+// 2. Require every singular field to keep an explicit presence label.
+// 3. Require `required` to be gone, and repeated fields to stay unlabelled.
+func TestProtobufMessageDocumentExplicitPresence(t *testing.T) {
+  document := protobufMessageDocumentRender([]*schemametadata.MetadataObjectType{
+    protobufMessageDocumentObject("IPresence",
+      testutil.Property("id", protobufMessageDocumentTagged("number", "int32")),
+      testutil.Property("nickname", protobufMessageDocumentNullable(testutil.AtomicMetadata("string"))),
+      testutil.Property("timeout", protobufMessageDocumentOptional(protobufMessageDocumentTagged("number", "int32"))),
+      testutil.Property("tags", testutil.ArrayMetadata(testutil.AtomicMetadata("string"))),
+    ),
+  })
+  for _, field := range []string{
+    "optional int32 id = 1;",
+    "optional string nickname = 2;",
+    "optional int32 timeout = 3;",
+    "repeated string tags = 4;",
+  } {
+    if strings.Contains(document, field) == false {
+      t.Errorf("emitted document must declare %q:\n%s", field, document)
+    }
+  }
+  if strings.Contains(document, "required") {
+    t.Errorf("proto3 document must not carry a `required` label:\n%s", document)
+  }
+  if strings.Contains(document, "optional repeated") {
+    t.Errorf("a repeated field must not take a presence label:\n%s", document)
+  }
+}

--- a/packages/typia/test/go.mod
+++ b/packages/typia/test/go.mod
@@ -2,6 +2,14 @@ module github.com/samchon/typia/packages/typia/test
 
 go 1.26
 
-require github.com/samchon/typia/packages/typia/native v0.0.0
+require (
+	github.com/bufbuild/protocompile v0.14.1
+	github.com/samchon/typia/packages/typia/native v0.0.0
+)
+
+require (
+	golang.org/x/sync v0.20.0 // indirect
+	google.golang.org/protobuf v1.34.2 // indirect
+)
 
 replace github.com/samchon/typia/packages/typia/native => ../native

--- a/packages/typia/test/go.sum
+++ b/packages/typia/test/go.sum
@@ -1,0 +1,6 @@
+github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
+github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
+google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=

--- a/packages/typia/test/internal/protobuforacle/protobuforacle.go
+++ b/packages/typia/test/internal/protobuforacle/protobuforacle.go
@@ -1,0 +1,39 @@
+// Package protobuforacle compiles an emitted `.proto` document with a strict
+// Protobuf compiler front end.
+//
+// A `.proto` document's only real oracle is a Protobuf compiler. typia's
+// protobuf coverage historically asserted with substring checks such as
+// `includes("int32 id")`, which `required int32 id = 1;` satisfies just as well
+// as a legal field, and the one test that parsed the document handed it to
+// protobuf.js — which accepts a proto3 document containing `required`, reports
+// its syntax as proto3, and records the label. Both of those oracles agree with
+// a document `protoc` rejects outright, so neither can witness an illegal label.
+//
+// protocompile is buf's Protobuf compiler front end. It enforces the proto3
+// label rules protobuf.js ignores and reports the same diagnosis protoc does
+// ("label 'required' is not allowed in proto3 or editions"), while remaining a
+// pure Go module, so this suite needs no protoc binary on PATH or in CI.
+package protobuforacle
+
+import (
+  "context"
+
+  "github.com/bufbuild/protocompile"
+)
+
+// FileName is the synthetic path the emitted document is compiled under.
+const FileName = "typia.proto"
+
+// Compile returns the error a strict Protobuf compiler raises for document, or
+// nil when the document compiles cleanly.
+func Compile(document string) error {
+  compiler := protocompile.Compiler{
+    Resolver: protocompile.WithStandardImports(&protocompile.SourceResolver{
+      Accessor: protocompile.SourceAccessorFromMap(map[string]string{
+        FileName: document,
+      }),
+    }),
+  }
+  _, err := compiler.Compile(context.Background(), FileName)
+  return err
+}

--- a/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_duplicate_name_identifier.ts
+++ b/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_duplicate_name_identifier.ts
@@ -21,8 +21,14 @@ interface IArguments {
  * identifier, so the separator has to survive `ProtobufNameEncoder`, or the
  * emitted schema is text no Protobuf parser accepts.
  *
- * The grammar is the oracle rather than a hand-written pattern: the document is
- * handed to protobuf.js, which is what a consumer would do with it.
+ * protobuf.js resolves the document the way a consumer would, which is what
+ * makes it a fair witness for *name resolution*: a collision or a broken
+ * separator shows up as a lookup failure rather than a pattern mismatch. It is
+ * not a witness for legality. protobuf.js is lenient — it accepts a proto3
+ * document containing `required`, reports its syntax as proto3, and records the
+ * label — so it agrees with documents a real compiler rejects. Whether the
+ * emitted document actually compiles is pinned separately, by
+ * `TestProtobufMessageDocumentCompiles`, against a strict compiler front end.
  *
  * 1. Reference two distinct types that share the declared name `Foo`.
  * 2. Parse the emitted document with protobuf.js and resolve every message.

--- a/website/src/content/docs/protobuf/message.mdx
+++ b/website/src/content/docs/protobuf/message.mdx
@@ -34,11 +34,13 @@ console.log(proto);
 //
 // syntax = "proto3";
 // message User {
-//   required string id = 1;
-//   required uint32 age = 2;
+//   optional string id = 1;
+//   optional uint32 age = 2;
 //   repeated string hobbies = 3;
 // }
 ```
+
+Every singular field is labelled `optional`, and array or map fields carry `repeated` or `map<...>` with no label. proto3 removed the `required` label, so a `.proto` that declares `syntax = "proto3"` and then writes `required` is rejected by `protoc` for the whole file. `optional` is proto3 explicit presence, which matches how `encode` writes the field — it emits the field even when the value equals the scalar default — so a consumer reading the schema in another language stays byte-compatible with typia's own codec.
 
 <Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>


### PR DESCRIPTION
Fixes #2155.

## Problem

`typia.protobuf.message<T>()` declared `syntax = "proto3";` and then wrote `required` — a label proto3 removed. A Protobuf compiler rejects the whole document, not the field, so any type with one required non-nullable scalar produced a `.proto` that will not compile. Handing that document to another language is the function's one documented job.

## Fix

`ProtobufMessageProgrammer.go` now labels every singular field `optional` instead of branching to `required`. Array and map fields keep taking no label; `oneof` members are unchanged. The only behavioural delta is required-non-nullable singular scalars flipping `required` → `optional`; every other shape is byte-identical output.

### Presence semantics — a deliberate choice, not formatting

proto3's `optional` is explicit presence; a bare field is implicit presence. They are not interchangeable:

- `ProtobufEncodeProgrammer` writes a required-non-nullable field **unguarded**, so it emits the field even when the value equals the scalar default (0 / "" / false).
- `ProtobufDecodeProgrammer` defaults an absent required number or boolean to `undefined`.

A bare (implicit-presence) field would tell a third-party encoder it may drop default values from the wire, which typia's own decoder would then read back as a missing property — trading an illegal document for a lossy one. `optional` matches what the codecs already do, so it is the truthful label.

## Oracle — replaced, not satisfied

The protobuf tests asserted substrings such as `includes("int32 id")`, which `required int32 id = 1;` satisfies as readily as a legal field, and the one parsing test handed the document to **protobuf.js**, which accepts proto3 `required`, reports the syntax as proto3, and records the label. Both agreed with the bug for ~21 months.

New `TestProtobufMessageDocumentCompiles` compiles the emitted document with **protocompile** (buf's Protobuf compiler front end): a pure-Go module, so CI needs no `protoc` binary. It rejects `required` in proto3 with protoc's own diagnosis (`label 'required' is not allowed in proto3 or editions`). It was cross-validated against a **real `protoc`** (via `grpcio-tools`) run over the real transform's real output for required/optional/nullable scalars, arrays, maps, bytes, nested messages, and `oneof` — all compile.

**Why the oracle can fail:** protocompile is a re-implementation of protoc's front end and could in principle diverge on some future grammar rule. It is mitigated by validating its verdict against real `protoc` on real emitted documents; protocompile is the in-CI gate, real `protoc` is the ground-truth cross-check.

`TestProtobufMessageDocumentExplicitPresence` pins the semantic choice a compiler cannot see (bare and `optional` both compile).

## Wire format is unchanged

Only `ProtobufMessageProgrammer.go` changes in shipped source; the codecs are untouched. `encode`→`decode` bytes were captured across the fix boundary and are **byte-identical** (same SHA256) over zero-valued scalars, nulls, containers, bytes, and both `oneof` branches, and the full `test-typia-automated` encode/decode matrix passes.

## Coordination

- **No `packages/typia/package.json` version bump.** The maintainer owns releases and version numbers; this PR does not touch it.
- The new Go dependency (`github.com/bufbuild/protocompile`) lands only in `packages/typia/test/go.mod` — the test module, which never ships. `native/go.mod` is unchanged, so npm consumers' plugin builds gain no dependency. Verified resolvable on a fresh module cache under the workspace with `-mod=readonly`.
- Independent of the other campaign batches; touches only the message grammar. #2158's protobuf key-diagnosis path is not disturbed.
- Campaign CI is suspended per the issue-campaign skill; local verification stands in for Actions.

## Local verification

- `go -C packages/typia/test test ../native/...` — 14 ok, 0 fail (incl. the corrected `TestProtobufSequenceFieldNumbersTransform`).
- `TestProtobufMessageDocumentCompiles` / `TestProtobufMessageDocumentExplicitPresence` — fail on the pre-fix label, pass after.
- `pnpm --filter ./tests/test-typia-schema start` — 160 cases, Success (incl. all `protobuf.decode` reader-contract cases from #2084/#2090/#2116/#2119, unchanged).
- `pnpm --filter ./tests/test-typia-automated start` — protobuf encode/decode round-trip matrix, Success.
