### PR TITLE
chore(spelling): use en-US spelling for the label family

### DIFF
--- a/packages/typia/native/core/programmers/json/JsonSchemasProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonSchemasProgrammer.go
@@ -104,7 +104,7 @@ func (jsonSchemasProgrammerNamespace) WriteSchemas(props struct {
 
 // jsonSchemasProgrammer_writeV3_0 builds the emended 3.1 document and rewrites
 // it into the OpenAPI 3.0 dialect. The version string is a claim about the
-// content, so relabelling the 3.1 document alone would emit `const`,
+// content, so relabeling the 3.1 document alone would emit `const`,
 // `prefixItems`, and 3.1 nullable type unions under a "3.0" banner that no
 // conformant 3.0 consumer can read.
 func jsonSchemasProgrammer_writeV3_0(metadataList []*nativemetadata.MetadataSchema) JsonSchemasProgrammer_IJsonSchemaCollection {

--- a/packages/typia/test/contract/native/protobuf_message_document_compiles_test.go
+++ b/packages/typia/test/contract/native/protobuf_message_document_compiles_test.go
@@ -14,7 +14,7 @@ import (
 //
 // `typia.protobuf.message<T>()` exists to hand a schema to another language, so
 // the document must compile under the syntax it declares. It declared
-// `syntax = "proto3"` while labelling required non-nullable scalars `required`,
+// `syntax = "proto3"` while labeling required non-nullable scalars `required`,
 // a label proto3 removed; because a Protobuf compiler rejects the whole file
 // rather than the field, one required scalar invalidated the entire document.
 // The substring assertions in the sibling suites cannot see this — a compiler

--- a/packages/typia/test/contract/native/protobuf_message_document_explicit_presence_test.go
+++ b/packages/typia/test/contract/native/protobuf_message_document_explicit_presence_test.go
@@ -8,7 +8,7 @@ import (
   testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
 )
 
-// TestProtobufMessageDocumentExplicitPresence verifies singular fields stay labelled.
+// TestProtobufMessageDocumentExplicitPresence verifies singular fields stay labeled.
 //
 // A Protobuf compiler accepts both `optional int32 id = 1;` and a bare
 // `int32 id = 1;`, so the compiler oracle cannot tell the two apart — but the
@@ -21,7 +21,7 @@ import (
 //
 // 1. Render a document whose scalars are required, optional, and nullable.
 // 2. Require every singular field to keep an explicit presence label.
-// 3. Require `required` to be gone, and repeated fields to stay unlabelled.
+// 3. Require `required` to be gone, and repeated fields to stay unlabeled.
 func TestProtobufMessageDocumentExplicitPresence(t *testing.T) {
   document := protobufMessageDocumentRender([]*schemametadata.MetadataObjectType{
     protobufMessageDocumentObject("IPresence",

--- a/packages/utils/src/validators/internal/OpenApiSchemaNamingRule.ts
+++ b/packages/utils/src/validators/internal/OpenApiSchemaNamingRule.ts
@@ -36,7 +36,7 @@ export namespace OpenApiSchemaNamingRule {
     // `minimum`, `maximum`, `exclusiveMinimum`, and `exclusiveMaximum` are all
     // numbers in the declaration, each an independent bound rather than a
     // boolean modifier on another. Read every one on its own value, so an
-    // exclusive bound is never dropped (including the falsy `0`) nor labelled
+    // exclusive bound is never dropped (including the falsy `0`) nor labeled
     // with a sibling's value.
     //
     // The normalized integer schema does not model `format`, but

--- a/tests/test-typia-schema/src/features/json.application/test_json_application_v3_0_dialect.ts
+++ b/tests/test-typia-schema/src/features/json.application/test_json_application_v3_0_dialect.ts
@@ -5,9 +5,9 @@ import typia from "typia";
  * Verifies typia.json.application emits the OpenAPI 3.0 dialect under "3.0".
  *
  * `json.application` is the third entry point sharing the collection writer that
- * relabelled a 3.1 document as "3.0". Its function parameter and return schemas
+ * relabeled a 3.1 document as "3.0". Its function parameter and return schemas
  * are filled from that same collection, so an application document is exactly as
- * mislabelled as a bare schema — and no test knew the dialect here either.
+ * mislabeled as a bare schema — and no test knew the dialect here either.
  *
  * 1. Declare a controller whose method takes a tuple and a literal union and
  *    returns a nullable type.

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_v3_0_dialect.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_v3_0_dialect.ts
@@ -6,7 +6,7 @@ import typia from "typia";
  *
  * `json.schema` routes through the same collection writer as `json.schemas`, so
  * the dialect defect was shared: fixing one entry point and leaving the others
- * would still ship a 3.1 document labelled "3.0". This pins the singular entry
+ * would still ship a 3.1 document labeled "3.0". This pins the singular entry
  * point, whose root schema is additionally dereferenced out of the components.
  *
  * 1. Declare a type carrying a nullable atomic, a literal union, and a tuple.

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
@@ -43,7 +43,7 @@ export const test_protobuf_reader_invalid_utf8 = (): void => {
  *
  * `string()` must resolve its bytes before entering the decoder's `try`, so a
  * declared length that overruns the buffer stays a boundary error instead of
- * being relabelled as an encoding fault. Reporting `invalid UTF-8 string` here
+ * being relabeled as an encoding fault. Reporting `invalid UTF-8 string` here
  * would blame the payload's encoding for a wire-framing defect.
  */
 const assertOverflow = (label: string, task: () => unknown): void => {
@@ -53,7 +53,7 @@ const assertOverflow = (label: string, task: () => unknown): void => {
     if (error instanceof Error && error.message === OVERFLOW_ERROR) return;
     if (error instanceof Error && error.message === INVALID_UTF8_ERROR)
       throw new Error(
-        `${label} was relabelled as an encoding fault.`,
+        `${label} was relabeled as an encoding fault.`,
         { cause: error },
       );
     throw new Error(`${label} raised an unstable error.`, { cause: error });

--- a/website/src/content/docs/protobuf/message.mdx
+++ b/website/src/content/docs/protobuf/message.mdx
@@ -40,7 +40,7 @@ console.log(proto);
 // }
 ```
 
-Every singular field is labelled `optional`, and array or map fields carry `repeated` or `map<...>` with no label. proto3 removed the `required` label, so a `.proto` that declares `syntax = "proto3"` and then writes `required` is rejected by `protoc` for the whole file. `optional` is proto3 explicit presence, which matches how `encode` writes the field — it emits the field even when the value equals the scalar default — so a consumer reading the schema in another language stays byte-compatible with typia's own codec.
+Every singular field is labeled `optional`, and array or map fields carry `repeated` or `map<...>` with no label. proto3 removed the `required` label, so a `.proto` that declares `syntax = "proto3"` and then writes `required` is rejected by `protoc` for the whole file. `optional` is proto3 explicit presence, which matches how `encode` writes the field — it emits the field even when the value equals the scalar default — so a consumer reading the schema in another language stays byte-compatible with typia's own codec.
 
 <Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>


### PR DESCRIPTION
The repository spell check (`crate-ci/typos`, `locale = 'en-us'`) flags en-GB spellings of the label family (`labelled`/`relabelling`/`unlabelled`/`mislabelled`/`labelling`) that campaign batches introduced into comments, one test assertion string, and one guide page. Normalized all 11 occurrences across 8 files to en-US.

Comments, one assertion message, and one Markdown line only — no code, no behavior, no schema declaration, no version bump. Native Go files keep their existing 2-space indentation; the repo-wide `pnpm format` (Post-Campaign Cleanup) normalizes that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)