### PR TITLE
docs(typia): remove removed-API and provider-behaviour claims from packages/typia/src doc comments

### DIFF
--- a/packages/typia/src/json.ts
+++ b/packages/typia/src/json.ts
@@ -101,10 +101,10 @@ export function application(): never;
  *
  * - Custom LLM function calling schema formats
  * - API documentation or code generation tools
- * - Alternative LLM integrations beyond built-in providers
+ * - Alternative LLM integrations that need full JSON Schema
  *
  * For standard LLM function calling, use {@link llm.application} instead, which
- * provides provider-specific schemas (ChatGPT, Claude, Gemini, etc.).
+ * builds the LLM-optimized function schema directly.
  *
  * @template Class Target class or interface type
  * @template Version OpenAPI version (`"3.0"` | `"3.1"`). Default `"3.1"`


### PR DESCRIPTION
Closes #2171.

## Scope

Documentation-only sweep of `packages/typia/src` doc comments for two classes the maintainer's ruling on #2171 condemns (latest spec only):

- **Provider-behaviour claims** — sentences predicting what OpenAI/Gemini/Anthropic do or don't support. Deleted, not "corrected" (a corrected claim rots identically). #2160/#2165 established this for `packages/interface/src`; this batch covers `packages/typia/src`, which that scope did not touch.
- **Removed-API descriptions** — comments describing a capability, option, or type that no longer exists. `json.ts:107`'s "provider-specific schemas (ChatGPT, Claude, Gemini, etc.)" is the seed: a survivor of the removed `ILlmSchema<Model>` era. `llm.application`'s only schema knob is `ILlmSchema.IConfig.strict`; there is no per-provider model.

The invariant: a doc comment describes the API that exists and states typia's contract, not a third party's behaviour. Naming a provider to explain an option's *origin* survives (e.g. `strict` is OpenAI's structured-output mode).

## Constraints honoured

- **No package version bump.** `packages/typia/package.json` is untouched; releases and version numbers belong to the maintainer.
- **`packages/typia/native/**` untouched.** `LlmSchemaProgrammer.go:157-158` ("OpenAI strict cannot express `not`") is owned by the #2156/#2157 batch, which removes it. Not touched here.
- **`packages/interface/src` declarations off-limits.** Already swept by #2160/#2165.
- No `pnpm format`; campaign CI suspended per the issue-campaign rules.

## Verification

- `pnpm --filter ./packages/typia build`; the emitted `.d.ts` differs only in the edited comments (byte-identical with JSDoc stripped, per #2165's method).
- Repository spell check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
