### PR TITLE
fix(native): accept int64/uint64 maximum's float form on the number path

### DIFF
--- a/packages/typia/native/core/factories/NumericRangeFactory.go
+++ b/packages/typia/native/core/factories/NumericRangeFactory.go
@@ -62,28 +62,22 @@ func numericRangeFactory_number_uint32(input *shimast.Expression, emit ...*shimp
   )
 }
 
-// numericRangeFactory_number_int64 bounds a `number` candidate at 2**63, exclusively.
-//
-// The true maximum, 2**63 - 1, is not a representable JavaScript number, so the
-// inclusive literal this used to emit rounded up to 2**63 and admitted a value
-// outside int64. The exclusive power-of-two bound is exact rather than merely
-// safer: doubles of this magnitude are 1024 apart, so none exists between
-// 2**63 - 1 and 2**63, and the largest double below it is a genuine int64. The
-// minimum stays inclusive because -(2**63) is a power of two, hence exact.
+// numericRangeFactory_number_int64 bounds a `number` candidate to the int64 range.
+// The maximum is 2**63 - 1, the int64 upper bound.
 func numericRangeFactory_number_int64(input *shimast.Expression, emit ...*shimprinter.EmitContext) *shimast.Node {
   return numericRangeFactory_logical_and(
     numericRangeFactory_integer(input, emit...),
-    numericRangeFactory_between_exclusive_maximum("-9223372036854775808", "9223372036854775808", emit...)(input),
+    numericRangeFactory_between("-9223372036854775808", "9223372036854775807", emit...)(input),
     emit...,
   )
 }
 
-// numericRangeFactory_number_uint64 bounds a `number` candidate at 2**64, exclusively.
-// See numericRangeFactory_number_int64; 2**64 - 1 is unrepresentable for the same reason.
+// numericRangeFactory_number_uint64 bounds a `number` candidate to the uint64 range.
+// The maximum is 2**64 - 1, the uint64 upper bound.
 func numericRangeFactory_number_uint64(input *shimast.Expression, emit ...*shimprinter.EmitContext) *shimast.Node {
   return numericRangeFactory_logical_and(
     numericRangeFactory_integer(input, emit...),
-    numericRangeFactory_between_exclusive_maximum("0", "18446744073709551616", emit...)(input),
+    numericRangeFactory_between("0", "18446744073709551615", emit...)(input),
     emit...,
   )
 }
@@ -121,34 +115,6 @@ func numericRangeFactory_between(x string, y string, emit ...*shimprinter.EmitCo
         input,
         nil,
         f.NewToken(shimast.KindLessThanEqualsToken),
-        f.NewIdentifier(y),
-      ),
-      emit...,
-    )
-  }
-}
-
-// numericRangeFactory_between_exclusive_maximum emits `x <= input && input < y`.
-//
-// Use this instead of numericRangeFactory_between whenever the true maximum is
-// not a representable JavaScript number: pass the next power of two as y, so the
-// exclusive comparison reads as the rounding boundary it actually is.
-func numericRangeFactory_between_exclusive_maximum(x string, y string, emit ...*shimprinter.EmitContext) func(input *shimast.Expression) *shimast.Node {
-  f := nativecontext.EmitFactoryOf(numericRangeFactory_factory, emit...)
-  return func(input *shimast.Expression) *shimast.Node {
-    return numericRangeFactory_logical_and(
-      f.NewBinaryExpression(
-        nil,
-        f.NewIdentifier(x),
-        nil,
-        f.NewToken(shimast.KindLessThanEqualsToken),
-        input,
-      ),
-      f.NewBinaryExpression(
-        nil,
-        input,
-        nil,
-        f.NewToken(shimast.KindLessThanToken),
         f.NewIdentifier(y),
       ),
       emit...,

--- a/packages/typia/native/core/factories/numeric_range_factory_enforces_64bit_bounds_test.go
+++ b/packages/typia/native/core/factories/numeric_range_factory_enforces_64bit_bounds_test.go
@@ -10,14 +10,13 @@ import (
 //
 // ProtobufFactory routes only "int64" and "uint64" into the bigint path, so its
 // fall-through was the int64 case and returned a bare `true` keyword: a union
-// candidate typed `bigint & Type<"int64">` matched every magnitude. The number
-// path had the mirror defect -- an inclusive maximum whose literal is not a
-// representable double -- so it must now compare exclusively against the power
-// of two, while the exactly-representable 32-bit bounds stay inclusive.
+// candidate typed `bigint & Type<"int64">` matched every magnitude. The bigint
+// path must therefore emit a real comparison, while every number predicate
+// bounds inclusively at its maximum (`2 ** 63 - 1`, `2 ** 64 - 1`, and the
+// exactly-representable 32-bit bounds).
 //
 // 1. Require neither bigint type to emit a bare `true` keyword.
-// 2. Require the 64-bit number predicates to use an exclusive upper bound.
-// 3. Require the 32-bit number predicates to keep their inclusive bound.
+// 2. Require every number predicate to use an inclusive upper bound.
 func TestNumericRangeFactoryEnforces64BitBounds(t *testing.T) {
   input := numericRangeFactory_factory.NewIdentifier("input")
 
@@ -31,14 +30,12 @@ func TestNumericRangeFactoryEnforces64BitBounds(t *testing.T) {
     }
   }
 
-  for _, name := range []string{"int64", "uint64"} {
-    if numericRangeFactoryCountTokens(NumericRangeFactory.Number(name, input), shimast.KindLessThanToken) != 1 {
-      t.Fatalf("number range %s must bound its unrepresentable maximum exclusively", name)
-    }
-  }
-  for _, name := range []string{"int32", "uint32"} {
+  for _, name := range []string{"int32", "uint32", "int64", "uint64"} {
     if numericRangeFactoryCountTokens(NumericRangeFactory.Number(name, input), shimast.KindLessThanToken) != 0 {
-      t.Fatalf("number range %s has an exactly representable maximum and must stay inclusive", name)
+      t.Fatalf("number range %s must bound its maximum inclusively", name)
+    }
+    if numericRangeFactoryCountTokens(NumericRangeFactory.Number(name, input), shimast.KindLessThanEqualsToken) != 2 {
+      t.Fatalf("number range %s must compare both bounds inclusively", name)
     }
   }
 }

--- a/packages/typia/src/internal/_isTypeInt64.ts
+++ b/packages/typia/src/internal/_isTypeInt64.ts
@@ -1,13 +1,6 @@
 export const _isTypeInt64 = (value: number): boolean =>
-  Math.floor(value) === value && MINIMUM <= value && value < MAXIMUM_EXCLUSIVE;
+  Math.floor(value) === value && MINIMUM <= value && value <= MAXIMUM;
 
-// The true maximum is `2 ** 63 - 1`, and no `number` can represent it: the
-// subtraction rounds straight back to `2 ** 63`. Spelling the bound as either
-// `2 ** 63 - 1` or `9223372036854775807` therefore compiles to `value <=
-// 2 ** 63` and admits `2 ** 63`, which `protobuf.encode` then wraps around to
-// the minimum. An exclusive bound loses nothing: doubles of this magnitude are
-// 1024 apart, so none exists between `2 ** 63 - 1` and `2 ** 63`, and the
-// largest double below the bound (`2 ** 63 - 1024`) is a genuine int64. The
-// minimum needs no such care -- `-(2 ** 63)` is a power of two, hence exact.
+// The maximum is `2 ** 63 - 1`, the int64 upper bound.
 const MINIMUM = -(2 ** 63);
-const MAXIMUM_EXCLUSIVE = 2 ** 63;
+const MAXIMUM = 2 ** 63 - 1;

--- a/packages/typia/src/internal/_isTypeUint64.ts
+++ b/packages/typia/src/internal/_isTypeUint64.ts
@@ -1,10 +1,6 @@
 export const _isTypeUint64 = (value: number): boolean =>
-  Math.floor(value) === value && MINIMUM <= value && value < MAXIMUM_EXCLUSIVE;
+  Math.floor(value) === value && MINIMUM <= value && value <= MAXIMUM;
 
-// The true maximum is `2 ** 64 - 1`, and no `number` can represent it: the
-// subtraction rounds straight back to `2 ** 64`. See `_isTypeInt64` for the
-// full reasoning; the exclusive bound is exact here too, because doubles of
-// this magnitude are 2048 apart, so none exists between `2 ** 64 - 1` and
-// `2 ** 64`.
+// The maximum is `2 ** 64 - 1`, the uint64 upper bound.
 const MINIMUM = 0;
-const MAXIMUM_EXCLUSIVE = 2 ** 64;
+const MAXIMUM = 2 ** 64 - 1;

--- a/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
@@ -22,20 +22,18 @@ interface ICommentBigint {
 }
 
 /**
- * Verifies that every int64 validator enforces the true signed 64-bit range.
+ * Verifies that the int64 validators enforce the signed 64-bit range on both the
+ * number and bigint paths.
  *
- * The int64 bound is reproduced by the runtime number helper, the runtime bigint
- * helper, and native JSDoc-tag generation. Two defects hid here at once: the
- * bigint path emitted a literal `true` and checked nothing, and the number path
- * spelled its maximum as `2 ** 63 - 1`, which rounds to `2 ** 63` and admitted
- * an out-of-range value. Every expectation below therefore comes from a BigInt
- * oracle -- a `number` cannot represent `2 ** 63 - 1`, so an expectation written
- * from the specification reproduces the defect inside the test.
+ * int64-max is `2 ** 63 - 1`, which no `number` can represent -- it rounds to
+ * `2 ** 63` -- so the number path accepts `2 ** 63` as int64-max's only float
+ * form. The bigint path represents the bound exactly, so it enforces the true
+ * inclusive range and still rejects magnitudes such as `2n ** 200n` that the
+ * bare-`true` bigint validator used to certify.
  *
- * 1. Derive every expectation from BigInt comparisons against the true bounds.
- * 2. Accept in-range values, including the largest double below `2 ** 63`.
- * 3. Reject `2 ** 63` on the number path and `2n ** 200n` on the bigint path.
- * 4. Require every certified value to survive a protobuf round trip unchanged.
+ * 1. Accept in-range numbers, including int64-max's float form `2 ** 63`.
+ * 2. Enforce the exact inclusive bounds on the bigint path from a BigInt oracle.
+ * 3. Require every certified bigint to survive a protobuf round trip unchanged.
  */
 export const test_type_int64_range = (): void => {
   const MINIMUM: bigint = -(2n ** 63n);
@@ -54,23 +52,22 @@ export const test_type_int64_range = (): void => {
   //----
   // NUMBER PATH
   //----
-  // `2 ** 63` is the nearest double to the unrepresentable maximum, and the
-  // value every owner used to admit. The largest double strictly below it is
-  // `2 ** 63 - 1024`, a genuine int64 that must still be accepted.
-  const numbers: number[] = [
-    0,
-    1,
-    -1,
-    2 ** 53,
-    -(2 ** 53),
-    9223372036854774784, // the largest double below 2 ** 63
-    -(2 ** 63), // the true minimum, exactly representable
-    2 ** 63, // one past the true maximum
-    2 ** 64,
-    -(2 ** 64),
+  // int64-max is `2 ** 63 - 1`, which rounds to `2 ** 63` as a `number`, so the
+  // number path accepts `2 ** 63`: no double can distinguish the two. `2 ** 64`
+  // and beyond stay out of range.
+  const numbers: [number, boolean][] = [
+    [0, true],
+    [1, true],
+    [-1, true],
+    [2 ** 53, true],
+    [-(2 ** 53), true],
+    [9223372036854774784, true], // the largest double below 2 ** 63
+    [-(2 ** 63), true], // the true minimum, exactly representable
+    [2 ** 63, true], // int64-max's only float form
+    [2 ** 64, false],
+    [-(2 ** 64), false],
   ];
-  for (const value of numbers) {
-    const expected: boolean = oracle(BigInt(value));
+  for (const [value, expected] of numbers) {
     TestValidator.equals(
       `_isTypeInt64(${value}) === ${expected}`,
       expected,
@@ -135,8 +132,8 @@ export const test_type_int64_range = (): void => {
   //----
   // ROUND TRIP
   //----
-  // The property that actually matters, and the one checkable without arguing
-  // about literals: typia never certifies a value its own encoder will corrupt.
+  // On the exact bigint path, typia never certifies a value its own encoder will
+  // corrupt: every in-range bigint survives protobuf byte-for-byte.
   for (const value of [MINIMUM, MAXIMUM, 0n, -1n, 1n, 2n ** 62n]) {
     TestValidator.equals(`round trip ${value} is certified`, true, oracle(value));
     const decoded: typia.Resolved<ITaggedBigint> = typia.protobuf.decode<

--- a/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
@@ -22,19 +22,19 @@ interface ICommentBigint {
 }
 
 /**
- * Verifies that every uint64 validator enforces the true unsigned 64-bit range.
+ * Verifies that the uint64 validators enforce the unsigned 64-bit range on both
+ * the number and bigint paths.
  *
- * The uint64 bigint path carried a lower bound and no upper bound at all, so any
- * non-negative magnitude was certified; the number path spelled its maximum as
- * `2 ** 64 - 1`, which rounds to `2 ** 64` and admitted an out-of-range value.
- * The lower bound was the only half that ever worked, so it is pinned here as a
- * regression alongside the two that did not. Expectations come from a BigInt
- * oracle, because a `number` cannot represent `2 ** 64 - 1`.
+ * uint64-max is `2 ** 64 - 1`, which no `number` can represent -- it rounds to
+ * `2 ** 64` -- so the number path accepts `2 ** 64` as uint64-max's only float
+ * form. The bigint path represents the bound exactly, so it enforces the true
+ * inclusive range and still rejects magnitudes such as `2n ** 64n` that the
+ * upper-bound-less bigint validator used to certify. Negatives are rejected on
+ * both paths.
  *
- * 1. Derive every expectation from BigInt comparisons against the true bounds.
- * 2. Accept in-range values, including the largest double below `2 ** 64`.
- * 3. Reject `2 ** 64` on the number path and `2n ** 64n` on the bigint path.
- * 4. Keep rejecting negatives, the one bound that was already enforced.
+ * 1. Accept in-range numbers, including uint64-max's float form `2 ** 64`.
+ * 2. Enforce the exact inclusive bounds on the bigint path from a BigInt oracle.
+ * 3. Require every certified bigint to survive a protobuf round trip unchanged.
  */
 export const test_type_uint64_range = (): void => {
   const MINIMUM: bigint = 0n;
@@ -57,18 +57,20 @@ export const test_type_uint64_range = (): void => {
   //----
   // NUMBER PATH
   //----
-  const numbers: number[] = [
-    0,
-    1,
-    2 ** 53,
-    2 ** 63, // in range for uint64, and a real protobuf decode result
-    18446744073709549568, // the largest double below 2 ** 64
-    -1,
-    -(2 ** 63),
-    2 ** 64, // one past the true maximum
+  // uint64-max is `2 ** 64 - 1`, which rounds to `2 ** 64` as a `number`, so the
+  // number path accepts `2 ** 64`: no double can distinguish the two. Negatives
+  // stay out of range.
+  const numbers: [number, boolean][] = [
+    [0, true],
+    [1, true],
+    [2 ** 53, true],
+    [2 ** 63, true], // in range for uint64, and a real protobuf decode result
+    [18446744073709549568, true], // the largest double below 2 ** 64
+    [-1, false],
+    [-(2 ** 63), false],
+    [2 ** 64, true], // uint64-max's only float form
   ];
-  for (const value of numbers) {
-    const expected: boolean = oracle(BigInt(value));
+  for (const [value, expected] of numbers) {
     TestValidator.equals(
       `_isTypeUint64(${value}) === ${expected}`,
       expected,
@@ -131,8 +133,8 @@ export const test_type_uint64_range = (): void => {
   //----
   // ROUND TRIP
   //----
-  // The property that actually matters: typia never certifies a value its own
-  // encoder will corrupt.
+  // On the exact bigint path, typia never certifies a value its own encoder will
+  // corrupt: every in-range bigint survives protobuf byte-for-byte.
   for (const value of [MINIMUM, MAXIMUM, 1n, 2n ** 63n]) {
     TestValidator.equals(`round trip ${value} is certified`, true, oracle(value));
     const decoded: typia.Resolved<ITaggedBigint> = typia.protobuf.decode<


### PR DESCRIPTION
## What this fixes

PR #2166 (issue #2159) tightened the `number & Type<"int64">` / `Type<"uint64">` **number-path** maximum from inclusive to **exclusive** (`value < 2 ** 63`, `value < 2 ** 64`). That rejected the maximum's only float representation and left `master` red on a fresh build.

### The float proof

int64-max is `2 ** 63 - 1`. No `number` can represent it — the subtraction rounds straight up to `2 ** 63`:

```
Number(9223372036854775807n) === 9223372036854776000 === 2 ** 63   // rounds UP
(2 ** 63 - 1) === 2 ** 63                                          // true
9223372036854775807 === 2 ** 63                                    // true
```

So a document that specifies an int64 maximum unavoidably writes `2 ** 63` as its number. With the exclusive bound, `value < 2 ** 63` rejects `2 ** 63`, which means **an int64 maximum cannot be expressed as a bound at all** — the type defeats its own purpose. The number path must accept `2 ** 63` (and uint64 must accept `2 ** 64`); it is indistinguishable from the true maximum at float precision, so accepting it is the only coherent behavior for the `number` path.

### The concrete breakage

`OpenApi.IJsonSchema.IInteger.maximum` (and `OpenApiV3` / `SwaggerV2`) is declared `number & tags.Type<"int64">`. The committed real OpenAI spec `tests/test-utils/examples/v3.0/openai.json` carries `seed: { "minimum": -9223372036854776000, "maximum": 9223372036854776000 }` (= ±`2 ** 63`). Under #2166, `test-utils`' `test_http_migrate_v30` and `test_document_upgrade_v30` fail with a `TypeGuardError` on `value: 9223372036854776000`. #2166 never ran `test-utils`, which is how it slipped through.

## The fix

Restore the number-path maximum to the spec value `2 ** 63 - 1` / `2 ** 64 - 1`, **inclusive**, in both owners of the number check so the runtime helper and the emitted validator agree:

- `packages/typia/src/internal/_isTypeInt64.ts` / `_isTypeUint64.ts`: `value <= MAXIMUM`, `MAXIMUM = 2 ** 63 - 1` / `2 ** 64 - 1`.
- `packages/typia/native/core/factories/NumericRangeFactory.go`: number path back to inclusive `numericRangeFactory_between(..., "9223372036854775807")` / `"18446744073709551615")`; removed the now-unused exclusive-maximum helper.

**The #2166 bigint path is unchanged and stays strict.** `_isTypeInt64Bigint` / `_isTypeUint64Bigint`, the `Type` tag's `validate.bigint` routing, and `NumericRangeFactory.Bigint` still take the exact inclusive bound through `BigInt("…")` strings and still reject `2n ** 200n` / `2n ** 64n`. That was the real bug #2159 fixed (`int64` bigint used to emit a bare `true`) and it is preserved.

Tests flipped to the corrected behavior: `test_type_int64_range` / `test_type_uint64_range` now expect `2 ** 63` / `2 ** 64` **accepted** on the number path, with the bigint rejections kept; the Go `TestNumericRangeFactoryEnforces64BitBounds` now asserts the number path bounds inclusively while keeping the bigint bare-`true` guard.

### Protobuf boundary trade-off (measured)

At exactly `2 ** 63`, `protobuf.encode`→`decode` on the **number** path wraps (`2 ** 63` int64 → `-2 ** 63`; `2 ** 64` uint64 → `0`), because those are the same doubles as the true maxima and overflow the wire integer. This is the unavoidable cost of accepting the maximum's float form, and it is confined to the number path. The **bigint** path is exact and round-trips byte-for-byte; it remains the way to carry true 64-bit integers through protobuf.

No `packages/typia/package.json` version bump — releases belong to the maintainer (as in #2166).

## Local verification (executed case counts, `GOMAXPROCS=12`)

- **`tests/test-utils`**: 302 cases, Success. `test_http_migrate_v30` and `test_document_upgrade_v30` pass. Fail-then-pass proven: reverting only the two runtime helpers to master's exclusive bound and rebuilding reproduces both failures (`TypeGuardError`, `value: 9223372036854776000`); the fix makes them pass.
- **`tests/test-typia-schema`**: 167 cases, Success (incl. flipped `test_type_int64_range` / `test_type_uint64_range`).
- **`tests/test-typia-automated`** (run solo): 3,947 cases, Success.
- **Go**: factories (2 pkg), native (14 pkg), public (17 pkg) — all `ok`, 0 fail.
- Runtime proof against the built lib: `_isTypeInt64(2 ** 63) === true` (was `false`), `_isTypeInt64(2 ** 64) === false`; bigint path unchanged — `_isTypeInt64Bigint(2n ** 200n) === false`, `_isTypeUint64Bigint(2n ** 64n) === false`.

Campaign CI for this branch is cancelled per the exact-SHA gate; verification above is local.
