### PR TITLE
fix(typia): decode absent required protobuf scalar to its proto3 default

### DIFF
--- a/packages/typia/native/core/programmers/protobuf/ProtobufDecodeProgrammer.go
+++ b/packages/typia/native/core/programmers/protobuf/ProtobufDecodeProgrammer.go
@@ -292,6 +292,12 @@ func protobufDecodeProgrammer_write_property_default_value(value *schemametadata
     )
   } else if protobufDecodeProgrammer_hasStringDefault(value) {
     expression = f.NewStringLiteral("", shimast.TokenFlagsNone)
+  } else if protobufDecodeProgrammer_hasAtomicDefault(value, "number") {
+    expression = f.NewNumericLiteral("0", shimast.TokenFlagsNone)
+  } else if protobufDecodeProgrammer_hasAtomicDefault(value, "boolean") {
+    expression = f.NewKeywordExpression(shimast.KindFalseKeyword)
+  } else if protobufDecodeProgrammer_hasAtomicDefault(value, "bigint") {
+    expression = f.NewBigIntLiteral("0n", shimast.TokenFlagsNone)
   } else if protobufDecodeProgrammer_hasDynamicObject(value) {
     expression = f.NewObjectLiteralExpression(nil, false)
   } else {
@@ -620,6 +626,21 @@ func protobufDecodeProgrammer_hasStringDefault(value *schemametadata.MetadataSch
   }
   for _, template := range value.Templates {
     if len(template.Row) == 1 && template.Row[0].GetName() == "string" {
+      return true
+    }
+  }
+  return false
+}
+
+// protobufDecodeProgrammer_hasAtomicDefault reports whether an absent required
+// field of this schema decodes to the proto3 typed default of the given atomic
+// kind. proto3 does not write a singular scalar equal to its default, so an
+// absent number/boolean/bigint must seed 0/false/0n the same way an absent
+// string seeds "" through protobufDecodeProgrammer_hasStringDefault; the atomic
+// kind is read exactly as hasStringDefault reads its own atomic branch.
+func protobufDecodeProgrammer_hasAtomicDefault(value *schemametadata.MetadataSchema, typ string) bool {
+  for _, atomic := range value.Atomics {
+    if atomic.Type == typ {
       return true
     }
   }

--- a/packages/typia/native/core/programmers/protobuf/protobuf_programmer_helper_coverage_test.go
+++ b/packages/typia/native/core/programmers/protobuf/protobuf_programmer_helper_coverage_test.go
@@ -267,6 +267,32 @@ func TestProtobufProgrammerHelperCoverage(t *testing.T) {
 			t.Fatal("protobuf decode default value returned nil")
 		}
 	}
+	// #2179: an absent required number/boolean/bigint seeds its proto3 typed
+	// default (0/false/0n), just as an absent required string seeds "". Each
+	// seed is wrapped in an `as any`, so unwrap it and pin the literal so a
+	// regression to `undefined` cannot pass.
+	for _, expected := range []struct {
+		typ  string
+		kind shimast.Kind
+		text string
+	}{
+		{typ: "number", kind: shimast.KindNumericLiteral, text: "0"},
+		{typ: "boolean", kind: shimast.KindFalseKeyword, text: ""},
+		{typ: "bigint", kind: shimast.KindBigIntLiteral, text: "0n"},
+		{typ: "string", kind: shimast.KindStringLiteral, text: ""},
+	} {
+		seed := protobufDecodeProgrammer_write_property_default_value(protobufProgrammerAtomic(expected.typ), emit)
+		if seed == nil || seed.Kind != shimast.KindAsExpression {
+			t.Fatalf("protobuf %s default should be an as-expression", expected.typ)
+		}
+		inner := seed.Expression()
+		if inner == nil || inner.Kind != expected.kind {
+			t.Fatalf("protobuf %s default seeded the wrong node kind", expected.typ)
+		}
+		if expected.text != "" && inner.Text() != expected.text {
+			t.Fatalf("protobuf %s default seeded %q instead of %q", expected.typ, inner.Text(), expected.text)
+		}
+	}
 	if protobufDecodeProgrammer_write_object_function_body(protobufDecodeProgrammer_objectBodyProps{
 		Context: nativecontext.ITypiaContext{},
 		Condition: protobufDecodeProgrammer_factory.NewKeywordExpression(

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_absent_scalar_defaults.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_absent_scalar_defaults.ts
@@ -1,0 +1,148 @@
+import typia from "typia";
+
+/**
+ * Verifies a decoded absent required scalar takes its proto3 typed default for
+ * every scalar kind, not only `string`.
+ *
+ * In proto3 a singular scalar equal to its default is not written on the wire,
+ * so a conformant peer encodes an all-defaults message as the empty payload and
+ * an absent scalar must decode to its type default: `number -> 0`,
+ * `boolean -> false`, `bigint -> 0n`, `string -> ""`. typia seeded an absent
+ * required `number`/`boolean`/`bigint` with `undefined` instead, so `decode`
+ * returned `undefined` and every validating decoder threw `invalid type` on a
+ * valid peer message. The typia encoder writes every required non-nullable
+ * field unconditionally even at the default, so this never surfaced in a
+ * typia-only round-trip; the oracle here is a hand-built absent-field payload,
+ * not typia's own encode output.
+ *
+ * 1. Decode the empty payload for a message of required `number`, `boolean`,
+ *    `bigint`, and `string` through every direct and factory decoder, asserting
+ *    each field takes its typed default and every validating decoder accepts it.
+ * 2. Assert an absent optional scalar stays `undefined` and an absent nullable
+ *    scalar stays `null`, so the new seed touches only the required scalar case.
+ * 3. Assert a constrained scalar at the default is judged by its constraint on
+ *    the seeded `0`, the precise diagnostic, not an `invalid type` on `undefined`.
+ */
+export const test_protobuf_decode_absent_scalar_defaults = (): void => {
+  // an all-defaults proto3 message: a conformant peer omits every field equal
+  // to its scalar default, so the whole message serializes to no bytes at all
+  const empty: Uint8Array = new Uint8Array(0);
+
+  const decoders: Array<
+    readonly [string, (input: Uint8Array) => typia.Resolved<IScalars>]
+  > = [
+    ["decode", (input) => typia.protobuf.decode<IScalars>(input)],
+    ["createDecode", typia.protobuf.createDecode<IScalars>()],
+    ["assertDecode", (input) => typia.protobuf.assertDecode<IScalars>(input)],
+    ["createAssertDecode", typia.protobuf.createAssertDecode<IScalars>()],
+    [
+      "isDecode",
+      (input) => must("isDecode", typia.protobuf.isDecode<IScalars>(input)),
+    ],
+    [
+      "createIsDecode",
+      (
+        (closure) => (input: Uint8Array) =>
+          must("createIsDecode", closure(input))
+      )(typia.protobuf.createIsDecode<IScalars>()),
+    ],
+    [
+      "validateDecode",
+      (input) =>
+        unwrap("validateDecode", typia.protobuf.validateDecode<IScalars>(input)),
+    ],
+    [
+      "createValidateDecode",
+      (
+        (closure) => (input: Uint8Array) =>
+          unwrap("createValidateDecode", closure(input))
+      )(typia.protobuf.createValidateDecode<IScalars>()),
+    ],
+  ];
+  for (const [label, decode] of decoders) {
+    const value: typia.Resolved<IScalars> = decode(empty);
+    if (value.n !== 0)
+      throw new Error(
+        `${label}: absent required number seeded ${String(value.n)} instead of 0.`,
+      );
+    if (value.b !== false)
+      throw new Error(
+        `${label}: absent required boolean seeded ${String(value.b)} instead of false.`,
+      );
+    if (value.big !== 0n)
+      throw new Error(
+        `${label}: absent required bigint seeded ${String(value.big)} instead of 0n.`,
+      );
+    if (value.s !== "")
+      throw new Error(
+        `${label}: absent required string seeded ${JSON.stringify(value.s)} instead of "".`,
+      );
+  }
+
+  // an absent optional scalar has no presence, so it stays undefined
+  const optional: typia.Resolved<IOptional> =
+    typia.protobuf.decode<IOptional>(empty);
+  if (
+    optional.n !== undefined ||
+    optional.b !== undefined ||
+    optional.big !== undefined
+  )
+    throw new Error("an absent optional scalar was seeded a default value.");
+
+  // an absent nullable scalar decodes to null, never the scalar default
+  const nullable: typia.Resolved<INullable> =
+    typia.protobuf.decode<INullable>(empty);
+  if (nullable.n !== null)
+    throw new Error(
+      `an absent nullable scalar decoded to ${String(nullable.n)} instead of null.`,
+    );
+
+  // a constrained scalar at the default is the peer's out-of-spec value: it is
+  // judged by its constraint on the seeded 0, not reported as an invalid type
+  // on undefined
+  const constrained: typia.IValidation<IConstrained> =
+    typia.protobuf.validateDecode<IConstrained>(empty);
+  if (constrained.success !== false)
+    throw new Error("a constrained scalar at the default passed validation.");
+  const error: typia.IValidation.IError | undefined = constrained.errors.find(
+    (e) => e.path === "$input.value",
+  );
+  if (error === undefined)
+    throw new Error("the constrained scalar reported no validation error.");
+  if (error.value !== 0)
+    throw new Error(
+      `the constrained scalar was judged at ${String(error.value)} instead of the seeded default 0.`,
+    );
+};
+
+interface IScalars {
+  n: number;
+  b: boolean;
+  big: bigint;
+  s: string;
+}
+
+interface IOptional {
+  n?: number;
+  b?: boolean;
+  big?: bigint;
+}
+
+interface INullable {
+  n: number | null;
+}
+
+interface IConstrained {
+  value: number & typia.tags.Minimum<1>;
+}
+
+const must = <T>(label: string, value: T | null): T => {
+  if (value === null) throw new Error(`${label} rejected a valid payload.`);
+  return value;
+};
+
+const unwrap = <T>(label: string, result: typia.IValidation<T>): T => {
+  if (result.success === false)
+    throw new Error(`${label} rejected a valid payload.`);
+  return result.data;
+};


### PR DESCRIPTION
Fixes #2179.

## Problem

`typia.protobuf.decode` / `assertDecode` / `validateDecode` seed an absent **required** `number` / `boolean` / `bigint` field to `undefined` instead of its proto3 typed default (`0` / `false` / `0n`), while an absent required `string` already defaults to `""`. Decoding a valid, all-defaults proto3 message (what any conformant peer produces by omitting default-valued fields) then throws `invalid type`.

Owner: `protobufDecodeProgrammer_write_property_default_value` in `packages/typia/native/core/programmers/protobuf/ProtobufDecodeProgrammer.go`. The `string -> ""` branch is `hasStringDefault`; there was no numeric / boolean / bigint equivalent, so those kinds fell through to the final `else -> undefined`.

## Fix

Add a number -> `0`, boolean -> `false`, bigint -> `0n` (a `BigInt` literal, not `0`) branch beside the existing `string -> ""`, reading the atomic kind the same way `hasStringDefault` reads it. Optional stays `undefined`, nullable stays `null`, array stays `[]`, map stays `new Map`, native stays `Uint8Array`.

## Why it is safe

typia's encoder writes every required non-nullable field unconditionally, even at the scalar default, so typia<->typia traffic never omits the field: the seed is always overwritten and the decoded object is unchanged, and the encoder is untouched so the wire bytes are byte-identical. Only a peer encoder (Go/Java/Python/C++) omits a default-valued field, and for those `undefined -> typed default` is a pure loosening that aligns typia with proto3. A constrained scalar (e.g. `number & Minimum<1>`) at default `0` now fails validation with the correct, more precise `minimum` error instead of an `invalid type` error.

## Scope

- Native Go only. No `packages/typia/package.json` version bump (releases belong to the maintainer).
- Same file family as #2084 / #2090 / #2119 / #2135; the reader contracts there are unchanged (this touches only the default-value seed, not the reader).

Local verification and the fail-then-pass regression evidence are recorded as a comment after implementation.

Campaign implementation pull request: automatic CI is deliberately suspended and exact-SHA runs are cancelled per push under the campaign's CI-suspension policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
