### PR TITLE
fix(native): classify a built-in native by identity, not name, so a user type is validated structurally (#2200)

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/native_name_collision_is_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/native_name_collision_is_transform_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestNativeNameCollisionIsTransform pins the runtime and emit behavior of
+// typia.is / assert / validate for a user type whose name collides with a
+// built-in native (#2200).
+//
+// Native classification matched a type against the simples table by name alone,
+// so a user `interface File { name; size }` yielded the base name "File", matched
+// iterate_metadata_native_simples["File"], and emitted `input instanceof File` —
+// ignoring the user's own members. Every valid `File` value was therefore
+// rejected, and in a runtime without the DOM/File global the check threw a
+// ReferenceError. The same struck `Blob`, `Date`, the typed arrays, and every
+// other simples name.
+//
+// After the fix native classification requires the matched symbol to be declared
+// in a `.d.ts` declaration file (a TypeScript default library or an ambient
+// package such as @types/node), which a real built-in always is and a user type
+// in a `.ts` module never is. A colliding user type then falls through to the
+// structural object path and validates against its declared members, while a
+// genuine native (`Date`, `Uint8Array`) keeps its native `instanceof` check.
+//
+//  1. Transform is / validate for user interfaces named File and Blob, a near-miss
+//     control (Filer), and the genuine natives Date and Uint8Array.
+//  2. Assert the emitted TypeScript drops `instanceof File` / `instanceof Blob`
+//     for the user types while keeping `instanceof Date` / `instanceof Uint8Array`
+//     for the real natives.
+//  3. Execute the emitted validators in Node against the boundary matrix, and
+//     require the runner to report the exact executed case count so a runner that
+//     silently skipped cases cannot pass as a false green.
+func TestNativeNameCollisionIsTransform(t *testing.T) {
+  project := nativeNameCollisionProject(t)
+  js := nativeNameCollisionTransform(t, project)
+  for _, gone := range []string{"instanceof File", "instanceof Blob"} {
+    if strings.Contains(js, gone) {
+      t.Fatalf("expected user type collision %q to be reclassified structurally, but it survived in:\n%s", gone, js)
+    }
+  }
+  for _, kept := range []string{"instanceof Date", "instanceof Uint8Array"} {
+    if !strings.Contains(js, kept) {
+      t.Fatalf("expected genuine native path %q to remain in transform output:\n%s", kept, js)
+    }
+  }
+  nativeNameCollisionRunRuntimeCases(t, project, js)
+}
+
+func nativeNameCollisionProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "native-name-collision-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(finiteOptionNumberLeafTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(nativeNameCollisionSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func nativeNameCollisionTransform(t *testing.T, project string) string {
+  t.Helper()
+  payload := `[{"config":{"transform":"typia/lib/transform"},"name":"typia","stage":"transform"}]`
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+      "--plugins-json", payload,
+    })
+  })
+  if code != 0 {
+    t.Fatalf("native name collision transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func nativeNameCollisionRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(nativeNameCollisionRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("native name collision runtime cases failed: %v\n%s", err, output)
+  }
+  const expected = "RAN 23 CASES"
+  if !strings.Contains(string(output), expected) {
+    t.Fatalf("native name collision runner did not report %q; got:\n%s", expected, output)
+  }
+}
+
+const nativeNameCollisionSource = `import typia from "typia";
+
+interface File {
+  name: string;
+  size: number;
+}
+interface Blob {
+  size: number;
+  type: string;
+}
+interface Filer {
+  name: string;
+}
+
+export const isFile = typia.createIs<File>();
+export const validateFile = typia.createValidate<File>();
+export const isBlob = typia.createIs<Blob>();
+export const isFiler = typia.createIs<Filer>();
+
+export const isDate = typia.createIs<Date>();
+export const isU8 = typia.createIs<Uint8Array>();
+`
+
+const nativeNameCollisionRuntimeRunner = `const mod = require("./main.cjs");
+
+let ran = 0;
+const eq = (name, actual, expected) => {
+  ran += 1;
+  if (actual !== expected) {
+    throw new Error(name + ": expected " + expected + " but got " + actual);
+  }
+};
+
+// A user interface named File must validate against its own members, not the
+// native File instanceof path (#2200 core cases).
+eq("isFile valid", mod.isFile({ name: "a", size: 1 }), true);
+eq("isFile missing size", mod.isFile({ name: "a" }), false);
+eq("isFile missing name", mod.isFile({ size: 1 }), false);
+eq("isFile wrong size type", mod.isFile({ name: "a", size: "1" }), false);
+eq("isFile null", mod.isFile(null), false);
+eq("isFile primitive", mod.isFile(5), false);
+
+// validate shares the structural object path, so it agrees with is and names no
+// File expected type.
+eq("validateFile valid", mod.validateFile({ name: "a", size: 1 }).success, true);
+eq("validateFile invalid", mod.validateFile({ name: "a" }).success, false);
+
+// A user interface named Blob is structural too.
+eq("isBlob valid", mod.isBlob({ size: 1, type: "x" }), true);
+eq("isBlob missing type", mod.isBlob({ size: 1 }), false);
+eq("isBlob null", mod.isBlob(null), false);
+
+// A near-miss name that is not a native was always structural and stays so.
+eq("isFiler valid", mod.isFiler({ name: "a" }), true);
+eq("isFiler invalid", mod.isFiler({}), false);
+
+// Genuine natives keep their instanceof check and accept a real instance while
+// rejecting a plain object of the same shape.
+eq("isDate real", mod.isDate(new Date()), true);
+eq("isDate plain object", mod.isDate({}), false);
+eq("isDate null", mod.isDate(null), false);
+
+eq("isU8 real", mod.isU8(new Uint8Array(4)), true);
+eq("isU8 plain object", mod.isU8({}), false);
+eq("isU8 array", mod.isU8([1, 2, 3]), false);
+eq("isU8 null", mod.isU8(null), false);
+
+// A user File/Blob value is not a real native instance, and a real native is not
+// a user shape: the two classifications stay disjoint.
+eq("isFile rejects a real Date", mod.isFile(new Date()), false);
+eq("isDate rejects a user File shape", mod.isDate({ name: "a", size: 1 }), false);
+eq("isBlob rejects a real Date", mod.isBlob(new Date()), false);
+
+console.log("RAN " + ran + " CASES");
+`

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -315,6 +315,28 @@ func metadata_symbol_from_default_lib(symbol *nativeast.Symbol) bool {
   return false
 }
 
+// metadata_symbol_from_declaration_file reports whether the symbol's first
+// locatable declaration lives in a `.d.ts` declaration file. It widens
+// metadata_symbol_from_default_lib beyond the TypeScript default libraries
+// (lib.*.d.ts) to any ambient declaration file, because a built-in native can be
+// declared by an ambient package rather than a default lib — the `File` and
+// `Blob` globals Node adds through @types/node are declared in `.d.ts` files that
+// are not `lib.*.d.ts`. Native classification uses this to keep a real built-in
+// native (declared in a `.d.ts`, whichever library) native, while a user type
+// that merely shares a native's name — an `interface File { name; size }` in a
+// `.ts` module — is not a declaration and falls through to the structural object
+// path (#2200).
+func metadata_symbol_from_declaration_file(symbol *nativeast.Symbol) bool {
+  for _, node := range metadata_node_declarations(symbol) {
+    src := nativeast.GetSourceFileOfNode(node)
+    if src == nil {
+      continue
+    }
+    return src.IsDeclarationFile
+  }
+  return false
+}
+
 func metadata_is_default_lib_file_name(fileName string) bool {
   slash := strings.ReplaceAll(fileName, "\\", "/")
   base := slash

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
@@ -3,19 +3,34 @@ package metadata
 import (
   "strings"
 
+  nativeast "github.com/microsoft/typescript-go/shim/ast"
   schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
 
 func Iterate_metadata_native(props IMetadataIteratorProps) bool {
+  var symbol *nativeast.Symbol
   name := ""
   if props.Type != nil {
+    symbol = props.Type.Symbol()
     name = metadata_type_symbol_base_name(props.Type)
   }
   if name == "" && props.Checker != nil && props.Type != nil {
-    name = metadata_type_symbol_base_name(props.Checker.GetApparentType(props.Type))
+    apparent := props.Checker.GetApparentType(props.Type)
+    if apparent != nil {
+      symbol = apparent.Symbol()
+    }
+    name = metadata_type_symbol_base_name(apparent)
   }
   name = iterate_metadata_native_getNativeName(name)
   if _, ok := iterate_metadata_native_simples[name]; ok {
+    // Match the built-in only when the type actually is the built-in, not merely
+    // a user type of the same name. A real native is declared in a `.d.ts`
+    // library, so a user `interface File { name; size }` in a `.ts` module falls
+    // through to the structural object path and is validated against its own
+    // members instead of `input instanceof File` (#2200).
+    if !metadata_symbol_from_declaration_file(symbol) {
+      return false
+    }
     iterate_metadata_native_take(props.Metadata, name)
     return true
   }


### PR DESCRIPTION
## Problem

`Iterate_metadata_native` classified a type as a built-in native by its symbol **base name alone**. A user `interface File { name: string; size: number }` yielded the name `"File"`, matched `iterate_metadata_native_simples["File"]`, and emitted `input => input instanceof File` — ignoring the user's members. Every valid value of such a type was rejected, and where the global does not exist at runtime the check threw `ReferenceError`. The same struck `Blob`, `Date`, `RegExp`, the typed arrays, `ArrayBuffer`, `DataView`, and the `Number`/`String`/`Boolean`/`BigInt` wrappers (#2200). This is the exact-name half of the class #2181 fixed for the WeakMap/WeakSet generic prefix.

## Fix

Native classification now requires the matched symbol to be declared in a `.d.ts` declaration file (`metadata_symbol_from_declaration_file`), which every real built-in native is — a TypeScript default library (`lib.*.d.ts`), or an ambient package such as `@types/node` for the `File`/`Blob` globals that `lib.dom.d.ts` does not carry. A colliding user type in a `.ts` module is not a declaration file, so it falls through to the structural object path and validates against its own members, while a genuine native keeps its `instanceof` check.

The declaration-file test (rather than #2178's stricter default-lib-only test) is deliberate: the real Node `File`/`Blob` come from `@types/node`, not `lib.*.d.ts`, so a pure default-lib guard would wrongly reject them. Any real global native is `.d.ts`-declared, so this predicate cannot over-reject one. The WeakMap/WeakSet generic-prefix guard (#2181) is left byte-identical.

## Emit before / after (user `interface File`, `Blob`; real `Date`, `Uint8Array`)

Before:
```js
isFile = input => input instanceof File;   // user members ignored
isBlob = input => input instanceof Blob;
isDate = input => input instanceof Date;
isU8   = input => input instanceof Uint8Array;
```
After:
```js
isFile = input => "object" === typeof input && null !== input && _io0(input); // _io0 checks name+size
isBlob = input => "object" === typeof input && null !== input && _io0(input);
isDate = input => input instanceof Date;         // real native unchanged
isU8   = input => input instanceof Uint8Array;   // real native unchanged
```

## Verification

- New transform test `TestNativeNameCollisionIsTransform` (emit + Node runtime, 23 executed cases): user `File`/`Blob`/`validate<File>` validate structurally and reject non-matching objects; real `Date`/`Uint8Array` keep `instanceof` and accept real instances.
- Full native Go test tree green (`packages/typia/native/...` and the CI `packages/typia/test/...` tree, incl. `metadata/*`, `contract/native`, `native/guard`).
- Sibling guards intact: #2181 WeakMap/WeakSet (`TestNativeGenericNameGuardIsTransform`) byte-identical; #2178 `is<Object>` / lowercase `object` / `{}` (`TestIsObjectFunctionMemberTransform`).
- `tests/test-typia-schema` — 171 cases, Success.
- Corpus emit-diff (whole `cmd/ttsc-typia` suite pre vs post): the only change is `TestNativeNameCollisionIsTransform` flipping red→green; no other type's emit changed.

No `@typia/interface` edit, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy