### PR TITLE
fix(compare,plain): stop the object branch over-matching arrays and native instances

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/compare_native_object_overmatch_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/compare_native_object_overmatch_transform_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestCompareNativeObjectOvermatchTransform pins equals/cover over native|object.
+//
+// CompareEqualProgrammer.schema ORs a branch per union member and the object
+// branch (`_eo`) guards only with `typeof === "object" && !Array.isArray`,
+// which a native instance also passes. For `Date | { timestamp: number }` the
+// object branch compares two Dates by the absent `timestamp` key — both
+// `undefined`, so it reports them equal, and the OR accepts even though the
+// Date branch (comparing getTime) correctly said not-equal. The object branch
+// must never claim a value a sibling native branch owns. This test drives Date,
+// Uint8Array, and RegExp unioned with an object, in both orders, and requires
+// two different natives to compare not-equal while every legitimate pair and
+// the native-alone / object-alone controls are unchanged.
+//
+//  1. Transform equals/cover factories over native|object and object|native.
+//  2. Require two different natives to compare not-equal (equals and cover).
+//  3. Require same natives, plain-object pairs, and the native-alone control
+//     to keep their correct equal / not-equal results.
+func TestCompareNativeObjectOvermatchTransform(t *testing.T) {
+  project := compareNativeObjectOvermatchProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("compare native/object over-match transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  compareNativeObjectOvermatchRunRuntimeCases(t, project, out)
+}
+
+func compareNativeObjectOvermatchProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "compare-native-object-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(compareNativeObjectOvermatchTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(compareNativeObjectOvermatchSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func compareNativeObjectOvermatchRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(compareNativeObjectOvermatchRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("compare native/object over-match runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const compareNativeObjectOvermatchTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const compareNativeObjectOvermatchSource = `import typia, { compare } from "typia";
+
+interface IStamp {
+  timestamp: number;
+}
+interface ISource {
+  source: string;
+}
+
+export const equalDateObj = typia.compare.createEquals<Date | IStamp>();
+export const coverDateObj = typia.compare.createCover<Date | IStamp>();
+export const equalObjDate = typia.compare.createEquals<IStamp | Date>();
+export const equalBytesObj = typia.compare.createEquals<Uint8Array | IStamp>();
+export const equalRegExpObj = typia.compare.createEquals<RegExp | ISource>();
+
+// controls: the native alone and the object alone must be unchanged.
+export const equalDate = typia.compare.createEquals<Date>();
+export const equalStamp = typia.compare.createEquals<IStamp>();
+`
+
+const compareNativeObjectOvermatchRuntimeRunner = `const mod = require("./main.cjs");
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + expected + ", got " + actual);
+  }
+};
+
+// Two different natives must NOT be reported equal by the object branch.
+expect("Date|obj: two different Dates equal", mod.equalDateObj(new Date(0), new Date(5000)), false);
+expect("Date|obj: cover two different Dates", mod.coverDateObj(new Date(0), new Date(5000)), false);
+expect("obj|Date: two different Dates equal", mod.equalObjDate(new Date(0), new Date(5000)), false);
+expect("Bytes|obj: different bytes equal", mod.equalBytesObj(new Uint8Array([1, 2, 3]), new Uint8Array([9, 9, 9])), false);
+expect("Bytes|obj: one-byte diff equal", mod.equalBytesObj(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 4])), false);
+expect("RegExp|obj: same source diff flags equal", mod.equalRegExpObj(/a/g, /a/i), false);
+
+// Legitimate equal cases must be preserved.
+expect("Date|obj: same Date equal", mod.equalDateObj(new Date(0), new Date(0)), true);
+expect("Date|obj: cover same Date", mod.coverDateObj(new Date(0), new Date(0)), true);
+expect("Date|obj: stamp object equal", mod.equalDateObj({ timestamp: 5 }, { timestamp: 5 }), true);
+expect("Date|obj: stamp object not equal", mod.equalDateObj({ timestamp: 5 }, { timestamp: 9 }), false);
+expect("Bytes|obj: same bytes equal", mod.equalBytesObj(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3])), true);
+expect("RegExp|obj: identical regexp equal", mod.equalRegExpObj(/a/g, /a/g), true);
+
+// Controls: native alone and object alone are unchanged.
+expect("control Date: equal", mod.equalDate(new Date(0), new Date(0)), true);
+expect("control Date: not equal", mod.equalDate(new Date(0), new Date(5000)), false);
+expect("control Stamp: equal", mod.equalStamp({ timestamp: 5 }, { timestamp: 5 }), true);
+expect("control Stamp: not equal", mod.equalStamp({ timestamp: 5 }, { timestamp: 9 }), false);
+`

--- a/packages/typia/native/cmd/ttsc-typia/plain_prune_union_object_overmatch_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/plain_prune_union_object_overmatch_transform_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestPlainPruneUnionObjectOvermatchTransform pins prune over mixed unions.
+//
+// PlainPruneProgrammer emits one independent `if` per union member, and the
+// object arm's guard is `IsObject` with `CheckArray:false`, which also matches
+// arrays and native instances. With no `else` the array/native arm AND the
+// object arm both run, so `Object.keys(input)` on a value another arm already
+// owns gets its slots deleted: a typed array throws on `delete input[0]`, a
+// plain array collapses to holes, and a native's own properties are stripped.
+// clone/classify resolve the same unions with a mutually exclusive ladder, so
+// the object arm is only reached when the value is a plain object. This test
+// drives every native kind unioned with an object in both orders, plus an
+// object∪tuple, and requires the native/array/tuple value to survive intact.
+//
+//  1. Transform prune factories over native|object, object|native, array|object
+//     and object|tuple unions.
+//  2. Execute prune against a typed array, Date, Map, Set, RegExp, plain array,
+//     and tuple, requiring each to keep its identity and own state.
+//  3. Require the object arm still prunes an ordinary object member.
+func TestPlainPruneUnionObjectOvermatchTransform(t *testing.T) {
+  project := plainPruneUnionObjectOvermatchProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("prune union/object over-match transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  plainPruneUnionObjectOvermatchRunRuntimeCases(t, project, out)
+}
+
+func plainPruneUnionObjectOvermatchProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "plain-prune-union-object-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(plainPruneUnionObjectOvermatchTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(plainPruneUnionObjectOvermatchSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func plainPruneUnionObjectOvermatchRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(plainPruneUnionObjectOvermatchRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("prune union/object over-match runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const plainPruneUnionObjectOvermatchTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const plainPruneUnionObjectOvermatchSource = `import typia from "typia";
+
+interface IBox {
+  x: number;
+}
+interface IElem {
+  y: number;
+}
+
+export const pruneBytesFirst = typia.plain.createPrune<Uint8Array | IBox>();
+export const pruneBytesLast = typia.plain.createPrune<IBox | Uint8Array>();
+export const pruneDateFirst = typia.plain.createPrune<Date | IBox>();
+export const pruneDateLast = typia.plain.createPrune<IBox | Date>();
+export const pruneMap = typia.plain.createPrune<Map<string, number> | IBox>();
+export const pruneSet = typia.plain.createPrune<IBox | Set<number>>();
+export const pruneRegExp = typia.plain.createPrune<RegExp | IBox>();
+export const pruneArray = typia.plain.createPrune<IElem[] | IBox>();
+export const pruneTuple = typia.plain.createPrune<IBox | [IElem, IElem]>();
+`
+
+const plainPruneUnionObjectOvermatchRuntimeRunner = `const mod = require("./main.cjs");
+
+const fail = (label, detail) => {
+  throw new Error(label + ": " + detail);
+};
+
+// 1. A typed array must survive prune untouched (the buggy object arm throws
+//    "Cannot delete property '0'" while deleting its integer-indexed slots).
+for (const [label, prune] of [
+  ["Uint8Array | IBox", mod.pruneBytesFirst],
+  ["IBox | Uint8Array", mod.pruneBytesLast],
+]) {
+  const bytes = new Uint8Array([1, 2, 3]);
+  prune(bytes);
+  if (!(bytes instanceof Uint8Array) || bytes.length !== 3 || bytes[0] !== 1 || bytes[1] !== 2 || bytes[2] !== 3)
+    fail(label, "typed array corrupted -> " + JSON.stringify(Array.from(bytes)));
+}
+
+// 2. A Date must keep its time and its own state; the object arm strips own keys.
+for (const [label, prune] of [
+  ["Date | IBox", mod.pruneDateFirst],
+  ["IBox | Date", mod.pruneDateLast],
+]) {
+  const date = new Date(1000);
+  date.tag = "keep";
+  prune(date);
+  if (!(date instanceof Date) || date.getTime() !== 1000)
+    fail(label, "Date time corrupted -> " + date.getTime());
+  if (date.tag !== "keep")
+    fail(label, "Date own property stripped");
+}
+
+// 3. A Map / Set must keep their contents and own state.
+{
+  const map = new Map([["a", 1]]);
+  map.tag = "keep";
+  mod.pruneMap(map);
+  if (!(map instanceof Map) || map.size !== 1 || map.get("a") !== 1 || map.tag !== "keep")
+    fail("Map<string,number> | IBox", "Map corrupted");
+}
+{
+  const set = new Set([7]);
+  set.tag = "keep";
+  mod.pruneSet(set);
+  if (!(set instanceof Set) || set.size !== 1 || set.has(7) === false || set.tag !== "keep")
+    fail("IBox | Set<number>", "Set corrupted");
+}
+
+// 4. A RegExp with equal source but its own state must survive.
+{
+  const re = /abc/gi;
+  re.tag = "keep";
+  mod.pruneRegExp(re);
+  if (!(re instanceof RegExp) || re.source !== "abc" || re.flags !== "gi" || re.tag !== "keep")
+    fail("RegExp | IBox", "RegExp corrupted");
+}
+
+// 5. A plain array must be pruned element-by-element, not deleted to holes.
+{
+  const arr = [{ y: 1, extra: 2 }, { y: 3, extra: 4 }];
+  mod.pruneArray(arr);
+  if (!Array.isArray(arr) || arr.length !== 2)
+    fail("IElem[] | IBox", "array shape corrupted -> " + JSON.stringify(arr));
+  if (arr[0] === undefined || arr[1] === undefined)
+    fail("IElem[] | IBox", "array slot deleted -> " + JSON.stringify(arr));
+  if (arr[0].y !== 1 || arr[1].y !== 3 || "extra" in arr[0] || "extra" in arr[1])
+    fail("IElem[] | IBox", "array elements not pruned as objects -> " + JSON.stringify(arr));
+}
+
+// 6. An object∪tuple must prune the tuple positionally, not delete its slots.
+{
+  const tuple = [{ y: 1, extra: 2 }, { y: 3, extra: 4 }];
+  mod.pruneTuple(tuple);
+  if (!Array.isArray(tuple) || tuple.length !== 2 || tuple[0] === undefined || tuple[1] === undefined)
+    fail("IBox | [IElem, IElem]", "tuple slot deleted -> " + JSON.stringify(tuple));
+  if (tuple[0].y !== 1 || tuple[1].y !== 3 || "extra" in tuple[0] || "extra" in tuple[1])
+    fail("IBox | [IElem, IElem]", "tuple elements not pruned -> " + JSON.stringify(tuple));
+}
+
+// 7. The object arm must still prune an ordinary object member (nothing lost).
+{
+  const box = { x: 1, junk: "drop" };
+  mod.pruneBytesFirst(box);
+  if (box.x !== 1 || "junk" in box)
+    fail("Uint8Array | IBox", "object member not pruned -> " + JSON.stringify(box));
+}
+`

--- a/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
+++ b/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
@@ -156,7 +156,18 @@ func (g *compareEqualProgrammerGenerator) schema(metadata *schemametadata.Metada
     branches = append(branches, g.array(array, x, y))
   }
   for _, object := range metadata.Objects {
-    branches = append(branches, g.objectCall(object.Type, x, y))
+    // Guard the object branch against the sibling native instances. `_eo`
+    // admits any `typeof === "object" && !Array.isArray` value, so a native
+    // (a Date is an object) would be compared by the object's declared keys,
+    // which the native lacks — two different Dates then look equal on their
+    // absent keys and the OR wrongly accepts. Excluding what a native branch
+    // owns makes the arms mutually exclusive, matching the clone/classify
+    // ladder whose object arm is unreachable once a native arm matches.
+    call := g.objectCall(object.Type, x, y)
+    if guard := g.notNatives(metadata.Natives, x, y); guard != "" {
+      call = g.and(guard, call)
+    }
+    branches = append(branches, call)
   }
   for _, alias := range metadata.Aliases {
     branches = append(branches, g.schema(alias.Type.Value, x, y))
@@ -407,6 +418,21 @@ func (g *compareEqualProgrammerGenerator) bytes(x string, y string) string {
 
 func (g *compareEqualProgrammerGenerator) objectGuard(x string, y string) string {
   return g.and(g.isObject(x), g.isObject(y))
+}
+
+// notNatives builds "neither x nor y is one of the union's native instances",
+// so the object branch never claims a value a native branch owns. Empty when
+// the union declares no native, keeping the object-only output unchanged.
+func (g *compareEqualProgrammerGenerator) notNatives(natives []*schemametadata.MetadataNative, x string, y string) string {
+  if len(natives) == 0 {
+    return ""
+  }
+  checks := []string{}
+  for _, native := range natives {
+    checks = append(checks, "!"+g.wrap(g.instanceof(x, native.Name)))
+    checks = append(checks, "!"+g.wrap(g.instanceof(y, native.Name)))
+  }
+  return g.and(checks...)
 }
 
 func (g *compareEqualProgrammerGenerator) isObject(input string) string {

--- a/packages/typia/native/core/programmers/plain/PlainPruneProgrammer.go
+++ b/packages/typia/native/core/programmers/plain/PlainPruneProgrammer.go
@@ -313,13 +313,27 @@ func plainPruneProgrammer_decode(props struct {
     })
   }
 
-  statements := make([]*shimast.Node, 0, len(unions))
-  for _, u := range unions {
-    statements = append(statements, f.NewIfStatement(
+  // Compose the arms as a mutually exclusive `if / else if` ladder rather than
+  // independent `if`s. The object arm is appended last and its guard is
+  // `IsObject` with CheckArray:false, which also matches arrays and native
+  // instances; with independent `if`s an array or native runs both its own arm
+  // and the object arm, and the object arm then deletes the keys of a value
+  // another arm already owns (a typed array throws, a plain array collapses to
+  // holes, a native loses its own properties). The ladder reaches the object
+  // arm only when every earlier arm missed, so each input is pruned by exactly
+  // one arm — the same shape clone/classify use.
+  var chain *shimast.Node
+  for i := len(unions) - 1; i >= 0; i-- {
+    u := unions[i]
+    chain = f.NewIfStatement(
       u.Is(),
       plainPruneProgrammer_to_statement(u.Value(), props.Context.Emit),
-      nil,
-    ))
+      chain,
+    )
+  }
+  statements := []*shimast.Node{}
+  if chain != nil {
+    statements = append(statements, chain)
   }
   return f.NewBlock(f.NewNodeList(statements), true)
 }


### PR DESCRIPTION
## Intent

Fixes #2180. Two independent programmers over-match with an object branch that also catches arrays and native instances, because the branch composition is unguarded. `clone`/`classify` handle the identical unions correctly with an `else`-if ladder — that is the control and the fix shape.

This is a draft claim reservation. Implementation follows as **two independent commits**, each revertable alone.

## Scope

1. **`plain.prune<T>`** over a union mixing an object with an array/tuple/native crashes or corrupts. `PlainPruneProgrammer.go` emits independent `if`s (no `else`) per union member; the object branch's guard is `IsObject` with `CheckArray: false`, so an array/native matches both its own branch and the object branch, and both run.
   - `prune<Uint8Array | {x}>` on a `Uint8Array` throws `Cannot delete property '0'`.
   - `prune<{y}[] | {x}>` on `[{y},{y}]` → `[null, null]`.
   - `prune<Date | {x}>` strips the Date's props.

2. **`compare.equals`/`cover<native | object>`** returns `true` for two different natives. `CompareEqualProgrammer.go` ORs all member branches; the object branch matches a `Date` and compares it by the absent declared keys of `{timestamp}` (both `undefined` → equal), so `equals<Date | {timestamp}>(Date(0), Date(5000))` → `true`.

## Invariant

The object branch matches only plain objects — not arrays, not native instances — and each input is handled by exactly one branch. `prune` adopts the `clone`/`classify` else-if ladder; `compare.equals`/`cover` guards its object branch against the sibling natives the union declares. Pure tightening in the accept-wrong direction: no legitimate prune target or equal pair is lost.

## Verification (planned)

- Runtime reproductions in `packages/typia/native/cmd/ttsc-typia` for all four failures, red before the fix and green after.
- `go -C packages/typia/test test -count=1 -p 2 ../native/core/programmers/plain/... ../native/core/programmers/compare/...`; `../native/...`.
- `pnpm --filter ./tests/test-typia-schema start`; `pnpm --filter ./tests/test-typia-automated start` (solo).
- Regression: `clone`/`classify` over these unions stay correct (the control).

## Coordination

Native Go. No `packages/typia/package.json` version bump (releases belong to the maintainer). Campaign CI is deliberately suspended; verification is local per the issue-campaign development skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
