### PR TITLE
fix(utils): name numeric exclusive bounds and declared integer format from the schema

### DIFF
--- a/packages/utils/src/validators/internal/OpenApiSchemaNamingRule.ts
+++ b/packages/utils/src/validators/internal/OpenApiSchemaNamingRule.ts
@@ -32,42 +32,59 @@ export namespace OpenApiSchemaNamingRule {
     return "unknown";
   };
 
-  const getNameOfInteger = (schema: OpenApi.IJsonSchema.IInteger): string[] => [
-    "number",
-    ...(schema.minimum !== undefined
-      ? [
-          schema.exclusiveMinimum
-            ? `tags.ExclusiveMinimum<${schema.minimum}>`
-            : `tags.Minimum<${schema.minimum}>`,
-        ]
-      : []),
-    ...(schema.maximum !== undefined
-      ? [
-          schema.exclusiveMaximum
-            ? `tags.ExclusiveMaximum<${schema.maximum}>`
-            : `tags.Maximum<${schema.maximum}>`,
-        ]
-      : []),
-    ...(schema.multipleOf !== undefined
-      ? [`tags.MultipleOf<${schema.multipleOf}>`]
-      : []),
-  ];
+  const getNameOfInteger = (schema: OpenApi.IJsonSchema.IInteger): string[] => {
+    // `minimum`, `maximum`, `exclusiveMinimum`, and `exclusiveMaximum` are all
+    // numbers in the declaration, each an independent bound rather than a
+    // boolean modifier on another. Read every one on its own value, so an
+    // exclusive bound is never dropped (including the falsy `0`) nor labelled
+    // with a sibling's value.
+    //
+    // The normalized integer schema does not model `format`, but
+    // `OpenApiConverter` passes an external document's `format` (`"int32"` /
+    // `"int64"`) straight through, so read it defensively and echo only what is
+    // there as `tags.Type<...>` — mirroring `OpenApiIntegerValidator.describeType`,
+    // which names the same declared width and invents none.
+    const format: unknown = (schema as { format?: unknown }).format;
+    return [
+      "number",
+      ...(typeof format === "string"
+        ? [`tags.Type<${JSON.stringify(format)}>`]
+        : []),
+      ...(schema.minimum !== undefined
+        ? [`tags.Minimum<${schema.minimum}>`]
+        : []),
+      ...(schema.exclusiveMinimum !== undefined
+        ? [`tags.ExclusiveMinimum<${schema.exclusiveMinimum}>`]
+        : []),
+      ...(schema.maximum !== undefined
+        ? [`tags.Maximum<${schema.maximum}>`]
+        : []),
+      ...(schema.exclusiveMaximum !== undefined
+        ? [`tags.ExclusiveMaximum<${schema.exclusiveMaximum}>`]
+        : []),
+      ...(schema.multipleOf !== undefined
+        ? [`tags.MultipleOf<${schema.multipleOf}>`]
+        : []),
+    ];
+  };
 
+  // Read each numeric bound on its own value, as in `getNameOfInteger`. Unlike
+  // integers, no `format` is echoed: `OpenApiNumberValidator` reports a bare
+  // `number & ...` and never names a number's `format`, so echoing one here
+  // would disagree with the validator on what the schema declares.
   const getNameOfNumber = (schema: OpenApi.IJsonSchema.INumber): string[] => [
     "number",
     ...(schema.minimum !== undefined
-      ? [
-          schema.exclusiveMinimum
-            ? `tags.ExclusiveMinimum<${schema.minimum}>`
-            : `tags.Minimum<${schema.minimum}>`,
-        ]
+      ? [`tags.Minimum<${schema.minimum}>`]
+      : []),
+    ...(schema.exclusiveMinimum !== undefined
+      ? [`tags.ExclusiveMinimum<${schema.exclusiveMinimum}>`]
       : []),
     ...(schema.maximum !== undefined
-      ? [
-          schema.exclusiveMaximum
-            ? `tags.ExclusiveMaximum<${schema.maximum}>`
-            : `tags.Maximum<${schema.maximum}>`,
-        ]
+      ? [`tags.Maximum<${schema.maximum}>`]
+      : []),
+    ...(schema.exclusiveMaximum !== undefined
+      ? [`tags.ExclusiveMaximum<${schema.exclusiveMaximum}>`]
       : []),
     ...(schema.multipleOf !== undefined
       ? [`tags.MultipleOf<${schema.multipleOf}>`]

--- a/tests/test-utils/src/features/openapi/test_openapi_naming_numeric_constraints.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_naming_numeric_constraints.ts
@@ -1,0 +1,130 @@
+import { TestValidator } from "@nestia/e2e";
+import { IValidation, OpenApi } from "@typia/interface";
+import { OpenApiValidator } from "@typia/utils";
+
+/**
+ * Verifies the schema naming rule names each numeric constraint the schema
+ * declares, with its own value.
+ *
+ * `OpenApiSchemaNamingRule` used to read `exclusiveMinimum`/`exclusiveMaximum`
+ * as booleans gating the `minimum`/`maximum` branch, so an exclusive bound alone
+ * named itself just `number`, a paired `minimum` leaked its value under the
+ * exclusive name, and the falsy-but-declared `exclusiveMinimum: 0` vanished. The
+ * declaration (`OpenApi.IJsonSchema.IInteger`/`INumber`) is authoritative: those
+ * fields are numbers. A declared integer `format` — carried through an external
+ * document by `OpenApiConverter` — is likewise dropped; it must echo as
+ * `tags.Type<...>`, agreeing with `OpenApiIntegerValidator.describeType`.
+ *
+ * 1. For each schema, validate a wrong-typed value so the report's `expected`
+ *    is exactly the top-level type name the naming rule produced.
+ * 2. Assert that name states every declared constraint with its own value,
+ *    including the `exclusiveMinimum: 0` boundary and a declared integer format.
+ * 3. Keep the negative regressions: a bare integer/number invents no format,
+ *    and a number never echoes a format its validator does not report.
+ */
+export const test_openapi_naming_numeric_constraints = (): void => {
+  const matrix: Array<{
+    title: string;
+    schema: OpenApi.IJsonSchema.IInteger | OpenApi.IJsonSchema.INumber;
+    expected: string;
+  }> = [
+    // INTEGER — exclusive bounds read as numbers, independent of minimum/maximum
+    {
+      title: "integer exclusiveMinimum alone",
+      schema: { type: "integer", exclusiveMinimum: 5 },
+      expected: "number & tags.ExclusiveMinimum<5>",
+    },
+    {
+      title: "integer minimum and exclusiveMinimum together",
+      schema: { type: "integer", minimum: 0, exclusiveMinimum: 5 },
+      expected: "number & tags.Minimum<0> & tags.ExclusiveMinimum<5>",
+    },
+    {
+      title: "integer exclusiveMinimum zero boundary",
+      schema: { type: "integer", exclusiveMinimum: 0 },
+      expected: "number & tags.ExclusiveMinimum<0>",
+    },
+    {
+      title: "integer exclusiveMaximum alone",
+      schema: { type: "integer", exclusiveMaximum: 7 },
+      expected: "number & tags.ExclusiveMaximum<7>",
+    },
+    {
+      title: "integer maximum and exclusiveMaximum together",
+      schema: { type: "integer", maximum: 10, exclusiveMaximum: 7 },
+      expected: "number & tags.Maximum<10> & tags.ExclusiveMaximum<7>",
+    },
+    // INTEGER — declared format echoed as tags.Type<...>
+    {
+      title: "integer declared format int32",
+      schema: { type: "integer", format: "int32" } as OpenApi.IJsonSchema.IInteger,
+      expected: 'number & tags.Type<"int32">',
+    },
+    {
+      title: "integer format and bounds combined",
+      schema: {
+        type: "integer",
+        format: "int64",
+        minimum: 3,
+        exclusiveMaximum: 9,
+      } as OpenApi.IJsonSchema.IInteger,
+      expected:
+        'number & tags.Type<"int64"> & tags.Minimum<3> & tags.ExclusiveMaximum<9>',
+    },
+    // INTEGER — regressions: no invented format, plain bounds unchanged
+    {
+      title: "bare integer invents no format",
+      schema: { type: "integer" },
+      expected: "number",
+    },
+    {
+      title: "integer minimum alone unchanged",
+      schema: { type: "integer", minimum: 0 },
+      expected: "number & tags.Minimum<0>",
+    },
+    {
+      title: "integer multipleOf unchanged",
+      schema: { type: "integer", multipleOf: 3 },
+      expected: "number & tags.MultipleOf<3>",
+    },
+    // NUMBER — exclusive bounds read as numbers, independent of minimum/maximum
+    {
+      title: "number exclusiveMinimum alone",
+      schema: { type: "number", exclusiveMinimum: 5 },
+      expected: "number & tags.ExclusiveMinimum<5>",
+    },
+    {
+      title: "number exclusiveMinimum zero boundary",
+      schema: { type: "number", exclusiveMinimum: 0 },
+      expected: "number & tags.ExclusiveMinimum<0>",
+    },
+    {
+      title: "number minimum and exclusiveMaximum together",
+      schema: { type: "number", minimum: -1.5, exclusiveMaximum: 2.5 },
+      expected: "number & tags.Minimum<-1.5> & tags.ExclusiveMaximum<2.5>",
+    },
+    // NUMBER — regression: number never echoes a format (its validator does not)
+    {
+      title: "number ignores format its validator never reports",
+      schema: { type: "number", format: "double" } as OpenApi.IJsonSchema.INumber,
+      expected: "number",
+    },
+    {
+      title: "number minimum alone unchanged",
+      schema: { type: "number", minimum: 0 },
+      expected: "number & tags.Minimum<0>",
+    },
+  ];
+
+  for (const { title, schema, expected } of matrix) {
+    const result: IValidation<unknown> = OpenApiValidator.validate({
+      components: {},
+      schema,
+      value: "not-a-number",
+      required: true,
+    });
+    if (result.success)
+      throw new Error(`Expected "${title}" to fail against a non-number value.`);
+    TestValidator.equals(title, expected, result.errors[0]?.expected);
+  }
+};


### PR DESCRIPTION
Implements #2169 — `OpenApiSchemaNamingRule` reads `exclusiveMinimum`/`exclusiveMaximum` as booleans while typia's own `OpenApi.IJsonSchema.IInteger`/`INumber` declare them as numbers, so an exclusive bound names itself just `number` (or, when paired with `minimum`, carries the wrong value under an exclusive name). Claim commit only at open; implementation follows.

## Scope (`@typia/utils` only)

`packages/utils/src/validators/internal/OpenApiSchemaNamingRule.ts`:

- **`getNameOfInteger` / `getNameOfNumber`** — read `exclusiveMinimum`/`exclusiveMaximum` as the independent numbers the declaration says they are, each with its own value, rather than as a boolean modifier gated on `minimum`/`maximum`. The decisive case is `exclusiveMinimum: 0`, falsy as a number, which the current `schema.exclusiveMinimum ?` test drops entirely.
- **`getNameOfInteger`** — echo a declared `format` as `tags.Type<...>`, defensively (the normalized `IInteger` does not model `format`, but `OpenApiConverter` passes an external document's `format` through at runtime). This mirrors `OpenApiIntegerValidator.describeType`, repaired in #2148.

## Invariant

The name states exactly the constraints the schema declares, each with its own value. Cross-checked so each naming function agrees with its paired validator on what a schema declares:

| naming function | paired validator | format echoed? |
| --- | --- | --- |
| `getNameOfInteger` | `OpenApiIntegerValidator` (`describeType`) | yes — `tags.Type<...>` |
| `getNameOfNumber` | `OpenApiNumberValidator` | no (validator does not echo format either) |
| `getNameOfString` | `OpenApiStringValidator` | already `tags.Format<...>`, unchanged |

## Regression

#2146's contract holds: no `int32` (or any format) is invented where the schema declares none.

## Coordination

No native Go. No package version bump — releases belong to the maintainer. No `pnpm format` on this campaign branch.

## Verification

Campaign CI is suspended; verification is local and recorded on this thread:

- `pnpm --filter ./tests/test-utils start`
- `./tests/test-utils-automated` (`pnpm --filter ./tests/test-utils-automated start`)
- `pnpm test:packages`
