### PR TITLE
fix(langchain,vercel): make typia's validation reachable in LangChain and fence the LLM feedback once

### DIFF
--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
+    "@standard-schema/spec": "^1.1.0",
     "@typia/interface": "workspace:^",
     "@typia/utils": "workspace:^"
   },

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -27,7 +27,7 @@
     "@typia/utils": "workspace:^"
   },
   "peerDependencies": {
-    "@langchain/core": ">=1.0.0"
+    "@langchain/core": ">=1.1.30"
   },
   "devDependencies": {
     "@langchain/core": "^1.1.31",

--- a/packages/langchain/src/internal/LangChainParameterConverter.ts
+++ b/packages/langchain/src/internal/LangChainParameterConverter.ts
@@ -1,3 +1,4 @@
+import { StandardJSONSchemaV1 } from "@standard-schema/spec";
 import { IHttpLlmFunction, ILlmFunction } from "@typia/interface";
 
 /**
@@ -22,17 +23,18 @@ import { IHttpLlmFunction, ILlmFunction } from "@typia/interface";
  * whose `validate` is likewise left undefined so that `safeValidateTypes`
  * short-circuits its own validation.
  *
- * `toJsonSchema` only reads `~standard.jsonSchema` from `@langchain/core@1.1.30`
- * onwards; older versions return the wrapper itself and would advertise it to the
- * model in place of the parameters. That is what the package's `@langchain/core`
- * peer range is pinned to.
+ * Two version floors hold this together, and both are pinned in the package
+ * manifest. `toJsonSchema` only reads `~standard.jsonSchema` from
+ * `@langchain/core@1.1.30` onwards — older versions return the wrapper itself and
+ * would advertise *that* to the model in place of the parameters — and
+ * `StandardJSONSchemaV1` only exists from `@standard-schema/spec@1.1.0`.
  *
  * @see https://github.com/standard-schema/standard-schema
  */
 export namespace LangChainParameterConverter {
   export const convert = (
     func: ILlmFunction | IHttpLlmFunction,
-  ): IStandardJsonSchema => {
+  ): StandardJSONSchemaV1 => {
     // Coercion never changes the shape a value must end up in, so the input and
     // output schemas are the same document.
     const jsonSchema = (): Record<string, unknown> =>
@@ -46,22 +48,6 @@ export namespace LangChainParameterConverter {
           output: jsonSchema,
         },
       },
-    };
-  };
-}
-
-/**
- * The `StandardJSONSchemaV1` interface of `@standard-schema/spec`, declared here
- * so that `@typia/langchain` states the contract without taking a dependency on
- * a package whose types would leak into its own public declarations.
- */
-export interface IStandardJsonSchema {
-  "~standard": {
-    version: 1;
-    vendor: string;
-    jsonSchema: {
-      input: () => Record<string, unknown>;
-      output: () => Record<string, unknown>;
     };
   };
 }

--- a/packages/langchain/src/internal/LangChainParameterConverter.ts
+++ b/packages/langchain/src/internal/LangChainParameterConverter.ts
@@ -1,0 +1,62 @@
+import { IHttpLlmFunction, ILlmFunction } from "@typia/interface";
+
+/**
+ * A Standard JSON Schema view of one typia function's parameters.
+ *
+ * LangChain's tool `schema` fills two roles at once: `toJsonSchema(tool.schema)`
+ * turns it into the parameters the model is shown, and `StructuredTool.call`
+ * validates incoming arguments against it before the tool body runs. Handing
+ * over a bare `ILlmSchema.IParameters` fills the first role but forfeits the
+ * second — LangChain validates it with `@cfworker/json-schema`, which rejects
+ * what typia would have coerced and reports the failure in its own words, so
+ * typia's coercion and its correctable feedback both become unreachable.
+ *
+ * Standard JSON Schema separates the two roles. It carries a model-facing schema
+ * under `~standard.jsonSchema` and, by declaring no `~standard.validate`, no
+ * validator — which is exactly typia's position: show the model this schema, and
+ * leave validation to `LlmJson.validateArguments` in the tool body. LangChain
+ * reads the schema back through its own `toJsonSchema`, so the model sees the
+ * same parameters document as before, byte for byte.
+ *
+ * `@typia/vercel` states the same contract to the AI SDK through `jsonSchema()`,
+ * whose `validate` is likewise left undefined so that `safeValidateTypes`
+ * short-circuits its own validation.
+ *
+ * @see https://github.com/standard-schema/standard-schema
+ */
+export namespace LangChainParameterConverter {
+  export const convert = (
+    func: ILlmFunction | IHttpLlmFunction,
+  ): IStandardJsonSchema => {
+    // Coercion never changes the shape a value must end up in, so the input and
+    // output schemas are the same document.
+    const jsonSchema = (): Record<string, unknown> =>
+      func.parameters as unknown as Record<string, unknown>;
+    return {
+      "~standard": {
+        version: 1,
+        vendor: "typia",
+        jsonSchema: {
+          input: jsonSchema,
+          output: jsonSchema,
+        },
+      },
+    };
+  };
+}
+
+/**
+ * The `StandardJSONSchemaV1` interface of `@standard-schema/spec`, declared here
+ * so that `@typia/langchain` states the contract without taking a dependency on
+ * a package whose types would leak into its own public declarations.
+ */
+export interface IStandardJsonSchema {
+  "~standard": {
+    version: 1;
+    vendor: string;
+    jsonSchema: {
+      input: () => Record<string, unknown>;
+      output: () => Record<string, unknown>;
+    };
+  };
+}

--- a/packages/langchain/src/internal/LangChainParameterConverter.ts
+++ b/packages/langchain/src/internal/LangChainParameterConverter.ts
@@ -22,6 +22,11 @@ import { IHttpLlmFunction, ILlmFunction } from "@typia/interface";
  * whose `validate` is likewise left undefined so that `safeValidateTypes`
  * short-circuits its own validation.
  *
+ * `toJsonSchema` only reads `~standard.jsonSchema` from `@langchain/core@1.1.30`
+ * onwards; older versions return the wrapper itself and would advertise it to the
+ * model in place of the parameters. That is what the package's `@langchain/core`
+ * peer range is pinned to.
+ *
  * @see https://github.com/standard-schema/standard-schema
  */
 export namespace LangChainParameterConverter {

--- a/packages/langchain/src/internal/LangChainToolsRegistrar.ts
+++ b/packages/langchain/src/internal/LangChainToolsRegistrar.ts
@@ -166,15 +166,15 @@ export namespace LangChainToolsRegistrar {
       {
         name: entry.name,
         description: entry.function.description ?? "",
-        // Declares the model-facing schema without a validator, so that the
-        // coerce-and-validate step above is the only one that runs. See
-        // `LangChainParameterConverter`.
-        // `tool()` still types `schema` as Zod-or-JSON-Schema, though the
-        // `toJsonSchema` it reads the schema back with accepts Standard JSON
+        // Declares the model-facing schema without a validator, so the
+        // coerce-and-validate step above is the only one that runs; see
+        // `LangChainParameterConverter`. The cast is needed because `tool()`
+        // still types `schema` as Zod-or-JSON-Schema, even though the
+        // `toJsonSchema` it reads that schema back with accepts Standard JSON
         // Schema by its own public signature.
         schema: LangChainParameterConverter.convert(
           entry.function,
-        ) as unknown as JSONSchema,
+        ) as JSONSchema,
       },
     );
 

--- a/packages/langchain/src/internal/LangChainToolsRegistrar.ts
+++ b/packages/langchain/src/internal/LangChainToolsRegistrar.ts
@@ -3,6 +3,7 @@ import {
   ToolInputParsingException,
   tool,
 } from "@langchain/core/tools";
+import type { JSONSchema } from "@langchain/core/utils/json_schema";
 import {
   IHttpLlmController,
   IHttpLlmFunction,
@@ -11,6 +12,8 @@ import {
   IValidation,
 } from "@typia/interface";
 import { HttpLlm, LlmJson } from "@typia/utils";
+
+import { LangChainParameterConverter } from "./LangChainParameterConverter";
 
 export namespace LangChainToolsRegistrar {
   export const convert = (props: {
@@ -136,7 +139,7 @@ export namespace LangChainToolsRegistrar {
         if (valid.success === false)
           throw new ToolInputParsingException(
             `Type errors in "${entry.name}" arguments:\n\n` +
-              `\`\`\`json\n${LlmJson.stringify(valid)}\n\`\`\``,
+              LlmJson.stringify(valid),
             JSON.stringify(args ?? {}),
           );
         try {
@@ -163,7 +166,15 @@ export namespace LangChainToolsRegistrar {
       {
         name: entry.name,
         description: entry.function.description ?? "",
-        schema: entry.function.parameters,
+        // Declares the model-facing schema without a validator, so that the
+        // coerce-and-validate step above is the only one that runs. See
+        // `LangChainParameterConverter`.
+        // `tool()` still types `schema` as Zod-or-JSON-Schema, though the
+        // `toJsonSchema` it reads the schema back with accepts Standard JSON
+        // Schema by its own public signature.
+        schema: LangChainParameterConverter.convert(
+          entry.function,
+        ) as unknown as JSONSchema,
       },
     );
 

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -157,7 +157,7 @@ export namespace VercelToolsRegistrar {
             success: false,
             error:
               `Type errors in "${name}" arguments:\n\n` +
-              `\`\`\`json\n${LlmJson.stringify(validation)}\n\`\`\``,
+              LlmJson.stringify(validation),
           } satisfies ITryResult;
         try {
           const result: unknown = await execute(validation.data);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
 
   packages/langchain:
     dependencies:
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@typia/interface':
         specifier: workspace:^
         version: link:../interface

--- a/tests/test-langchain/src/features/test_langchain_class_controller_coercion.ts
+++ b/tests/test-langchain/src/features/test_langchain_class_controller_coercion.ts
@@ -1,0 +1,45 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toLangChainTools } from "@typia/langchain";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+/**
+ * Verifies LangChain tool calls coerce loosely-typed arguments before dispatch.
+ *
+ * LLMs frequently emit numbers as strings (`"42"` instead of `42`), so the
+ * registrar runs the shared `LlmJson.validateArguments` (coerce, then validate)
+ * and dispatches its coerced `data`. That coercion is unreachable whenever
+ * LangChain validates the registered `schema` itself, because
+ * `@cfworker/json-schema` rejects the string before the tool body runs and never
+ * coerces. `@typia/mcp` and `@typia/vercel` both accept this exact input; this
+ * pins `@typia/langchain` to the same answer.
+ *
+ * 1. Build a class controller and convert it to LangChain tools.
+ * 2. Invoke `add` with a stringified operand `{ x: "42", y: 5 }`.
+ * 3. Assert the call executes and returns the computed `47`.
+ */
+export const test_langchain_class_controller_coercion =
+  async (): Promise<void> => {
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+    const tools: DynamicStructuredTool[] = toLangChainTools({
+      controllers: [controller],
+    });
+    const addTool: DynamicStructuredTool | undefined = tools.find(
+      (t) => t.name === "add",
+    );
+    if (addTool === undefined) throw new Error("Missing add tool");
+
+    const result: unknown = await addTool.invoke({ x: "42", y: 5 });
+    TestValidator.equals(
+      "stringified operand is coerced and executed",
+      result,
+      {
+        success: true,
+        data: { value: 47 },
+      },
+    );
+  };

--- a/tests/test-langchain/src/features/test_langchain_class_controller_validation.ts
+++ b/tests/test-langchain/src/features/test_langchain_class_controller_validation.ts
@@ -9,38 +9,67 @@ import typia from "typia";
 
 import { Calculator } from "../structures/Calculator";
 
+/**
+ * Verifies typia — not LangChain — rejects a class tool's invalid arguments.
+ *
+ * `toLangChainTools` promises that every tool call is validated by typia, and
+ * that a failure returns `LlmJson.stringify` feedback the model can correct
+ * itself from. LangChain's `StructuredTool.call` runs `@cfworker/json-schema`
+ * against whatever `schema` a tool registers and throws before the tool body,
+ * so registering a bare JSON Schema silently hands validation to LangChain and
+ * reduces the feedback to its generic "Received tool input did not match
+ * expected schema". Asserting only that `ToolInputParsingException` is thrown
+ * cannot tell the two sources apart, so this pins the message instead: deleting
+ * the registrar's typia validation must fail this test.
+ *
+ * 1. Build a class controller and convert it to LangChain tools.
+ * 2. Invoke `add` with a non-numeric operand.
+ * 3. Assert the throw carries typia's annotated feedback for `$input.x` and
+ *    never LangChain's schema message.
+ * 4. Assert valid arguments still execute.
+ */
 export const test_langchain_class_controller_validation =
   async (): Promise<void> => {
-    // 1. Create class-based controller using typia.llm.controller
     const controller: ILlmController<Calculator> =
       typia.llm.controller<Calculator>("calculator", new Calculator());
-
-    // 2. Convert to LangChain tools
     const tools: DynamicStructuredTool[] = toLangChainTools({
       controllers: [controller],
     });
+    const addTool: DynamicStructuredTool | undefined = tools.find(
+      (t) => t.name === "add",
+    );
+    if (addTool === undefined) throw new Error("Missing add tool");
 
-    // 3. Find add tool
-    const addTool = tools.find((t) => t.name === "add");
-    if (!addTool) {
-      throw new Error("Missing add tool");
-    }
+    const error: unknown = await addTool
+      .invoke({ x: "not a number", y: 5 })
+      .then(() => undefined)
+      .catch((exp: unknown) => exp);
+    TestValidator.predicate(
+      "invalid arguments throw ToolInputParsingException",
+      () => error instanceof ToolInputParsingException,
+    );
 
-    // 4. Test with invalid arguments - should throw ToolInputParsingException
-    //    (may be thrown by LangChain's JSON Schema validation or typia's validation)
-    try {
-      await addTool.invoke({ x: "not a number", y: 5 });
-      throw new Error("Expected ToolInputParsingException to be thrown.");
-    } catch (error) {
-      TestValidator.predicate(
-        "should throw ToolInputParsingException",
-        () => error instanceof ToolInputParsingException,
-      );
-    }
+    const message: string = (error as Error).message;
+    TestValidator.predicate(
+      "feedback comes from typia, not LangChain's JSON Schema validation",
+      () =>
+        message.includes(
+          "Received tool input did not match expected schema",
+        ) === false,
+    );
+    TestValidator.predicate("feedback is titled by the registrar", () =>
+      message.includes('Type errors in "add" arguments:'),
+    );
+    TestValidator.predicate(
+      "feedback annotates the offending property with typia's expected type",
+      () =>
+        message.includes("// ❌") &&
+        message.includes('"path":"$input.x"') &&
+        message.includes('"expected":"number"'),
+    );
 
-    // 5. Test with valid arguments - should succeed
-    const validResult = await addTool.invoke({ x: 10, y: 5 });
-    TestValidator.equals("valid args should work", validResult, {
+    const valid: unknown = await addTool.invoke({ x: 10, y: 5 });
+    TestValidator.equals("valid arguments execute", valid, {
       success: true,
       data: { value: 15 },
     });

--- a/tests/test-langchain/src/features/test_langchain_http_controller_coercion.ts
+++ b/tests/test-langchain/src/features/test_langchain_http_controller_coercion.ts
@@ -1,0 +1,109 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { TestValidator } from "@nestia/e2e";
+import { IHttpLlmController, IHttpResponse, OpenApi } from "@typia/interface";
+import { toLangChainTools } from "@typia/langchain";
+import { HttpLlm } from "@typia/utils";
+
+/**
+ * Verifies an HTTP tool dispatches typia's coerced arguments, not the raw ones.
+ *
+ * The class and HTTP controllers share one `createTool`, which dispatches the
+ * `data` of `LlmJson.validateArguments` — the coerced arguments — rather than
+ * what the model sent. Registering a schema LangChain validates itself defeats
+ * that for both protocols at once: `@cfworker/json-schema` rejects a stringified
+ * `"42"` before the tool body, so the request is never issued at all. Injecting
+ * the controller's own `execute` observes the dispatched arguments without a
+ * live server.
+ *
+ * 1. Build an OpenAPI document whose request body needs two numbers.
+ * 2. Inject an `execute` that records the arguments it receives.
+ * 3. Invoke the operation with a stringified operand.
+ * 4. Assert the recorded body is coerced to numbers and the call succeeds.
+ */
+export const test_langchain_http_controller_coercion =
+  async (): Promise<void> => {
+    const document: OpenApi.IDocument = {
+      openapi: "3.2.0",
+      "x-typia-emended-v12": true,
+      components: {},
+      paths: {
+        "/calculate/add": {
+          post: {
+            operationId: "calculate_add",
+            summary: "Add two numbers",
+            requestBody: {
+              required: true,
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      x: { type: "number", description: "First operand" },
+                      y: { type: "number", description: "Second operand" },
+                    },
+                    required: ["x", "y"],
+                  } satisfies OpenApi.IJsonSchema.IObject,
+                },
+              },
+            },
+            responses: {
+              "200": {
+                description: "Sum result",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: { value: { type: "number" } },
+                      required: ["value"],
+                    } satisfies OpenApi.IJsonSchema.IObject,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    let dispatched: unknown = undefined;
+    const controller: IHttpLlmController = {
+      ...HttpLlm.controller({
+        name: "calculator",
+        document,
+        connection: { host: "http://localhost:3000" },
+      }),
+      execute: async (props): Promise<IHttpResponse> => {
+        dispatched = props.arguments;
+        const { body } = props.arguments as {
+          body: { x: number; y: number };
+        };
+        return {
+          status: 200,
+          headers: {},
+          body: { value: body.x + body.y },
+        };
+      },
+    };
+
+    const tools: DynamicStructuredTool[] = toLangChainTools({
+      controllers: [controller],
+    });
+    const addTool: DynamicStructuredTool | undefined = tools.find(
+      (t) => t.name === "calculate_add_post",
+    );
+    if (addTool === undefined)
+      throw new Error("Missing calculate_add_post tool");
+
+    const result: unknown = await addTool.invoke({
+      body: { x: "42", y: 5 },
+    });
+    TestValidator.equals(
+      "the request body is dispatched with coerced numbers",
+      dispatched,
+      { body: { x: 42, y: 5 } },
+    );
+    TestValidator.equals("the coerced call returns the sum", result, {
+      success: true,
+      data: { value: 47 },
+    });
+  };

--- a/tests/test-langchain/src/features/test_langchain_http_controller_validation.ts
+++ b/tests/test-langchain/src/features/test_langchain_http_controller_validation.ts
@@ -7,9 +7,26 @@ import { IHttpLlmController, OpenApi } from "@typia/interface";
 import { toLangChainTools } from "@typia/langchain";
 import { HttpLlm } from "@typia/utils";
 
+/**
+ * Verifies typia — not LangChain — rejects an HTTP tool's invalid arguments.
+ *
+ * The class and HTTP controllers share one `createTool`, so whichever framework
+ * owns argument validation owns it for both protocols. LangChain's
+ * `StructuredTool.call` validates a registered JSON Schema with
+ * `@cfworker/json-schema` and throws before the tool body, which would replace
+ * typia's correctable feedback with its generic "Received tool input did not
+ * match expected schema" here too. Asserting only that
+ * `ToolInputParsingException` is thrown accepts either source and so pins
+ * neither; this pins the message.
+ *
+ * 1. Build an OpenAPI document whose request body needs two numbers.
+ * 2. Convert its HTTP controller to LangChain tools.
+ * 3. Invoke the operation with a non-numeric operand.
+ * 4. Assert the throw carries typia's annotated feedback for the body path and
+ *    never LangChain's schema message.
+ */
 export const test_langchain_http_controller_validation =
   async (): Promise<void> => {
-    // 1. Create minimal OpenApi document with a simple numeric schema
     const bodySchema: OpenApi.IJsonSchema.IObject = {
       type: "object",
       properties: {
@@ -56,38 +73,45 @@ export const test_langchain_http_controller_validation =
       },
     };
 
-    // 2. Create controller
     const controller: IHttpLlmController = HttpLlm.controller({
       name: "calculator",
       document,
       connection: { host: "http://localhost:3000" },
     });
-
-    // 3. Convert to LangChain tools
     const tools: DynamicStructuredTool[] = toLangChainTools({
       controllers: [controller],
     });
-
-    // 4. Find the add tool
-    const addTool = tools.find((t) => t.name === "calculate_add_post");
-    if (!addTool) {
+    const addTool: DynamicStructuredTool | undefined = tools.find(
+      (t) => t.name === "calculate_add_post",
+    );
+    if (addTool === undefined)
       throw new Error("Missing calculate_add_post tool");
-    }
 
-    // 5. Test validation failure: wrong type (string instead of number)
-    //    (may be thrown by LangChain's JSON Schema validation or typia's validation)
-    try {
-      await addTool.invoke({
-        body: {
-          x: "not a number",
-          y: 5,
-        },
-      });
-      throw new Error("Expected ToolInputParsingException to be thrown.");
-    } catch (error) {
-      TestValidator.predicate(
-        "should throw ToolInputParsingException",
-        () => error instanceof ToolInputParsingException,
-      );
-    }
+    const error: unknown = await addTool
+      .invoke({ body: { x: "not a number", y: 5 } })
+      .then(() => undefined)
+      .catch((exp: unknown) => exp);
+    TestValidator.predicate(
+      "invalid arguments throw ToolInputParsingException",
+      () => error instanceof ToolInputParsingException,
+    );
+
+    const message: string = (error as Error).message;
+    TestValidator.predicate(
+      "feedback comes from typia, not LangChain's JSON Schema validation",
+      () =>
+        message.includes(
+          "Received tool input did not match expected schema",
+        ) === false,
+    );
+    TestValidator.predicate("feedback is titled by the registrar", () =>
+      message.includes('Type errors in "calculate_add_post" arguments:'),
+    );
+    TestValidator.predicate(
+      "feedback annotates the offending body property",
+      () =>
+        message.includes("// ❌") &&
+        message.includes('"path":"$input.body.x"') &&
+        message.includes('"expected":"number"'),
+    );
   };

--- a/tests/test-langchain/src/features/test_langchain_json_pointer_reference_arguments.ts
+++ b/tests/test-langchain/src/features/test_langchain_json_pointer_reference_arguments.ts
@@ -2,22 +2,29 @@ import {
   DynamicStructuredTool,
   ToolInputParsingException,
 } from "@langchain/core/tools";
+import { Validator, toJsonSchema } from "@langchain/core/utils/json_schema";
 import { TestValidator } from "@nestia/e2e";
 import { ILlmController } from "@typia/interface";
 import { toLangChainTools } from "@typia/langchain";
 import typia from "typia";
 
 /**
- * Verifies LangChain resolves generated canonical local references.
+ * Verifies a generated canonical local reference resolves for model and tool.
  *
- * LangChain validates tool input against the advertised schema before typia's
- * own coercion runs, so this boundary is an independent JSON Schema oracle: it
- * can only reject a violation of the referenced definition after resolving
- * `#/$defs/RecursiveA~1B`. A fail-open reference would admit both negatives.
+ * A definition key containing `/` has to reach the model as the JSON Pointer
+ * escape `#/$defs/RecursiveA~1B`, and both readers of that reference must
+ * resolve it: the JSON Schema the model is shown, and the validator the tool
+ * runs. `@cfworker/json-schema` — which LangChain re-exports, and which never
+ * sees typia's own inversion — is the independent oracle for the first, since a
+ * fail-open reference would admit every negative instead of resolving the
+ * escaped key. Typia's validator is the authority for the second.
  *
  * 1. Advertise a recursive argument whose generated definition key contains `/`.
- * 2. Execute a valid recursive value through the real LangChain tool.
- * 3. Reject values violating only the referenced schema at LangChain's own gate.
+ * 2. Resolve the advertised schema with an independent JSON Schema validator and
+ *    confirm it accepts a conforming value and rejects a violation of the
+ *    referenced definition alone.
+ * 3. Execute a valid recursive value through the real LangChain tool.
+ * 4. Reject a value violating only the referenced schema, with typia's feedback.
  */
 export const test_langchain_json_pointer_reference_arguments =
   async (): Promise<void> => {
@@ -37,30 +44,42 @@ export const test_langchain_json_pointer_reference_arguments =
       count: 42,
       children: [{ value: "A/B", count: 7, children: [] }],
     };
+
+    // The model-facing schema must resolve the escaped key on its own terms.
+    const validator: Validator = new Validator(
+      toJsonSchema(tool.schema) as object,
+    );
+    TestValidator.predicate(
+      "the advertised schema accepts a conforming referenced value",
+      () => validator.validate({ input: tree }).valid,
+    );
+    TestValidator.predicate(
+      "the advertised schema resolves the encoded reference to reject a violation",
+      () =>
+        validator.validate({
+          input: { value: "wrong", count: 0, children: [] },
+        }).valid === false,
+    );
+
     const valid = await tool.invoke({ input: tree });
     TestValidator.equals("valid referenced argument executes", valid, {
       success: true,
       data: tree,
     });
 
-    // Both negatives violate only the referenced `Recursive<"A/B">` definition,
-    // so LangChain can reject them only by resolving the encoded reference.
-    for (const [label, input] of [
-      ["referenced numeric property", { value: "A/B", count: "42" }],
-      ["referenced literal property", { value: "wrong", count: 0 }],
-    ] as const) {
-      try {
-        await tool.invoke({ input: { ...input, children: [] } });
-        throw new Error(`Expected ${label} to be rejected.`);
-      } catch (error) {
-        TestValidator.predicate(
-          `LangChain resolves the encoded reference to reject a ${label}`,
-          () =>
-            error instanceof ToolInputParsingException &&
-            error.message.includes("did not match expected schema"),
-        );
-      }
-    }
+    // Violates only the referenced `Recursive<"A/B">` definition, and survives
+    // coercion, so typia can reject it only by resolving the encoded reference.
+    const error: unknown = await tool
+      .invoke({ input: { value: "wrong", count: 0, children: [] } })
+      .then(() => undefined)
+      .catch((exp: unknown) => exp);
+    TestValidator.predicate(
+      "typia resolves the encoded reference to reject a referenced literal",
+      () =>
+        error instanceof ToolInputParsingException &&
+        error.message.includes('Type errors in "echo" arguments:') &&
+        error.message.includes('"path":"$input.input.value"'),
+    );
   };
 
 type Recursive<T extends string> = {

--- a/tests/test-langchain/src/features/test_langchain_json_pointer_reference_arguments.ts
+++ b/tests/test-langchain/src/features/test_langchain_json_pointer_reference_arguments.ts
@@ -21,10 +21,11 @@ import typia from "typia";
  *
  * 1. Advertise a recursive argument whose generated definition key contains `/`.
  * 2. Resolve the advertised schema with an independent JSON Schema validator and
- *    confirm it accepts a conforming value and rejects a violation of the
+ *    confirm it accepts a conforming value and rejects violations of the
  *    referenced definition alone.
  * 3. Execute a valid recursive value through the real LangChain tool.
- * 4. Reject a value violating only the referenced schema, with typia's feedback.
+ * 4. Reject both a referenced numeric and a referenced literal violation, each
+ *    with typia's feedback naming the path under the reference.
  */
 export const test_langchain_json_pointer_reference_arguments =
   async (): Promise<void> => {
@@ -58,6 +59,9 @@ export const test_langchain_json_pointer_reference_arguments =
       () =>
         validator.validate({
           input: { value: "wrong", count: 0, children: [] },
+        }).valid === false &&
+        validator.validate({
+          input: { value: "A/B", count: "not a number", children: [] },
         }).valid === false,
     );
 
@@ -67,19 +71,34 @@ export const test_langchain_json_pointer_reference_arguments =
       data: tree,
     });
 
-    // Violates only the referenced `Recursive<"A/B">` definition, and survives
-    // coercion, so typia can reject it only by resolving the encoded reference.
-    const error: unknown = await tool
-      .invoke({ input: { value: "wrong", count: 0, children: [] } })
-      .then(() => undefined)
-      .catch((exp: unknown) => exp);
-    TestValidator.predicate(
-      "typia resolves the encoded reference to reject a referenced literal",
-      () =>
-        error instanceof ToolInputParsingException &&
-        error.message.includes('Type errors in "echo" arguments:') &&
-        error.message.includes('"path":"$input.input.value"'),
-    );
+    // Each negative violates only the referenced `Recursive<"A/B">` definition
+    // and survives coercion — `"42"` would not, since typia coerces it to `42`
+    // and accepts the call — so typia can reject them only by resolving the
+    // encoded reference.
+    for (const [label, input, path] of [
+      [
+        "referenced numeric property",
+        { value: "A/B", count: "not a number" },
+        "$input.input.count",
+      ],
+      [
+        "referenced literal property",
+        { value: "wrong", count: 0 },
+        "$input.input.value",
+      ],
+    ] as const) {
+      const error: unknown = await tool
+        .invoke({ input: { ...input, children: [] } })
+        .then(() => undefined)
+        .catch((exp: unknown) => exp);
+      TestValidator.predicate(
+        `typia resolves the encoded reference to reject a ${label}`,
+        () =>
+          error instanceof ToolInputParsingException &&
+          error.message.includes('Type errors in "echo" arguments:') &&
+          error.message.includes(`"path":"${path}"`),
+      );
+    }
   };
 
 type Recursive<T extends string> = {

--- a/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
+++ b/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
@@ -42,7 +42,9 @@ export const test_langchain_tool_error_single_json_fence =
       .invoke(args)
       .then(() => undefined)
       .catch((exp: unknown) => exp);
-    const message: string = (error as Error).message;
+    if (error instanceof Error === false)
+      throw new Error("Expected invalid arguments to be rejected.");
+    const message: string = error.message;
 
     TestValidator.equals(
       "argument feedback opens exactly one json fence",

--- a/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
+++ b/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
@@ -1,0 +1,68 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController, ILlmFunction, IValidation } from "@typia/interface";
+import { toLangChainTools } from "@typia/langchain";
+import { LlmJson } from "@typia/utils";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+/**
+ * Verifies a LangChain argument failure fences typia's feedback exactly once.
+ *
+ * `LlmJson.stringify` owns the markdown fence around its annotated JSON, so a
+ * caller that wraps the return value in a second ```` ```json ```` fence hands
+ * the model ```` ```json\n```json ```` — broken markdown, in the one payload
+ * whose whole purpose is to be read back and corrected. Counting the fence is
+ * what pins this, because asserting the feedback merely `includes("```json")`
+ * passes with one fence or two; asserting the body is `LlmJson.stringify`'s
+ * output verbatim additionally pins that the registrar wraps it in nothing at
+ * all.
+ *
+ * 1. Build a class controller and convert it to LangChain tools.
+ * 2. Invoke `add` with a non-numeric operand to force typia's feedback.
+ * 3. Assert the message opens exactly one ```` ```json ```` fence.
+ * 4. Assert the message is the registrar's title followed by `LlmJson.stringify`
+ *    verbatim.
+ */
+export const test_langchain_tool_error_single_json_fence =
+  async (): Promise<void> => {
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+    const tools: DynamicStructuredTool[] = toLangChainTools({
+      controllers: [controller],
+    });
+    const addTool: DynamicStructuredTool | undefined = tools.find(
+      (t) => t.name === "add",
+    );
+    if (addTool === undefined) throw new Error("Missing add tool");
+
+    const args: object = { x: "not a number", y: 5 };
+    const error: unknown = await addTool
+      .invoke(args)
+      .then(() => undefined)
+      .catch((exp: unknown) => exp);
+    const message: string = (error as Error).message;
+
+    TestValidator.equals(
+      "argument feedback opens exactly one json fence",
+      message.split("```json").length - 1,
+      1,
+    );
+
+    const func: ILlmFunction | undefined = controller.application.functions.find(
+      (f) => f.name === "add",
+    );
+    if (func === undefined) throw new Error("Missing add function");
+    const validation: IValidation<unknown> = LlmJson.validateArguments(
+      func,
+      args,
+    );
+    TestValidator.predicate(
+      "argument feedback is LlmJson.stringify verbatim, wrapped in nothing",
+      () =>
+        validation.success === false &&
+        message ===
+          `Type errors in "add" arguments:\n\n${LlmJson.stringify(validation)}`,
+    );
+  };

--- a/tests/test-langchain/src/features/test_langchain_tool_model_facing_schema.ts
+++ b/tests/test-langchain/src/features/test_langchain_tool_model_facing_schema.ts
@@ -1,0 +1,71 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { convertToOpenAITool } from "@langchain/core/utils/function_calling";
+import { toJsonSchema } from "@langchain/core/utils/json_schema";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController, ILlmFunction } from "@typia/interface";
+import { toLangChainTools } from "@typia/langchain";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+/**
+ * Verifies a LangChain tool still shows the model typia's parameters schema.
+ *
+ * A LangChain tool's `schema` is read for two different purposes: LangChain
+ * validates arguments against it, and `toJsonSchema` turns it into the
+ * parameters the provider is sent. Because typia validates arguments itself, the
+ * registrar declines the first role by registering Standard JSON Schema — and
+ * the whole point of that shape is that it does not cost the second. Nothing
+ * else asserts the model-facing artifact, so a regression that traded the schema
+ * away to reclaim validation would leave the model calling tools blind, with
+ * every other test still green.
+ *
+ * 1. Build a class controller and convert it to LangChain tools.
+ * 2. Assert `toJsonSchema` yields typia's parameters document unchanged.
+ * 3. Assert the OpenAI tool definition LangChain sends carries the same
+ *    document, with the properties and required list the model needs.
+ */
+export const test_langchain_tool_model_facing_schema =
+  async (): Promise<void> => {
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+    const tools: DynamicStructuredTool[] = toLangChainTools({
+      controllers: [controller],
+    });
+    const addTool: DynamicStructuredTool | undefined = tools.find(
+      (t) => t.name === "add",
+    );
+    const func: ILlmFunction | undefined = controller.application.functions.find(
+      (f) => f.name === "add",
+    );
+    if (addTool === undefined) throw new Error("Missing add tool");
+    if (func === undefined) throw new Error("Missing add function");
+
+    TestValidator.equals(
+      "toJsonSchema yields typia's parameters unchanged",
+      toJsonSchema(addTool.schema),
+      func.parameters,
+    );
+
+    const definition = convertToOpenAITool(addTool);
+    TestValidator.equals(
+      "the tool definition sent to the model carries typia's parameters",
+      definition.function.parameters,
+      func.parameters,
+    );
+    TestValidator.predicate(
+      "the model is still shown both operands and their requirement",
+      () => {
+        const parameters = definition.function.parameters as {
+          properties?: Record<string, unknown>;
+          required?: string[];
+        };
+        return (
+          parameters.properties?.x !== undefined &&
+          parameters.properties?.y !== undefined &&
+          parameters.required?.includes("x") === true &&
+          parameters.required?.includes("y") === true
+        );
+      },
+    );
+  };

--- a/tests/test-langchain/src/features/test_langchain_tool_model_facing_schema.ts
+++ b/tests/test-langchain/src/features/test_langchain_tool_model_facing_schema.ts
@@ -13,7 +13,7 @@ import { Calculator } from "../structures/Calculator";
  *
  * A LangChain tool's `schema` is read for two different purposes: LangChain
  * validates arguments against it, and `toJsonSchema` turns it into the
- * parameters the provider is sent. Because typia validates arguments itself, the
+ * parameters the model is shown. Because typia validates arguments itself, the
  * registrar declines the first role by registering Standard JSON Schema — and
  * the whole point of that shape is that it does not cost the second. Nothing
  * else asserts the model-facing artifact, so a regression that traded the schema

--- a/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
@@ -1,5 +1,4 @@
 import { TestValidator } from "@nestia/e2e";
-import { ILlmController } from "@typia/interface";
 import { toVercelTools } from "@typia/vercel";
 import type { Tool } from "ai";
 import typia from "typia";

--- a/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
@@ -10,11 +10,10 @@ import { Calculator } from "../structures/Calculator";
  *
  * `LlmJson.stringify` already wraps its output in a ```` ```json ```` fence, so
  * a caller that adds a second one hands the model ```` ```json\n```json ````.
- * The arguments and output paths of `VercelToolsRegistrar` format the same
- * `LlmJson.stringify` result fifteen lines apart, and only the output path
- * leaves it alone — so the invariant has to be asserted on both paths at once,
- * and by counting the fence rather than by testing for the doubled form, which
- * an `includes("```json")` check cannot see.
+ * `VercelToolsRegistrar` formats that same result on two separate paths — once
+ * for invalid arguments and once for an invalid output — and a fence added back
+ * to either one is invisible to an `includes("```json")` check, which passes
+ * with one fence or two. Counting the fence on both paths is what pins it.
  *
  * 1. Build a controller whose method both takes and returns a typed value.
  * 2. Force an argument failure and count the fences in its feedback.

--- a/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
@@ -1,0 +1,92 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+/**
+ * Verifies Vercel tool feedback fences typia's annotated JSON exactly once.
+ *
+ * `LlmJson.stringify` already wraps its output in a ```` ```json ```` fence, so
+ * a caller that adds a second one hands the model ```` ```json\n```json ````.
+ * The arguments and output paths of `VercelToolsRegistrar` format the same
+ * `LlmJson.stringify` result fifteen lines apart, and only the output path
+ * leaves it alone — so the invariant has to be asserted on both paths at once,
+ * and by counting the fence rather than by testing for the doubled form, which
+ * an `includes("```json")` check cannot see.
+ *
+ * 1. Build a controller whose method both takes and returns a typed value.
+ * 2. Force an argument failure and count the fences in its feedback.
+ * 3. Force an output failure and count the fences in its feedback.
+ */
+export const test_vercel_tool_error_single_json_fence =
+  async (): Promise<void> => {
+    const calculator: Record<string, Tool> = toVercelTools(
+      typia.llm.controller<Calculator>("calculator", new Calculator()),
+    );
+    const argumentError: string = await failureOf(calculator["add"]!, {
+      x: "not a number",
+      y: 5,
+    });
+    TestValidator.predicate("argument feedback is typia's", () =>
+      argumentError.includes('Type errors in "add" arguments:'),
+    );
+    TestValidator.equals(
+      "argument feedback opens exactly one json fence",
+      countFences(argumentError),
+      1,
+    );
+
+    const outputs: Record<string, Tool> = toVercelTools(
+      typia.llm.controller<OutputController>("output", new OutputController()),
+    );
+    const outputError: string = await failureOf(outputs["read"]!, { seed: 1 });
+    TestValidator.predicate("output feedback is typia's", () =>
+      outputError.includes('Type errors in "read" output:'),
+    );
+    TestValidator.equals(
+      "output feedback opens exactly one json fence",
+      countFences(outputError),
+      1,
+    );
+  };
+
+class OutputController {
+  /**
+   * Read the stored value.
+   *
+   * @param input The lookup seed
+   * @returns The stored value
+   */
+  read(input: OutputController.IInput): OutputController.IResult {
+    return { value: `not a number: ${input.seed}` } as never;
+  }
+}
+namespace OutputController {
+  export interface IInput {
+    /** Lookup seed */
+    seed: number;
+  }
+  export interface IResult {
+    /** Stored value */
+    value: number;
+  }
+}
+
+const failureOf = async (tool: Tool, args: object): Promise<string> => {
+  const result: unknown = await tool.execute!(args, {
+    toolCallId: "test-fence",
+    messages: [],
+    abortSignal: undefined as any,
+  });
+  const failure = result as { success?: boolean; error?: string };
+  if (failure.success !== false || typeof failure.error !== "string")
+    throw new Error(
+      `Expected a failure result, but got ${JSON.stringify(result)}`,
+    );
+  return failure.error;
+};
+
+const countFences = (text: string): number => text.split("```json").length - 1;

--- a/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
@@ -18,6 +18,10 @@ import { Calculator } from "../structures/Calculator";
  * 2. Preserve a valid nested object in the typed success branch.
  * 3. Route undefined, null, array, primitive, and wrong-shaped values through the
  *    schema-conforming failure branch with actionable paths.
+ *
+ * The markdown fencing of that feedback is asserted by
+ * `test_vercel_tool_error_single_json_fence`, which counts the fence on both the
+ * arguments and output paths.
  */
 export const test_vercel_tool_output_schema = async (): Promise<void> => {
   const controller: ILlmController<Calculator> =
@@ -89,8 +93,7 @@ export const test_vercel_tool_output_schema = async (): Promise<void> => {
         failure.success === false &&
         typeof failure.error === "string" &&
         failure.error.includes('Type errors in "read" output:') &&
-        failure.error.includes(path) &&
-        !failure.error.includes("```json\n```json")
+        failure.error.includes(path)
       );
     });
   }

--- a/website/src/content/docs/utilization/langchain.mdx
+++ b/website/src/content/docs/utilization/langchain.mdx
@@ -182,7 +182,9 @@ For the mechanics see [`LlmJson`](/docs/llm/json).
 
 A LangChain tool's `schema` normally does two jobs: it becomes the parameters the model is shown, and LangChain validates arguments against it with [`@cfworker/json-schema`](https://github.com/cfworker/cfworker) before the tool body runs. That second job would preempt typia — a stringified `"42"` would be rejected instead of coerced to `42`, and the model would get LangChain's `Received tool input did not match expected schema` instead of the annotated feedback above.
 
-So `@typia/langchain` registers the parameters as a [Standard JSON Schema](https://github.com/standard-schema/standard-schema): a schema for the model, with no validator attached. LangChain reads it back through its own `toJsonSchema`, so the model sees the same parameters document either way, and typia's coerce-then-validate path is the only one that runs. `@typia/vercel` says the same thing to the AI SDK through `jsonSchema()`, and `@typia/mcp` through the tool's `inputSchema` — all three adapters answer identical arguments identically.
+So `@typia/langchain` registers the parameters as a [Standard JSON Schema](https://github.com/standard-schema/standard-schema): a schema for the model, with no validator attached. LangChain reads it back through its own `toJsonSchema`, so the model sees the same parameters document either way, and typia's coerce-then-validate path is the only one that runs. `@typia/vercel` states the same contract to the AI SDK through `jsonSchema()`, whose absent `validate` makes the SDK skip its own check; `@typia/mcp` needs no such statement, because the low-level MCP server never validates a call's `arguments` for itself. Byte-identical arguments now get byte-identical answers from all three.
+
+This is why `@typia/langchain` requires `@langchain/core@1.1.30` or newer — that is the release whose `toJsonSchema` reads a Standard JSON Schema back.
 </Callout>
 
 ## Runtime errors

--- a/website/src/content/docs/utilization/langchain.mdx
+++ b/website/src/content/docs/utilization/langchain.mdx
@@ -178,9 +178,11 @@ Every tool carries the harness: type coercion, validation, and model-readable fe
 For the mechanics see [`LlmJson`](/docs/llm/json).
 
 <Callout type="info">
-**How LangChain validation fits**
+**Why LangChain doesn't validate first**
 
-LangChain may reject malformed tool inputs before the adapter body runs. For inputs that reach the tool body, `@typia/langchain` still runs typia's coerce-then-validate path, so TypeScript constraints and typia tags become the feedback the model sees.
+A LangChain tool's `schema` normally does two jobs: it becomes the parameters the model is shown, and LangChain validates arguments against it with [`@cfworker/json-schema`](https://github.com/cfworker/cfworker) before the tool body runs. That second job would preempt typia — a stringified `"42"` would be rejected instead of coerced to `42`, and the model would get LangChain's `Received tool input did not match expected schema` instead of the annotated feedback above.
+
+So `@typia/langchain` registers the parameters as a [Standard JSON Schema](https://github.com/standard-schema/standard-schema): a schema for the model, with no validator attached. LangChain reads it back through its own `toJsonSchema`, so the model sees the same parameters document either way, and typia's coerce-then-validate path is the only one that runs. `@typia/vercel` says the same thing to the AI SDK through `jsonSchema()`, and `@typia/mcp` through the tool's `inputSchema` — all three adapters answer identical arguments identically.
 </Callout>
 
 ## Runtime errors


### PR DESCRIPTION
Implements #2151.

## Scope

Two defects that must land together, because the second one's LangChain instance is masked by the first.

1. **`@typia/langchain` never reaches typia.** `LangChainToolsRegistrar.createTool` registers with `schema: entry.function.parameters` — a raw JSON Schema. LangChain's `StructuredTool.call` runs `@cfworker/json-schema` against that schema *before* invoking the tool body, so `LlmJson.validateArguments` never sees invalid arguments and `valid.data` — the coerced arguments — is never produced. Both advertised features of the package are unreachable.
2. **The arguments path double-fences typia's feedback.** `LlmJson.stringify` already emits its own ` ```json ` fence; `VercelToolsRegistrar` and `LangChainToolsRegistrar` each wrap it in a second one on the arguments path. The output path in both is already correct.

## Verification

Local only — campaign CI is suspended and cancelled per exact-SHA gate.

Pending; recorded on this thread as it completes.
