### PR TITLE
fix(typia): make random reject an unsatisfiable unbounded pattern instead of returning a non-matching string (#2204)

### DIFF
--- a/packages/typia/src/internal/_randomPattern.ts
+++ b/packages/typia/src/internal/_randomPattern.ts
@@ -24,9 +24,9 @@ export const _randomPattern = (regex: RegExp, props?: _ILengthProps): string => 
     )
       return str;
   }
-  if (bounded)
-    throw new Error(
-      "unable to generate a random string matching the pattern within the length range.",
-    );
-  return r.gen();
+  throw new Error(
+    bounded
+      ? "unable to generate a random string matching the pattern within the length range."
+      : "unable to generate a random string matching the pattern.",
+  );
 };

--- a/tests/test-typia-schema/src/features/random/test_random_string_pattern_non_ascii.ts
+++ b/tests/test-typia-schema/src/features/random/test_random_string_pattern_non_ascii.ts
@@ -1,0 +1,116 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies typia.random never returns a value its own `is` rejects for a string
+ * leaf whose only constraint is a non-ASCII character-class pattern.
+ *
+ * The unbounded pattern path used to fall back to an unchecked `r.gen()`, and
+ * RandExp yields `""` for a class of only non-ASCII code points (e.g. `[가-힣]+`
+ * or `[À-ÿ]+`), so `random` emitted `""` which fails `Pattern<P>`. RandExp
+ * cannot construct any matching value for such a class, so `random` must throw
+ * the same way an impossible length window already does, never silently return
+ * a non-matching string. This round trip pins both directions.
+ *
+ * 1. Draw a large sample of each generatable pattern and require every draw to
+ *    pass `is` of the same type (ASCII and mixed ASCII+non-ASCII, unchanged).
+ * 2. Require each pure non-ASCII class, which RandExp cannot satisfy, to throw on
+ *    draw rather than return an `is`-rejected value.
+ */
+export const test_random_string_pattern_non_ascii = (): void => {
+  // POSITIVE: generatable patterns still round-trip through `is`, unchanged.
+  {
+    // ASCII-only control.
+    type T = string & tags.Pattern<"^[0-9]+$">;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "ascii pattern",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    // Mixed ASCII+non-ASCII class: RandExp draws from the ASCII sub-range.
+    type T = string & tags.Pattern<"[a-z가-힣]+">;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "mixed pattern",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    // Mixed class with a bounded quantifier stays generatable and accepted.
+    type T = string & tags.Pattern<"[a-z가-힣]{3,8}">;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "mixed bounded-quantifier pattern",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    // Mixed class carrying typia length tags exercises the bounded path.
+    type T = string &
+      tags.Pattern<"[a-z가-힣]+"> &
+      tags.MinLength<3> &
+      tags.MaxLength<8>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "mixed pattern & length window",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+
+  // NEGATIVE: a pure non-ASCII class RandExp cannot satisfy must throw on draw,
+  // never return the `is`-rejected `""` the unbounded fallback used to emit.
+  assertThrows("korean class +", () =>
+    typia.random<string & tags.Pattern<"[가-힣]+">>(),
+  );
+  assertThrows("latin-1 class +", () =>
+    typia.random<string & tags.Pattern<"[À-ÿ]+">>(),
+  );
+  assertThrows("latin-1 class bounded quantifier", () =>
+    typia.random<string & tags.Pattern<"[À-ÿ]{2,4}">>(),
+  );
+  assertThrows("korean class anchored", () =>
+    typia.random<string & tags.Pattern<"^[가-힣]+$">>(),
+  );
+  assertThrows("korean single-codepoint class", () =>
+    typia.random<string & tags.Pattern<"[가-힣]">>(),
+  );
+};
+
+const COUNT = 1_000;
+
+const roundTrip = (
+  title: string,
+  is: (input: unknown) => boolean,
+  ...draws: Array<() => unknown>
+): void => {
+  let failures: number = 0;
+  let first: string | null = null;
+  for (let i = 0; i < COUNT; ++i) {
+    const value: unknown = draws[i % draws.length]!();
+    if (is(value) === false) {
+      ++failures;
+      if (first === null) first = String(value);
+    }
+  }
+  TestValidator.equals(`${title} (first invalid: ${first})`, failures, 0);
+};
+
+const assertThrows = (title: string, closure: () => unknown): void => {
+  let thrown: boolean = false;
+  try {
+    closure();
+  } catch {
+    thrown = true;
+  }
+  TestValidator.equals(title, thrown, true);
+};


### PR DESCRIPTION
## Problem

Closes #2204.

`typia.random<string & Pattern<P>>()` could return a value its own `is` rejects when `P` is a character class of only non-ASCII code points with no length bound. The unbounded path of `packages/typia/src/internal/_randomPattern.ts` ran a match-checked retry loop and then, if none matched, fell back to an **unchecked** `return r.gen()`. RandExp yields `""` for classes like `[가-힣]+` or `[À-ÿ]+` on every draw, so `random` emitted `""`, which `is<string & Pattern<"[가-힣]+">>` rejects — a generator/validator divergence (same class as #2189/#2192, which fixed the length window but left this path).

## Fix

Replace the unchecked fallback with the same throw the bounded path already uses. The retry loop is untouched, so every ASCII or mixed pattern RandExp can satisfy still returns from the loop unchanged; only the formerly silent non-matching fallback now fails loudly with `"unable to generate a random string matching the pattern."`.

Verified empirically that RandExp produces a matching value 0/2000 times for a pure non-ASCII class, so no retry count can succeed — throwing is the correct outcome, not a silent non-matching string.

## Evidence

End-to-end through the typia pipeline:

| pattern | before | after |
| --- | --- | --- |
| `[가-힣]+` | returns `""`, `is` = **false** | **throws** |
| `[À-ÿ]+` | returns `""`, `is` = **false** | **throws** |
| `^[0-9]+$` (ASCII) | valid, `is` = true | valid, `is` = true (unchanged) |
| `[a-z가-힣]+` (mixed) | valid, `is` = true | valid, `is` = true (unchanged) |

## Tests

New `tests/test-typia-schema/src/features/random/test_random_string_pattern_non_ascii.ts` — a `random`→`is` round-trip: ASCII/mixed/mixed-bounded patterns must stay `is`-accepted; pure non-ASCII classes (`[가-힣]+`, `[À-ÿ]+`, `[À-ÿ]{2,4}`, `^[가-힣]+$`, single-codepoint) must throw. RED before the fix, GREEN after.

`pnpm --filter ./tests/test-typia-schema start`: 172/172 pass, including the existing `test_random_string_pattern_format_length` (#2189/#2192), unchanged.

## Coordination

- Touches only the runtime helper `packages/typia/src/internal/_randomPattern.ts` and the new test. No version bump; no `packages/interface` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
