### PR TITLE
fix(typia): resolve the generate wizard path through createRequire so the ESM build works (#2203)

### DIFF
--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -835,7 +835,7 @@ export namespace TypiaGenerateWizard {
   function resolveFromRoots(request: string, roots: string[]): string | null {
     for (const root of roots) {
       try {
-        return require.resolve(request, { paths: [root] });
+        return createRequire(path.join(root, "package.json")).resolve(request);
       } catch {
         continue;
       }


### PR DESCRIPTION
## Problem

Fixes #2203.

The `generate` setup wizard's `resolveFromRoots()` used a bare `require.resolve(request, { paths: [root] })` at `TypiaGenerateWizard.ts:838`, while its two siblings correctly go through `createRequire` (`:750`, `:777`). In the ESM (`.mjs`) build, rolldown rewrites the bare `require` to an `__require` shim. In a genuine `.mjs`, `require` is undefined at module scope, so `__require.resolve` is `undefined`; calling it throws, `resolveFromRoots()` swallows the error in its `try/catch`, and the wizard silently returns `null` — a `.js` vs `.mjs` behavioral disagreement.

## Fix

One line — route the resolution through `createRequire`, anchored at a `package.json` under each root, mirroring sibling `:777` (`createRequire(<file path>).resolve(...)`):

```diff
-        return require.resolve(request, { paths: [root] });
+        return createRequire(path.join(root, "package.json")).resolve(request);
```

`createRequire(path.join(root, "package.json"))` anchors resolution at `root/node_modules` upward, exactly matching the CJS `{ paths: [root] }` semantics.

## Evidence

- **ESM rewrite reproduced** on the exact source expression: rolldown emits `return __require.resolve(request, { paths: [root] });`, and in a genuine `.mjs` `__require.resolve is not a function` throws → the wizard's `try/catch` returns `null`.
- **Real build after the fix**: `lib/executable/TypiaGenerateWizard.mjs` uses `createRequire(path.join(root, "package.json")).resolve(request)`; the module references `__require` nowhere. `lib/executable/TypiaGenerateWizard.js` (CJS) matches.
- **CJS regression**: against the real installed `ttsc`/`typescript`, old and new forms resolve **byte-identically** for `ttsc` and `typescript/package.json` (the wizard's primary targets).

## Scope

- `packages/typia/src` (TS), not native. **No version bump.**
- All three resolution sites now go through `createRequire`; no bare `require.resolve` remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy