### PR TITLE
fix(utils): align NamingConvention case converters with the notation contract (#2193)

### DIFF
--- a/packages/utils/src/utils/NamingConvention.ts
+++ b/packages/utils/src/utils/NamingConvention.ts
@@ -2,9 +2,14 @@
  * String naming convention converters.
  *
  * `NamingConvention` converts between common code naming conventions:
- * camelCase, PascalCase, and snake_case. Handles edge cases like consecutive
- * uppercase letters (e.g., `XMLParser` → `xml_parser`) and leading
- * underscores.
+ * camelCase, PascalCase, snake_case, and kebab-case. The four converters share
+ * the case-conversion contract of `typia.notations.*` and the `CamelCase<T>` /
+ * `PascalCase<T>` / `SnakeCase<T>` / `KebabCase<T>` typings, and are kept in
+ * step with them: each runs the case-boundary walk within every
+ * underscore-delimited segment (`fooBar_baz` → `foo_bar_baz`), lowercases the
+ * inner characters of an all-caps run (`MAX_COUNT` → `MaxCount` under pascal),
+ * collapses an acronym run (`XMLParser` → `xmlparser` under snake), and
+ * preserves leading underscores.
  *
  * Functions:
  *
@@ -24,16 +29,18 @@ export namespace NamingConvention {
    * @param str Input string
    * @returns CamelCase string
    */
-  export function camel(str: string) {
-    return unsnake({
+  export function camel(str: string): string {
+    return renameOuter({
+      // `CamelCase<T>` lowercases an all-caps key and otherwise lowercases only
+      // the first character of an underscore-free key (`HTTP` → `http`, `userID`
+      // stays).
       plain: (str) =>
-        str.length
-          ? str === str.toUpperCase()
-            ? str.toLocaleLowerCase()
-            : `${str[0]!.toLowerCase()}${str.substring(1)}`
-          : str,
-      snake: (str, i) =>
-        i === 0 ? str.toLowerCase() : capitalize(str.toLowerCase()),
+        str === str.toUpperCase()
+          ? str.toLowerCase()
+          : `${str[0]!.toLowerCase()}${str.substring(1)}`,
+      // With an underscore present, the character after each underscore is
+      // uppercased and the rest lowercased, matching `CamelizeSnakeString`.
+      snake: camelSnake,
     })(str);
   }
 
@@ -43,11 +50,14 @@ export namespace NamingConvention {
    * @param str Input string
    * @returns PascalCase string
    */
-  export function pascal(str: string) {
-    return unsnake({
-      plain: (str) =>
-        str.length ? `${str[0]!.toUpperCase()}${str.substring(1)}` : str,
-      snake: capitalize,
+  export function pascal(str: string): string {
+    return renameOuter({
+      // `PascalCase<T>` capitalizes the first character of an underscore-free
+      // key and keeps the rest verbatim (`userID` → `UserID`).
+      plain: (str) => `${str[0]!.toUpperCase()}${str.substring(1)}`,
+      // With an underscore present, each segment is capitalized and its tail is
+      // lowercased (`MAX_COUNT` → `MaxCount`), matching `PascalizeSnakeString`.
+      snake: pascalSnake,
     })(str);
   }
 
@@ -61,7 +71,6 @@ export namespace NamingConvention {
     if (str.length === 0) return str;
 
     // PREFIX
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let prefix: string = "";
     for (let i: number = 0; i < str.length; i++) {
       if (str[i] === "_") prefix += "_";
@@ -69,37 +78,14 @@ export namespace NamingConvention {
     }
     if (prefix.length !== 0) str = str.substring(prefix.length);
 
-    const out = (s: string) => `${prefix}${s}`;
-
     // SNAKE CASE
-    const items: string[] = str.split("_");
-    if (items.length > 1)
-      return out(items.map((s) => s.toLowerCase()).join("_"));
-
-    // CAMEL OR PASCAL CASE
-    const indexes: number[] = [];
-    for (let i: number = 0; i < str.length; i++) {
-      const code: number = str.charCodeAt(i);
-      if (65 <= code && code <= 90) indexes.push(i);
-    }
-    for (let i: number = indexes.length - 1; i > 0; --i) {
-      const now: number = indexes[i]!;
-      const prev: number = indexes[i - 1]!;
-      if (now - prev === 1) indexes.splice(i, 1);
-    }
-    if (indexes.length !== 0 && indexes[0] === 0) indexes.splice(0, 1);
-    if (indexes.length === 0) return out(str.toLowerCase());
-
-    let ret: string = "";
-    for (let i: number = 0; i < indexes.length; i++) {
-      const first: number = i === 0 ? 0 : indexes[i - 1]!;
-      const last: number = indexes[i]!;
-
-      ret += str.substring(first, last).toLowerCase();
-      ret += "_";
-    }
-    ret += str.substring(indexes[indexes.length - 1]!).toLowerCase();
-    return out(ret);
+    //
+    // Run the case-boundary walk within each underscore-delimited segment, not
+    // over the whole segment at once. Lowercasing a segment atomically would
+    // drop the camelCase boundary inside it (`["fooBar", "baz"]` →
+    // `["foobar", "baz"]` → `foobar_baz`), diverging from `SnakeCase<T>`; the
+    // per-segment walk keeps it (`["foo_bar", "baz"]` → `foo_bar_baz`).
+    return `${prefix}${str.split("_").map(snakeWord).join("_")}`;
   }
 
   /**
@@ -112,13 +98,13 @@ export namespace NamingConvention {
    * @returns Kebab-case string
    */
   export function kebab(str: string): string {
-    const snaked: string = snake(str);
+    let snaked: string = snake(str);
     let prefix: string = "";
-    for (let i: number = 0; i < snaked.length; i++) {
-      if (snaked[i] === "_") prefix += "_";
-      else break;
+    while (snaked.startsWith("_")) {
+      prefix += "_";
+      snaked = snaked.substring(1);
     }
-    return prefix + snaked.substring(prefix.length).split("_").join("-");
+    return `${prefix}${snaked.replaceAll("_", "-")}`;
   }
 
   /**
@@ -287,27 +273,101 @@ const RESTRICTED: Set<string> = new Set([
   ...STRICT_RESTRICTED_BINDINGS,
 ]);
 
-const unsnake =
+/**
+ * Shared outer walk for {@link NamingConvention.camel} and
+ * {@link NamingConvention.pascal}.
+ *
+ * Mirrors the `CamelCase<T>` / `PascalCase<T>` typings: leading underscores are
+ * preserved verbatim, an all-underscore key stays untouched, and the presence
+ * of any remaining underscore — not the number of non-empty segments — selects
+ * the `snake` conversion. Routing on underscore presence keeps a trailing or
+ * doubled underscore (`fooBar_`) on the same path the type takes, instead of
+ * collapsing it to the underscore-free `plain` path.
+ */
+const renameOuter =
   (props: {
     plain: (str: string) => string;
-    snake: (str: string, index: number) => string;
+    snake: (str: string) => string;
   }) =>
   (str: string): string => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let prefix: string = "";
-    for (let i: number = 0; i < str.length; i++) {
-      if (str[i] === "_") prefix += "_";
-      else break;
+    while (str.startsWith("_")) {
+      prefix += "_";
+      str = str.substring(1);
     }
-    if (prefix.length !== 0) str = str.substring(prefix.length);
-
-    const out = (s: string) => `${prefix}${s}`;
-    if (str.length === 0) return out("");
-
-    const items: string[] = str.split("_").filter((s) => s.length !== 0);
-    return items.length === 0
-      ? out("")
-      : items.length === 1
-        ? out(props.plain(items[0]!))
-        : out(items.map(props.snake).join(""));
+    if (str.length === 0) return prefix;
+    return `${prefix}${str.includes("_") ? props.snake(str) : props.plain(str)}`;
   };
+
+/**
+ * snake_case conversion of one underscore-free segment.
+ *
+ * Splits on case boundaries, collapsing an acronym run into a single word
+ * (`XMLParser` → `xmlparser`, `toHTML` → `to_html`).
+ */
+const snakeWord = (str: string): string => {
+  const indexes: number[] = [];
+  for (let i: number = 0; i < str.length; i++) {
+    const code: number = str.charCodeAt(i);
+    if (65 <= code && code <= 90) indexes.push(i);
+  }
+  for (let i: number = indexes.length - 1; i > 0; --i) {
+    const now: number = indexes[i]!;
+    const prev: number = indexes[i - 1]!;
+    if (now - prev === 1) indexes.splice(i, 1);
+  }
+  if (indexes.length !== 0 && indexes[0] === 0) indexes.splice(0, 1);
+  if (indexes.length === 0) return str.toLowerCase();
+
+  let ret: string = "";
+  for (let i: number = 0; i < indexes.length; i++) {
+    const first: number = i === 0 ? 0 : indexes[i - 1]!;
+    const last: number = indexes[i]!;
+
+    ret += str.substring(first, last).toLowerCase();
+    ret += "_";
+  }
+  ret += str.substring(indexes[indexes.length - 1]!).toLowerCase();
+  return ret;
+};
+
+/**
+ * camelCase conversion of a key that contains at least one underscore.
+ *
+ * Uppercases the character after each underscore and lowercases the rest,
+ * matching `CamelizeSnakeString`. A trailing underscore has no character to
+ * uppercase, so it falls through to lowercasing the whole key (`foo_` → `foo_`),
+ * and a doubled underscore collapses to a single one before continuing.
+ */
+const camelSnake = (str: string): string => {
+  while (str.startsWith("_")) str = str.substring(1);
+  if (str.length === 0) return "";
+  const index: number = str.indexOf("_");
+  if (index < 0) return str.toLowerCase();
+  const middle: string | undefined = str[index + 1];
+  if (middle === undefined) return str.toLowerCase();
+  return middle === "_"
+    ? camelSnake(`${str.substring(0, index)}_${str.substring(index + 2)}`)
+    : `${str
+        .substring(0, index)
+        .toLowerCase()}${middle.toUpperCase()}${camelSnake(
+        str.substring(index + 2),
+      )}`;
+};
+
+/**
+ * PascalCase conversion of a key that contains at least one underscore.
+ *
+ * Capitalizes each underscore-delimited segment and lowercases its tail
+ * (`MAX_COUNT` → `MaxCount`), matching `PascalizeSnakeString`.
+ */
+const pascalSnake = (str: string): string => {
+  while (str.startsWith("_")) str = str.substring(1);
+  if (str.length === 0) return "";
+  const index: number = str.indexOf("_");
+  return index < 0
+    ? `${str[0]!.toUpperCase()}${str.substring(1).toLowerCase()}`
+    : `${str[0]!.toUpperCase()}${str
+        .substring(1, index)
+        .toLowerCase()}${pascalSnake(str.substring(index + 1))}`;
+};

--- a/tests/test-utils/src/features/naming/test_naming_convention_camel.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_camel.ts
@@ -1,0 +1,49 @@
+import { TestValidator } from "@nestia/e2e";
+import { NamingConvention } from "@typia/utils";
+
+/**
+ * Verifies NamingConvention.camel derives camelCase names.
+ *
+ * The camel derivation drives the `typia.notations.camel` transform and the
+ * `CamelCase<T>` typing, so this utility must stay byte-identical to that
+ * contract. Issue #2193: on a key mixing an underscore with a case boundary the
+ * converter filtered empty segments and routed a trailing underscore onto the
+ * underscore-free path, so `fooBar_` collapsed to `fooBar` instead of the
+ * `CamelCase<T>` result `foobar_`. The character after each underscore must be
+ * uppercased and the rest of every segment lowercased, while a trailing or
+ * doubled underscore stays on the snake path.
+ *
+ * 1. Convert camelCase, PascalCase, and snake_case inputs.
+ * 2. Convert underscore-plus-case-boundary, all-caps, and trailing-underscore
+ *    keys (#2193), including the `a_b_c` single-char-middle asymmetry.
+ * 3. Convert degenerate inputs (empty, underscores only, single word).
+ */
+export const test_naming_convention_camel = (): void => {
+  const expectations: [string, string][] = [
+    ["userId", "userId"],
+    ["UserId", "userId"],
+    ["user_name", "userName"],
+    ["_privateValue", "_privateValue"],
+    ["__doublePrefix", "__doublePrefix"],
+    ["HTTP", "http"],
+    // underscore-plus-case-boundary, all-caps, and trailing-underscore (#2193)
+    ["fooBar_baz", "foobarBaz"],
+    ["openAI_key", "openaiKey"],
+    ["HTTP_fooBar", "httpFoobar"],
+    ["fooBar", "fooBar"],
+    ["fooBar_", "foobar_"],
+    ["_fooBar", "_fooBar"],
+    ["userID", "userID"],
+    ["a_b_c", "aBc"],
+    ["MAX_COUNT", "maxCount"],
+    ["", ""],
+    ["___", "___"],
+    ["word", "word"],
+  ];
+  for (const [input, expected] of expectations)
+    TestValidator.equals(
+      `camel(${JSON.stringify(input)})`,
+      NamingConvention.camel(input),
+      expected,
+    );
+};

--- a/tests/test-utils/src/features/naming/test_naming_convention_kebab.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_kebab.ts
@@ -9,11 +9,15 @@ import { NamingConvention } from "@typia/utils";
  * drives the `typia.notations.kebab` transform and the `KebabCase<T>` typing,
  * so this utility must stay byte-identical to that contract — including the
  * acronym-run collapse the snake derivation performs and the leading-underscore
- * preservation on inputs without word separation (#1926).
+ * preservation on inputs without word separation (#1926). Issue #2193: because
+ * the snake derivation lowercased each underscore-delimited segment atomically,
+ * an underscore-plus-case-boundary key (`fooBar_baz`) produced `foobar-baz`
+ * rather than the `KebabCase<T>` result `foo-bar-baz`.
  *
  * 1. Convert camelCase, PascalCase, and snake_case inputs.
  * 2. Convert leading-underscore and acronym-run inputs.
- * 3. Convert degenerate inputs (empty, underscores only, single word).
+ * 3. Convert underscore-plus-case-boundary and all-caps keys (#2193).
+ * 4. Convert degenerate inputs (empty, underscores only, single word).
  */
 export const test_naming_convention_kebab = (): void => {
   const expectations: [string, string][] = [
@@ -25,6 +29,14 @@ export const test_naming_convention_kebab = (): void => {
     ["XMLParser", "xmlparser"],
     ["toHTML", "to-html"],
     ["already-plain", "already-plain"],
+    // underscore-plus-case-boundary and all-caps keys (#2193)
+    ["fooBar_baz", "foo-bar-baz"],
+    ["openAI_key", "open-ai-key"],
+    ["HTTP_fooBar", "http-foo-bar"],
+    ["fooBar_", "foo-bar-"],
+    ["_fooBar", "_foo-bar"],
+    ["MAX_COUNT", "max-count"],
+    ["a_b_c", "a-b-c"],
     ["", ""],
     ["___", "___"],
     ["_solo", "_solo"],

--- a/tests/test-utils/src/features/naming/test_naming_convention_notation_parity.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_notation_parity.ts
@@ -1,0 +1,79 @@
+import { TestValidator } from "@nestia/e2e";
+import { NamingConvention } from "@typia/utils";
+import typia from "typia";
+
+/**
+ * Verifies NamingConvention's converters equal `typia.notations.*` per key.
+ *
+ * `NamingConvention.{snake,kebab,camel,pascal}` is a third, independent copy of
+ * the case-conversion contract owned by `typia.notations.*` and the `*Case<T>`
+ * types. It drifted: on a key mixing an underscore with an internal case
+ * boundary the snake/kebab copy lowercased each underscore-delimited segment
+ * atomically (`fooBar_baz` -> `foobar_baz`) and the pascal copy dropped the
+ * inner-character lowercasing of an all-caps run (`MAX_COUNT` -> `MAXCOUNT`),
+ * both diverging from the notation contract (#2186, #2190). This asserts the two
+ * producers agree over the exact #2190 witness matrix by comparing each
+ * `NamingConvention` output to the live `typia.notations.*` conversion of the
+ * same key, so the copy can never silently diverge from the contract again.
+ *
+ * 1. Convert a witness object of underscore-boundary, all-caps, and plain keys
+ *    through each `typia.notations.*` transform and read the produced key list.
+ * 2. Convert every source key through the matching `NamingConvention` helper.
+ * 3. Require each helper output to equal the notation-produced key.
+ */
+export const test_naming_convention_notation_parity = (): void => {
+  // The #2190 witness matrix: keys mixing an underscore with a case boundary,
+  // trailing and leading underscores, an acronym run, and a plain camelCase key.
+  const witness = {
+    fooBar_baz: 0,
+    openAI_key: 0,
+    HTTP_fooBar: 0,
+    fooBar: 0,
+    fooBar_: 0,
+    _fooBar: 0,
+    userID: 0,
+    a_b_c: 0,
+    MAX_COUNT: 0,
+  };
+  const inputs: string[] = Object.keys(witness);
+
+  // `typia.notations.*` builds the destination object by walking the source
+  // keys in declaration order, so its produced key list aligns index-by-index
+  // with `Object.keys(witness)`. That makes the notation output the oracle each
+  // `NamingConvention` helper must reproduce for the same key.
+  const check = (
+    label: string,
+    convention: (str: string) => string,
+    produced: string[],
+  ): void => {
+    TestValidator.equals(`${label} key count`, produced.length, inputs.length);
+    inputs.forEach((key, i) =>
+      TestValidator.equals(
+        `${label}(${JSON.stringify(key)})`,
+        convention(key),
+        produced[i]!,
+      ),
+    );
+  };
+
+  check(
+    "snake",
+    NamingConvention.snake,
+    Object.keys(typia.notations.snake(witness)),
+  );
+  check(
+    "kebab",
+    NamingConvention.kebab,
+    Object.keys(typia.notations.kebab(witness)),
+  );
+  check(
+    "camel",
+    NamingConvention.camel,
+    Object.keys(typia.notations.camel(witness)),
+  );
+  check(
+    "pascal",
+    NamingConvention.pascal,
+    Object.keys(typia.notations.pascal(witness)),
+  );
+};

--- a/tests/test-utils/src/features/naming/test_naming_convention_pascal.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_pascal.ts
@@ -1,0 +1,49 @@
+import { TestValidator } from "@nestia/e2e";
+import { NamingConvention } from "@typia/utils";
+
+/**
+ * Verifies NamingConvention.pascal derives PascalCase names.
+ *
+ * The pascal derivation drives the `typia.notations.pascal` transform and the
+ * `PascalCase<T>` typing, so this utility must stay byte-identical to that
+ * contract. Issue #2186/#2193: the converter capitalized each underscore
+ * segment without lowercasing its inner characters, so an all-caps key
+ * (`MAX_COUNT`) produced `MAXCOUNT` and an underscore-plus-case-boundary key
+ * (`fooBar_baz`) kept its inner boundary as `FooBarBaz`, both diverging from the
+ * `PascalCase<T>` results `MaxCount` and `FoobarBaz`. Each segment's first
+ * character is uppercased and its tail lowercased, while a trailing underscore
+ * is dropped (`fooBar_` → `Foobar`) — the asymmetry against camelCase.
+ *
+ * 1. Convert camelCase, PascalCase, and snake_case inputs.
+ * 2. Convert underscore-plus-case-boundary, all-caps, and trailing-underscore
+ *    keys (#2186/#2193), including the `a_b_c` single-char-segment run.
+ * 3. Convert degenerate inputs (empty, underscores only, single word).
+ */
+export const test_naming_convention_pascal = (): void => {
+  const expectations: [string, string][] = [
+    ["userId", "UserId"],
+    ["UserId", "UserId"],
+    ["user_name", "UserName"],
+    ["_privateValue", "_PrivateValue"],
+    ["__doublePrefix", "__DoublePrefix"],
+    // underscore-plus-case-boundary, all-caps, and trailing-underscore (#2193)
+    ["fooBar_baz", "FoobarBaz"],
+    ["openAI_key", "OpenaiKey"],
+    ["HTTP_fooBar", "HttpFoobar"],
+    ["fooBar", "FooBar"],
+    ["fooBar_", "Foobar"],
+    ["_fooBar", "_FooBar"],
+    ["userID", "UserID"],
+    ["a_b_c", "ABC"],
+    ["MAX_COUNT", "MaxCount"],
+    ["", ""],
+    ["___", "___"],
+    ["word", "Word"],
+  ];
+  for (const [input, expected] of expectations)
+    TestValidator.equals(
+      `pascal(${JSON.stringify(input)})`,
+      NamingConvention.pascal(input),
+      expected,
+    );
+};

--- a/tests/test-utils/src/features/naming/test_naming_convention_snake.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_snake.ts
@@ -8,11 +8,16 @@ import { NamingConvention } from "@typia/utils";
  * `SnakeCase<T>` typing, so this utility must stay byte-identical to that
  * contract. Issue #1926: the no-word-separation fallback used to drop the
  * leading underscores (`snake("_foo")` returned `"foo"`) while the typing
- * preserves them — the prefix must survive on every path.
+ * preserves them — the prefix must survive on every path. Issue #2193: on a key
+ * mixing an underscore with an internal case boundary (`fooBar_baz`) the
+ * converter lowercased each underscore-delimited segment atomically and
+ * produced `foobar_baz`, dropping the camelCase boundary and diverging from
+ * `SnakeCase<T>` (`foo_bar_baz`); the walk must run within each segment.
  *
  * 1. Convert camelCase, PascalCase, and snake_case inputs.
  * 2. Convert leading-underscore inputs with and without word separation.
- * 3. Convert degenerate inputs (empty, underscores only, acronym runs).
+ * 3. Convert underscore-plus-case-boundary and all-caps keys (#2193).
+ * 4. Convert degenerate inputs (empty, underscores only, acronym runs).
  */
 export const test_naming_convention_snake = (): void => {
   const expectations: [string, string][] = [
@@ -26,6 +31,15 @@ export const test_naming_convention_snake = (): void => {
     ["___", "___"],
     ["XMLParser", "xmlparser"],
     ["toHTML", "to_html"],
+    // underscore-plus-case-boundary and all-caps keys (#2193)
+    ["fooBar_baz", "foo_bar_baz"],
+    ["openAI_key", "open_ai_key"],
+    ["HTTP_fooBar", "http_foo_bar"],
+    ["fooBar_", "foo_bar_"],
+    ["_fooBar", "_foo_bar"],
+    ["userID", "user_id"],
+    ["a_b_c", "a_b_c"],
+    ["MAX_COUNT", "max_count"],
     ["", ""],
     ["word", "word"],
   ];


### PR DESCRIPTION
Fixes #2193.

## Intent

`@typia/utils`' `NamingConvention` (`packages/utils/src/utils/NamingConvention.ts`) was a third, independent copy of the case-conversion contract that #2186 and PR #2191 (issue #2190) fixed in the notation helpers and their Go twins — and it still carried both bugs:

- `NamingConvention.snake("fooBar_baz")` → `"foobar_baz"` (should be `"foo_bar_baz"`)
- `NamingConvention.pascal("MAX_COUNT")` → `"MAXCOUNT"` (should be `"MaxCount"`)

The invariant: `NamingConvention.{snake,kebab,camel,pascal}` must produce the same result as `typia.notations.*` and the `*Case<T>` types. There should not be a third divergent copy.

## Scope

- `@typia/utils` only. Ports the #2186 / #2191 (issue #2190) case-boundary fixes into `NamingConvention` exactly, mirroring the now-correct `_notationSnake`/`_notationCamel`/`_notationPascal`/`_notationKebab` per-segment walk. Sharing the implementation across the package boundary is impractical — `@typia/utils` depends only on `@typia/interface`, and the notation runtime helpers are internal to the `typia` package (not exported) — so the issue's fallback (port exactly + assert equivalence in a test) applies.
- Updates the existing `NamingConvention` tests that pinned the buggy "byte-identical" values, and adds a regression test that asserts `NamingConvention.{snake,kebab,camel,pascal}` equals `typia.notations.*` over the #2190 matrix.
- No `packages/interface/src` change (the `*Case<T>` types are the authority). No `packages/typia/package.json` version bump.

## Verification

Local (draft; will be filled in on the implementation push):

- `pnpm --filter ./tests/test-utils start`
- `pnpm --filter ./tests/test-typia-schema start`

## Campaign

Issue-campaign implementation PR. Automatic CI for campaign commits is cancelled per the exact-SHA gate; local verification is the gate. No repository Actions or workflow settings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
