### PR TITLE
fix(native): make is honor the finite option so assert and validate reject NaN and Infinity (#2196)

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/finite_option_number_leaf_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/finite_option_number_leaf_transform_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+  "fmt"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestFiniteOptionNumberLeafTransform pins the finite/numeric option matrix for a
+// bare `number` leaf across typia.is, typia.assert, and typia.validate (#2196).
+//
+// The `finite` option is documented as an independent flag that rejects both NaN
+// and Infinity, yet it was inert unless `numeric` was also set: typia.is dropped
+// `finite` when it built its number gate, and assert/validate gate their verdict
+// on that same is-checker, so all three accepted NaN and Infinity under
+// `finite:true` alone. The other three rows are regression guards that must not
+// move:
+//
+//   - finite alone   -> reject NaN, Infinity, -Infinity (the #2196 red case)
+//   - numeric alone  -> reject NaN, ACCEPT Infinity/-Infinity (numeric != finite)
+//   - finite+numeric -> reject NaN, Infinity, -Infinity (already worked)
+//   - neither option -> ACCEPT everything (the documented default)
+//
+//  1. Transform the same `number`-leaf fixture once per option row, injecting the
+//     row's options through the resolved --plugins-json payload (the only option
+//     source runTransform reads).
+//  2. Execute the emitted validators in Node against a finite value plus NaN,
+//     Infinity, and -Infinity, requiring is/assert/validate to agree with the row.
+//  3. Require the runner to report the exact executed case count so a runner that
+//     silently exercised nothing cannot pass as green.
+func TestFiniteOptionNumberLeafTransform(t *testing.T) {
+  for _, tc := range finiteOptionNumberLeafCases() {
+    t.Run(tc.name, func(t *testing.T) {
+      project := finiteOptionNumberLeafProject(t)
+      js := finiteOptionNumberLeafTransform(t, project, tc.payload())
+      finiteOptionNumberLeafRunRuntimeCases(t, project, js, tc)
+    })
+  }
+}
+
+type finiteOptionNumberLeafCase struct {
+  name string
+  // config is the JSON fragment appended to typia's resolved plugin entry, e.g.
+  // `,"finite":true`. Empty means typia's documented defaults.
+  config string
+  // acceptNaN and acceptInfinity are the expected verdicts for the non-finite
+  // inputs; a finite value is always accepted.
+  acceptNaN      bool
+  acceptInfinity bool
+}
+
+func (tc finiteOptionNumberLeafCase) payload() string {
+  return `[{"config":{"transform":"typia/lib/transform"` + tc.config + `},"name":"typia","stage":"transform"}]`
+}
+
+func finiteOptionNumberLeafCases() []finiteOptionNumberLeafCase {
+  return []finiteOptionNumberLeafCase{
+    {
+      name:           "finite alone rejects NaN and Infinity",
+      config:         `,"finite":true`,
+      acceptNaN:      false,
+      acceptInfinity: false,
+    },
+    {
+      name:           "numeric alone rejects NaN but accepts Infinity",
+      config:         `,"numeric":true`,
+      acceptNaN:      false,
+      acceptInfinity: true,
+    },
+    {
+      name:           "finite and numeric together reject NaN and Infinity",
+      config:         `,"finite":true,"numeric":true`,
+      acceptNaN:      false,
+      acceptInfinity: false,
+    },
+    {
+      name:           "neither option accepts NaN and Infinity",
+      config:         ``,
+      acceptNaN:      true,
+      acceptInfinity: true,
+    },
+  }
+}
+
+func finiteOptionNumberLeafProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "finite-option-number-leaf-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(finiteOptionNumberLeafTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(finiteOptionNumberLeafSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func finiteOptionNumberLeafTransform(t *testing.T, project string, payload string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+      "--plugins-json", payload,
+    })
+  })
+  if code != 0 {
+    t.Fatalf("finite option transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func finiteOptionNumberLeafRunRuntimeCases(t *testing.T, project string, js string, tc finiteOptionNumberLeafCase) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(finiteOptionNumberLeafRuntimeRunner(tc)), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = project
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("finite option runtime cases failed: %v\n%s", err, output)
+  }
+  // Every input drives is, validate, and assert, so the runner must report one
+  // executed assertion per (input, function) pair. Pinning the count keeps a
+  // runner that short-circuited or skipped cases from passing as a false green.
+  const expected = "RAN 12 CASES"
+  if !strings.Contains(string(output), expected) {
+    t.Fatalf("finite option runner did not report %q; got:\n%s", expected, output)
+  }
+}
+
+func finiteOptionNumberLeafRuntimeRunner(tc finiteOptionNumberLeafCase) string {
+  return fmt.Sprintf(`const mod = require("./main.cjs");
+
+const cases = [
+  { name: "finite 1", value: 1, accept: true },
+  { name: "NaN", value: Number.NaN, accept: %[1]t },
+  { name: "Infinity", value: Number.POSITIVE_INFINITY, accept: %[2]t },
+  { name: "-Infinity", value: Number.NEGATIVE_INFINITY, accept: %[2]t },
+];
+
+let ran = 0;
+for (const c of cases) {
+  const result = mod.run(c.value);
+
+  ran += 1;
+  if (result.is !== c.accept) {
+    throw new Error(c.name + ": typia.is expected " + c.accept + " but got " + result.is);
+  }
+
+  ran += 1;
+  if (result.validate !== c.accept) {
+    throw new Error(c.name + ": typia.validate.success expected " + c.accept + " but got " + result.validate);
+  }
+
+  ran += 1;
+  const assertAccepted = result.assertThrew === false;
+  if (assertAccepted !== c.accept) {
+    throw new Error(c.name + ": typia.assert accepted=" + assertAccepted + " but expected " + c.accept);
+  }
+}
+
+console.log("RAN " + ran + " CASES");
+`, tc.acceptNaN, tc.acceptInfinity)
+}
+
+const finiteOptionNumberLeafTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const finiteOptionNumberLeafSource = `import typia from "typia";
+
+interface FiniteBox {
+  value: number;
+}
+
+const check = typia.createIs<FiniteBox>();
+const validate = typia.createValidate<FiniteBox>();
+const assert = typia.createAssert<FiniteBox>();
+
+const captureThrow = (task: () => void): boolean => {
+  try {
+    task();
+    return false;
+  } catch {
+    return true;
+  }
+};
+
+export const run = (value: number) => ({
+  is: check({ value }),
+  validate: validate({ value }).success,
+  assertThrew: captureThrow(() => assert({ value })),
+});
+`

--- a/packages/typia/native/cmd/ttsc-typia/json_is_stringify_finite_number_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_is_stringify_finite_number_transform_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestJsonIsStringifyFiniteNumberTransform pins json.isStringify against a bare
+// number leaf so a non-finite value cannot leak into the serialized text (#2196).
+//
+// json.isStringify forces Options.Finite on its inner `__is` guard precisely to
+// keep NaN and Infinity out of JSON. Because `is` dropped `finite`, that guard
+// accepted NaN, so `__is(input) ? __stringify(input) : null` serialized the input
+// instead of returning the top-level null it owes an invalid value. Both option
+// rows reproduce a distinct failure the fix must close:
+//
+//   - default options: the validated stringify folds the number through
+//     _jsonStringifyNumber, so NaN silently became `{"value":null}` -- an accepted
+//     invalid input rather than a rejected one.
+//   - finite:true: the validated stringify emits raw `String(input)` for the
+//     number, so NaN became the literal `{"value":NaN}` token -- invalid JSON that
+//     JSON.parse throws on. This is the corruption hole the guard closes.
+//
+//  1. Transform a `json.isStringify<{ value: number }>` fixture per option row.
+//  2. Execute the emitted serializer in Node.
+//  3. Require a finite value to serialize and NaN/Infinity/-Infinity to yield null.
+func TestJsonIsStringifyFiniteNumberTransform(t *testing.T) {
+  for _, tc := range jsonIsStringifyFiniteNumberCases() {
+    t.Run(tc.name, func(t *testing.T) {
+      project := jsonIsStringifyFiniteNumberProject(t)
+      js := jsonIsStringifyFiniteNumberTransform(t, project, tc.payload)
+      jsonIsStringifyFiniteNumberRunRuntime(t, project, js)
+    })
+  }
+}
+
+type jsonIsStringifyFiniteNumberCase struct {
+  name    string
+  payload string
+}
+
+func jsonIsStringifyFiniteNumberCases() []jsonIsStringifyFiniteNumberCase {
+  return []jsonIsStringifyFiniteNumberCase{
+    {
+      name:    "default options",
+      payload: `[{"config":{"transform":"typia/lib/transform"},"name":"typia","stage":"transform"}]`,
+    },
+    {
+      name:    "finite option on",
+      payload: `[{"config":{"transform":"typia/lib/transform","finite":true},"name":"typia","stage":"transform"}]`,
+    },
+  }
+}
+
+func jsonIsStringifyFiniteNumberProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "json-is-stringify-finite-number-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(jsonIsStringifyFiniteNumberTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonIsStringifyFiniteNumberSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func jsonIsStringifyFiniteNumberTransform(t *testing.T, project string, payload string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+      "--plugins-json", payload,
+    })
+  })
+  if code != 0 {
+    t.Fatalf("json isStringify finite transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func jsonIsStringifyFiniteNumberRunRuntime(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  stubs := map[string]string{
+    "json-stringify-number-stub.cjs":  jsonIsStringifyScopedCheckerNumberStub,
+    "json-stringify-string-stub.cjs":  jsonIsStringifyScopedCheckerStringStub,
+    "throw-type-guard-error-stub.cjs": jsonIsStringifyScopedCheckerThrowStub,
+  }
+  for name, content := range stubs {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  runtimeJS := strings.ReplaceAll(js, `require("typia/lib/internal/_jsonStringifyNumber")`, `require("./json-stringify-number-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyString")`, `require("./json-stringify-string-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
+  runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(jsonIsStringifyFiniteNumberRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("json isStringify finite runtime failed: %v\n%s", err, output)
+  }
+  const expected = "RAN 4 CASES"
+  if !strings.Contains(string(output), expected) {
+    t.Fatalf("json isStringify finite runner did not report %q; got:\n%s", expected, output)
+  }
+}
+
+const jsonIsStringifyFiniteNumberTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const jsonIsStringifyFiniteNumberSource = `import typia from "typia";
+
+interface Box {
+  value: number;
+}
+
+export const stringify = (input: unknown): string | null =>
+  typia.json.isStringify<Box>(input);
+`
+
+const jsonIsStringifyFiniteNumberRunner = `const mod = require("./main.cjs");
+
+const finite = mod.stringify({ value: 1 });
+if (finite === null) {
+  throw new Error("json.isStringify rejected a finite number");
+}
+const parsed = JSON.parse(finite);
+if (parsed.value !== 1) {
+  throw new Error("json.isStringify serialized the wrong value: " + finite);
+}
+
+let ran = 1;
+for (const [name, value] of [
+  ["NaN", Number.NaN],
+  ["Infinity", Number.POSITIVE_INFINITY],
+  ["-Infinity", Number.NEGATIVE_INFINITY],
+]) {
+  const out = mod.stringify({ value });
+  ran += 1;
+  if (out !== null) {
+    throw new Error(
+      name + " leaked into json.isStringify output instead of null: " + JSON.stringify(out),
+    );
+  }
+}
+
+console.log("RAN " + ran + " CASES");
+`

--- a/packages/typia/native/cmd/ttsc-typia/protobuf_is_encode_finite_number_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/protobuf_is_encode_finite_number_transform_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestProtobufIsEncodeFiniteNumberTransform pins protobuf.isEncode against a bare
+// number leaf so a non-finite value cannot be encoded into the message (#2196).
+//
+// protobuf.isEncode forces Options.Finite on its inner `__is` guard, then emits
+// `__is(input) ? __encode(input) : null`. A protobuf double can hold NaN and
+// Infinity, so the guard is the only thing keeping them out of the wire. While
+// `is` dropped `finite`, that guard accepted NaN and the encoder wrote it; the
+// guard must now carry Number.isFinite on the number leaf. Because isEncode has no
+// separate error-path checker, the guard is the sole place the number leaf's
+// finite check can appear, so its presence in the emit is an unambiguous oracle.
+//
+//  1. Transform a `protobuf.isEncode<{ value: number }>` fixture with default options.
+//  2. Assert the emitted `__is` guards the number leaf with Number.isFinite.
+func TestProtobufIsEncodeFiniteNumberTransform(t *testing.T) {
+  project := protobufIsEncodeFiniteNumberProject(t)
+  js := protobufIsEncodeFiniteNumberTransform(t, project)
+  needle := "Number.isFinite(input.value)"
+  if !strings.Contains(js, needle) {
+    t.Fatalf("protobuf.isEncode did not guard the number leaf with %q:\n%s", needle, js)
+  }
+}
+
+func protobufIsEncodeFiniteNumberProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "protobuf-is-encode-finite-number-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(protobufIsEncodeFiniteNumberTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(protobufIsEncodeFiniteNumberSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func protobufIsEncodeFiniteNumberTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("protobuf isEncode finite transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+const protobufIsEncodeFiniteNumberTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const protobufIsEncodeFiniteNumberSource = `import typia from "typia";
+
+interface Box {
+  value: number;
+}
+
+export const encode = (input: unknown): Uint8Array | null =>
+  typia.protobuf.isEncode<Box>(input);
+`

--- a/packages/typia/native/core/programmers/IsProgrammer.go
+++ b/packages/typia/native/core/programmers/IsProgrammer.go
@@ -18,6 +18,7 @@ var IsProgrammer = isProgrammerNamespace{}
 
 type IsProgrammer_CONFIG_IOptions struct {
   Numeric   *bool
+  Finite    *bool
   Undefined *bool
   Object    func(props IsProgrammer_CONFIG_IOptions_ObjectProps) *shimast.Node
 }
@@ -182,6 +183,7 @@ func (isProgrammerNamespace) Decompose(props IsProgrammer_DecomposeProps) native
   f := nativecontext.EmitFactoryOf(isProgrammer_factory, props.Context.Emit)
   options := &IsProgrammer_CONFIG_IOptions{
     Numeric: props.Context.Options.Numeric,
+    Finite:  props.Context.Options.Finite,
     Object: func(v IsProgrammer_CONFIG_IOptions_ObjectProps) *shimast.Node {
       return nativeiterate.Check_object(nativeiterate.Check_objectProps{
         Config: nativeiterate.Check_object_IConfig{
@@ -397,8 +399,20 @@ func isProgrammer_binary(left *shimast.Expression, operator shimast.Kind, right 
   )
 }
 
+// isProgrammer_option_numeric reports whether the number leaf gate must be
+// emitted at all. It opens on `finite` as well as `numeric` so that `finite:true`
+// alone rejects NaN and Infinity, matching how assert/validate open the same gate
+// via OptionPredicator.Numeric (which is likewise finite || numeric) and the
+// documented independence of the two flags (samchon/typia#2196). The gate only
+// decides whether check_number emits a guard; check_number's own inner selection
+// then picks Number.isFinite for `finite` or !Number.isNaN for `numeric`.
 func isProgrammer_option_numeric(options *IsProgrammer_CONFIG_IOptions) bool {
-  return options != nil && options.Numeric != nil && *options.Numeric
+  if options == nil {
+    return false
+  }
+  finite := options.Finite != nil && *options.Finite
+  numeric := options.Numeric != nil && *options.Numeric
+  return finite || numeric
 }
 
 func isProgrammer_option_undefined(options *IsProgrammer_CONFIG_IOptions) bool {


### PR DESCRIPTION
## Summary

Fixes #2196. The `finite` validation option was **inert unless `numeric` was also set**. Under `{ "finite": true }` with `numeric` unset, `typia.is`/`assert`/`validate` accepted `NaN`, `Infinity`, and `-Infinity` for every `number` leaf — contradicting the documented behavior (`finite` is an independent flag that rejects both `NaN` and `Infinity`).

## Root cause

`typia.is` built its number-leaf gate from `numeric` alone, dropping `finite`. Because `assert`/`validate` gate their verdict on that same is-checker (`if (false === __is(input))`), and their own finite-aware error-path checker only runs when `__is` returns false, all three accepted non-finite numbers. The gate itself (`iterate/check_number.go`) already picks `Number.isFinite` vs `!Number.isNaN` correctly once opened — only the opening condition in `IsProgrammer` was wrong.

The same inert `__is` reached `json.isStringify`/`isParse` and `protobuf.isEncode`, which force `Finite` on their inner guard precisely to keep non-finite numbers out of JSON/proto. Under a global `finite:true`, `json.isStringify` of a `NaN` number leaf emitted the raw `String(NaN)` token — the invalid JSON `{"value":NaN}` (a corruption hole this fix closes).

## Fix

Open the `is` number gate on `finite || numeric` — the same value `assert`/`validate` compute via `OptionPredicator.Numeric`. `Finite` is carried on the Decompose-built options and `isProgrammer_option_numeric` opens on either flag. Nil-option scoped checkers (union discrimination inside `plain.clone/prune/classify`, `notations`, validated `json.stringify` internals, `protobuf encode`) and the assert/validate fast-path combiners are untouched because they never carry `Finite`, so only the top-level `is`/`assert`/`validate` and the `json`/`protobuf` is-encoders change. `check_number.go`'s inner selection is untouched.

Invariants preserved: `numeric` alone still rejects `NaN` and **accepts** `Infinity`; `finite`+`numeric` unchanged; the both-false default still accepts everything.

## Tests

Three new emitter+runtime transform tests in `cmd/ttsc-typia` (each verified red on the pre-fix code, green after):

- `finite_option_number_leaf_transform_test.go` — a 4-row option matrix drives `is`/`assert`/`validate` at runtime against a finite value plus `NaN`/`Infinity`/`-Infinity`, with an executed-case-count assertion.
- `json_is_stringify_finite_number_transform_test.go` — `json.isStringify<{ value: number }>` must yield `null` (not a serialized non-finite) under default and `finite:true`.
- `protobuf_is_encode_finite_number_transform_test.go` — `protobuf.isEncode<{ value: number }>` must guard the number leaf with `Number.isFinite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy