### PR TITLE
fix(native): align the date-time format aliases and enforce array-form tag exclusivity

### DIFF
--- a/packages/typia/native/core/factories/FormatCheatSheet.go
+++ b/packages/typia/native/core/factories/FormatCheatSheet.go
@@ -4,6 +4,39 @@ func formatCheatSheet_RegexCall(text string) string {
   return text + ".test($input)"
 }
 
+// formatCheatSheet_ALIASES maps an alternative `@format` spelling onto the
+// canonical FormatCheatSheet key it means.
+//
+// An alias owns no validator. It resolves to the cheat sheet entry through
+// formatCheatSheet_resolve, so FormatCheatSheet stays the single owner of every
+// format's validator and a correction to one reaches every spelling of it. The
+// aliases previously carried validator strings of their own, which made each of
+// them a second implementation sharing a name and free to drift: `datetime`
+// emitted `format: "date-time"` while validating with `new Date`, so it accepted
+// February 30th and rejected the RFC 3339 leap second the cheat sheet handles.
+//
+// Aliases live beside the cheat sheet so that enumerating this file enumerates
+// every owner of the `@format` contract.
+var formatCheatSheet_ALIASES = map[string]string{
+  "datetime": "date-time",
+  "dateTime": "date-time",
+}
+
+// formatCheatSheet_resolve resolves a written `@format` value to the canonical
+// format name and the validator FormatCheatSheet owns for it, reporting whether
+// the value names a supported format at all.
+func formatCheatSheet_resolve(value string) (string, string, bool) {
+  name := value
+  if canonical, ok := formatCheatSheet_ALIASES[value]; ok {
+    name = canonical
+  }
+  validate, ok := FormatCheatSheet[name]
+  if ok == false {
+    return "", "", false
+  }
+  return name, validate, true
+}
+
 var FormatCheatSheet = map[string]string{
   "byte":                  `/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test($input)`,
   "password":              "true",

--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -274,11 +274,11 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
-    matched, ok := metadataCommentTagFactory_FORMATS[props.Value]
+    name, validate, ok := formatCheatSheet_resolve(props.Value)
     if ok == false {
       return metadataCommentTagFactory_TagRecord{}
     }
-    return metadataCommentTagFactory_TagRecord{"string": {{Name: "Format<" + strconv.Quote(matched[0]) + ">", Target: "string", Kind: "format", Value: matched[0], Validate: matched[1], Exclusive: true, Schema: map[string]any{"format": matched[0]}}}}
+    return metadataCommentTagFactory_TagRecord{"string": {{Name: "Format<" + strconv.Quote(name) + ">", Target: "string", Kind: "format", Value: name, Validate: validate, Exclusive: true, Schema: map[string]any{"format": name}}}}
   },
   "pattern": func(props struct {
     Report func(msg string) any
@@ -436,16 +436,6 @@ func metadataCommentTagFactory_parse_integer(props struct {
   value := int(parsed)
   return &value
 }
-
-var metadataCommentTagFactory_FORMATS = func() map[string][2]string {
-  output := map[string][2]string{}
-  for key, value := range FormatCheatSheet {
-    output[key] = [2]string{key, value}
-  }
-  output["datetime"] = [2]string{"date-time", "!isNaN(new Date($input).getTime())"}
-  output["dateTime"] = [2]string{"date-time", "!isNaN(new Date($input).getTime())"}
-  return output
-}()
 
 func metadataCommentTagFactory_includes(values []string, target string) bool {
   for _, value := range values {

--- a/packages/typia/native/core/factories/MetadataTypeTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataTypeTagFactory.go
@@ -246,9 +246,21 @@ func (metadataTypeTagFactoryNamespace) Validate(props struct {
         }{Property: nil, Message: "kind '" + tag.Kind + "' can't be duplicated"})
       }
     case []string:
+      // The `exclusive` list names every kind this tag may not share a property
+      // with, itself included, and it is the authoritative spec. Reject when any
+      // other tag's kind appears in the list, matching kinds against kinds.
+      //
+      // Two bugs made this inert: it compared the list of kinds against
+      // `opposite.Name` ("minimum" against "Minimum<0>"), which never matched,
+      // and it also required `opposite.Kind == tag.Kind`, which excluded the
+      // cross-kind partners the list exists to catch. Both must go, or a
+      // forbidden combination keeps compiling: `Minimum<5> & Minimum<0>` emits
+      // `{"minimum":0}` yet its validator requires 5, and `Minimum<0> &
+      // ExclusiveMinimum<5>` or `Format<"uuid"> & Pattern<...>` coexist though
+      // the declarations forbid it.
       var some *schemametadata.IMetadataTypeTag
       for j, opposite := range props.Tags {
-        if i != j && opposite.Kind == tag.Kind && metadataTypeTagFactory_includes(exclusive, opposite.Name) {
+        if i != j && metadataTypeTagFactory_includes(exclusive, opposite.Kind) {
           copied := opposite
           some = &copied
           break

--- a/packages/typia/native/core/factories/factory_utility_coverage_test.go
+++ b/packages/typia/native/core/factories/factory_utility_coverage_test.go
@@ -499,8 +499,14 @@ export let inner!: Outer.Inner;
 		Report: typeTagReport,
 		Type:   "string",
 		Tags: []schemametadata.IMetadataTypeTag{
-			{Target: "string", Kind: "range", Name: "minimum", Exclusive: []string{"maximum"}},
-			{Target: "string", Kind: "range", Name: "maximum", Exclusive: []string{"minimum"}},
+			// Format and Pattern as they are actually declared: both list the
+			// kinds `["format", "pattern"]`, so intersecting them on one property
+			// is forbidden. The cross-kind conflict fires on the opposite's kind,
+			// not its name, and without a same-kind guard. The previous fixture
+			// named the opposite in `exclusive` by tag name, the only shape the
+			// doubly-broken check could fire on and no real declaration produces.
+			{Target: "string", Kind: "format", Name: "Format<\"uuid\">", Exclusive: []string{"format", "pattern"}},
+			{Target: "string", Kind: "pattern", Name: "Pattern<\"^x$\">", Exclusive: []string{"format", "pattern"}},
 		},
 	})
 	invalidExclusiveReports := []string{}

--- a/packages/typia/native/core/factories/format_alias_resolves_to_cheat_sheet_test.go
+++ b/packages/typia/native/core/factories/format_alias_resolves_to_cheat_sheet_test.go
@@ -1,0 +1,57 @@
+package factories
+
+import (
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestFormatAliasResolvesToCheatSheet verifies every `@format` alias generates the cheat sheet validator it emits.
+//
+// An alias that carries its own validator string is not an alias; it is a
+// second implementation sharing a name, free to drift from the format it
+// claims. `@format datetime` did exactly that: it emitted `format: "date-time"`
+// while validating with `!isNaN(new Date($input).getTime())`, so it accepted
+// February 30th and rejected the RFC 3339 leap second the cheat sheet handles.
+// This pins the alias to the cheat sheet as the single owner of the validator.
+//
+// 1. Parse each alias spelling of the `date-time` format as a JSDoc comment tag.
+// 2. Require the emitted format name, schema, and tag name to be the canonical one.
+// 3. Require the generated validator to be the cheat sheet entry verbatim.
+func TestFormatAliasResolvesToCheatSheet(t *testing.T) {
+  canonical := "date-time"
+  expected, ok := FormatCheatSheet[canonical]
+  if ok == false {
+    t.Fatalf("the cheat sheet must own the %s format", canonical)
+  }
+  for _, alias := range []string{"datetime", "dateTime", "date-time"} {
+    record := metadataCommentTagFactory_parse(struct {
+      Report func(msg string) any
+      Tag    schemametadata.IJsDocTagInfo
+    }{
+      Report: func(msg string) any { return nil },
+      Tag: schemametadata.IJsDocTagInfo{
+        Name: "format",
+        Text: []schemametadata.IJsDocTagInfo_IText{{Text: alias}},
+      },
+    })
+    tags := record["string"]
+    if len(tags) != 1 {
+      t.Fatalf("@format %s should generate exactly one string tag, generated %d", alias, len(tags))
+    }
+    tag := tags[0]
+    if tag.Value != canonical {
+      t.Fatalf("@format %s should carry the canonical %s value, carried %v", alias, canonical, tag.Value)
+    }
+    if tag.Name != "Format<\""+canonical+"\">" {
+      t.Fatalf("@format %s should name the canonical format tag, named %s", alias, tag.Name)
+    }
+    schema, ok := tag.Schema.(map[string]any)
+    if ok == false || schema["format"] != canonical {
+      t.Fatalf("@format %s should emit format %s, emitted %v", alias, canonical, tag.Schema)
+    }
+    if tag.Validate != expected {
+      t.Fatalf("@format %s must validate as the cheat sheet %s entry does, validated with %s", alias, canonical, tag.Validate)
+    }
+  }
+}

--- a/packages/typia/native/core/factories/format_alias_table_targets_the_cheat_sheet_test.go
+++ b/packages/typia/native/core/factories/format_alias_table_targets_the_cheat_sheet_test.go
@@ -1,0 +1,44 @@
+package factories
+
+import "testing"
+
+// TestFormatAliasTableTargetsTheCheatSheet verifies every declared `@format` alias names a real cheat sheet format.
+//
+// The original defect was structural, not arithmetic: the aliases were appended
+// after a loop that copied the cheat sheet, so they were invisible to any sweep
+// that enumerated the cheat sheet's entries and could drift from the format they
+// emit without contradicting anything. The alias table now holds only cheat
+// sheet keys, and this pins that shape — an alias pointing nowhere, or shadowing
+// a real format with a different meaning, fails here rather than at a user's
+// call site.
+//
+// 1. Require every alias to resolve to an existing cheat sheet entry.
+// 2. Require no alias to shadow a cheat sheet key of its own name.
+// 3. Require resolution to reject a format the cheat sheet does not own.
+func TestFormatAliasTableTargetsTheCheatSheet(t *testing.T) {
+  if len(formatCheatSheet_ALIASES) == 0 {
+    t.Fatal("the alias table should stay the enumerable owner of every alternative spelling")
+  }
+  for alias, canonical := range formatCheatSheet_ALIASES {
+    expected, ok := FormatCheatSheet[canonical]
+    if ok == false {
+      t.Fatalf("the alias %s targets %s, which the cheat sheet does not own", alias, canonical)
+    }
+    if _, ok := FormatCheatSheet[alias]; ok {
+      t.Fatalf("the alias %s shadows a cheat sheet format of the same name", alias)
+    }
+    name, validate, ok := formatCheatSheet_resolve(alias)
+    if ok == false || name != canonical || validate != expected {
+      t.Fatalf("the alias %s must resolve to the cheat sheet %s entry, resolved to %s", alias, canonical, name)
+    }
+  }
+  for name, validate := range FormatCheatSheet {
+    resolvedName, resolvedValidate, ok := formatCheatSheet_resolve(name)
+    if ok == false || resolvedName != name || resolvedValidate != validate {
+      t.Fatalf("the canonical format %s must resolve to itself", name)
+    }
+  }
+  if _, _, ok := formatCheatSheet_resolve("not-a-format"); ok {
+    t.Fatal("an unsupported format must not resolve")
+  }
+}

--- a/packages/typia/native/core/factories/metadata_type_tag_factory_accepts_legal_tag_combinations_test.go
+++ b/packages/typia/native/core/factories/metadata_type_tag_factory_accepts_legal_tag_combinations_test.go
@@ -1,0 +1,60 @@
+package factories
+
+import (
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestMetadataTypeTagFactoryAcceptsLegalTagCombinations verifies enforcing exclusivity rejects nothing a declaration permits.
+//
+// This is the negative twin of the rejection tests. Making an inert check fire
+// is only correct if it fires on exactly the declared `exclusive` pairs: a check
+// that over-matches would reject `Minimum<0> & Maximum<10>`, which neither tag's
+// `exclusive` list names and which every bounded-range type depends on.
+//
+// 1. Combine each array-form tag with a kind absent from its exclusive list.
+// 2. Combine bool-form tags of differing kinds, which the untouched branch owns.
+// 3. Require every combination, and each tag alone, to validate.
+func TestMetadataTypeTagFactoryAcceptsLegalTagCombinations(t *testing.T) {
+  declarations := metadataTypeTagFactoryTestDeclarations()
+  byKind := map[string]metadataTypeTagFactoryTestDeclaration{}
+  for _, declaration := range declarations {
+    byKind[declaration.kind] = declaration
+    success, messages := metadataTypeTagFactoryTestValidate(
+      declaration.target,
+      []schemametadata.IMetadataTypeTag{declaration.tag("A")},
+    )
+    if success == false {
+      t.Fatalf("a lone %s tag must validate, reported %#v", declaration.kind, messages)
+    }
+  }
+
+  for _, pair := range [][2]string{
+    {"minimum", "maximum"},
+    {"minimum", "exclusiveMaximum"},
+    {"exclusiveMinimum", "maximum"},
+    {"exclusiveMinimum", "exclusiveMaximum"},
+  } {
+    left := byKind[pair[0]]
+    right := byKind[pair[1]]
+    success, messages := metadataTypeTagFactoryTestValidate(
+      left.target,
+      []schemametadata.IMetadataTypeTag{left.tag("0"), right.tag("10")},
+    )
+    if success == false {
+      t.Fatalf("%s and %s bound opposite ends and must combine, reported %#v", pair[0], pair[1], messages)
+    }
+  }
+
+  boolFormTarget := "string"
+  boolForm := []schemametadata.IMetadataTypeTag{
+    {Target: boolFormTarget, Name: "MinLength<3>", Kind: "minLength", Exclusive: true},
+    {Target: boolFormTarget, Name: "MaxLength<7>", Kind: "maxLength", Exclusive: true},
+    {Target: boolFormTarget, Name: "Format<\"uuid\">", Kind: "format", Exclusive: true},
+  }
+  success, messages := metadataTypeTagFactoryTestValidate(boolFormTarget, boolForm)
+  if success == false {
+    t.Fatalf("bool-form tags of differing kinds must combine, reported %#v", messages)
+  }
+}

--- a/packages/typia/native/core/factories/metadata_type_tag_factory_declarations_test.go
+++ b/packages/typia/native/core/factories/metadata_type_tag_factory_declarations_test.go
@@ -1,0 +1,86 @@
+package factories
+
+import (
+  "fmt"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// metadataTypeTagFactoryTestDeclaration mirrors one type tag declaration from
+// `packages/interface/src/tags`, which is the specification the native check
+// must enforce. `exclusive` names kinds, never tag names.
+type metadataTypeTagFactoryTestDeclaration struct {
+  target    string
+  kind      string
+  exclusive []string
+  name      string
+}
+
+// tag materializes the declaration as the metadata tag the factory receives.
+func (d metadataTypeTagFactoryTestDeclaration) tag(value string) schemametadata.IMetadataTypeTag {
+  return schemametadata.IMetadataTypeTag{
+    Target:    d.target,
+    Name:      fmt.Sprintf(d.name, value),
+    Kind:      d.kind,
+    Exclusive: d.exclusive,
+    Value:     value,
+  }
+}
+
+// metadataTypeTagFactoryTestDeclarations transcribes every array-form tag
+// declaration, in the exact `kind` and `exclusive` shape each publishes:
+//
+//   - Minimum          kind "minimum"          exclusive ["minimum", "exclusiveMinimum"]
+//   - Maximum          kind "maximum"          exclusive ["maximum", "exclusiveMaximum"]
+//   - ExclusiveMinimum kind "exclusiveMinimum" exclusive ["exclusiveMinimum", "minimum"]
+//   - ExclusiveMaximum kind "exclusiveMaximum" exclusive ["exclusiveMaximum", "maximum"]
+//   - Format           kind "format"           exclusive ["format", "pattern"]
+//   - Pattern          kind "pattern"          exclusive ["format", "pattern"]
+//
+// Each list names its own kind, so no tag may be duplicated, plus exactly one
+// cross-kind partner.
+func metadataTypeTagFactoryTestDeclarations() []metadataTypeTagFactoryTestDeclaration {
+  return []metadataTypeTagFactoryTestDeclaration{
+    {target: "number", kind: "minimum", exclusive: []string{"minimum", "exclusiveMinimum"}, name: "Minimum<%s>"},
+    {target: "number", kind: "maximum", exclusive: []string{"maximum", "exclusiveMaximum"}, name: "Maximum<%s>"},
+    {target: "number", kind: "exclusiveMinimum", exclusive: []string{"exclusiveMinimum", "minimum"}, name: "ExclusiveMinimum<%s>"},
+    {target: "number", kind: "exclusiveMaximum", exclusive: []string{"exclusiveMaximum", "maximum"}, name: "ExclusiveMaximum<%s>"},
+    {target: "string", kind: "format", exclusive: []string{"format", "pattern"}, name: "Format<%s>"},
+    {target: "string", kind: "pattern", exclusive: []string{"format", "pattern"}, name: "Pattern<%s>"},
+  }
+}
+
+// metadataTypeTagFactoryTestReport collects the factory's validation messages.
+func metadataTypeTagFactoryTestReport(messages *[]string) func(struct {
+  Property *string
+  Message  string
+}) bool {
+  return func(next struct {
+    Property *string
+    Message  string
+  }) bool {
+    *messages = append(*messages, next.Message)
+    return false
+  }
+}
+
+// metadataTypeTagFactoryTestValidate runs the factory check over one tag list.
+func metadataTypeTagFactoryTestValidate(
+  target string,
+  tags []schemametadata.IMetadataTypeTag,
+) (bool, []string) {
+  messages := []string{}
+  success := MetadataTypeTagFactory.Validate(struct {
+    Report func(struct {
+      Property *string
+      Message  string
+    }) bool
+    Type string
+    Tags []schemametadata.IMetadataTypeTag
+  }{
+    Report: metadataTypeTagFactoryTestReport(&messages),
+    Type:   target,
+    Tags:   tags,
+  })
+  return success, messages
+}

--- a/packages/typia/native/core/factories/metadata_type_tag_factory_keeps_bool_form_exclusivity_test.go
+++ b/packages/typia/native/core/factories/metadata_type_tag_factory_keeps_bool_form_exclusivity_test.go
@@ -1,0 +1,38 @@
+package factories
+
+import (
+  "strings"
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestMetadataTypeTagFactoryKeepsBoolFormExclusivity verifies the bool-form exclusivity branch still rejects a duplicated kind.
+//
+// The bool branch was never broken; it is the working neighbor of the inert
+// array-form branch and shares the same loop and reporting path. Repairing the
+// array-form branch must not disturb it, so this pins its behavior in both
+// directions independently of the array-form tests.
+//
+// 1. Duplicate a bool-form kind and require rejection naming the kind.
+// 2. Require an opted-out `exclusive: false` tag to permit its own duplicate.
+func TestMetadataTypeTagFactoryKeepsBoolFormExclusivity(t *testing.T) {
+  success, messages := metadataTypeTagFactoryTestValidate("string", []schemametadata.IMetadataTypeTag{
+    {Target: "string", Name: "Format<\"uuid\">", Kind: "format", Exclusive: true},
+    {Target: "string", Name: "Format<\"email\">", Kind: "format", Exclusive: true},
+  })
+  if success {
+    t.Fatal("a duplicated bool-form kind must be rejected")
+  }
+  if len(messages) != 1 || strings.Contains(messages[0], "format") == false {
+    t.Fatalf("the bool-form duplication report must name the kind, reported %#v", messages)
+  }
+
+  success, messages = metadataTypeTagFactoryTestValidate("string", []schemametadata.IMetadataTypeTag{
+    {Target: "string", Name: "Example<\"first\">", Kind: "example", Exclusive: false},
+    {Target: "string", Name: "Example<\"second\">", Kind: "example", Exclusive: false},
+  })
+  if success == false {
+    t.Fatalf("a tag opting out of exclusivity must permit its own duplicate, reported %#v", messages)
+  }
+}

--- a/packages/typia/native/core/factories/metadata_type_tag_factory_rejects_cross_kind_exclusive_tags_test.go
+++ b/packages/typia/native/core/factories/metadata_type_tag_factory_rejects_cross_kind_exclusive_tags_test.go
@@ -1,0 +1,65 @@
+package factories
+
+import (
+  "strings"
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestMetadataTypeTagFactoryRejectsCrossKindExclusiveTags verifies each array-form tag rejects the cross-kind partner it declares.
+//
+// The cross-kind partner is the whole reason an `exclusive` list holds more
+// than the tag's own kind: `Minimum` lists `exclusiveMinimum`, `Format` lists
+// `pattern`. The declaration is the spec and it forbids the coexistence, so
+// `number & Minimum<0> & ExclusiveMinimum<5>` and
+// `string & Format<"uuid"> & Pattern<...>` must not compile. The original check
+// scanned only same-kind tags, so the two never met; dropping that same-kind
+// guard is what lets this fire, so restoring the guard turns this red while
+// leaving the same-kind duplication test green.
+//
+// 1. Derive every declared cross-kind pair from the declarations themselves.
+// 2. Validate each pair, both orders, and require rejection naming the conflict.
+// 3. Require all six declarations to contribute exactly one cross-kind partner.
+func TestMetadataTypeTagFactoryRejectsCrossKindExclusiveTags(t *testing.T) {
+  declarations := metadataTypeTagFactoryTestDeclarations()
+  byKind := map[string]metadataTypeTagFactoryTestDeclaration{}
+  for _, declaration := range declarations {
+    byKind[declaration.kind] = declaration
+  }
+
+  covered := 0
+  for _, declaration := range declarations {
+    for _, kind := range declaration.exclusive {
+      if kind == declaration.kind {
+        continue
+      }
+      opposite, ok := byKind[kind]
+      if ok == false {
+        t.Fatalf("%s declares the unknown partner kind %s", declaration.kind, kind)
+      }
+      if opposite.target != declaration.target {
+        t.Fatalf("%s and %s must share a target to ever conflict", declaration.kind, kind)
+      }
+      covered++
+
+      subject := declaration.tag("A")
+      partner := opposite.tag("B")
+      success, messages := metadataTypeTagFactoryTestValidate(
+        declaration.target,
+        []schemametadata.IMetadataTypeTag{subject, partner},
+      )
+      if success {
+        t.Fatalf("kind %s must not be used with kind %s", declaration.kind, kind)
+      }
+      if len(messages) != 1 ||
+        strings.Contains(messages[0], declaration.kind) == false ||
+        strings.Contains(messages[0], partner.Name) == false {
+        t.Fatalf("the %s and %s conflict report must name the conflict, reported %#v", declaration.kind, kind, messages)
+      }
+    }
+  }
+  if covered != len(declarations) {
+    t.Fatalf("every array-form declaration should name exactly one cross-kind partner, covered %d of %d", covered, len(declarations))
+  }
+}

--- a/packages/typia/native/core/factories/metadata_type_tag_factory_rejects_duplicated_array_form_tags_test.go
+++ b/packages/typia/native/core/factories/metadata_type_tag_factory_rejects_duplicated_array_form_tags_test.go
@@ -1,0 +1,41 @@
+package factories
+
+import (
+  "strings"
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestMetadataTypeTagFactoryRejectsDuplicatedArrayFormTags verifies an array-form tag rejects a second tag of its own kind.
+//
+// Every array-form `exclusive` list names its own kind, so the tag can never be
+// duplicated. The check compared that list of kinds against the opposite tag's
+// `Name` — `"minimum"` against `"Minimum<0>"` — which never matches, so
+// `number & Minimum<5> & Minimum<0>` compiled and emitted `{"minimum": 0}`
+// while its validator required 5. This is one half of the mutation proof:
+// reverting the kind comparison back to `Name` turns this red. Restoring the
+// same-kind guard leaves this green, because a duplicate is same-kind; it reds
+// only the cross-kind rejection test instead.
+//
+// 1. Build two tags of one kind from each array-form declaration.
+// 2. Validate the pair and require rejection.
+// 3. Require the report to name the kind and the conflicting tag.
+func TestMetadataTypeTagFactoryRejectsDuplicatedArrayFormTags(t *testing.T) {
+  for _, declaration := range metadataTypeTagFactoryTestDeclarations() {
+    first := declaration.tag("A")
+    second := declaration.tag("B")
+    success, messages := metadataTypeTagFactoryTestValidate(
+      declaration.target,
+      []schemametadata.IMetadataTypeTag{first, second},
+    )
+    if success {
+      t.Fatalf("kind %s must not be duplicated on one property", declaration.kind)
+    }
+    if len(messages) != 1 ||
+      strings.Contains(messages[0], declaration.kind) == false ||
+      strings.Contains(messages[0], second.Name) == false {
+      t.Fatalf("the %s duplication report must name the conflict, reported %#v", declaration.kind, messages)
+    }
+  }
+}

--- a/tests/test-error/src/tag/error_tag_format_and_pattern.ts
+++ b/tests/test-error/src/tag/error_tag_format_and_pattern.ts
@@ -1,0 +1,7 @@
+import typia, { tags } from "typia";
+
+// Format and Pattern both declare `exclusive: ["format", "pattern"]`, and
+// Format's doc comment states it is "Mutually exclusive with Pattern". The
+// declaration is the spec, so intersecting them on one property must be a
+// compile error, even though each writes a different JSON Schema keyword.
+typia.createIs<string & tags.Format<"uuid"> & tags.Pattern<"^[0-9a-f]+$">>();

--- a/tests/test-error/src/tag/error_tag_format_duplicated.ts
+++ b/tests/test-error/src/tag/error_tag_format_duplicated.ts
@@ -1,0 +1,8 @@
+import typia, { tags } from "typia";
+
+// Format declares `exclusive: ["format", "pattern"]`, naming its own kind, so
+// two Format tags on one property are forbidden: the emitted schema keeps one
+// `format` while the generated validator enforces both. The check rejects both
+// this same-kind duplicate and the cross-kind Format & Pattern conflict (see
+// error_tag_format_and_pattern.ts).
+typia.createIs<string & tags.Format<"uuid"> & tags.Format<"email">>();

--- a/tests/test-error/src/tag/error_tag_minimum_and_exclusive_minimum.ts
+++ b/tests/test-error/src/tag/error_tag_minimum_and_exclusive_minimum.ts
@@ -1,0 +1,7 @@
+import typia, { tags } from "typia";
+
+// Minimum declares `exclusive: ["minimum", "exclusiveMinimum"]` and its doc
+// comment states it is "mutually exclusive with ExclusiveMinimum - you cannot
+// use both on the same property". The declaration is the spec, so this cross-
+// kind intersection must be a compile error.
+typia.createIs<number & tags.Minimum<0> & tags.ExclusiveMinimum<5>>();

--- a/tests/test-error/src/tag/error_tag_minimum_duplicated.ts
+++ b/tests/test-error/src/tag/error_tag_minimum_duplicated.ts
@@ -1,0 +1,6 @@
+import typia, { tags } from "typia";
+
+// Minimum declares `exclusive: ["minimum", "exclusiveMinimum"]`, naming its own
+// kind first, so one property may never carry two of them. Left unenforced, this
+// emitted `{"minimum": 0}` while generating a validator that required 5.
+typia.createIs<number & tags.Minimum<5> & tags.Minimum<0>>();

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_parity_invert.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_parity_invert.ts
@@ -57,11 +57,7 @@ export const test_llm_schema_parity_invert = (): void => {
   );
 
   const strict = typia.llm.schema<
-    string &
-      tags.Format<"uuid"> &
-      tags.MinLength<36> &
-      tags.MaxLength<36> &
-      tags.Pattern<"^[0-9a-f-]+$">,
+    string & tags.Format<"uuid"> & tags.MinLength<36> & tags.MaxLength<36>,
     { strict: true }
   >({});
   const strictInverted = LlmSchemaConverter.invert({
@@ -77,19 +73,46 @@ export const test_llm_schema_parity_invert = (): void => {
       format: strictInverted.format,
       minLength: strictInverted.minLength,
       maxLength: strictInverted.maxLength,
-      pattern: strictInverted.pattern,
     }),
     clean({
       type: "string",
       format: "uuid",
       minLength: 36,
       maxLength: 36,
-      pattern: "^[0-9a-f-]+$",
     } satisfies typeof strictTargetSchema),
   );
   TestValidator.equals(
     "strict descriptor tags consumed",
     strictInverted.description,
+    undefined,
+  );
+
+  // Format and Pattern are mutually exclusive tags, so the pattern round-trips
+  // through strict inversion on its own string.
+  const strictPattern = typia.llm.schema<
+    string & tags.Pattern<"^[0-9a-f-]+$">,
+    { strict: true }
+  >({});
+  const strictPatternInverted = LlmSchemaConverter.invert({
+    config: { strict: true },
+    components: {},
+    schema: strictPattern,
+    $defs: {},
+  }) as OpenApi.IJsonSchema.IString;
+  TestValidator.equals(
+    "strict description inversion pattern",
+    clean({
+      type: strictPatternInverted.type,
+      pattern: strictPatternInverted.pattern,
+    }),
+    clean({
+      type: "string",
+      pattern: "^[0-9a-f-]+$",
+    } satisfies { type: "string"; pattern: string }),
+  );
+  TestValidator.equals(
+    "strict pattern descriptor tags consumed",
+    strictPatternInverted.description,
     undefined,
   );
 };
@@ -99,7 +122,6 @@ declare const strictTargetSchema: {
   format: "uuid";
   minLength: 36;
   maxLength: 36;
-  pattern: "^[0-9a-f-]+$";
 };
 
 const stripXDiscriminator = <T>(value: T): T => {

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_strict_string.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_strict_string.ts
@@ -2,15 +2,18 @@ import { TestValidator } from "@nestia/e2e";
 import typia, { tags } from "typia";
 
 export const test_llm_schema_spec_strict_string = (): void => {
+  // Format and Pattern are mutually exclusive tags, so the format-bearing and
+  // pattern-bearing constraint sets are shifted on two separate strings; both
+  // still verify that strict mode moves every string keyword into the
+  // description.
   TestValidator.equals(
-    "strict string shifts constraints",
+    "strict string shifts format constraints",
     clean(
       typia.llm.schema<
         string &
           tags.Format<"uuid"> &
           tags.MinLength<36> &
           tags.MaxLength<36> &
-          tags.Pattern<"^[0-9a-f-]+$"> &
           tags.ContentMediaType<"text/plain"> &
           tags.Default<"00000000-0000-0000-0000-000000000000">,
         { strict: true }
@@ -22,10 +25,21 @@ export const test_llm_schema_spec_strict_string = (): void => {
         "@minLength 36",
         "@maxLength 36",
         "@format uuid",
-        "@pattern ^[0-9a-f-]+$",
         "@contentMediaType text/plain",
         "@default 00000000-0000-0000-0000-000000000000",
       ].join("\n"),
+    },
+  );
+  TestValidator.equals(
+    "strict string shifts pattern constraint",
+    clean(
+      typia.llm.schema<string & tags.Pattern<"^[0-9a-f-]+$">, { strict: true }>(
+        {},
+      ),
+    ),
+    {
+      type: "string",
+      description: "@pattern ^[0-9a-f-]+$",
     },
   );
 };

--- a/tests/test-typia-schema/src/features/tags/test_format_datetime_alias.ts
+++ b/tests/test-typia-schema/src/features/tags/test_format_datetime_alias.ts
@@ -1,0 +1,112 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import typia from "typia";
+
+interface IHyphenated {
+  /** @format date-time */
+  value: string;
+}
+
+interface ILowercaseAlias {
+  /** @format datetime */
+  value: string;
+}
+
+interface ICamelAlias {
+  /** @format dateTime */
+  value: string;
+}
+
+/**
+ * Verifies the `@format datetime` aliases validate exactly as `@format
+ * date-time` does.
+ *
+ * The aliases emit `format: "date-time"` but once carried a validator of their
+ * own, `!isNaN(new Date($input).getTime())`. That accepted
+ * "2020-02-30T00:00:00Z", because `Date` silently rolls February 30th over to
+ * March 1, and rejected the RFC 3339 leap second, because `Date` cannot parse
+ * `:60` — leaving typia's emitted schema contradicting typia's generated
+ * validator on a type typia itself accepted. An alias is not an alias while it
+ * owns a second validator.
+ *
+ * 1. Assert every spelling emits the same `date-time` schema.
+ * 2. Assert all three agree on ordinary, rolled-over, and leap-second inputs.
+ * 3. Pin February 30th as rejected and the legal leap second as accepted.
+ */
+export const test_format_datetime_alias = (): void => {
+  const valids: string[] = [
+    "2020-02-29T00:00:00Z", // 2020 is a leap year
+    "2016-12-31T23:59:60Z", // a legal RFC 3339 leap second
+    "2015-06-30T23:59:60Z", // a legal leap second at the mid-year insertion point
+    "2020-01-01T00:00:00.123+09:00",
+  ];
+  const invalids: string[] = [
+    "2020-02-30T00:00:00Z", // February has no 30th; Date rolls it to March 1
+    "2021-02-29T00:00:00Z", // 2021 is not a leap year
+    "2020-04-31T00:00:00Z", // April has 30 days; Date rolls it to May 1
+    "2020-01-01T00:00:61Z",
+    "2020-13-01T00:00:00Z",
+    "not a timestamp",
+  ];
+
+  for (const value of valids) {
+    TestValidator.equals(
+      `@format date-time accepts ${value}`,
+      true,
+      typia.is<IHyphenated>({ value }),
+    );
+    TestValidator.equals(
+      `@format datetime accepts ${value}`,
+      true,
+      typia.is<ILowercaseAlias>({ value }),
+    );
+    TestValidator.equals(
+      `@format dateTime accepts ${value}`,
+      true,
+      typia.is<ICamelAlias>({ value }),
+    );
+  }
+  for (const value of invalids) {
+    TestValidator.equals(
+      `@format date-time rejects ${value}`,
+      false,
+      typia.is<IHyphenated>({ value }),
+    );
+    TestValidator.equals(
+      `@format datetime rejects ${value}`,
+      false,
+      typia.is<ILowercaseAlias>({ value }),
+    );
+    TestValidator.equals(
+      `@format dateTime rejects ${value}`,
+      false,
+      typia.is<ICamelAlias>({ value }),
+    );
+  }
+
+  const format = (
+    unit: { components: OpenApi.IComponents },
+    key: string,
+  ): string | undefined => {
+    const schema = unit.components.schemas?.[
+      key
+    ] as OpenApi.IJsonSchema.IObject;
+    const value = schema.properties?.value as OpenApi.IJsonSchema.IString;
+    return value.format;
+  };
+  TestValidator.equals(
+    "@format date-time emits the date-time format",
+    "date-time",
+    format(typia.json.schema<IHyphenated>(), "IHyphenated"),
+  );
+  TestValidator.equals(
+    "@format datetime emits the date-time format",
+    "date-time",
+    format(typia.json.schema<ILowercaseAlias>(), "ILowercaseAlias"),
+  );
+  TestValidator.equals(
+    "@format dateTime emits the date-time format",
+    "date-time",
+    format(typia.json.schema<ICamelAlias>(), "ICamelAlias"),
+  );
+};

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_constraints_survive.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_documented_constraints_survive.ts
@@ -12,7 +12,9 @@ import typia, { ILlmSchema, tags } from "typia";
  * object for every non-strict leaf, and spreading it over the schema erased the
  * real keywords. Only a leaf carrying a `description` reached that spread, so
  * documenting a property silently disabled its validation. This pins all
- * thirteen keywords across the numeric, string, and array inverters.
+ * thirteen keywords across the numeric, string, and array inverters. `format`
+ * and `pattern` are mutually exclusive tags, so they live on separate string
+ * leaves (`thumbnail` and `homepage`).
  *
  * Each keyword is asserted on its own rather than as one object, because
  * `TestValidator.equals` walks the keys of its first argument and skips the
@@ -36,9 +38,10 @@ export const test_llm_invert_documented_constraints_survive = (): void => {
     thumbnail: string &
       tags.Format<"uri"> &
       tags.ContentMediaType<"image/png"> &
-      tags.Pattern<"^https://"> &
       tags.MinLength<8> &
       tags.MaxLength<255>;
+    /** The member's homepage. */
+    homepage: string & tags.Pattern<"^https://">;
     /** What the member likes. */
     hobbies: Array<string> &
       tags.MinItems<1> &
@@ -51,9 +54,9 @@ export const test_llm_invert_documented_constraints_survive = (): void => {
     thumbnail: string &
       tags.Format<"uri"> &
       tags.ContentMediaType<"image/png"> &
-      tags.Pattern<"^https://"> &
       tags.MinLength<8> &
       tags.MaxLength<255>;
+    homepage: string & tags.Pattern<"^https://">;
     hobbies: Array<string> &
       tags.MinItems<1> &
       tags.MaxItems<10> &
@@ -77,6 +80,7 @@ export const test_llm_invert_documented_constraints_survive = (): void => {
   const age = properties.age as OpenApi.IJsonSchema.INumber;
   const score = properties.score as OpenApi.IJsonSchema.INumber;
   const thumbnail = properties.thumbnail as OpenApi.IJsonSchema.IString;
+  const homepage = properties.homepage as OpenApi.IJsonSchema.IString;
   const hobbies = properties.hobbies as OpenApi.IJsonSchema.IArray;
 
   TestValidator.equals("documented minimum", 0, age.minimum);
@@ -98,7 +102,7 @@ export const test_llm_invert_documented_constraints_survive = (): void => {
     "image/png",
     thumbnail.contentMediaType,
   );
-  TestValidator.equals("documented pattern", "^https://", thumbnail.pattern);
+  TestValidator.equals("documented pattern", "^https://", homepage.pattern);
   TestValidator.equals("documented minLength", 8, thumbnail.minLength);
   TestValidator.equals("documented maxLength", 255, thumbnail.maxLength);
   TestValidator.equals("documented minItems", 1, hobbies.minItems);

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_strict_constraints_restored.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_strict_constraints_restored.ts
@@ -11,7 +11,8 @@ import typia, { tags } from "typia";
  * the only thing that can put them back. Gating the read on `strict` — the same
  * gate the write uses — must not weaken that half: all thirteen keywords have
  * to survive the round trip, and the consumed tags must leave the description
- * behind as plain prose.
+ * behind as plain prose. `format` and `pattern` are mutually exclusive tags, so
+ * they live on separate string leaves (`thumbnail` and `homepage`).
  *
  * Each keyword is asserted on its own rather than as one object, because
  * `TestValidator.equals` walks the keys of its first argument and skips the
@@ -33,9 +34,10 @@ export const test_llm_invert_strict_constraints_restored = (): void => {
     thumbnail: string &
       tags.Format<"uri"> &
       tags.ContentMediaType<"image/png"> &
-      tags.Pattern<"^https://"> &
       tags.MinLength<8> &
       tags.MaxLength<255>;
+    /** The member's homepage. */
+    homepage: string & tags.Pattern<"^https://">;
     /** What the member likes. */
     hobbies: Array<string> &
       tags.MinItems<1> &
@@ -54,6 +56,7 @@ export const test_llm_invert_strict_constraints_restored = (): void => {
   const age = properties.age as OpenApi.IJsonSchema.INumber;
   const score = properties.score as OpenApi.IJsonSchema.INumber;
   const thumbnail = properties.thumbnail as OpenApi.IJsonSchema.IString;
+  const homepage = properties.homepage as OpenApi.IJsonSchema.IString;
   const hobbies = properties.hobbies as OpenApi.IJsonSchema.IArray;
 
   TestValidator.equals("strict minimum", 0, age.minimum);
@@ -67,7 +70,7 @@ export const test_llm_invert_strict_constraints_restored = (): void => {
     "image/png",
     thumbnail.contentMediaType,
   );
-  TestValidator.equals("strict pattern", "^https://", thumbnail.pattern);
+  TestValidator.equals("strict pattern", "^https://", homepage.pattern);
   TestValidator.equals("strict minLength", 8, thumbnail.minLength);
   TestValidator.equals("strict maxLength", 255, thumbnail.maxLength);
   TestValidator.equals("strict minItems", 1, hobbies.minItems);
@@ -88,6 +91,11 @@ export const test_llm_invert_strict_constraints_restored = (): void => {
     "strict thumbnail description",
     "Where to reach the member.",
     thumbnail.description,
+  );
+  TestValidator.equals(
+    "strict homepage description",
+    "The member's homepage.",
+    homepage.description,
   );
   TestValidator.equals(
     "strict hobbies description",


### PR DESCRIPTION
Fixes #2153. Fixes #2154.

Two adjacent but independently caused defects in `packages/typia/native/core/factories/`. They share one sentence — **typia's own emitted schema contradicts typia's own generated validator, for a type typia itself accepted** — and no code. They land as two separate commits so either can be reverted alone.

## #2153 — `@format datetime` accepts February 30th

`MetadataCommentTagFactory` copies every `FormatCheatSheet` entry into its format table, then overrides the `datetime` / `dateTime` aliases with their own validator string. Both aliases emit `format: "date-time"` while validating with `!isNaN(new Date($input).getTime())`, so `"2020-02-30T00:00:00Z"` is accepted (`Date` rolls it to March 1) and a legal RFC 3339 leap second is rejected (`Date` cannot parse `:60`) — the opposite of what `@format date-time` does in both directions.

An alias that carries its own validator string is not an alias; it is a second implementation sharing a name. The fix makes the aliases **resolve to** the cheat sheet rather than copy a corrected string into a third place.

`@format datetime` is a supported feature (#563) and is **aligned, not removed**. #2075's format-parity work is not reverted.

## #2154 — every array-form tag exclusivity is inert

`MetadataTypeTagFactory.Validate`'s `[]string` branch compares a list of **kinds** against a tag's **Name**, behind a same-kind guard that excludes exactly the cross-kind pairs the list exists to catch. No real tag declaration can satisfy both. All six array-form tags — `Minimum`, `Maximum`, `ExclusiveMinimum`, `ExclusiveMaximum`, `Format`, `Pattern` — accept combinations their own published contract forbids.

The `exclusive` declarations in `packages/interface/src/tags` are correct; the Go check is the defect. Fixing it turns previously-compiling types into compile errors — intended, and covered in `tests/test-error`.

## Deferred

No `packages/typia/package.json` version bump. Native Go normally owes one, but releases and version numbers belong to the maintainer.

## Verification

Pending — recorded on this thread before the review-ready hand-off. Campaign CI is suspended per `.agents/skills/issue-campaign/development.md`; verification is local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
