### PR TITLE
fix(native): classify the global Function interface as a function so is<Object> validates (#2178)

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/is_object_function_member_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/is_object_function_member_transform_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestIsObjectFunctionMemberTransform pins the runtime behaviour of typia.is /
+// assert / validate for the global `Object` interface and for `Function`-typed
+// members (#2178).
+//
+// The global TS `Object` interface carries `constructor: Function`. The global
+// `Function` interface is declared as an `InterfaceDeclaration`, so before the
+// fix typia failed to recognise it as a function type and expanded it
+// structurally to `{ prototype, length, arguments, caller, name }`. That made
+// the `constructor` member emit `"object" === typeof input.constructor`, which
+// is never satisfied by a real constructor (`typeof === "function"`), so
+// `is<Object>(x)` was false for every input. The same defect struck any explicit
+// `Function`-typed member and any interface that `extends Object`.
+//
+// After the fix the lib `Function` interface is classified as a function and
+// routes through the same lenient member path typia already uses for
+// `() => void` members, so `is<Object>` collapses to a non-null-object gate.
+// The lowercase `object` keyword and the `{}` type must stay byte-identical
+// (they keep their `Array.isArray` guard), and the null / undefined / primitive
+// boundaries must stay false.
+//
+//  1. Transform one fixture that exports is / assert / validate for `Object`, an
+//     explicit `{ fn: Function }`, a `Moment extends Object` interface, plus the
+//     lowercase `object` and `{}` regression guards.
+//  2. Execute the emitted validators in Node against the boundary matrix.
+//  3. Require the runner to report the exact executed case count so a runner that
+//     silently skipped cases cannot pass as a false green.
+func TestIsObjectFunctionMemberTransform(t *testing.T) {
+  project := isObjectFunctionMemberProject(t)
+  js := isObjectFunctionMemberTransform(t, project)
+  isObjectFunctionMemberRunRuntimeCases(t, project, js)
+}
+
+func isObjectFunctionMemberProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "is-object-function-member-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(finiteOptionNumberLeafTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(isObjectFunctionMemberSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func isObjectFunctionMemberTransform(t *testing.T, project string) string {
+  t.Helper()
+  payload := `[{"config":{"transform":"typia/lib/transform"},"name":"typia","stage":"transform"}]`
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+      "--plugins-json", payload,
+    })
+  })
+  if code != 0 {
+    t.Fatalf("is<Object> transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func isObjectFunctionMemberRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(isObjectFunctionMemberRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = project
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("is<Object> runtime cases failed: %v\n%s", err, output)
+  }
+  const expected = "RAN 27 CASES"
+  if !strings.Contains(string(output), expected) {
+    t.Fatalf("is<Object> runner did not report %q; got:\n%s", expected, output)
+  }
+}
+
+const isObjectFunctionMemberSource = `import typia from "typia";
+
+interface Moment extends Object {
+  valueOf(): number;
+}
+
+export const isObject = typia.createIs<Object>();
+export const assertObject = typia.createAssert<Object>();
+export const validateObject = typia.createValidate<Object>();
+
+export const isFuncMember = typia.createIs<{ fn: Function }>();
+export const isMoment = typia.createIs<Moment>();
+
+export const isLowerObject = typia.createIs<object>();
+export const isEmptyObject = typia.createIs<{}>();
+
+// random must produce a sample that its own is accepts (round trip). Object and
+// a Function-only member need no numeric generator stub, so they stay hermetic.
+export const randomObject = typia.createRandom<Object>();
+export const randomFuncOnly = typia.createRandom<{ fn: Function }>();
+
+export const captureThrow = (task: () => void): boolean => {
+  try {
+    task();
+    return false;
+  } catch {
+    return true;
+  }
+};
+`
+
+const isObjectFunctionMemberRuntimeRunner = `const mod = require("./main.cjs");
+
+let ran = 0;
+const eq = (name, actual, expected) => {
+  ran += 1;
+  if (actual !== expected) {
+    throw new Error(name + ": expected " + expected + " but got " + actual);
+  }
+};
+
+// is<Object>: every non-null object is accepted, including arrays and class
+// instances; null / undefined / primitives stay rejected (#2178 core cases).
+eq("is<Object>({})", mod.isObject({}), true);
+eq("is<Object>({a:1})", mod.isObject({ a: 1 }), true);
+eq("is<Object>(new Object())", mod.isObject(new Object()), true);
+eq("is<Object>(new Date())", mod.isObject(new Date()), true);
+eq("is<Object>([])", mod.isObject([]), true);
+eq("is<Object>(null)", mod.isObject(null), false);
+eq("is<Object>(undefined)", mod.isObject(undefined), false);
+eq("is<Object>(5)", mod.isObject(5), false);
+eq("is<Object>('x')", mod.isObject("x"), false);
+
+// validate and assert share the checker object path, so they must agree with is.
+eq("validate<Object>({})", mod.validateObject({}).success, true);
+eq("validate<Object>({a:1})", mod.validateObject({ a: 1 }).success, true);
+eq("validate<Object>(null)", mod.validateObject(null).success, false);
+eq("assert<Object>({}) no throw", mod.captureThrow(() => mod.assertObject({})), false);
+eq("assert<Object>(null) throws", mod.captureThrow(() => mod.assertObject(null)), true);
+
+// Explicit Function-typed member: the same lenient function path as () => void.
+eq("is<{fn:Function}>({fn(){}})", mod.isFuncMember({ fn() {} }), true);
+eq("is<{fn:Function}>({fn:()=>{}})", mod.isFuncMember({ fn: () => {} }), true);
+eq("is<{fn:Function}>(null)", mod.isFuncMember(null), false);
+
+// interface Moment extends Object: the inherited constructor member no longer
+// breaks a real instance.
+eq("is<Moment>(real)", mod.isMoment({ valueOf: () => 1 }), true);
+eq("is<Moment>(null)", mod.isMoment(null), false);
+
+// lowercase object keeps its Array.isArray guard (byte-identical, unchanged).
+eq("is<object>({})", mod.isLowerObject({}), true);
+eq("is<object>([])", mod.isLowerObject([]), false);
+eq("is<object>(null)", mod.isLowerObject(null), false);
+
+// {} empty object type keeps its Array.isArray guard (byte-identical, unchanged).
+eq("is<{}>({})", mod.isEmptyObject({}), true);
+eq("is<{}>([])", mod.isEmptyObject([]), false);
+eq("is<{}>(null)", mod.isEmptyObject(null), false);
+
+// random <-> is round trip: the generated Object / Function-member sample must
+// pass its own is checker.
+eq("is<Object>(random<Object>())", mod.isObject(mod.randomObject()), true);
+eq("is<{fn:Function}>(random)", mod.isFuncMember(mod.randomFuncOnly()), true);
+
+console.log("RAN " + ran + " CASES");
+`

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -151,6 +151,21 @@ func metadata_get_function_node(typ *nativechecker.Type) *nativeast.Node {
   if nativeast.IsFunctionLike(node) {
     return node
   }
+  // The global `Function` interface (declared in a default `lib.*.d.ts`) is
+  // callable and newable at runtime, so a `Function`-typed member is a function,
+  // not a structural object: `constructor: Function` on the global `Object`
+  // interface, an explicit `x: Function`, or any member inherited through
+  // `extends Object`. Its symbol resolves to an `InterfaceDeclaration` rather
+  // than a function-like node, so without this branch it is expanded
+  // structurally (`{ prototype, length, arguments, caller, name }`) and its
+  // `typeof` is mis-checked as `"object"` even though a real function reports
+  // `"function"`, making `is<Object>` universally false (#2178). Returning the
+  // interface declaration routes the member through the same function path typia
+  // already uses for `() => void` members: a lenient pass under default options
+  // and a signature-based check under `functional`.
+  if metadata_is_global_function_interface(symbol, node) {
+    return node
+  }
   if nativeast.IsPropertyAssignment(node) {
     initializer := node.AsPropertyAssignment().Initializer
     if nativeast.IsFunctionLike(initializer) {
@@ -264,6 +279,25 @@ func metadata_node_type_js_doc_tags(symbol *nativeast.Symbol) []schemametadata.I
     return []schemametadata.IJsDocTagInfo{}
   }
   return metadata_node_js_doc_tags(symbol)
+}
+
+// metadata_is_global_function_interface reports whether the type behind `symbol`
+// is the global `Function` interface from a TypeScript default library. The
+// match is intentionally narrow — the symbol name is exactly `"Function"`, its
+// first declaration is an `InterfaceDeclaration`, and that declaration lives in a
+// `lib.*.d.ts` — so it recognizes only the lib `Function` and never a
+// user-declared `interface Function`, a `function Function()` value, or any
+// other callable object type (a hybrid `interface Foo { (): void; x: number }`
+// keeps its data properties). See metadata_get_function_node for why the lib
+// `Function` must be treated as a function type (#2178).
+func metadata_is_global_function_interface(symbol *nativeast.Symbol, node *nativeast.Node) bool {
+  if symbol == nil || symbol.Name != "Function" {
+    return false
+  }
+  if node == nil || node.Kind != nativeast.KindInterfaceDeclaration {
+    return false
+  }
+  return metadata_symbol_from_default_lib(symbol)
 }
 
 // metadata_symbol_from_default_lib reports whether the symbol's first locatable


### PR DESCRIPTION
## Problem (#2178)

`typia.is<Object>(x)` returned **false for every input**. The global TS `Object` interface carries `constructor: Function`. The global `Function` interface is declared as an `InterfaceDeclaration`, so `metadata_get_function_node` — which only recognized a function when a symbol's first declaration was `IsFunctionLike` — returned `nil` for it. `Function` was then expanded structurally to `{ prototype, length, arguments, caller, name }`, so the `constructor` member emitted `"object" === typeof input.constructor`, which a real constructor (`typeof === "function"`) never satisfies.

The defect generalizes to any `Function`-typed member: `is<{ fn: Function }>` and any interface that `extends Object` (e.g. the reporter's `interface Moment extends Object`) were also universally false.

### Emitted bytes, before

```js
createIs<Object>() = (input) => "object"===typeof input && null!==input && _io0(input);
_io0 = (input) => "object"===typeof input.constructor && null!==input.constructor && _io1(input.constructor);
```

## Fix

Recognize the lib `Function` interface (symbol name `Function`, an `InterfaceDeclaration`, declared in a default `lib.*.d.ts`) as a function type in `metadata_get_function_node`, routing it through the **same** path typia already uses for `() => void` members:

- **default options** — a lenient pass (the member is always-satisfied), so `is<Object>` collapses to a non-null-object gate, byte-consistent with `{}` and lowercase `object`.
- **`functional: true`** — a real `"function" === typeof input.fn` check (verified unchanged).

### Emitted bytes, after

```js
createIs<Object>() = (input) => "object"===typeof input && null!==input && _io0(input);
_io0 = input => true;
```

## Scope / boundaries preserved

- The match is intentionally narrow: a user-declared `interface Function`, a `function Function()` value, and hybrid callable objects (`interface Foo { (): void; x: number }`) are untouched.
- `is<Object>(null)` / `is<Object>(undefined)` stay **false**; boxed primitives (`is<Object>(5)`, `is<Object>("x")`) stay **false** (deliberate non-change — typia's structural stance is `typeof === "object"`).
- Lowercase `object` and `{}` emit is **byte-identical**; the existing arrow/method-signature function path is **byte-identical**.
- No `@typia/interface` edit, no version bump.

## Verification

- New native transform test `is_object_function_member_transform_test.go` (27 executed runtime cases incl. random↔is round trip) — red on pre-fix code, green after.
- Full native `go test ./...`: the only test whose status changed is the new one (red→green); the pre-existing environment-artifact degenerates fail identically pre/post.
- Emit-diff over a broad corpus (objects, arrays, tuples, unions, natives, templates, recursive, function members) across is/assert/validate/random/json/protobuf/plain/llm: **only Function-containing types changed**; every non-Function type and the lowercase `object`/`{}` path are byte-identical.
- TS suites green: `test-typia-schema` (171), `test-typia-automated` (3947), `test-mcp` (20), `test-feature-identity`, `test-typia-exact-optional`, `test-interface`, and `test-typia-generate` (full generate + golden identity + filesystem chain, `# fail 0`).

One flagged, in-scope convergence: `json.application` on a method with a `Function` parameter now errors like a `() => void` parameter already did (pre-fix it silently emitted a garbage `{ prototype, length, caller, name }` schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy