### PR TITLE
fix(native): single-source JSDoc tag exclusivity from the interface authority (#2182)

### DIFF
--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -207,8 +207,8 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
       Value    string
     }{Report: props.Report, Value: props.Value, Unsigned: true})
     return metadataCommentTagFactory_TagRecord{"array": {
-      {Name: "MinItems<" + props.Value + ">", Target: "array", Kind: "minItems", Value: value, Validate: props.Value + " <= $input.length", Exclusive: true, Schema: map[string]any{"minItems": value}},
-      {Name: "MaxItems<" + props.Value + ">", Target: "array", Kind: "maxItems", Value: value, Validate: "$input.length <= " + props.Value, Exclusive: true, Schema: map[string]any{"maxItems": value}},
+      {Name: "MinItems<" + props.Value + ">", Target: "array", Kind: "minItems", Value: value, Validate: props.Value + " <= $input.length", Exclusive: metadataCommentTagFactory_exclusive("minItems"), Schema: map[string]any{"minItems": value}},
+      {Name: "MaxItems<" + props.Value + ">", Target: "array", Kind: "maxItems", Value: value, Validate: "$input.length <= " + props.Value, Exclusive: metadataCommentTagFactory_exclusive("maxItems"), Schema: map[string]any{"maxItems": value}},
     }}
   },
   "minItems": func(props struct {
@@ -220,7 +220,7 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
       Unsigned bool
       Value    string
     }{Report: props.Report, Value: props.Value, Unsigned: true})
-    return metadataCommentTagFactory_TagRecord{"array": {{Name: "MinItems<" + props.Value + ">", Target: "array", Kind: "minItems", Value: value, Validate: props.Value + " <= $input.length", Exclusive: true, Schema: map[string]any{"minItems": value}}}}
+    return metadataCommentTagFactory_TagRecord{"array": {{Name: "MinItems<" + props.Value + ">", Target: "array", Kind: "minItems", Value: value, Validate: props.Value + " <= $input.length", Exclusive: metadataCommentTagFactory_exclusive("minItems"), Schema: map[string]any{"minItems": value}}}}
   },
   "maxItems": func(props struct {
     Report func(msg string) any
@@ -231,44 +231,44 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
       Unsigned bool
       Value    string
     }{Report: props.Report, Value: props.Value, Unsigned: true})
-    return metadataCommentTagFactory_TagRecord{"array": {{Name: "MaxItems<" + props.Value + ">", Target: "array", Kind: "maxItems", Value: value, Validate: "$input.length <= " + props.Value, Exclusive: true, Schema: map[string]any{"maxItems": value}}}}
+    return metadataCommentTagFactory_TagRecord{"array": {{Name: "MaxItems<" + props.Value + ">", Target: "array", Kind: "maxItems", Value: value, Validate: "$input.length <= " + props.Value, Exclusive: metadataCommentTagFactory_exclusive("maxItems"), Schema: map[string]any{"maxItems": value}}}}
   },
   "uniqueItems": func(props struct {
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
-    return metadataCommentTagFactory_TagRecord{"array": {{Name: "UniqueItems", Target: "array", Kind: "uniqueItems", Value: true, Validate: "$importInternal(\"isUniqueItems\")($input)", Exclusive: true, Schema: map[string]any{"uniqueItems": true}}}}
+    return metadataCommentTagFactory_TagRecord{"array": {{Name: "UniqueItems", Target: "array", Kind: "uniqueItems", Value: true, Validate: "$importInternal(\"isUniqueItems\")($input)", Exclusive: metadataCommentTagFactory_exclusive("uniqueItems"), Schema: map[string]any{"uniqueItems": true}}}}
   },
   "type": metadataCommentTagFactory_parse_type,
   "minimum": func(props struct {
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
-    return metadataCommentTagFactory_numeric(props, "Minimum", "minimum", props.Value+" <= $input", props.Value+" <= $input", []string{"minimum", "exclusiveMinimum"})
+    return metadataCommentTagFactory_numeric(props, "Minimum", "minimum", props.Value+" <= $input", props.Value+" <= $input")
   },
   "maximum": func(props struct {
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
-    return metadataCommentTagFactory_numeric(props, "Maximum", "maximum", "$input <= "+props.Value, "$input <= "+props.Value, []string{"maximum", "exclusiveMaximum"})
+    return metadataCommentTagFactory_numeric(props, "Maximum", "maximum", "$input <= "+props.Value, "$input <= "+props.Value)
   },
   "exclusiveMinimum": func(props struct {
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
-    return metadataCommentTagFactory_numeric(props, "ExclusiveMinimum", "exclusiveMinimum", props.Value+" < $input", props.Value+" < $input", []string{"minimum", "exclusiveMinimum"})
+    return metadataCommentTagFactory_numeric(props, "ExclusiveMinimum", "exclusiveMinimum", props.Value+" < $input", props.Value+" < $input")
   },
   "exclusiveMaximum": func(props struct {
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
-    return metadataCommentTagFactory_numeric(props, "ExclusiveMaximum", "exclusiveMaximum", "$input < "+props.Value, "$input < "+props.Value, []string{"maximum", "exclusiveMaximum"})
+    return metadataCommentTagFactory_numeric(props, "ExclusiveMaximum", "exclusiveMaximum", "$input < "+props.Value, "$input < "+props.Value)
   },
   "multipleOf": func(props struct {
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
-    return metadataCommentTagFactory_numeric(props, "MultipleOf", "multipleOf", "$importInternal(\"_isMultipleOf\")($input, "+props.Value+")", "$input % "+props.Value+"n === 0n", true)
+    return metadataCommentTagFactory_numeric(props, "MultipleOf", "multipleOf", "$importInternal(\"_isMultipleOf\")($input, "+props.Value+")", "$input % "+props.Value+"n === 0n")
   },
   "format": func(props struct {
     Report func(msg string) any
@@ -278,13 +278,13 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
     if ok == false {
       return metadataCommentTagFactory_TagRecord{}
     }
-    return metadataCommentTagFactory_TagRecord{"string": {{Name: "Format<" + strconv.Quote(name) + ">", Target: "string", Kind: "format", Value: name, Validate: validate, Exclusive: true, Schema: map[string]any{"format": name}}}}
+    return metadataCommentTagFactory_TagRecord{"string": {{Name: "Format<" + strconv.Quote(name) + ">", Target: "string", Kind: "format", Value: name, Validate: validate, Exclusive: metadataCommentTagFactory_exclusive("format"), Schema: map[string]any{"format": name}}}}
   },
   "pattern": func(props struct {
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
-    return metadataCommentTagFactory_TagRecord{"string": {{Name: "Pattern<" + strconv.Quote(props.Value) + ">", Target: "string", Kind: "pattern", Value: props.Value, Validate: "RegExp(" + strconv.Quote(props.Value) + ").test($input)", Exclusive: []string{"format"}, Schema: map[string]any{"pattern": props.Value}}}}
+    return metadataCommentTagFactory_TagRecord{"string": {{Name: "Pattern<" + strconv.Quote(props.Value) + ">", Target: "string", Kind: "pattern", Value: props.Value, Validate: "RegExp(" + strconv.Quote(props.Value) + ").test($input)", Exclusive: metadataCommentTagFactory_exclusive("pattern"), Schema: map[string]any{"pattern": props.Value}}}}
   },
   "length": func(props struct {
     Report func(msg string) any
@@ -292,8 +292,8 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
   }) metadataCommentTagFactory_TagRecord {
     value := metadataCommentTagFactory_parse_number(props)
     return metadataCommentTagFactory_TagRecord{"string": {
-      {Name: "MinLength<" + props.Value + ">", Target: "string", Kind: "minLength", Value: value, Validate: props.Value + " <= $importInternal(\"_stringLength\")($input)", Exclusive: true, Schema: map[string]any{"minLength": value}},
-      {Name: "MaxLength<" + props.Value + ">", Target: "string", Kind: "maxLength", Value: value, Validate: "$importInternal(\"_stringLength\")($input) <= " + props.Value, Exclusive: true, Schema: map[string]any{"maxLength": value}},
+      {Name: "MinLength<" + props.Value + ">", Target: "string", Kind: "minLength", Value: value, Validate: props.Value + " <= $importInternal(\"_stringLength\")($input)", Exclusive: metadataCommentTagFactory_exclusive("minLength"), Schema: map[string]any{"minLength": value}},
+      {Name: "MaxLength<" + props.Value + ">", Target: "string", Kind: "maxLength", Value: value, Validate: "$importInternal(\"_stringLength\")($input) <= " + props.Value, Exclusive: metadataCommentTagFactory_exclusive("maxLength"), Schema: map[string]any{"maxLength": value}},
     }}
   },
   "minLength": func(props struct {
@@ -301,15 +301,56 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
     Value  string
   }) metadataCommentTagFactory_TagRecord {
     value := metadataCommentTagFactory_parse_number(props)
-    return metadataCommentTagFactory_TagRecord{"string": {{Name: "MinLength<" + props.Value + ">", Target: "string", Kind: "minLength", Value: value, Validate: props.Value + " <= $importInternal(\"_stringLength\")($input)", Exclusive: true, Schema: map[string]any{"minLength": value}}}}
+    return metadataCommentTagFactory_TagRecord{"string": {{Name: "MinLength<" + props.Value + ">", Target: "string", Kind: "minLength", Value: value, Validate: props.Value + " <= $importInternal(\"_stringLength\")($input)", Exclusive: metadataCommentTagFactory_exclusive("minLength"), Schema: map[string]any{"minLength": value}}}}
   },
   "maxLength": func(props struct {
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
     value := metadataCommentTagFactory_parse_number(props)
-    return metadataCommentTagFactory_TagRecord{"string": {{Name: "MaxLength<" + props.Value + ">", Target: "string", Kind: "maxLength", Value: value, Validate: "$importInternal(\"_stringLength\")($input) <= " + props.Value, Exclusive: true, Schema: map[string]any{"maxLength": value}}}}
+    return metadataCommentTagFactory_TagRecord{"string": {{Name: "MaxLength<" + props.Value + ">", Target: "string", Kind: "maxLength", Value: value, Validate: "$importInternal(\"_stringLength\")($input) <= " + props.Value, Exclusive: metadataCommentTagFactory_exclusive("maxLength"), Schema: map[string]any{"maxLength": value}}}}
   },
+}
+
+// metadataCommentTagFactory_EXCLUSIVE is the single authority for every JSDoc
+// comment tag's mutual-exclusivity rule, keyed by tag kind and transcribing the
+// `exclusive` field the matching @typia/interface tag declares
+// (packages/interface/src/tags/*.ts). The JSDoc path and the type-tag path must
+// enforce the same exclusivity, because MetadataTypeTagFactory.Validate reads
+// this list for both; the type-tag path takes it straight from the declaration,
+// so the comment path must publish the identical value. Hand-copying a separate
+// list per parser is exactly what let `@format` (a bare `true`) and `@pattern`
+// (`["format"]`, missing its own kind) drift from the declared
+// `["format", "pattern"]`. Every parser now reads its list from here, so no one
+// list can diverge on its own again. Each `[]string` names its own kind plus
+// every cross-kind partner it may not share a property with, in the declaration
+// order; `true` forbids only same-kind duplication.
+var metadataCommentTagFactory_EXCLUSIVE = map[string]any{
+  "minItems":         true,
+  "maxItems":         true,
+  "uniqueItems":      true,
+  "type":             true,
+  "minimum":          []string{"minimum", "exclusiveMinimum"},
+  "maximum":          []string{"maximum", "exclusiveMaximum"},
+  "exclusiveMinimum": []string{"exclusiveMinimum", "minimum"},
+  "exclusiveMaximum": []string{"exclusiveMaximum", "maximum"},
+  "multipleOf":       true,
+  "format":           []string{"format", "pattern"},
+  "pattern":          []string{"format", "pattern"},
+  "minLength":        true,
+  "maxLength":        true,
+}
+
+// metadataCommentTagFactory_exclusive returns the declared exclusivity rule for
+// a tag kind. It panics on an unknown kind so a newly added comment tag that
+// forgets its rule fails loudly here rather than silently emitting a tag with a
+// nil `Exclusive` that the validator would never check.
+func metadataCommentTagFactory_exclusive(kind string) any {
+  value, ok := metadataCommentTagFactory_EXCLUSIVE[kind]
+  if ok == false {
+    panic("no exclusive rule for comment tag kind: " + kind)
+  }
+  return value
 }
 
 func metadataCommentTagFactory_parse_type(props struct {
@@ -363,7 +404,7 @@ func metadataCommentTagFactory_parse_type(props struct {
     bigintSchema = map[string]any{"minimum": 0}
   }
   record := metadataCommentTagFactory_TagRecord{
-    "number": {{Name: "Type<" + strconv.Quote(value) + ">", Target: "number", Kind: "type", Value: value, Validate: validate, Exclusive: true, Schema: numberSchema}},
+    "number": {{Name: "Type<" + strconv.Quote(value) + ">", Target: "number", Kind: "type", Value: value, Validate: validate, Exclusive: metadataCommentTagFactory_exclusive("type"), Schema: numberSchema}},
   }
   if value == "int64" || value == "uint64" {
     // The bigint form used to emit `true` for int64 and a lower bound only for
@@ -375,7 +416,7 @@ func metadataCommentTagFactory_parse_type(props struct {
       bigintValidate = "$importInternal(\"isTypeInt64Bigint\")($input)"
     }
     record["bigint"] = []schemametadata.IMetadataTypeTag{
-      {Name: "Type<" + strconv.Quote(value) + ">", Target: "bigint", Kind: "type", Value: value, Validate: bigintValidate, Exclusive: true, Schema: bigintSchema},
+      {Name: "Type<" + strconv.Quote(value) + ">", Target: "bigint", Kind: "type", Value: value, Validate: bigintValidate, Exclusive: metadataCommentTagFactory_exclusive("type"), Schema: bigintSchema},
     }
   }
   return record
@@ -384,13 +425,14 @@ func metadataCommentTagFactory_parse_type(props struct {
 func metadataCommentTagFactory_numeric(props struct {
   Report func(msg string) any
   Value  string
-}, name string, kind string, numberValidate string, bigintValidate string, exclusive any) metadataCommentTagFactory_TagRecord {
+}, name string, kind string, numberValidate string, bigintValidate string) metadataCommentTagFactory_TagRecord {
   number := metadataCommentTagFactory_parse_number(props)
   integer := metadataCommentTagFactory_parse_integer(struct {
     Report   func(msg string) any
     Unsigned bool
     Value    string
   }{Report: func(string) any { return nil }, Value: props.Value, Unsigned: false})
+  exclusive := metadataCommentTagFactory_exclusive(kind)
   record := metadataCommentTagFactory_TagRecord{
     "number": {{Name: name + "<" + props.Value + ">", Target: "number", Kind: kind, Value: number, Validate: numberValidate, Exclusive: exclusive, Schema: map[string]any{kind: number}}},
   }

--- a/packages/typia/native/core/factories/metadata_comment_tag_factory_exclusivity_matches_interface_test.go
+++ b/packages/typia/native/core/factories/metadata_comment_tag_factory_exclusivity_matches_interface_test.go
@@ -1,0 +1,84 @@
+package factories
+
+import (
+  "reflect"
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestMetadataCommentTagFactoryExclusivityMatchesInterface pins every JSDoc
+// comment tag's `Exclusive` value to the @typia/interface declaration.
+//
+// The JSDoc path and the type-tag path both feed
+// MetadataTypeTagFactory.Validate, which reads a tag's `Exclusive` list to
+// reject forbidden combinations. The type-tag path takes that list straight
+// from the interface declaration, but the comment factory used to hand-copy it
+// per parser, and two copies drifted: `@format` published a bare `true` and
+// `@pattern` published `["format"]` (missing its own kind), so `@pattern ^a`
+// `@pattern ^b` compiled while `Pattern<...> & Pattern<...>` is a compile error.
+// This test transcribes the authority once via
+// metadataTypeTagFactoryTestDeclarations -- the same mirror the type-tag tests
+// use -- and asserts the comment factory now produces the identical list.
+//
+// 1. Build the array-form authority (kind -> exclusive kinds) from the shared
+//    declaration mirror, and note the kinds that declare a bare `true`.
+// 2. Parse one representative JSDoc comment per tag kind through the factory.
+// 3. Assert the produced tag's kind and `Exclusive` match the authority exactly,
+//    so `@format`/`@pattern` carry `["format", "pattern"]` and no list drifts.
+func TestMetadataCommentTagFactoryExclusivityMatchesInterface(t *testing.T) {
+  arrayForm := map[string][]string{}
+  for _, declaration := range metadataTypeTagFactoryTestDeclarations() {
+    arrayForm[declaration.kind] = declaration.exclusive
+  }
+
+  report := func(string) any { return nil }
+  cases := []struct {
+    tag  string
+    text string
+    kind string
+    key  string
+  }{
+    {tag: "minimum", text: "0", kind: "minimum", key: "number"},
+    {tag: "maximum", text: "10", kind: "maximum", key: "number"},
+    {tag: "exclusiveMinimum", text: "0", kind: "exclusiveMinimum", key: "number"},
+    {tag: "exclusiveMaximum", text: "10", kind: "exclusiveMaximum", key: "number"},
+    {tag: "format", text: "uuid", kind: "format", key: "string"},
+    {tag: "pattern", text: "^x$", kind: "pattern", key: "string"},
+    {tag: "multipleOf", text: "2", kind: "multipleOf", key: "number"},
+    {tag: "minItems", text: "1", kind: "minItems", key: "array"},
+    {tag: "maxItems", text: "2", kind: "maxItems", key: "array"},
+    {tag: "uniqueItems", text: "", kind: "uniqueItems", key: "array"},
+    {tag: "minLength", text: "1", kind: "minLength", key: "string"},
+    {tag: "maxLength", text: "2", kind: "maxLength", key: "string"},
+    {tag: "type", text: "int32", kind: "type", key: "number"},
+  }
+  for _, tuple := range cases {
+    info := schemametadata.IJsDocTagInfo{Name: tuple.tag}
+    if tuple.text != "" {
+      info.Text = []schemametadata.IJsDocTagInfo_IText{{Text: tuple.text}}
+    }
+    record := metadataCommentTagFactory_parse(struct {
+      Report func(msg string) any
+      Tag    schemametadata.IJsDocTagInfo
+    }{Report: report, Tag: info})
+    tags := record[tuple.key]
+    if len(tags) == 0 {
+      t.Fatalf("@%s should produce a %q tag", tuple.tag, tuple.key)
+    }
+    produced := tags[0]
+    if produced.Kind != tuple.kind {
+      t.Fatalf("@%s should produce kind %q, got %q", tuple.tag, tuple.kind, produced.Kind)
+    }
+    var expected any = true
+    if list, ok := arrayForm[tuple.kind]; ok {
+      expected = list
+    }
+    if reflect.DeepEqual(produced.Exclusive, expected) == false {
+      t.Fatalf(
+        "@%s exclusive drifted from the interface authority: got %#v, want %#v",
+        tuple.tag, produced.Exclusive, expected,
+      )
+    }
+  }
+}

--- a/tests/test-error/src/tag/error_tag_jsdoc_exclusive_maximum_and_maximum.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_exclusive_maximum_and_maximum.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+// Reverse order of error_tag_jsdoc_maximum_and_exclusive_maximum: exclusivity
+// is symmetric, so declaring `@exclusiveMaximum` before `@maximum` must reject
+// too. ExclusiveMaximum declares `exclusive: ["exclusiveMaximum", "maximum"]`.
+interface IValue {
+  /**
+   * @exclusiveMaximum 5
+   * @maximum 10
+   */
+  value: number;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_exclusive_maximum_duplicated.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_exclusive_maximum_duplicated.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+// ExclusiveMaximum declares `exclusive: ["exclusiveMaximum", "maximum"]`, naming
+// its own kind first, so one property may never carry two `@exclusiveMaximum`
+// tags: the emitted schema keeps one bound while the validator enforces both.
+interface IValue {
+  /**
+   * @exclusiveMaximum 10
+   * @exclusiveMaximum 5
+   */
+  value: number;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_exclusive_minimum_and_minimum.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_exclusive_minimum_and_minimum.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+// Reverse order of error_tag_jsdoc_minimum_and_exclusive_minimum: exclusivity
+// is symmetric, so declaring `@exclusiveMinimum` before `@minimum` must reject
+// too. ExclusiveMinimum declares `exclusive: ["exclusiveMinimum", "minimum"]`.
+interface IValue {
+  /**
+   * @exclusiveMinimum 5
+   * @minimum 0
+   */
+  value: number;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_exclusive_minimum_duplicated.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_exclusive_minimum_duplicated.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+// ExclusiveMinimum declares `exclusive: ["exclusiveMinimum", "minimum"]`, naming
+// its own kind first, so one property may never carry two `@exclusiveMinimum`
+// tags: the emitted schema keeps one bound while the validator enforces both.
+interface IValue {
+  /**
+   * @exclusiveMinimum 5
+   * @exclusiveMinimum 0
+   */
+  value: number;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_format_and_pattern.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_format_and_pattern.ts
@@ -1,0 +1,14 @@
+import typia from "typia";
+
+// The JSDoc path must enforce the same exclusivity as the type tags: Format and
+// Pattern both declare `exclusive: ["format", "pattern"]`, so `@format` and
+// `@pattern` on one property is a compile error, just as
+// `string & Format<"email"> & Pattern<"^x">` is.
+interface IValue {
+  /**
+   * @format email
+   * @pattern ^x
+   */
+  value: string;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_format_duplicated.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_format_duplicated.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+// Format declares `exclusive: ["format", "pattern"]`, naming its own kind, so
+// two `@format` tags on one property are forbidden: the emitted schema keeps one
+// `format` while the generated validator enforces both.
+interface IValue {
+  /**
+   * @format uuid
+   * @format email
+   */
+  value: string;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_maximum_and_exclusive_maximum.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_maximum_and_exclusive_maximum.ts
@@ -1,0 +1,14 @@
+import typia from "typia";
+
+// The JSDoc path must enforce the same exclusivity as the type tags: Maximum
+// declares `exclusive: ["maximum", "exclusiveMaximum"]`, so `@maximum` and
+// `@exclusiveMaximum` on one property is a compile error, just as
+// `number & Maximum<10> & ExclusiveMaximum<5>` is.
+interface IValue {
+  /**
+   * @maximum 10
+   * @exclusiveMaximum 5
+   */
+  value: number;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_maximum_duplicated.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_maximum_duplicated.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+// Maximum declares `exclusive: ["maximum", "exclusiveMaximum"]`, naming its own
+// kind first, so one property may never carry two `@maximum` tags: the emitted
+// schema keeps one `maximum` while the generated validator enforces both.
+interface IValue {
+  /**
+   * @maximum 10
+   * @maximum 5
+   */
+  value: number;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_minimum_and_exclusive_minimum.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_minimum_and_exclusive_minimum.ts
@@ -1,0 +1,14 @@
+import typia from "typia";
+
+// The JSDoc path must enforce the same exclusivity as the type tags: Minimum
+// declares `exclusive: ["minimum", "exclusiveMinimum"]`, so `@minimum` and
+// `@exclusiveMinimum` on one property is a compile error, just as
+// `number & Minimum<0> & ExclusiveMinimum<5>` is.
+interface IValue {
+  /**
+   * @minimum 0
+   * @exclusiveMinimum 5
+   */
+  value: number;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_minimum_duplicated.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_minimum_duplicated.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+// Minimum declares `exclusive: ["minimum", "exclusiveMinimum"]`, naming its own
+// kind first, so one property may never carry two `@minimum` tags: the emitted
+// schema keeps one `minimum` while the generated validator enforces both.
+interface IValue {
+  /**
+   * @minimum 5
+   * @minimum 0
+   */
+  value: number;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_pattern_and_format.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_pattern_and_format.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+// Reverse order of error_tag_jsdoc_format_and_pattern: exclusivity is
+// symmetric, so declaring `@pattern` before `@format` must reject too. Pattern
+// declares `exclusive: ["format", "pattern"]`.
+interface IValue {
+  /**
+   * @pattern ^x
+   * @format email
+   */
+  value: string;
+}
+typia.createIs<IValue>();

--- a/tests/test-error/src/tag/error_tag_jsdoc_pattern_duplicated.ts
+++ b/tests/test-error/src/tag/error_tag_jsdoc_pattern_duplicated.ts
@@ -1,0 +1,14 @@
+import typia from "typia";
+
+// Pattern declares `exclusive: ["format", "pattern"]`, naming its own kind, so
+// two `@pattern` tags on one property are forbidden. Left unenforced, this
+// emitted `{"pattern": "^b"}` while the validator ANDs both regexes, so
+// `is({ value: "b" })` returned false against a schema typia itself emitted.
+interface IValue {
+  /**
+   * @pattern ^a
+   * @pattern ^b
+   */
+  value: string;
+}
+typia.createIs<IValue>();


### PR DESCRIPTION
## Summary

Fixes #2182.

The tag-exclusivity contract that #2168 enforced for **type tags** (`Minimum<0> & ExclusiveMinimum<5>` is a compile error) was under-enforced for the same constraints written as **JSDoc comment tags**, because the comment factory's hand-written `Exclusive` lists had drifted from the `@typia/interface` tag declarations that are the authority.

At `origin/master` the only divergent lists are:

| JSDoc tag | factory `Exclusive` (before) | interface authority |
| --- | --- | --- |
| `@format` | `true` | `["format", "pattern"]` |
| `@pattern` | `["format"]` | `["format", "pattern"]` |

`@minimum`/`@maximum`/`@exclusiveMinimum`/`@exclusiveMaximum` already carried correct lists (the issue's "field absent" claim was against an earlier state). The consequence of the two divergent lists: `@pattern ^a` + `@pattern ^b` and `@format email` + `@pattern ^x` compiled through JSDoc while the type-tag equivalents are compile errors, emitting a schema that contradicts the generated validator with no diagnostic.

## Approach

Single-source every JSDoc tag's `Exclusive` value from one authority table in the comment factory, keyed by kind and mirroring `packages/interface/src/tags/*.ts`. Both the numeric parsers and the string `@format`/`@pattern` parsers now read their list from the one table, so a hand-copied list can no longer drift per-parser. The interface declarations are unchanged (they are the authority).

## Scope

- **Native Go only.** `packages/typia/native/core/factories/MetadataCommentTagFactory.go`.
- **No `packages/interface/src` change** — the `exclusive` declarations are the authority.
- **No `packages/typia/package.json` version bump** — release belongs to the maintainer.
- Regression fixtures added to `tests/test-error` for every interface-declared mutually-exclusive JSDoc pair (both orders) plus same-kind duplication.

## Verification

Local verification recorded in the campaign knowledge base; CI intentionally suspended per the issue-campaign flow (exact-SHA runs cancelled after each push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
