### PR TITLE
fix(native): honor a tuple's optional trailing element in compare.equals and plain.clone/classify (#2202)

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/tuple_optional_compare_clone_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/tuple_optional_compare_clone_transform_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestTupleOptionalCompareCloneTransform pins optional-trailing tuple semantics
+// across is / compare.equals / plain.clone / plain.classify.
+//
+// Issue #2202: for a tuple with an omitted optional trailing element, `is`
+// correctly validates with a length range (`1 <= length && 2 >= length`), but
+// `compare.equals` emitted a hard `x.length === 2` gate and `plain.clone` /
+// `plain.classify` materialized the absent element as a phantom `undefined`
+// (`[input[0], input[1]]`). So `equals(["a"], ["a"])` was false (reflexivity
+// broken; disagrees with `is`) and `clone(["a"])` was `["a", undefined]`
+// (length 2), not deep-equal to its input. The three must honor the same
+// optional-trailing semantics as `is`.
+//
+//  1. Transform is / equals / clone / classify over `[string, number?]` and
+//     `[string, number?, boolean?]`, plus fully-required and rest controls.
+//  2. Require equals reflexive over omitted-optional values, clone/classify to
+//     produce the correct length with no phantom slot, and `equals(x, clone(x))`
+//     to hold for every is-valid x.
+//  3. Require fully-populated tuples and rest tuples to be unchanged.
+func TestTupleOptionalCompareCloneTransform(t *testing.T) {
+  project := tupleOptionalCompareCloneProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("tuple optional compare/clone transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  tupleOptionalCompareCloneRunRuntimeCases(t, project, out)
+}
+
+func tupleOptionalCompareCloneProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "tuple-optional-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(tupleOptionalCompareCloneTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(tupleOptionalCompareCloneSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func tupleOptionalCompareCloneRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(tupleOptionalCompareCloneRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("tuple optional compare/clone runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const tupleOptionalCompareCloneTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const tupleOptionalCompareCloneSource = `import typia from "typia";
+
+export const isPair = typia.createIs<[string, number?]>();
+export const equalsPair = typia.compare.createEquals<[string, number?]>();
+export const clonePair = typia.plain.createClone<[string, number?]>();
+export const classifyPair = typia.plain.createClassify<[string, number?]>();
+
+export const isTriple = typia.createIs<[string, number?, boolean?]>();
+export const equalsTriple = typia.compare.createEquals<[string, number?, boolean?]>();
+export const cloneTriple = typia.plain.createClone<[string, number?, boolean?]>();
+export const classifyTriple = typia.plain.createClassify<[string, number?, boolean?]>();
+
+// boundary: a tuple whose only element is optional.
+export const equalsSolo = typia.compare.createEquals<[number?]>();
+export const cloneSolo = typia.plain.createClone<[number?]>();
+
+// boundary: an optional trailing element that is itself a nested tuple.
+export const equalsNested = typia.compare.createEquals<[string, [number, boolean]?]>();
+export const cloneNested = typia.plain.createClone<[string, [number, boolean]?]>();
+
+// control: a fully-required tuple must stay byte-identical.
+export const equalsFixed = typia.compare.createEquals<[string, number]>();
+export const cloneFixed = typia.plain.createClone<[string, number]>();
+
+// control: a rest tuple must stay byte-identical.
+export const equalsRest = typia.compare.createEquals<[string, ...number[]]>();
+export const cloneRest = typia.plain.createClone<[string, ...number[]]>();
+`
+
+const tupleOptionalCompareCloneRuntimeRunner = `const mod = require("./main.cjs");
+
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + expected + ", got " + actual);
+  }
+};
+
+// A clone must be a distinct array, deep-equal to expected, with no phantom
+// trailing slot (length matches, and the first out-of-range index is absent).
+const expectClone = (label, result, expected) => {
+  if (!Array.isArray(result)) throw new Error(label + ": not an array");
+  if (result.length !== expected.length)
+    throw new Error(label + ": length " + result.length + " !== " + expected.length);
+  if (expected.length in result)
+    throw new Error(label + ": phantom slot at index " + expected.length);
+  for (let i = 0; i < expected.length; ++i)
+    if (result[i] !== expected[i])
+      throw new Error(label + ": [" + i + "] " + result[i] + " !== " + expected[i]);
+};
+
+// --- is: the reference range semantics (unchanged) ---
+expect("is pair omitted", mod.isPair(["a"]), true);
+expect("is pair present", mod.isPair(["a", 1]), true);
+expect("is pair too long", mod.isPair(["a", 1, 2]), false);
+expect("is triple omitted", mod.isTriple(["a"]), true);
+
+// --- equals: reflexive over omitted optional; matches is ---
+expect("equals pair omitted reflexive", mod.equalsPair(["a"], ["a"]), true);
+expect("equals pair omitted vs present", mod.equalsPair(["a"], ["a", 1]), false);
+expect("equals pair present reflexive", mod.equalsPair(["a", 1], ["a", 1]), true);
+expect("equals pair present differ", mod.equalsPair(["a", 1], ["a", 2]), false);
+expect("equals triple omitted reflexive", mod.equalsTriple(["a"], ["a"]), true);
+expect("equals triple mid present reflexive", mod.equalsTriple(["a", 1], ["a", 1]), true);
+expect("equals triple full reflexive", mod.equalsTriple(["a", 1, true], ["a", 1, true]), true);
+expect("equals triple omitted vs present", mod.equalsTriple(["a"], ["a", 1]), false);
+
+// --- clone: correct length, no phantom undefined ---
+expectClone("clone pair omitted", mod.clonePair(["a"]), ["a"]);
+expectClone("clone pair present", mod.clonePair(["a", 1]), ["a", 1]);
+expectClone("clone triple omitted", mod.cloneTriple(["a"]), ["a"]);
+expectClone("clone triple mid present", mod.cloneTriple(["a", 1]), ["a", 1]);
+expectClone("clone triple full", mod.cloneTriple(["a", 1, true]), ["a", 1, true]);
+
+// --- classify: same tuple-inline path as clone ---
+expectClone("classify pair omitted", mod.classifyPair(["a"]), ["a"]);
+expectClone("classify triple omitted", mod.classifyTriple(["a"]), ["a"]);
+
+// --- equals(x, clone(x)) holds for every is-valid x ---
+for (const x of [["a"], ["a", 1]]) {
+  if (mod.isPair(x)) expect("equals pair (x, clone x) " + JSON.stringify(x), mod.equalsPair(x, mod.clonePair(x)), true);
+}
+for (const x of [["a"], ["a", 1], ["a", 1, true]]) {
+  if (mod.isTriple(x)) expect("equals triple (x, clone x) " + JSON.stringify(x), mod.equalsTriple(x, mod.cloneTriple(x)), true);
+}
+
+// --- boundary: only-optional tuple ---
+expect("equals solo empty reflexive", mod.equalsSolo([], []), true);
+expect("equals solo empty vs present", mod.equalsSolo([], [1]), false);
+expect("equals solo present reflexive", mod.equalsSolo([1], [1]), true);
+expectClone("clone solo empty", mod.cloneSolo([]), []);
+expectClone("clone solo present", mod.cloneSolo([1]), [1]);
+
+// --- boundary: nested tuple as the optional trailing element ---
+expect("equals nested omitted reflexive", mod.equalsNested(["a"], ["a"]), true);
+expect("equals nested present reflexive", mod.equalsNested(["a", [1, true]], ["a", [1, true]]), true);
+expect("equals nested omitted vs present", mod.equalsNested(["a"], ["a", [1, true]]), false);
+expectClone("clone nested omitted", mod.cloneNested(["a"]), ["a"]);
+{
+  const nested = mod.cloneNested(["a", [1, true]]);
+  if (nested.length !== 2) throw new Error("clone nested present: outer length " + nested.length);
+  if (1 in nested === false) throw new Error("clone nested present: missing inner tuple");
+  expectClone("clone nested inner", nested[1], [1, true]);
+}
+
+// --- controls: fully-required and rest tuples unchanged ---
+expect("equals fixed reflexive", mod.equalsFixed(["a", 1], ["a", 1]), true);
+expect("equals fixed differ", mod.equalsFixed(["a", 1], ["a", 2]), false);
+expectClone("clone fixed", mod.cloneFixed(["a", 1]), ["a", 1]);
+
+expect("equals rest solo", mod.equalsRest(["a"], ["a"]), true);
+expect("equals rest multi", mod.equalsRest(["a", 1, 2], ["a", 1, 2]), true);
+expect("equals rest length differ", mod.equalsRest(["a", 1], ["a", 1, 2]), false);
+expectClone("clone rest solo", mod.cloneRest(["a"]), ["a"]);
+expectClone("clone rest multi", mod.cloneRest(["a", 1, 2]), ["a", 1, 2]);
+`

--- a/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
+++ b/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
@@ -244,7 +244,27 @@ func (g *compareEqualProgrammerGenerator) tupleInline(tuple *schemametadata.Meta
     g.same(g.access(x, "length"), g.access(y, "length")),
   }
   if rest == nil {
-    checks = append(checks, g.same(g.access(x, "length"), strconv.Itoa(fixed)))
+    // An omitted optional trailing element makes the tuple's length a range
+    // [required, fixed] — exactly the gate `is` emits. A hard `=== fixed`
+    // rejects a value `is` accepts and breaks reflexivity of `equals`; the
+    // per-element `x[i] === y[i]` prefix already treats both-absent as equal,
+    // so only the length gate needs the range. A fully-required tuple keeps
+    // its byte-identical `x.length === fixed`.
+    required := 0
+    allRequired := true
+    for i := 0; i < fixed; i++ {
+      if tuple.Elements[i].Optional {
+        allRequired = false
+      } else {
+        required++
+      }
+    }
+    if allRequired {
+      checks = append(checks, g.same(g.access(x, "length"), strconv.Itoa(fixed)))
+    } else {
+      length := g.access(x, "length")
+      checks = append(checks, fmt.Sprintf("%d <= %s && %d >= %s", required, length, fixed, length))
+    }
   } else {
     checks = append(checks, fmt.Sprintf("%s.length >= %d", g.wrap(x), fixed))
   }

--- a/packages/typia/native/core/programmers/helpers/CloneJoiner.go
+++ b/packages/typia/native/core/programmers/helpers/CloneJoiner.go
@@ -28,6 +28,13 @@ type CloneJoiner_TupleProps struct {
   Emit     *shimprinter.EmitContext
 }
 
+type CloneJoiner_OptionalElementProps struct {
+  Input *shimast.Expression
+  Value *shimast.Expression
+  Index int
+  Emit  *shimprinter.EmitContext
+}
+
 type CloneJoiner_ArrayProps struct {
   Input *shimast.Expression
   Arrow *shimast.Expression
@@ -187,6 +194,31 @@ func (cloneJoinerNamespace) Tuple(props CloneJoiner_TupleProps) *shimast.Node {
       true,
     ),
     nativefactories.TypeFactory.Keyword("any", props.Emit),
+  )
+}
+
+// OptionalTupleElement wraps a cloned tuple element in a presence-gated spread
+// so an omitted optional trailing element is never materialized as a phantom
+// `undefined`. It mirrors `is`, whose length range accepts the shorter tuple:
+// the element is spread in only when `index < input.length`, so `clone(["a"])`
+// for `[string, number?]` stays `["a"]` (length 1) and round-trips under
+// `compare.equals`, while a present optional keeps its value.
+func (cloneJoinerNamespace) OptionalTupleElement(props CloneJoiner_OptionalElementProps) *shimast.Node {
+  f := nativecontext.EmitFactoryOf(cloneJoiner_factory, props.Emit)
+  condition := f.NewBinaryExpression(
+    nil,
+    nativefactories.ExpressionFactory.Number(props.Index, props.Emit),
+    nil,
+    f.NewToken(shimast.KindLessThanToken),
+    nativefactories.IdentifierFactory.Access(props.Emit, props.Input, "length"),
+  )
+  return f.NewSpreadElement(
+    f.NewParenthesizedExpression(nativefactories.ExpressionFactory.Conditional(
+      condition,
+      f.NewArrayLiteralExpression(f.NewNodeList([]*shimast.Node{props.Value}), false),
+      f.NewArrayLiteralExpression(f.NewNodeList(nil), false),
+      props.Emit,
+    )),
   )
 }
 

--- a/packages/typia/native/core/programmers/plain/PlainClassifyProgrammer.go
+++ b/packages/typia/native/core/programmers/plain/PlainClassifyProgrammer.go
@@ -571,7 +571,7 @@ func plainClassifyProgrammer_decode_tuple_inline(props plainClassifyProgrammer_d
     explore := props.Explore
     explore.From = "array"
     explore.Postfix = postfix
-    elements = append(elements, plainClassifyProgrammer_decode(struct {
+    value := plainClassifyProgrammer_decode(struct {
       Context  nativecontext.ITypiaContext
       Config   nativeinternal.FeatureProgrammer_IConfig
       Functor  *nativehelpers.FunctionProgrammer
@@ -585,7 +585,18 @@ func plainClassifyProgrammer_decode_tuple_inline(props plainClassifyProgrammer_d
       Input:    f.NewElementAccessExpression(props.Input, nil, nativefactories.ExpressionFactory.Number(index, props.Context.Emit), shimast.NodeFlagsNone),
       Metadata: elem,
       Explore:  explore,
-    }))
+    })
+    if elem.Optional {
+      // An omitted optional trailing element must not become a phantom
+      // `undefined`; gate it on presence so `classify(["a"])` stays `["a"]`.
+      value = nativehelpers.CloneJoiner.OptionalTupleElement(nativehelpers.CloneJoiner_OptionalElementProps{
+        Input: props.Input,
+        Value: value,
+        Index: index,
+        Emit:  props.Context.Emit,
+      })
+    }
+    elements = append(elements, value)
   }
   var rest *shimast.Node
   if len(props.Tuple.Elements) != 0 {

--- a/packages/typia/native/core/programmers/plain/PlainCloneProgrammer.go
+++ b/packages/typia/native/core/programmers/plain/PlainCloneProgrammer.go
@@ -531,7 +531,7 @@ func plainCloneProgrammer_decode_tuple_inline(props plainCloneProgrammer_decodeT
     explore := props.Explore
     explore.From = "array"
     explore.Postfix = postfix
-    elements = append(elements, plainCloneProgrammer_decode(struct {
+    value := plainCloneProgrammer_decode(struct {
       Context  nativecontext.ITypiaContext
       Config   nativeinternal.FeatureProgrammer_IConfig
       Functor  *nativehelpers.FunctionProgrammer
@@ -545,7 +545,18 @@ func plainCloneProgrammer_decode_tuple_inline(props plainCloneProgrammer_decodeT
       Input:    f.NewElementAccessExpression(props.Input, nil, nativefactories.ExpressionFactory.Number(index, props.Context.Emit), shimast.NodeFlagsNone),
       Metadata: elem,
       Explore:  explore,
-    }))
+    })
+    if elem.Optional {
+      // An omitted optional trailing element must not become a phantom
+      // `undefined`; gate it on presence so `clone(["a"])` stays `["a"]`.
+      value = nativehelpers.CloneJoiner.OptionalTupleElement(nativehelpers.CloneJoiner_OptionalElementProps{
+        Input: props.Input,
+        Value: value,
+        Index: index,
+        Emit:  props.Context.Emit,
+      })
+    }
+    elements = append(elements, value)
   }
   var rest *shimast.Node
   if len(props.Tuple.Elements) != 0 {


### PR DESCRIPTION
## Problem

Fixes #2202. For a tuple with an omitted optional trailing element, `is` validates with a length range (`1 <= length && 2 >= length`), but `compare.equals`, `plain.clone`, and `plain.classify` dropped `MetadataSchema.Optional` and treated every element as required:

- `equals<[string, number?]>(["a"], ["a"])` (distinct refs) → **`false`** — reflexivity broken; disagrees with `is`.
- `clone<[string, number?]>(["a"])` → **`["a", undefined]`** (length 2) — not deep-equal to input; `equals(["a"], clone(["a"]))` is `false`.

The comparator/cloner/classifier silently diverged from the validator on the same type.

## Root cause (one contract, three owners)

- `compare/CompareEqualProgrammer.go` — `fixed := len(Elements)`, decremented only for a trailing `Rest`, then emitted `x.length === fixed`; `Optional` never read.
- `plain/PlainCloneProgrammer.go` and `plain/PlainClassifyProgrammer.go` (`decode_tuple_inline`) — skipped only `Rest` and emitted `[input[0], input[1]]`, so an absent optional index became a present `undefined`.

## Fix — mirror `is`'s own tuple range semantics

- **compare**: when a non-rest element is optional, gate the length by the range `required <= x.length && fixed >= x.length` (exactly what `is` emits) instead of `x.length === fixed`. The per-element `x[i] === y[i]` prefix already treats "both absent" as equal, so only the length gate changes. A fully-required tuple keeps its byte-identical `x.length === fixed`.
- **clone / classify**: build an optional element as a presence-gated spread via a new `CloneJoiner.OptionalTupleElement` helper — `...(index < input.length ? [value] : [])` — so an absent optional trailing element is not materialized and `clone(["a"])` stays `["a"]` (length 1).

`Rest` handling is preserved untouched.

## Verification

- **Red → green** `cmd/ttsc-typia` transform test emits `is`/`equals`/`clone`/`classify` for `[string, number?]`, `[string, number?, boolean?]`, a only-optional `[number?]`, a nested `[string, [number, boolean]?]`, and fully-required / rest controls; runs the emitted JS in node and asserts reflexivity, `equals(x, clone(x))` for every is-valid `x`, correct clone length with no phantom slot, and unchanged controls. Confirmed RED on `origin/master` before the fix.
- **Emit-diff (byte-level scope)**: only the two `equals` length gates (`x.length === N` → `1 <= x.length && N >= x.length`) and the optional clone/classify elements (`input[i]` → `...(i < input.length ? [input[i]] : [])`) change. `is`, fully-populated tuples (`equalsFixed`/`cloneFixed`), and `Rest` tuples (`equalsRest`/`cloneRest`) are byte-identical.
- **End-to-end** through the real `ttsx` → native-Go → node pipeline (`tests/debug`): the full matrix passes.
- **`tests/test-typia-schema start`**: Success (incl. tuple cases).
- The 13 unrelated `cmd/ttsc-typia` failures in this environment are pre-existing on base `9ba43d73b4` (TypeScript type-inference/typecheck steps needing full provisioning) and are neither caused nor fixed by this change.

No `packages/typia/package.json` version bump; no `packages/interface/src` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy