### PR TITLE
fix(native): escape json.stringify object keys for the template-literal context (#2201)

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/json_stringify_special_key_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_stringify_special_key_transform_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestJsonStringifySpecialKeyTransform pins json.createStringify (and the
+// guarded isStringify / assertStringify / validateStringify variants) against a
+// static object key that contains a double quote, a backslash, a control
+// character, a `${` interpolation sequence, an empty string, or a backtick
+// (#2201).
+//
+// StringifyJoinder emits each static key by JSON-escaping it with
+// json.Marshal, then splicing the JSON bytes into a *template literal* through
+// TemplateFactory.Generate. JSON escaping and template-literal escaping
+// disagree, so at runtime `\"`->`"`, `\\`->`\`, a control char stays raw, a raw
+// backtick closes the template (a SyntaxError in the emitted module), and `${`
+// starts a live interpolation (a serialize-time ReferenceError / injection).
+// The result is invalid JSON, or a crash, for exactly these keys, while
+// ordinary keys, dynamic Record keys, and all string values stay correct.
+//
+//  1. Transform a fixture that exports json.createStringify (plus the guarded
+//     variants) for an object whose keys are `q"k`, `back\slash`, a TAB,
+//     `interp${bad}here`, the empty string, and a backtick.
+//  2. Execute the emitted serializer in Node with a faithful
+//     _jsonStringifyNumber stub.
+//  3. Require the serialized document to JSON.parse back to the original object
+//     for every key, and report the exact executed case count so a runner that
+//     silently skipped a key cannot pass as a false green.
+func TestJsonStringifySpecialKeyTransform(t *testing.T) {
+  project := jsonStringifySpecialKeyProject(t)
+  js := jsonStringifySpecialKeyTransform(t, project)
+  jsonStringifySpecialKeyRunRuntime(t, project, js)
+}
+
+func jsonStringifySpecialKeyProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "json-stringify-special-key-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(jsonStringifySpecialKeyTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonStringifySpecialKeySource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func jsonStringifySpecialKeyTransform(t *testing.T, project string) string {
+  t.Helper()
+  payload := `[{"config":{"transform":"typia/lib/transform"},"name":"typia","stage":"transform"}]`
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+      "--plugins-json", payload,
+    })
+  })
+  if code != 0 {
+    t.Fatalf("json stringify special-key transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func jsonStringifySpecialKeyRunRuntime(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  stubs := map[string]string{
+    "json-stringify-number-stub.cjs":  jsonStringifySpecialKeyNumberStub,
+    "json-stringify-string-stub.cjs":  jsonStringifySpecialKeyStringStub,
+    "throw-type-guard-error-stub.cjs": jsonStringifySpecialKeyThrowStub,
+  }
+  for name, content := range stubs {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  runtimeJS := strings.ReplaceAll(js, `require("typia/lib/internal/_jsonStringifyNumber")`, `require("./json-stringify-number-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyString")`, `require("./json-stringify-string-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
+  runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(jsonStringifySpecialKeyRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("json stringify special-key runtime failed: %v\n%s", err, output)
+  }
+  const expected = "RAN 24 CASES"
+  if !strings.Contains(string(output), expected) {
+    t.Fatalf("json stringify special-key runner did not report %q; got:\n%s", expected, output)
+  }
+}
+
+const jsonStringifySpecialKeyTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const jsonStringifySpecialKeySource = `import typia from "typia";
+
+interface Special {
+  "q\"k": number;
+  "back\\slash": number;
+  "\t": number;
+  "interp${bad}here": number;
+  "": number;
+  "` + "`" + `": number;
+}
+
+export const stringifySpecial = typia.json.createStringify<Special>();
+export const isStringifySpecial = typia.json.createIsStringify<Special>();
+export const assertStringifySpecial = typia.json.createAssertStringify<Special>();
+export const validateStringifySpecial = typia.json.createValidateStringify<Special>();
+`
+
+const jsonStringifySpecialKeyNumberStub = `module.exports._jsonStringifyNumber = (value) => (Number.isFinite(value) ? String(value) : "null");
+`
+
+const jsonStringifySpecialKeyStringStub = `module.exports._jsonStringifyString = (value) => JSON.stringify(value);
+`
+
+const jsonStringifySpecialKeyThrowStub = `module.exports._throwTypeGuardError = (props) => {
+  const error = new Error(props.expected);
+  Object.assign(error, props);
+  throw error;
+};
+`
+
+const jsonStringifySpecialKeyRunner = `const mod = require("./main.cjs");
+
+const TAB = String.fromCharCode(9);
+const BQ = String.fromCharCode(96);
+
+const makeInput = () => {
+  const input = {};
+  input['q"k'] = 1;
+  input['back\\slash'] = 2;
+  input[TAB] = 3;
+  input['interp${bad}here'] = 4;
+  input[''] = 5;
+  input[BQ] = 6;
+  return input;
+};
+
+const entries = [
+  ['q"k', 1],
+  ['back\\slash', 2],
+  [TAB, 3],
+  ['interp${bad}here', 4],
+  ['', 5],
+  [BQ, 6],
+];
+
+let ran = 0;
+
+const roundTrip = (label, text) => {
+  const parsed = JSON.parse(text);
+  for (const [key, expected] of entries) {
+    ran += 1;
+    if (parsed[key] !== expected) {
+      throw new Error(
+        label + ": key " + JSON.stringify(key) + " round-trip failed; got " +
+          JSON.stringify(parsed[key]) + " in " + text,
+      );
+    }
+  }
+  if (Object.keys(parsed).length !== entries.length) {
+    throw new Error(label + ": unexpected key count in " + text);
+  }
+};
+
+// json.createStringify: the raw serializer must emit valid JSON for every key.
+roundTrip("createStringify", mod.stringifySpecial(makeInput()));
+
+// json.createIsStringify: valid input serializes; the document must round-trip.
+const isText = mod.isStringifySpecial(makeInput());
+if (isText === null) {
+  throw new Error("isStringify rejected a valid special-key object");
+}
+roundTrip("isStringify", isText);
+
+// json.createAssertStringify: valid input passes the guard, then serializes.
+roundTrip("assertStringify", mod.assertStringifySpecial(makeInput()));
+
+// json.createValidateStringify: success carries the serialized document.
+const validated = mod.validateStringifySpecial(makeInput());
+if (validated.success !== true) {
+  throw new Error("validateStringify rejected a valid special-key object: " + JSON.stringify(validated));
+}
+roundTrip("validateStringify", validated.data);
+
+console.log("RAN " + ran + " CASES");
+`

--- a/packages/typia/native/core/programmers/helpers/StringifyJoinder.go
+++ b/packages/typia/native/core/programmers/helpers/StringifyJoinder.go
@@ -3,6 +3,7 @@ package helpers
 import (
   "encoding/json"
   "sort"
+  "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimprinter "github.com/microsoft/typescript-go/shim/printer"
@@ -143,8 +144,13 @@ func stringifyJoiner_regular_properties(regular []IExpressionEntry, dynamic []IE
     if err != nil {
       encoded = []byte("\"" + *key + "\"")
     }
+    // encoded is escaped for a JSON string, but the literal becomes a part of a
+    // template literal (TemplateFactory.Generate). The two contexts disagree, so
+    // re-escape the JSON bytes for the template-literal context: otherwise `\"`
+    // decays to `"`, `\\` to `\`, a control-char escape's backslash is dropped, a
+    // raw backtick closes the template, and `${` starts a live interpolation.
     base := []*shimast.Node{
-      f.NewStringLiteral(string(encoded)+":", shimast.TokenFlagsNone),
+      f.NewStringLiteral(stringifyJoiner_escape_template(string(encoded))+":", shimast.TokenFlagsNone),
       entry.Expression,
     }
     if index != len(regular)-1 || len(dynamic) != 0 {
@@ -395,6 +401,31 @@ func stringifyJoiner_all_string_literals(elements []*shimast.Expression) bool {
     }
   }
   return true
+}
+
+// stringifyJoiner_escape_template escapes an already-JSON-encoded key so that,
+// spliced verbatim into a backtick template literal, it reproduces the exact
+// JSON bytes at runtime. It doubles every backslash (so JSON escapes such as
+// `\"`, `\\`, `\t`, `<` survive), escapes a backtick (which would close the
+// template), and escapes the `$` of a `${` pair (which would start a live
+// interpolation). A `$` not followed by `{` and every ordinary character stay
+// byte-identical, so keys that need none of these are unchanged.
+func stringifyJoiner_escape_template(text string) string {
+  var builder strings.Builder
+  builder.Grow(len(text))
+  for i := 0; i < len(text); i++ {
+    switch c := text[i]; {
+    case c == '\\':
+      builder.WriteString("\\\\")
+    case c == '`':
+      builder.WriteString("\\`")
+    case c == '$' && i+1 < len(text) && text[i+1] == '{':
+      builder.WriteString("\\$")
+    default:
+      builder.WriteByte(c)
+    }
+  }
+  return builder.String()
 }
 
 func joinStrings(values []string, sep string) string {


### PR DESCRIPTION
## Problem

Fixes #2201. `typia.json.stringify` (and `createStringify` / `isStringify` / `assertStringify` / `validateStringify`) emitted **invalid JSON**, or crashed at serialize time, whenever a statically-known object key contained a double quote, backslash, control character, backtick, or `${` sequence.

`StringifyJoinder.stringifyJoiner_regular_properties` JSON-escaped each static key with `json.Marshal`, then spliced the JSON bytes into a backtick **template literal** via `TemplateFactory.Generate`. JSON escaping and template-literal escaping disagree, so at runtime:

| Key | Emitted (template) | Runtime string | Result |
| --- | --- | --- | --- |
| `q"k` | `"q\"k"` | `"q"k"` | invalid JSON |
| `back\slash` | `"back\slash"` | `"back\slash"` | invalid JSON (illegal `\s`) |
| TAB | raw TAB | raw TAB | invalid JSON (control char) |
| `` ` `` | raw backtick | closes the template | **SyntaxError** in the emitted module |
| `interp${bad}here` | `"interp${bad}here"` | evaluates `${bad}` | **ReferenceError** / live injection |

Dynamic (`Record`) keys and all string *values* were already correct (escaped at runtime); only the compile-time static-key path was broken.

## Fix

Re-escape the already-JSON-encoded key for the template-literal context before it becomes a literal part: double every backslash, escape a backtick, and escape the `$` of a `${` pair. A `$` not followed by `{` and every ordinary character stay byte-identical, so keys that need none of these are unchanged.

## Verification

- **Red test first:** the new `TestJsonStringifySpecialKeyTransform` (`cmd/ttsc-typia`) emits the serializer for keys `q"k`, `back\slash`, a TAB, `interp${bad}here`, the empty string, and a backtick, runs it in Node, and asserts `JSON.parse` deep-equals the input for `createStringify` + all three guarded variants (24 cases). It fails on `master` (SyntaxError / ReferenceError / invalid JSON) and passes after the fix.
- **Emit-diff:** only the special-key serializer's key literals change; ordinary keys (including a `dollar$ref` key) are byte-identical, and every property accessor is unchanged.
- **Full toolchain:** built `typia`, ran `tests/test-typia-schema` (Success), and round-tripped a special-key `json.createStringify` / `createAssertStringify` fixture through `ttsx` — runtime output `{"q\"k":1,"back\slash":2,"\t":3,"interp${bad}here":4,"":5,"`+"`"+`":6}` `JSON.parse`s back to the input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy