### PR TITLE
fix(native): make json.application report a malformed function property instead of dropping it (#2195)

### DIFF
--- a/packages/typia/native/core/programmers/json/JsonApplicationProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonApplicationProgrammer.go
@@ -54,16 +54,18 @@ func (jsonApplicationProgrammerNamespace) Validate(props struct {
       value := p.Value
       if len(value.Functions) != 0 {
         least = true
-        if valid == false {
-          if len(value.Functions) != 1 || value.Size() != 1 {
-            output = append(output, "JSON application's function type does not allow union type.")
-          }
-          if value.IsRequired() == false {
-            output = append(output, "JSON application's function type must be required.")
-          }
-          if value.Nullable == true {
-            output = append(output, "JSON application's function type must not be nullable.")
-          }
+        // These per-function shape checks must run for every function
+        // property, independent of the top-level `valid`: otherwise a
+        // malformed function (union/optional/nullable) is silently dropped by
+        // WriteApplication with no diagnostic at all (issue #2195).
+        if len(value.Functions) != 1 || value.Size() != 1 {
+          output = append(output, "JSON application's function type does not allow union type.")
+        }
+        if value.IsRequired() == false {
+          output = append(output, "JSON application's function type must be required.")
+        }
+        if value.Nullable == true {
+          output = append(output, "JSON application's function type must not be nullable.")
         }
       }
     }

--- a/packages/typia/native/core/programmers/llm/LlmApplicationProgrammer.go
+++ b/packages/typia/native/core/programmers/llm/LlmApplicationProgrammer.go
@@ -139,16 +139,18 @@ func (llmApplicationProgrammerNamespace) Validate(props struct {
       }
       least = true
       name := fmt.Sprintf("%q", *rawName)
-      if isValidType == false {
-        if len(value.Functions) != 1 || value.Size() != 1 {
-          output = append(output, "LLM application's function ("+name+") type does not allow union type.")
-        }
-        if value.IsRequired() == false {
-          output = append(output, "LLM application's function ("+name+") type must be required.")
-        }
-        if value.Nullable {
-          output = append(output, "LLM application's function ("+name+") type must not be nullable.")
-        }
+      // These per-function shape checks must run for every function property,
+      // independent of the top-level `isValidType`: otherwise a malformed
+      // function (union/optional/nullable) is silently dropped by
+      // WriteApplication with no diagnostic at all (issue #2195).
+      if len(value.Functions) != 1 || value.Size() != 1 {
+        output = append(output, "LLM application's function ("+name+") type does not allow union type.")
+      }
+      if value.IsRequired() == false {
+        output = append(output, "LLM application's function ("+name+") type must be required.")
+      }
+      if value.Nullable {
+        output = append(output, "LLM application's function ("+name+") type must not be nullable.")
       }
       prefix := "LLM application's function (" + name + ")"
       output = append(output, llmApplicationProgrammer_validateName(prefix, *rawName)...)

--- a/tests/test-error/src/json/json.application.nullable.ts
+++ b/tests/test-error/src/json/json.application.nullable.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+// A NULLABLE FUNCTION PROPERTY MUST BE REJECTED, NOT SILENTLY DROPPED
+typia.json.application<{
+  good(): number;
+  bad: (() => number) | null;
+}>();

--- a/tests/test-error/src/json/json.application.optional.ts
+++ b/tests/test-error/src/json/json.application.optional.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+// AN OPTIONAL FUNCTION PROPERTY MUST BE REJECTED, NOT SILENTLY DROPPED
+typia.json.application<{
+  good(): number;
+  bad?(): number;
+}>();

--- a/tests/test-error/src/json/json.application.union.ts
+++ b/tests/test-error/src/json/json.application.union.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+// A UNION-OF-FUNCTIONS PROPERTY MUST BE REJECTED, NOT SILENTLY DROPPED
+typia.json.application<{
+  good(): number;
+  bad: (() => number) | ((value: number) => string);
+}>();

--- a/tests/test-error/src/llm/llm.application.nullable.ts
+++ b/tests/test-error/src/llm/llm.application.nullable.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+// A NULLABLE FUNCTION PROPERTY MUST BE REJECTED, NOT SILENTLY DROPPED
+typia.llm.application<{
+  good(p: { value: string }): void;
+  bad: ((p: { value: string }) => void) | null;
+}>();

--- a/tests/test-error/src/llm/llm.application.optional.ts
+++ b/tests/test-error/src/llm/llm.application.optional.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+// AN OPTIONAL FUNCTION PROPERTY MUST BE REJECTED, NOT SILENTLY DROPPED
+typia.llm.application<{
+  good(p: { value: string }): void;
+  bad?(p: { value: string }): void;
+}>();

--- a/tests/test-error/src/llm/llm.application.union.ts
+++ b/tests/test-error/src/llm/llm.application.union.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+// A UNION-OF-FUNCTIONS PROPERTY MUST BE REJECTED, NOT SILENTLY DROPPED
+typia.llm.application<{
+  good(p: { value: string }): void;
+  bad: ((p: { value: string }) => void) | ((p: { flag: boolean }) => void);
+}>();


### PR DESCRIPTION
## Issue

Closes #2195.

`typia.json.application<T>()` silently **dropped** any function property that was optional, nullable, or a union-of-functions. The three diagnostics written for exactly those shapes never ran.

```ts
interface App {
  good(): number;
  bad?(): number; // silently omitted from `functions`, no error
}
typia.json.application<App>(); // -> functions: ["good"]
```

## Root cause

In `JsonApplicationProgrammer.Validate` the per-function `union / required / nullable` checks were wrapped in `if valid == false`. `valid` is computed from the **top** metadata alone (is the application itself a single required non-nullable object). For a normal, otherwise-valid application `valid == true`, so those three checks were **dead code**. `WriteApplication` then silently `continue`d over any property that was not a sole-literal, single, required, non-nullable, single function — so the malformed member vanished with no diagnostic.

## Fix

Remove the inner `if valid == false` gate so the per-function shape checks run for **every** function property, independent of the top-level `valid`. A malformed function property now fails validation with a clear message instead of being silently dropped. The top-level "must be a class/interface type" gate is untouched. The now-unreachable silent `continue` in `WriteApplication` is left as defense in depth.

### Sibling: `LlmApplicationProgrammer`

`LlmApplicationProgrammer.Validate` carried the byte-identical `if isValidType == false` gate. It was **reproduced** (via `test-error` probes) to silently drop a malformed function property with no diagnostic too, so the same unwrap is applied there.

## Tests

Six new `tests/test-error` fixtures (optional / nullable / union-of-functions, for both `json.application` and `llm.application`). Each produced **no** diagnostic before the fix (silent drop, red) and now asserts its exact message.

- `test-error`: green — 72 files, 867 typia diagnostics (all 6 new fixtures named)
- native Go `json` + `llm` programmer/transformer tests: pass
- `test-typia-schema` (171 cases) and `test-mcp` (20 cases): pass — no valid application regressed

No version bump. No `@typia/interface` shape edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy