### PR TITLE
fix(native): OpenAPI 3.0 dialect downgrade and strict numeric default (#2156, #2157)

### DIFF
--- a/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader.go
+++ b/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader.go
@@ -1,0 +1,637 @@
+package iterate
+
+import (
+  "reflect"
+  "strings"
+
+  nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
+)
+
+// OpenApiV3Downgrader rewrites an emended (OpenAPI 3.1) schema collection into
+// the OpenAPI 3.0 dialect. `json.schema`, `json.schemas`, and `json.application`
+// all build their document through json_schema_station, which speaks 3.1 only:
+// it emits `const`, `prefixItems`, and a `{"type": "null"}` union member for a
+// nullable type. None of those exist in 3.0, which spells the same three things
+// as `enum`, `items` + `minItems`/`maxItems`, and the `nullable` flag.
+//
+// This is a port of `@typia/utils`' OpenApiV3Downgrader, which the TypeScript
+// implementation of JsonSchemasProgrammer called through
+// `OpenApiConverter.downgradeComponents` / `downgradeSchema` before the Go port
+// replaced it. The Go transform cannot call into TypeScript, so the two are
+// necessarily separate implementations of one contract; the port is kept
+// deliberately literal so the correspondence stays reviewable, and
+// `tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_parity_converter.ts`
+// pins the two owners against each other on every emitted construct.
+//
+// Only the components-and-schemas surface is ported. The TypeScript owner also
+// downgrades paths, operations, and security schemes, none of which typia emits.
+type OpenApiV3Downgrader_IComponentsCollection struct {
+  // Original is the emended 3.1 collection, read to resolve `$ref` targets
+  // while deciding nullability. It is never mutated.
+  Original *OpenApi_IComponents
+  // Downgraded accumulates the 3.0 result, including the `X.Nullable`
+  // companion schemas that a nullable reference forces into existence.
+  Downgraded *OpenApi_IComponents
+}
+
+// OpenApiV3Downgrader_downgrade_components downgrades every schema of the
+// collection, preserving the discovery order recorded in Order. A schema is
+// downgraded before its own key is registered, so the `X.Nullable` companions
+// that its references create land ahead of it exactly as the TypeScript owner's
+// argument-evaluation order places them.
+func OpenApiV3Downgrader_downgrade_components(input *OpenApi_IComponents) *OpenApiV3Downgrader_IComponentsCollection {
+  collection := &OpenApiV3Downgrader_IComponentsCollection{
+    Original:   input,
+    Downgraded: &OpenApi_IComponents{},
+  }
+  if input == nil || input.Schemas == nil {
+    return collection
+  }
+  collection.Downgraded.Schemas = map[string]JsonSchema{}
+  for _, key := range input.Order {
+    value, ok := input.Schemas[key]
+    if ok == false {
+      continue
+    }
+    downgraded := OpenApiV3Downgrader_downgrade_schema(collection, value)
+    collection.Downgraded.emplaceSchemaKey(key)
+    collection.Downgraded.Schemas[key] = downgraded
+  }
+  return collection
+}
+
+// OpenApiV3Downgrader_downgrade_schema rewrites one emended schema into 3.0.
+//
+// The emended dialect expresses a union as `oneOf` and nullability as a
+// `{"type": "null"}` member of it. 3.0 has neither, so the schema is flattened
+// into a union of concrete members, the null member is dropped, and the
+// surviving members carry `nullable: true` instead. Constants collapse into the
+// `enum` of a member of the same primitive type.
+func OpenApiV3Downgrader_downgrade_schema(collection *OpenApiV3Downgrader_IComponentsCollection, input JsonSchema) JsonSchema {
+  nullable := openApiV3Downgrader_is_nullable(map[string]bool{}, collection.Original, input)
+  union := []JsonSchema{}
+
+  var discriminator any
+  if openApiV3Downgrader_is_one_of(input) {
+    if value, ok := input["discriminator"]; ok && openApiV3Downgrader_is_nil(value) == false {
+      discriminator = openApiV3Downgrader_clone_value(value)
+    }
+  }
+  // A nullable union cannot keep its discriminator: 3.0 requires every mapped
+  // branch to stay a distinct `oneOf` member, and the null member is gone.
+  preserveDiscriminator := discriminator != nil && nullable == false
+
+  var visit func(schema JsonSchema)
+  visit = func(schema JsonSchema) {
+    if openApiV3Downgrader_is_boolean(schema) {
+      union = append(union, JsonSchema{"type": "boolean"})
+    } else if openApiV3Downgrader_is_integer(schema) ||
+      openApiV3Downgrader_is_number(schema) ||
+      openApiV3Downgrader_is_string(schema) ||
+      openApiV3Downgrader_is_reference(schema) {
+      union = append(union, openApiV3Downgrader_omit_examples(schema))
+    } else if openApiV3Downgrader_is_array(schema) {
+      next := openApiV3Downgrader_omit_examples(schema)
+      next["items"] = OpenApiV3Downgrader_downgrade_schema(
+        collection,
+        openApiV3Downgrader_schema(schema["items"]),
+      )
+      union = append(union, next)
+    } else if openApiV3Downgrader_is_tuple(schema) {
+      union = append(union, openApiV3Downgrader_downgrade_tuple(collection, schema))
+    } else if openApiV3Downgrader_is_object(schema) {
+      union = append(union, openApiV3Downgrader_downgrade_object(collection, schema))
+    } else if openApiV3Downgrader_is_one_of(schema) {
+      tracked := openApiV3Downgrader_same(schema, input) && discriminator != nil
+      for _, branch := range openApiV3Downgrader_schema_array(schema["oneOf"]) {
+        previous := len(union)
+        visit(branch)
+        // A branch that did not contribute exactly one member (a constant,
+        // or a nested union) breaks the one-branch-per-mapping rule the
+        // discriminator depends on.
+        if tracked && len(union) != previous+1 {
+          preserveDiscriminator = false
+        }
+      }
+    }
+  }
+
+  insertConstant := func(value any) {
+    typeName := openApiV3Downgrader_typeof(value)
+    for _, member := range union {
+      if member["type"] == typeName {
+        enum, _ := member["enum"].([]any)
+        member["enum"] = append(enum, value)
+        return
+      }
+    }
+    union = append(union, JsonSchema{"type": typeName, "enum": []any{value}})
+  }
+  visitConstant := func(schema JsonSchema) {
+    if openApiV3Downgrader_is_constant(schema) {
+      insertConstant(schema["const"])
+    } else if openApiV3Downgrader_is_one_of(schema) {
+      for _, branch := range openApiV3Downgrader_schema_array(schema["oneOf"]) {
+        if openApiV3Downgrader_is_constant(branch) {
+          insertConstant(branch["const"])
+        }
+      }
+    }
+  }
+
+  visit(input)
+  visitConstant(input)
+
+  if nullable {
+    for _, member := range union {
+      // A reference cannot carry `nullable` in 3.0, because the flag would sit
+      // beside `$ref` where 3.0 ignores every sibling key. The target is
+      // duplicated as an `X.Nullable` companion schema instead.
+      if openApiV3Downgrader_is_reference(member) {
+        openApiV3Downgrader_downgrade_nullable_reference(map[string]bool{}, collection, member)
+      } else {
+        member["nullable"] = true
+      }
+    }
+  }
+  if nullable && len(union) == 0 {
+    output := JsonSchema{"type": "null"}
+    openApiV3Downgrader_apply_attribute(output, input)
+    return output
+  }
+
+  output := JsonSchema{}
+  if len(union) == 0 {
+    output["type"] = nil
+  } else if len(union) == 1 {
+    for key, value := range union[0] {
+      output[key] = value
+    }
+  } else {
+    output["oneOf"] = union
+    if preserveDiscriminator && discriminator != nil {
+      output["discriminator"] = discriminator
+    }
+  }
+  openApiV3Downgrader_apply_attribute(output, input)
+  return output
+}
+
+// openApiV3Downgrader_downgrade_tuple rewrites `prefixItems` into 3.0's single
+// `items` schema. 3.0 cannot type each position, so the positional types
+// collapse into one `oneOf` and the arity is pinned by minItems/maxItems, which
+// is the closest 3.0 gets to a tuple.
+func openApiV3Downgrader_downgrade_tuple(collection *OpenApiV3Downgrader_IComponentsCollection, schema JsonSchema) JsonSchema {
+  next := openApiV3Downgrader_omit_examples(schema)
+  prefixItems := openApiV3Downgrader_schema_array(schema["prefixItems"])
+  additional := schema["additionalItems"]
+
+  var items JsonSchema
+  if flag, ok := additional.(bool); ok && flag {
+    // `additionalItems: true` admits anything at any position.
+    items = JsonSchema{}
+  } else {
+    elements := []JsonSchema{}
+    elements = append(elements, prefixItems...)
+    if rest := openApiV3Downgrader_schema(additional); rest != nil {
+      elements = append(elements, OpenApiV3Downgrader_downgrade_schema(collection, rest))
+    }
+    if len(elements) == 0 {
+      items = JsonSchema{}
+    } else {
+      oneOf := make([]JsonSchema, 0, len(elements))
+      for _, element := range elements {
+        oneOf = append(oneOf, OpenApiV3Downgrader_downgrade_schema(collection, element))
+      }
+      items = JsonSchema{"oneOf": oneOf}
+    }
+  }
+
+  next["items"] = items
+  next["minItems"] = len(prefixItems)
+  if openApiV3Downgrader_truthy(additional) {
+    // A rest element leaves the tuple unbounded above.
+    delete(next, "maxItems")
+  } else {
+    next["maxItems"] = len(prefixItems)
+  }
+  delete(next, "prefixItems")
+  delete(next, "additionalItems")
+  return next
+}
+
+func openApiV3Downgrader_downgrade_object(collection *OpenApiV3Downgrader_IComponentsCollection, schema JsonSchema) JsonSchema {
+  next := openApiV3Downgrader_omit_examples(schema)
+  if properties, ok := schema["properties"]; ok && openApiV3Downgrader_is_nil(properties) == false {
+    next["properties"] = openApiV3Downgrader_map_properties(properties, func(value JsonSchema) JsonSchema {
+      return OpenApiV3Downgrader_downgrade_schema(collection, value)
+    })
+  } else {
+    delete(next, "properties")
+  }
+  if additional, ok := schema["additionalProperties"]; ok && openApiV3Downgrader_is_nil(additional) == false {
+    if nested := openApiV3Downgrader_schema(additional); nested != nil {
+      next["additionalProperties"] = OpenApiV3Downgrader_downgrade_schema(collection, nested)
+    } else {
+      next["additionalProperties"] = additional
+    }
+  } else {
+    delete(next, "additionalProperties")
+  }
+  return next
+}
+
+// openApiV3Downgrader_downgrade_nullable_reference redirects a nullable `$ref`
+// at an `X.Nullable` companion schema, creating it on first demand.
+//
+// The companion is registered as an empty placeholder before it is built, so a
+// self-referential type resolves against the in-progress entry instead of
+// recursing forever.
+func openApiV3Downgrader_downgrade_nullable_reference(
+  visited map[string]bool,
+  collection *OpenApiV3Downgrader_IComponentsCollection,
+  schema JsonSchema,
+) {
+  ref, ok := schema["$ref"].(string)
+  if ok == false {
+    return
+  }
+  key := openApiV3Downgrader_ref_key(ref)
+  if strings.HasSuffix(key, ".Nullable") {
+    return
+  }
+  var found JsonSchema
+  if collection.Original != nil && collection.Original.Schemas != nil {
+    found = collection.Original.Schemas[key]
+  }
+  if found == nil {
+    return
+  }
+  // The target already admits null on its own; the plain reference is enough.
+  if openApiV3Downgrader_is_nullable(visited, collection.Original, found) {
+    return
+  }
+
+  nullableKey := key + ".Nullable"
+  if collection.Downgraded.Schemas == nil || collection.Downgraded.Schemas[nullableKey] == nil {
+    collection.Downgraded.emplaceSchemaKey(nullableKey)
+    collection.Downgraded.Schemas[nullableKey] = JsonSchema{}
+
+    var target JsonSchema
+    if openApiV3Downgrader_is_one_of(found) {
+      target = openApiV3Downgrader_shallow_clone(found)
+      branches := openApiV3Downgrader_schema_array(found["oneOf"])
+      appended := make([]JsonSchema, 0, len(branches)+1)
+      appended = append(appended, branches...)
+      appended = append(appended, JsonSchema{"type": "null"})
+      target["oneOf"] = appended
+    } else {
+      target = JsonSchema{
+        "oneOf": []JsonSchema{found, {"type": "null"}},
+      }
+      for _, attribute := range []string{"title", "description", "example", "examples"} {
+        if value, ok := found[attribute]; ok && openApiV3Downgrader_is_nil(value) == false {
+          target[attribute] = value
+        }
+      }
+      for attribute, value := range found {
+        if strings.HasPrefix(attribute, "x-") && openApiV3Downgrader_is_nil(value) == false {
+          target[attribute] = value
+        }
+      }
+    }
+    collection.Downgraded.Schemas[nullableKey] = OpenApiV3Downgrader_downgrade_schema(collection, target)
+  }
+  schema["$ref"] = ref + ".Nullable"
+}
+
+// openApiV3Downgrader_apply_attribute copies the dialect-independent annotations
+// from the source schema onto the rewritten one. An annotation absent from the
+// source is deleted rather than left behind, because the rewritten schema may
+// have inherited one from a single flattened union member that the source itself
+// does not carry.
+func openApiV3Downgrader_apply_attribute(output JsonSchema, input JsonSchema) {
+  for _, key := range []string{
+    "title",
+    "description",
+    "deprecated",
+    "readOnly",
+    "writeOnly",
+    "example",
+  } {
+    if value, ok := input[key]; ok && openApiV3Downgrader_is_nil(value) == false {
+      output[key] = value
+    } else {
+      delete(output, key)
+    }
+  }
+  for key, value := range input {
+    if strings.HasPrefix(key, "x-") && openApiV3Downgrader_is_nil(value) == false {
+      output[key] = value
+    }
+  }
+}
+
+// openApiV3Downgrader_is_nullable reports whether the schema admits null,
+// following `$ref` targets through the emended components. The visited set stops
+// a recursive type from looping.
+func openApiV3Downgrader_is_nullable(visited map[string]bool, components *OpenApi_IComponents, schema JsonSchema) bool {
+  if openApiV3Downgrader_is_null(schema) {
+    return true
+  }
+  if openApiV3Downgrader_is_reference(schema) {
+    ref, ok := schema["$ref"].(string)
+    if ok == false {
+      return false
+    }
+    if visited[ref] {
+      return false
+    }
+    visited[ref] = true
+    if components == nil || components.Schemas == nil {
+      return false
+    }
+    next, ok := components.Schemas[openApiV3Downgrader_ref_key(ref)]
+    if ok == false {
+      return false
+    }
+    return openApiV3Downgrader_is_nullable(visited, components, next)
+  }
+  if openApiV3Downgrader_is_one_of(schema) {
+    for _, branch := range openApiV3Downgrader_schema_array(schema["oneOf"]) {
+      if openApiV3Downgrader_is_nullable(visited, components, branch) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+/* -----------------------------------------------------------
+  TYPE CHECKERS
+----------------------------------------------------------- */
+
+func openApiV3Downgrader_is_null(schema JsonSchema) bool {
+  return schema != nil && schema["type"] == "null"
+}
+
+func openApiV3Downgrader_is_constant(schema JsonSchema) bool {
+  if schema == nil {
+    return false
+  }
+  value, ok := schema["const"]
+  return ok && openApiV3Downgrader_is_nil(value) == false
+}
+
+func openApiV3Downgrader_is_boolean(schema JsonSchema) bool {
+  return schema != nil && schema["type"] == "boolean"
+}
+
+func openApiV3Downgrader_is_integer(schema JsonSchema) bool {
+  return schema != nil && schema["type"] == "integer"
+}
+
+func openApiV3Downgrader_is_number(schema JsonSchema) bool {
+  return schema != nil && schema["type"] == "number"
+}
+
+func openApiV3Downgrader_is_string(schema JsonSchema) bool {
+  return schema != nil && schema["type"] == "string"
+}
+
+func openApiV3Downgrader_is_array(schema JsonSchema) bool {
+  if schema == nil || schema["type"] != "array" {
+    return false
+  }
+  value, ok := schema["items"]
+  return ok && openApiV3Downgrader_is_nil(value) == false
+}
+
+func openApiV3Downgrader_is_tuple(schema JsonSchema) bool {
+  if schema == nil || schema["type"] != "array" {
+    return false
+  }
+  value, ok := schema["prefixItems"]
+  return ok && openApiV3Downgrader_is_nil(value) == false
+}
+
+func openApiV3Downgrader_is_object(schema JsonSchema) bool {
+  return schema != nil && schema["type"] == "object"
+}
+
+func openApiV3Downgrader_is_reference(schema JsonSchema) bool {
+  if schema == nil {
+    return false
+  }
+  value, ok := schema["$ref"]
+  return ok && openApiV3Downgrader_is_nil(value) == false
+}
+
+func openApiV3Downgrader_is_one_of(schema JsonSchema) bool {
+  if schema == nil {
+    return false
+  }
+  value, ok := schema["oneOf"]
+  return ok && openApiV3Downgrader_is_nil(value) == false
+}
+
+/* -----------------------------------------------------------
+  UTILITIES
+----------------------------------------------------------- */
+
+// openApiV3Downgrader_omit_examples shallow-copies the schema without
+// `examples`, which 3.0 does not define. The copy is what keeps the rewritten
+// members from mutating the emended input.
+func openApiV3Downgrader_omit_examples(schema JsonSchema) JsonSchema {
+  output := JsonSchema{}
+  for key, value := range schema {
+    if key == "examples" {
+      continue
+    }
+    output[key] = value
+  }
+  return output
+}
+
+// openApiV3Downgrader_shallow_clone copies a schema's own keys, leaving nested
+// values shared. It stands in for the object spread the TypeScript owner uses
+// when it rebuilds a union with an extra null member.
+func openApiV3Downgrader_shallow_clone(schema JsonSchema) JsonSchema {
+  output := JsonSchema{}
+  for key, value := range schema {
+    output[key] = value
+  }
+  return output
+}
+
+// openApiV3Downgrader_map_properties rewrites each property schema while keeping
+// the emitted key order. Object properties are carried as an ordered literal
+// rather than a Go map precisely because their order is observable in the
+// emitted output.
+func openApiV3Downgrader_map_properties(value any, mapper func(JsonSchema) JsonSchema) any {
+  if ordered, ok := value.(nativefactories.LiteralFactory_OrderedObject); ok {
+    values := make(map[string]any, len(ordered.Values))
+    keys := make([]string, 0, len(ordered.Keys))
+    for _, key := range ordered.Keys {
+      entry, ok := ordered.Values[key]
+      if ok == false || openApiV3Downgrader_is_nil(entry) {
+        continue
+      }
+      if schema := openApiV3Downgrader_schema(entry); schema != nil {
+        values[key] = mapper(schema)
+      } else {
+        values[key] = entry
+      }
+      keys = append(keys, key)
+    }
+    return nativefactories.LiteralFactory_OrderedObject{Keys: keys, Values: values}
+  }
+  if plain, ok := value.(map[string]any); ok {
+    output := map[string]any{}
+    for key, entry := range plain {
+      if openApiV3Downgrader_is_nil(entry) {
+        continue
+      }
+      if schema := openApiV3Downgrader_schema(entry); schema != nil {
+        output[key] = mapper(schema)
+      } else {
+        output[key] = entry
+      }
+    }
+    return output
+  }
+  return value
+}
+
+// openApiV3Downgrader_schema coerces a schema-valued map to JsonSchema, whether
+// it arrived already named or as a bare map. It returns nil for anything that is
+// not a schema, which is how the tuple and additionalProperties paths tell an
+// object apart from a boolean flag.
+func openApiV3Downgrader_schema(value any) JsonSchema {
+  switch typed := value.(type) {
+  case JsonSchema:
+    return typed
+  case map[string]any:
+    return JsonSchema(typed)
+  }
+  return nil
+}
+
+func openApiV3Downgrader_schema_array(value any) []JsonSchema {
+  switch typed := value.(type) {
+  case []JsonSchema:
+    return typed
+  case []any:
+    output := make([]JsonSchema, 0, len(typed))
+    for _, element := range typed {
+      if schema := openApiV3Downgrader_schema(element); schema != nil {
+        output = append(output, schema)
+      }
+    }
+    return output
+  }
+  return nil
+}
+
+// openApiV3Downgrader_typeof names the 3.0 primitive type of a constant value,
+// mirroring the JavaScript `typeof` the TypeScript owner keys its enum merge on.
+//
+// A numeric literal arrives as the compiler's `jsnum.Number` (defined `type
+// Number float64`), a named type an explicit `case float64` does not match, so
+// numbers are classified by reflected kind rather than by concrete type. Getting
+// this wrong labels a numeric literal `object`, which then fails to merge with a
+// sibling number member and mislabels the union branch.
+func openApiV3Downgrader_typeof(value any) string {
+  switch value.(type) {
+  case string:
+    return "string"
+  case bool:
+    return "boolean"
+  }
+  if value != nil {
+    switch reflect.ValueOf(value).Kind() {
+    case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+      reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+      reflect.Float32, reflect.Float64:
+      return "number"
+    }
+  }
+  return "object"
+}
+
+// openApiV3Downgrader_truthy mirrors the JavaScript truthiness the tuple path
+// tests `additionalItems` for: an absent or `false` rest closes the tuple, while
+// `true` or a schema leaves it open.
+func openApiV3Downgrader_truthy(value any) bool {
+  if openApiV3Downgrader_is_nil(value) {
+    return false
+  }
+  if flag, ok := value.(bool); ok {
+    return flag
+  }
+  return true
+}
+
+// openApiV3Downgrader_is_nil treats a typed nil pointer, map, or slice as absent,
+// matching how LiteralFactory decides a value is not emitted. A plain `value ==
+// nil` misses a nil *string held in an interface, which is what the schema
+// builders store for an absent title or description.
+func openApiV3Downgrader_is_nil(value any) bool {
+  if value == nil {
+    return true
+  }
+  reflected := reflect.ValueOf(value)
+  switch reflected.Kind() {
+  case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+    return reflected.IsNil()
+  default:
+    return false
+  }
+}
+
+// openApiV3Downgrader_same reports whether two schemas are the same underlying
+// map, standing in for the identity comparison the TypeScript owner uses to tell
+// the root union apart from a nested one.
+func openApiV3Downgrader_same(x JsonSchema, y JsonSchema) bool {
+  if x == nil || y == nil {
+    return false
+  }
+  return reflect.ValueOf(x).Pointer() == reflect.ValueOf(y).Pointer()
+}
+
+func openApiV3Downgrader_ref_key(ref string) string {
+  if index := strings.LastIndex(ref, "/"); index != -1 {
+    return ref[index+1:]
+  }
+  return ref
+}
+
+func openApiV3Downgrader_clone_value(value any) any {
+  switch typed := value.(type) {
+  case JsonSchema:
+    output := JsonSchema{}
+    for key, entry := range typed {
+      output[key] = openApiV3Downgrader_clone_value(entry)
+    }
+    return output
+  case map[string]any:
+    output := map[string]any{}
+    for key, entry := range typed {
+      output[key] = openApiV3Downgrader_clone_value(entry)
+    }
+    return output
+  case []JsonSchema:
+    output := make([]JsonSchema, 0, len(typed))
+    for _, entry := range typed {
+      output = append(output, openApiV3Downgrader_schema(openApiV3Downgrader_clone_value(entry)))
+    }
+    return output
+  case []any:
+    output := make([]any, 0, len(typed))
+    for _, entry := range typed {
+      output = append(output, openApiV3Downgrader_clone_value(entry))
+    }
+    return output
+  }
+  return value
+}

--- a/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader_test.go
+++ b/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader_test.go
@@ -1,0 +1,123 @@
+package iterate
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+// TestOpenApiV3DowngraderRewritesDialect verifies the 3.0 downgrade rewrites the
+// three constructs the emended 3.1 writer emits that OpenAPI 3.0 does not define.
+//
+// json_schema_station speaks 3.1 only: a nullable type is a `{"type": "null"}`
+// union member, a literal is `const`, and a tuple is `prefixItems`. The "3.0"
+// entry points used to relabel that document without rewriting it, so a document
+// declaring 3.0 carried keywords no conformant 3.0 consumer can read. The
+// expected shapes below come from the OpenAPI 3.0 specification, not from what
+// the downgrader happens to produce.
+//
+// 1. Downgrade a nullable atomic, a literal union, and a tuple.
+// 2. Assert each uses the 3.0 spelling: nullable flag, enum, bounded array.
+// 3. Assert no 3.1-only keyword (`const`, `prefixItems`, a null union member)
+//    survives.
+func TestOpenApiV3DowngraderRewritesDialect(t *testing.T) {
+  collection := OpenApiV3Downgrader_downgrade_components(&OpenApi_IComponents{})
+
+  cases := []struct {
+    label    string
+    input    JsonSchema
+    expected JsonSchema
+  }{
+    {
+      label: "nullable atomic uses the nullable flag",
+      input: JsonSchema{
+        "oneOf": []JsonSchema{
+          {"type": "null"},
+          {"type": "string"},
+        },
+      },
+      expected: JsonSchema{"type": "string", "nullable": true},
+    },
+    {
+      label: "literal union collapses to enum",
+      input: JsonSchema{
+        "oneOf": []JsonSchema{
+          {"const": "alpha"},
+          {"const": "beta"},
+        },
+      },
+      expected: JsonSchema{"type": "string", "enum": []any{"alpha", "beta"}},
+    },
+    {
+      // A numeric literal reaches the downgrader as the compiler's named
+      // `jsnum.Number` (underlying float64), so classifying constants by
+      // concrete type mislabels the numeric branch `object`. The named type
+      // below stands in for it.
+      label: "mixed literal union labels the numeric branch number",
+      input: JsonSchema{
+        "oneOf": []JsonSchema{
+          {"const": "three"},
+          {"const": openApiV3DowngraderTestNumber(1)},
+          {"const": openApiV3DowngraderTestNumber(2)},
+        },
+      },
+      expected: JsonSchema{
+        "oneOf": []JsonSchema{
+          {"type": "string", "enum": []any{"three"}},
+          {"type": "number", "enum": []any{openApiV3DowngraderTestNumber(1), openApiV3DowngraderTestNumber(2)}},
+        },
+      },
+    },
+    {
+      label: "tuple degrades to a bounded array",
+      input: JsonSchema{
+        "type": "array",
+        "prefixItems": []JsonSchema{
+          {"type": "string"},
+          {"type": "number"},
+        },
+        "additionalItems": false,
+      },
+      expected: JsonSchema{
+        "type": "array",
+        "items": JsonSchema{
+          "oneOf": []JsonSchema{
+            {"type": "string"},
+            {"type": "number"},
+          },
+        },
+        "minItems": 2,
+        "maxItems": 2,
+      },
+    },
+  }
+
+  for _, tc := range cases {
+    actual := OpenApiV3Downgrader_downgrade_schema(collection, tc.input)
+    if openApiV3DowngraderTestJSON(t, actual) != openApiV3DowngraderTestJSON(t, tc.expected) {
+      t.Fatalf("%s: got %s, want %s", tc.label,
+        openApiV3DowngraderTestJSON(t, actual),
+        openApiV3DowngraderTestJSON(t, tc.expected))
+    }
+    serialized := openApiV3DowngraderTestJSON(t, actual)
+    for _, keyword := range []string{`"const"`, `"prefixItems"`, `"type":"null"`} {
+      if strings.Contains(serialized, keyword) {
+        t.Fatalf("%s: 3.1-only keyword %s leaked into 3.0 output: %s", tc.label, keyword, serialized)
+      }
+    }
+  }
+}
+
+// openApiV3DowngraderTestNumber is a named float64 type standing in for the
+// compiler's `jsnum.Number`, so the test exercises the reflected-kind path
+// rather than the plain `float64` a literal never actually carries.
+type openApiV3DowngraderTestNumber float64
+
+func openApiV3DowngraderTestJSON(t *testing.T, schema JsonSchema) string {
+  t.Helper()
+  bytes, err := json.Marshal(schema)
+  if err != nil {
+    t.Fatalf("marshal failed: %v", err)
+  }
+  return string(bytes)
+}

--- a/packages/typia/native/core/programmers/json/JsonSchemasProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonSchemasProgrammer.go
@@ -102,12 +102,22 @@ func (jsonSchemasProgrammerNamespace) WriteSchemas(props struct {
   return jsonSchemasProgrammer_writeV3_1(props.Metadatas)
 }
 
+// jsonSchemasProgrammer_writeV3_0 builds the emended 3.1 document and rewrites
+// it into the OpenAPI 3.0 dialect. The version string is a claim about the
+// content, so relabelling the 3.1 document alone would emit `const`,
+// `prefixItems`, and 3.1 nullable type unions under a "3.0" banner that no
+// conformant 3.0 consumer can read.
 func jsonSchemasProgrammer_writeV3_0(metadataList []*nativemetadata.MetadataSchema) JsonSchemasProgrammer_IJsonSchemaCollection {
   collection := jsonSchemasProgrammer_writeV3_1(metadataList)
+  downgrader := nativeiterate.OpenApiV3Downgrader_downgrade_components(collection.Components)
+  schemas := make([]nativeiterate.JsonSchema, 0, len(collection.Schemas))
+  for _, schema := range collection.Schemas {
+    schemas = append(schemas, nativeiterate.OpenApiV3Downgrader_downgrade_schema(downgrader, schema))
+  }
   return JsonSchemasProgrammer_IJsonSchemaCollection{
     Version:    "3.0",
-    Components: collection.Components,
-    Schemas:    collection.Schemas,
+    Components: downgrader.Downgraded,
+    Schemas:    schemas,
   }
 }
 

--- a/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
+++ b/packages/typia/native/core/programmers/llm/LlmSchemaProgrammer.go
@@ -154,8 +154,9 @@ func (llmSchemaProgrammerNamespace) Validate(props struct {
         }
       }
     }
-    // OpenAI strict structured outputs cannot express the `not` keyword the
-    // exclude tag compiles to (supported subset: types, enum, anyOf, $defs).
+    // The strict schema subset typia emits has no `not` keyword, which is what
+    // the exclude tag compiles to, so an exclude tag has no representation here
+    // and is rejected.
     excluded := false
     scan := func(matrix [][]schemametadata.IMetadataTypeTag) {
       for _, row := range matrix {
@@ -729,14 +730,13 @@ func llmSchemaProgrammer_shift_numeric(schema map[string]any) map[string]any {
   output := llmSchemaProgrammer_clone(schema)
   llmSchemaProgrammer_emend_exclusive(output)
   tags := []string{}
-  for _, key := range []string{"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"} {
+  for _, key := range []string{"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf", "default"} {
     if value, ok := output[key]; ok {
       tags = append(tags, "@"+key+" "+fmt.Sprint(value))
       delete(output, key)
     }
   }
   llmSchemaProgrammer_write_tag_with_description(output, tags)
-  delete(output, "default")
   return output
 }
 

--- a/packages/utils/src/converters/internal/LlmDescriptionInverter.ts
+++ b/packages/utils/src/converters/internal/LlmDescriptionInverter.ts
@@ -27,6 +27,7 @@ export namespace LlmDescriptionInverter {
     | "exclusiveMinimum"
     | "exclusiveMaximum"
     | "multipleOf"
+    | "default"
     | "description"
   > => {
     const description: string | undefined = read(props);
@@ -34,8 +35,8 @@ export namespace LlmDescriptionInverter {
 
     const lines: string[] = description.split("\n");
     return {
-      ...compact(
-        OpenApiExclusiveEmender.emend({
+      ...compact({
+        ...OpenApiExclusiveEmender.emend({
           minimum: find({
             type: "number",
             name: "minimum",
@@ -62,13 +63,22 @@ export namespace LlmDescriptionInverter {
             lines,
           }),
         }),
-      ),
+        // The write half shifts `default` into the description as `@default 7`
+        // just like every other numeric keyword; restore it here so the numeric
+        // path round-trips symmetrically with the string path.
+        default: find({
+          type: "number",
+          name: "default",
+          lines,
+        }),
+      }),
       description: describe(lines, [
         "minimum",
         "maximum",
         "exclusiveMinimum",
         "exclusiveMaximum",
         "multipleOf",
+        "default",
       ]),
     };
   };
@@ -83,6 +93,7 @@ export namespace LlmDescriptionInverter {
     | "contentMediaType"
     | "minLength"
     | "maxLength"
+    | "default"
     | "description"
   > => {
     const description: string | undefined = read(props);
@@ -116,6 +127,14 @@ export namespace LlmDescriptionInverter {
           name: "maxLength",
           lines,
         }),
+        // The write half shifts `default` into the description as
+        // `@default value`; restore it here so a documented string default is
+        // read back rather than left behind as prose.
+        default: find({
+          type: "string",
+          name: "default",
+          lines,
+        }),
       }),
       description: describe(lines, [
         "format",
@@ -123,6 +142,7 @@ export namespace LlmDescriptionInverter {
         "contentMediaType",
         "minLength",
         "maxLength",
+        "default",
       ]),
     };
   };

--- a/tests/test-typia-schema/src/features/json.application/test_json_application_v3_0_dialect.ts
+++ b/tests/test-typia-schema/src/features/json.application/test_json_application_v3_0_dialect.ts
@@ -1,0 +1,46 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+/**
+ * Verifies typia.json.application emits the OpenAPI 3.0 dialect under "3.0".
+ *
+ * `json.application` is the third entry point sharing the collection writer that
+ * relabelled a 3.1 document as "3.0". Its function parameter and return schemas
+ * are filled from that same collection, so an application document is exactly as
+ * mislabelled as a bare schema — and no test knew the dialect here either.
+ *
+ * 1. Declare a controller whose method takes a tuple and a literal union and
+ *    returns a nullable type.
+ * 2. Emit its application document under "3.0".
+ * 3. Assert the parameter and return schemas use the 3.0 spellings only.
+ */
+export const test_json_application_v3_0_dialect = (): void => {
+  interface IV3Controller {
+    lookup(pair: [string, number], literal: "alpha" | "beta"): string | null;
+  }
+
+  const app = typia.json.application<IV3Controller, "3.0">();
+  TestValidator.equals("version", app.version, "3.0");
+
+  const fn = app.functions[0]!;
+  TestValidator.equals("tuple parameter", clean(fn.parameters[0]!.schema), {
+    type: "array",
+    items: { oneOf: [{ type: "string" }, { type: "number" }] },
+    minItems: 2,
+    maxItems: 2,
+  });
+  TestValidator.equals("literal parameter", clean(fn.parameters[1]!.schema), {
+    type: "string",
+    enum: ["alpha", "beta"],
+  });
+  TestValidator.equals("nullable output", clean(fn.output?.schema), {
+    type: "string",
+    nullable: true,
+  });
+
+  const serialized: string = JSON.stringify(app);
+  for (const keyword of ["const", "prefixItems", '"type":"null"'])
+    TestValidator.equals(`no ${keyword} under 3.0`, serialized.includes(keyword), false);
+};
+
+const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_v3_0_dialect.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_v3_0_dialect.ts
@@ -1,0 +1,46 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+/**
+ * Verifies typia.json.schema emits the OpenAPI 3.0 dialect under "3.0".
+ *
+ * `json.schema` routes through the same collection writer as `json.schemas`, so
+ * the dialect defect was shared: fixing one entry point and leaving the others
+ * would still ship a 3.1 document labelled "3.0". This pins the singular entry
+ * point, whose root schema is additionally dereferenced out of the components.
+ *
+ * 1. Declare a type carrying a nullable atomic, a literal union, and a tuple.
+ * 2. Emit its single schema under "3.0".
+ * 3. Assert the dereferenced root uses the 3.0 spellings only.
+ */
+export const test_json_schema_v3_0_dialect = (): void => {
+  interface IV3Single {
+    nullableName: string | null;
+    literal: "alpha" | "beta";
+    pair: [string, number];
+  }
+
+  const unit = typia.json.schema<IV3Single, "3.0">();
+  TestValidator.equals("version", unit.version, "3.0");
+  TestValidator.equals("dereferenced root", clean(unit.schema), {
+    type: "object",
+    properties: {
+      nullableName: { type: "string", nullable: true },
+      literal: { type: "string", enum: ["alpha", "beta"] },
+      pair: {
+        type: "array",
+        items: { oneOf: [{ type: "string" }, { type: "number" }] },
+        minItems: 2,
+        maxItems: 2,
+      },
+    },
+    required: ["nullableName", "literal", "pair"],
+    additionalProperties: false,
+  });
+
+  const serialized: string = JSON.stringify(unit);
+  for (const keyword of ["const", "prefixItems", '"type":"null"'])
+    TestValidator.equals(`no ${keyword} under 3.0`, serialized.includes(keyword), false);
+};
+
+const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));

--- a/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_dialect.ts
+++ b/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_dialect.ts
@@ -1,0 +1,59 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+/**
+ * Verifies typia.json.schemas emits the OpenAPI 3.0 dialect under "3.0".
+ *
+ * The "3.0" writer used to build the 3.1 document and rewrite only its version
+ * string, so a document declaring 3.0 still carried the three constructs 3.0
+ * does not define: a `{"type": "null"}` union member instead of the `nullable`
+ * flag, `const`, and `prefixItems`. The expectations below come from the
+ * OpenAPI 3.0 specification, not from what the emitter happens to produce.
+ *
+ * 1. Declare a type carrying a nullable atomic, a string literal union, and a
+ *    tuple — one witness for each dialect difference.
+ * 2. Emit its schema collection under "3.0".
+ * 3. Assert the 3.0 spellings are used and that no 3.1-only keyword survives.
+ */
+export const test_json_schemas_v3_0_dialect = (): void => {
+  interface IV3Target {
+    nullableName: string | null;
+    literal: "alpha" | "beta";
+    pair: [string, number];
+  }
+
+  const collection = typia.json.schemas<[IV3Target], "3.0">();
+  TestValidator.equals("collection version", collection.version, "3.0");
+  TestValidator.equals("root reference", clean(collection.schemas), [
+    { $ref: "#/components/schemas/IV3Target" },
+  ]);
+  TestValidator.equals(
+    "downgraded component",
+    clean(collection.components.schemas?.IV3Target),
+    {
+      type: "object",
+      properties: {
+        // 3.0 has no `{"type": "null"}` union member; nullability is a flag.
+        nullableName: { type: "string", nullable: true },
+        // 3.0 has no `const`; a literal is a single-valued `enum`.
+        literal: { type: "string", enum: ["alpha", "beta"] },
+        // 3.0 has no `prefixItems`; a tuple degrades to a bounded array.
+        pair: {
+          type: "array",
+          items: { oneOf: [{ type: "string" }, { type: "number" }] },
+          minItems: 2,
+          maxItems: 2,
+        },
+      },
+      required: ["nullableName", "literal", "pair"],
+      additionalProperties: false,
+    },
+  );
+
+  // The negative twin: no 3.1-only keyword may appear anywhere in the document.
+  const serialized: string = JSON.stringify(collection);
+  for (const keyword of ["const", "prefixItems", '"type":"null"'])
+    TestValidator.equals(`no ${keyword} under 3.0`, serialized.includes(keyword), false);
+};
+
+const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));

--- a/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_parity_converter.ts
+++ b/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_parity_converter.ts
@@ -1,0 +1,87 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiConverter } from "@typia/utils";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies the native "3.0" writer agrees with `@typia/utils`' downgrader.
+ *
+ * Two owners implement one OpenAPI 3.0 downgrade contract: the Go emitter that
+ * `typia.json.*` calls, and `OpenApiConverter` in `@typia/utils`, which the
+ * TypeScript implementation of this programmer called directly before the Go
+ * port replaced it. The Go transform cannot call into TypeScript, so the pair
+ * cannot be collapsed into one owner — this test is what keeps them aligned,
+ * and it fails whichever of the two drifts.
+ *
+ * The fixture exercises every construct the downgrade rewrites rather than a
+ * sample, because a parity test whose fixture omits the disputed construct
+ * proves nothing about it.
+ *
+ * 1. Emit the same types under "3.1" and under "3.0".
+ * 2. Downgrade the "3.1" collection with `@typia/utils`' converter.
+ * 3. Assert the native "3.0" output equals the converter's downgrade.
+ */
+export const test_json_schemas_v3_0_parity_converter = (): void => {
+  interface IParityChild {
+    code: string & tags.MinLength<2> & tags.Pattern<"^[a-z]+$">;
+    count: number & tags.Minimum<1> & tags.Maximum<9> & tags.Default<7>;
+  }
+  interface ICircle {
+    kind: "circle";
+    radius: number;
+  }
+  interface ISquare {
+    kind: "square";
+    side: number;
+  }
+  interface IParityRoot {
+    /** A nullable reference forces an `X.Nullable` companion schema. */
+    child: IParityChild | null;
+    plain: IParityChild;
+    recursive: IParityRoot | null;
+    nullableAtomic: string | null;
+    nullableArray: (string & tags.Format<"uuid">)[] | null;
+    literal: "alpha" | "beta";
+    mixedLiteral: 1 | 2 | "three";
+    booleanValue: boolean;
+    tuple: [string, number];
+    restTuple: [string, ...number[]];
+    dictionary: Record<string, number>;
+    /** A tagged union keeps its discriminator through the downgrade. */
+    shape: ICircle | ISquare;
+    /** A nullable tagged union must drop the discriminator. */
+    nullableShape: ICircle | ISquare | null;
+    /** @deprecated */
+    annotated: string & tags.MaxLength<4>;
+    unknownValue: unknown;
+  }
+
+  const emended = typia.json.schemas<[IParityRoot, IParityChild], "3.1">();
+  const actual = typia.json.schemas<[IParityRoot, IParityChild], "3.0">();
+
+  const components: OpenApi.IComponents =
+    emended.components as OpenApi.IComponents;
+  const downgraded = OpenApiConverter.downgradeComponents(components, "3.0");
+  const expectedSchemas = emended.schemas.map((schema) =>
+    OpenApiConverter.downgradeSchema({
+      version: "3.0",
+      components,
+      schema: schema as OpenApi.IJsonSchema,
+      downgraded,
+    }),
+  );
+
+  TestValidator.equals("version", actual.version, "3.0");
+  TestValidator.equals(
+    "downgraded components",
+    clean(actual.components),
+    clean(downgraded),
+  );
+  TestValidator.equals(
+    "downgraded schemas",
+    clean(actual.schemas),
+    clean(expectedSchemas),
+  );
+};
+
+const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_invert_default_round_trip.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_invert_default_round_trip.ts
@@ -1,0 +1,63 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { LlmSchemaConverter } from "@typia/utils";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies a strict `default` survives the shift-then-invert round trip.
+ *
+ * Under `strict`, the write half moves `default` into the description as a
+ * `@default value` tag; inversion must read it back as a keyword rather than
+ * leave it behind as prose. The numeric path used to drop `default` on the
+ * write side and no reader restored it on either path, so a numeric default was
+ * lost outright and a string default leaked as literal `@default …` text. This
+ * pins both directions: the tag is emitted on write and restored on read, for
+ * numeric and string alike.
+ *
+ * 1. Build strict LLM schemas for a numeric and a string property, each with a
+ *    `Default` alongside another constraint.
+ * 2. Invert each under `strict`.
+ * 3. Assert `default` is restored to a keyword and the tag is consumed from the
+ *    description.
+ */
+export const test_llm_schema_invert_default_round_trip = (): void => {
+  const numeric = typia.llm.schema<
+    number & tags.Minimum<1> & tags.Default<7>,
+    { strict: true }
+  >({});
+  const numericInverted = LlmSchemaConverter.invert({
+    config: { strict: true },
+    components: {},
+    schema: numeric,
+    $defs: {},
+  }) as OpenApi.IJsonSchema.INumber;
+  TestValidator.equals("numeric default restored", numericInverted.default, 7);
+  TestValidator.equals("numeric minimum restored", numericInverted.minimum, 1);
+  TestValidator.equals(
+    "numeric tags consumed",
+    numericInverted.description,
+    undefined,
+  );
+
+  const string = typia.llm.schema<
+    string & tags.MinLength<2> & tags.Default<"body">,
+    { strict: true }
+  >({});
+  const stringInverted = LlmSchemaConverter.invert({
+    config: { strict: true },
+    components: {},
+    schema: string,
+    $defs: {},
+  }) as OpenApi.IJsonSchema.IString;
+  TestValidator.equals("string default restored", stringInverted.default, "body");
+  TestValidator.equals(
+    "string minLength restored",
+    stringInverted.minLength,
+    2,
+  );
+  TestValidator.equals(
+    "string tags consumed",
+    stringInverted.description,
+    undefined,
+  );
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_parity_converter_strict.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_parity_converter_strict.ts
@@ -3,16 +3,48 @@ import { IJsonSchemaCollection, ILlmSchema, OpenApi } from "@typia/interface";
 import { LlmSchemaConverter } from "@typia/utils";
 import typia, { tags } from "typia";
 
+/**
+ * Verifies the native strict LLM schema agrees with `@typia/utils`' converter.
+ *
+ * Under `strict`, constraint keywords are shifted out of the schema and into the
+ * description as `@tag value` lines. Two owners implement that shift — the Go
+ * emitter `typia.llm.*` calls, and `OpenApiConstraintShifter` in `@typia/utils`
+ * — and they once disagreed on `default`, which the numeric path deleted instead
+ * of shifting. The oracle below was already correct when that shipped; only the
+ * fixture was blind, because it omitted the single tag they disagreed on.
+ *
+ * The fixture therefore exercises every tag both shift functions handle rather
+ * than a sample: a correct comparison over an incomplete input proves nothing
+ * about the missing case.
+ *
+ * 1. Declare properties covering the full numeric, string, and array tag sets.
+ * 2. Convert the same type through `@typia/utils` under `strict`.
+ * 3. Assert the native schema and `$defs` equal the converter's output.
+ */
 export const test_llm_schema_parity_converter_strict = (): void => {
   interface IStrictChild {
-    code: string & tags.MinLength<2> & tags.Pattern<"^[a-z]+$">;
-    count: number & tags.Minimum<1> & tags.Maximum<9>;
+    // The complete string shift set: minLength, maxLength, format, pattern,
+    // contentMediaType, default.
+    code: string & tags.MinLength<2> & tags.MaxLength<8> & tags.Pattern<"^[a-z]+$">;
+    media: string & tags.ContentMediaType<"text/plain"> & tags.Default<"body">;
+    id: string & tags.Format<"uuid">;
+    // The complete numeric shift set: minimum, maximum, exclusiveMinimum,
+    // exclusiveMaximum, multipleOf, default.
+    count: number & tags.Minimum<1> & tags.Maximum<9> & tags.Default<7>;
+    ratio: number & tags.ExclusiveMinimum<0> & tags.ExclusiveMaximum<1>;
+    step: number & tags.MultipleOf<5> & tags.Default<10>;
   }
   interface IStrictRoot {
     child: IStrictChild;
-    labels: (string & tags.MinLength<1>)[] & tags.MinItems<1>;
+    // The complete array shift set: minItems, maxItems, uniqueItems.
+    labels: (string & tags.MinLength<1>)[] &
+      tags.MinItems<1> &
+      tags.MaxItems<4> &
+      tags.UniqueItems;
     mode: "alpha" | "beta";
     enabled: boolean;
+    /** A description the shifted tags must be appended to, not replace. */
+    described: number & tags.Minimum<2> & tags.Default<3>;
   }
 
   const collection: IJsonSchemaCollection = typia.json.schemas<[IStrictRoot]>();

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_strict_number.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_spec_strict_number.ts
@@ -16,9 +16,12 @@ export const test_llm_schema_spec_strict_number = (): void => {
     ),
     {
       type: "number",
-      description: ["@minimum 1", "@exclusiveMaximum 10", "@multipleOf 1"].join(
-        "\n",
-      ),
+      description: [
+        "@minimum 1",
+        "@exclusiveMaximum 10",
+        "@multipleOf 1",
+        "@default 3",
+      ].join("\n"),
     },
   );
 };


### PR DESCRIPTION
Campaign batch: two independent defects in `packages/typia/native/core/programmers/`, each where the Go port dropped a step its TypeScript predecessor performed. Two separate commits on one branch so each can be reverted alone.

## #2156 — `"3.0"` emitted a 3.1 document with the version string rewritten

`json.schema`/`json.schemas`/`json.application` under `"3.0"` built the emended 3.1 document and rewrote only its version string, so the output declared 3.0 while carrying `{"type":"null"}` union members (not the `nullable` flag), `const`, and `prefixItems` — none of which OpenAPI 3.0 defines. The TypeScript implementation called `@typia/utils`' `OpenApiConverter.downgrade*`; the Go port kept `writeV3_0`'s skeleton and dropped the downgrade. There was zero 3.0-dialect coverage to catch it.

**Decision — reimplement the downgrade in Go.** The Go transform cannot call into TypeScript, so `"3.0"` cannot be honoured by delegating to `@typia/utils`; dropping the option is a public-contract change the maintainer owns. `OpenApiV3Downgrader` (new, in the iterate package) is a faithful, deliberately literal port of `@typia/utils`' `OpenApiV3Downgrader`. That makes `@typia/utils` a **second owner** of one contract; they are kept aligned by `test_json_schemas_v3_0_parity_converter`, which runs both owners on the same emended input over the full construct set and fails whichever drifts.

Covers all three shared entry points (`schema`/`schemas`/`application`) with dialect-aware tests plus a colocated Go unit test. The `"3.1"` default path is unchanged.

## #2157 — `llm.*` with `strict` silently dropped a numeric `default`

`shift_numeric` did `delete(output, "default")` with no tag, while `shift_string` shifts it to `@default <value>`. PR #2062 fixed the `@typia/utils` copy and left the Go emitter that `typia.llm.*` calls. `"default"` now joins the numeric key list.

**Read-side counterpart (per the #2157 lead comment, verified against merged #2162):** even the string `@default` that was written leaked back as prose on inversion — `LlmDescriptionInverter` restored no `default` and `describe()` filtered none. Both readers now restore `default` and drop its tag, so the value round-trips symmetrically for numeric and string.

The durable finding is the blind fixture: `test_llm_schema_parity_converter_strict` now exercises the full numeric/string/array shift sets rather than a sample, and `test_llm_schema_invert_default_round_trip` pins the round trip. Severity is low — reachable only under `strict`. Also removes a provider-behaviour comment at the exclude-tag gate, reworded to typia's own mechanic per the campaign rule (relates to #2171).

## Release / scope

**No `packages/typia/package.json` version bump.** Native Go normally owes one, but the maintainer owns releases and this campaign defers version numbers to them. No `pnpm format`. No schema declarations touched — the runtime was the defect in both cases.

## Local verification

Campaign CI is suspended per the exact-SHA cancellation gate; verification is local. See PR comments for executed case counts and the fail-then-pass observation for both issues.

Closes #2156
Closes #2157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
