### PR TITLE
chore(spelling): use en-US spelling in the #2178 metadata comments and test

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/is_object_function_member_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/is_object_function_member_transform_test.go
@@ -8,13 +8,13 @@ import (
   "testing"
 )
 
-// TestIsObjectFunctionMemberTransform pins the runtime behaviour of typia.is /
+// TestIsObjectFunctionMemberTransform pins the runtime behavior of typia.is /
 // assert / validate for the global `Object` interface and for `Function`-typed
 // members (#2178).
 //
 // The global TS `Object` interface carries `constructor: Function`. The global
 // `Function` interface is declared as an `InterfaceDeclaration`, so before the
-// fix typia failed to recognise it as a function type and expanded it
+// fix typia failed to recognize it as a function type and expanded it
 // structurally to `{ prototype, length, arguments, caller, name }`. That made
 // the `constructor` member emit `"object" === typeof input.constructor`, which
 // is never satisfied by a real constructor (`typeof === "function"`), so

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -158,7 +158,7 @@ func metadata_get_function_node(typ *nativechecker.Type) *nativeast.Node {
   // `extends Object`. Its symbol resolves to an `InterfaceDeclaration` rather
   // than a function-like node, so without this branch it is expanded
   // structurally (`{ prototype, length, arguments, caller, name }`) and its
-  // `typeof` is mis-checked as `"object"` even though a real function reports
+  // `typeof` is checked as `"object"` even though a real function reports
   // `"function"`, making `is<Object>` universally false (#2178). Returning the
   // interface declaration routes the member through the same function path typia
   // already uses for `() => void` members: a lenient pass under default options


### PR DESCRIPTION
The typos spell-check (en-US) flags `behaviour`/`recognise` and the `mis-` token that #2178 introduced in `is_object_function_member_transform_test.go` and `MetadataHelper.go`, turning every PR's spell-check red. Reword to `behavior`, `recognize`, and `checked`. Comment/text only — no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy