### PR TITLE
fix(typia): generate a >=2-char TLD for idn hostname/email so random honors the idn format under a length tag (#2215)

### DIFF
--- a/packages/typia/src/internal/_randomFormatHostname.ts
+++ b/packages/typia/src/internal/_randomFormatHostname.ts
@@ -7,7 +7,7 @@ export const _randomFormatHostname = (props?: _ILengthProps): string => {
     return `${random(10)}.${random(3)}`;
   // A hostname is dot-joined labels of 1..63 chars whose total is capped at 253,
   // so the requested length is realized by splitting it across enough labels.
-  return ofLength(pickLength(props));
+  return _randomHostnameLabels(pickLength(props));
 };
 
 const MAX_TOTAL = 253;
@@ -27,7 +27,12 @@ const pickLength = (props: _ILengthProps): number => {
   return _randomInteger({ type: "integer", minimum: low, maximum: high });
 };
 
-const ofLength = (length: number): string => {
+/**
+ * Builds dot-joined hostname labels totalling exactly `length` characters, each
+ * label within 63 chars. Shared with the idn-hostname generator, which reserves
+ * a fixed `.<tld>` suffix and realizes the rest as these leading labels.
+ */
+export const _randomHostnameLabels = (length: number): string => {
   const parts: string[] = [];
   let remaining: number = length;
   while (remaining > MAX_LABEL + 1) {

--- a/packages/typia/src/internal/_randomFormatHostname.ts
+++ b/packages/typia/src/internal/_randomFormatHostname.ts
@@ -28,7 +28,7 @@ const pickLength = (props: _ILengthProps): number => {
 };
 
 /**
- * Builds dot-joined hostname labels totalling exactly `length` characters, each
+ * Builds dot-joined hostname labels totaling exactly `length` characters, each
  * label within 63 chars. Shared with the idn-hostname generator, which reserves
  * a fixed `.<tld>` suffix and realizes the rest as these leading labels.
  */

--- a/packages/typia/src/internal/_randomFormatIdnEmail.ts
+++ b/packages/typia/src/internal/_randomFormatIdnEmail.ts
@@ -1,5 +1,19 @@
-import { _randomFormatEmail } from "./_randomFormatEmail";
-import { _ILengthProps } from "./_randomStringLength";
+import { _randomString } from "./_randomString";
+import { _ILengthProps, _randomSegmentLength } from "./_randomStringLength";
 
-export const _randomFormatIdnEmail = (props?: _ILengthProps): string =>
-  _randomFormatEmail(props);
+export const _randomFormatIdnEmail = (props?: _ILengthProps): string => {
+  if (props?.minLength === undefined && props?.maxLength === undefined)
+    return `${random(10)}@${random(10)}.${random(3)}`;
+  // `_isFormatIdnEmail` requires a >=2-char TLD (`(…\.)+[^…]{2,}`), so the fixed
+  // overhead is `@` + domain(1) + `.` + tld(2) = 5 and the local part absorbs the
+  // requested length; a one-character TLD (the non-idn generator's length path)
+  // would be rejected by the idn checker on every draw.
+  return `${_randomSegmentLength(props, 5, 10, 1)}@${random(1)}.${random(2)}`;
+};
+
+const random = (length: number) =>
+  _randomString({
+    type: "string",
+    minLength: length,
+    maxLength: length,
+  });

--- a/packages/typia/src/internal/_randomFormatIdnHostname.ts
+++ b/packages/typia/src/internal/_randomFormatIdnHostname.ts
@@ -1,5 +1,35 @@
-import { _randomFormatHostname } from "./_randomFormatHostname";
+import { _randomHostnameLabels } from "./_randomFormatHostname";
+import { _randomInteger } from "./_randomInteger";
+import { _randomString } from "./_randomString";
 import { _ILengthProps } from "./_randomStringLength";
 
-export const _randomFormatIdnHostname = (props?: _ILengthProps): string =>
-  _randomFormatHostname(props);
+export const _randomFormatIdnHostname = (props?: _ILengthProps): string => {
+  if (props?.minLength === undefined && props?.maxLength === undefined)
+    return `${random(10)}.${random(3)}`;
+  // `_isFormatIdnHostname` requires at least one label, a dot, and a >=2-char
+  // TLD (`(…\.)+[a-z¡-￿]{2,}`), none of which the non-idn hostname generator
+  // guarantees on its length path (it can emit a single dotless label). Reserve
+  // a fixed `.<2-char TLD>` and realize the rest as dot-joined leading labels.
+  const length: number = pickLength(props);
+  return `${_randomHostnameLabels(length - 3)}.${random(2)}`;
+};
+
+const MAX_TOTAL = 253;
+const MIN_TOTAL = 4; // the shortest idn hostname, `x.yy`: label(1) + `.` + tld(2)
+
+const pickLength = (props: _ILengthProps): number => {
+  let low: number = props.minLength === undefined ? MIN_TOTAL : props.minLength;
+  if (low < MIN_TOTAL) low = MIN_TOTAL;
+  const high: number =
+    props.maxLength === undefined
+      ? Math.min(MAX_TOTAL, low + 14)
+      : Math.min(MAX_TOTAL, props.maxLength);
+  if (high < low)
+    throw new Error(
+      "unable to generate a random idn hostname satisfying both the format and the length constraints.",
+    );
+  return _randomInteger({ type: "integer", minimum: low, maximum: high });
+};
+
+const random = (length: number) =>
+  _randomString({ type: "string", minLength: length, maxLength: length });

--- a/tests/test-typia-schema/src/features/random/test_random_string_pattern_format_length.ts
+++ b/tests/test-typia-schema/src/features/random/test_random_string_pattern_format_length.ts
@@ -13,6 +13,12 @@ import typia, { tags } from "typia";
  * with a throw the way an impossible numeric range already is, never silently
  * produced. This round trip pins both directions.
  *
+ * The `idn-hostname`/`idn-email` cases below cover a narrower regression of the
+ * same class (issue #2215): the length path delegated to the laxer non-idn
+ * generators, which emit a one-character TLD (and, for the hostname, a dotless
+ * single label), but the idn checkers require a dot plus a `>=2`-character TLD,
+ * so every length-tagged draw failed the type's own `is`.
+ *
  * 1. Draw a large sample of each satisfiable pattern/format + length type.
  * 2. Require every draw to pass `is` of the same type and honor the bounds.
  * 3. Require an unsatisfiable pattern/format + length type to throw on draw.
@@ -132,6 +138,94 @@ export const test_random_string_pattern_format_length = (): void => {
     );
   }
 
+  // IDN formats (issue #2215): the length path must yield a dot plus a
+  // >=2-character TLD so the stricter idn checker accepts every draw.
+  {
+    type T = string & tags.Format<"idn-hostname"> & tags.MinLength<40>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-hostname & minLength",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"idn-hostname"> &
+      tags.MinLength<40> &
+      tags.MaxLength<64>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-hostname & minLength & maxLength",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    // A minLength beyond a single 63-char label exercises multi-label building.
+    type T = string & tags.Format<"idn-hostname"> & tags.MinLength<80>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-hostname & multi-label minLength",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    // A short window near the idn-hostname minimum (`x.yy`) forces the short path.
+    type T = string &
+      tags.Format<"idn-hostname"> &
+      tags.MinLength<4> &
+      tags.MaxLength<8>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-hostname & short window",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    type T = string & tags.Format<"idn-email"> & tags.MinLength<40>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-email & minLength",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"idn-email"> &
+      tags.MinLength<40> &
+      tags.MaxLength<64>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-email & minLength & maxLength",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    // A short window near the idn-email minimum (`x@x.yy`) forces the short path.
+    type T = string &
+      tags.Format<"idn-email"> &
+      tags.MinLength<6> &
+      tags.MaxLength<9>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-email & short window",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+
   // BOUNDARY: an exactly-pinned length window still round-trips.
   {
     type T = string &
@@ -141,6 +235,32 @@ export const test_random_string_pattern_format_length = (): void => {
     const create = typia.createRandom<T>();
     roundTrip(
       "pattern exact length",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"idn-hostname"> &
+      tags.MinLength<12> &
+      tags.MaxLength<12>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-hostname exact length",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"idn-email"> &
+      tags.MinLength<12> &
+      tags.MaxLength<12>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-email exact length",
       (v) => typia.is<T>(v),
       () => typia.random<T>(),
       () => create(),
@@ -169,6 +289,27 @@ export const test_random_string_pattern_format_length = (): void => {
     );
   }
   {
+    // Unconstrained idn formats already passed; pin that they still do.
+    type T = string & tags.Format<"idn-hostname">;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-hostname only",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    type T = string & tags.Format<"idn-email">;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-email only",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
     type T = string & tags.MinLength<10>;
     const create = typia.createRandom<T>();
     roundTrip(
@@ -188,6 +329,14 @@ export const test_random_string_pattern_format_length = (): void => {
   );
   assertThrows("fixed-length format & conflicting maxLength", () =>
     typia.random<string & tags.Format<"uuid"> & tags.MaxLength<10>>(),
+  );
+  // Below the idn minimums (`x@x.yy` = 6, `x.yy` = 4) there is no matching value
+  // to emit, so the draw must throw rather than yield a `is`-rejected string.
+  assertThrows("idn-email & impossible maxLength", () =>
+    typia.random<string & tags.Format<"idn-email"> & tags.MaxLength<5>>(),
+  );
+  assertThrows("idn-hostname & impossible maxLength", () =>
+    typia.random<string & tags.Format<"idn-hostname"> & tags.MaxLength<3>>(),
   );
 };
 


### PR DESCRIPTION
## Problem

Fixes #2215.

`typia.random<string & Format<"idn-hostname"> & (length tag)>()` and the `idn-email` counterpart emitted values their own `is` rejects on **every** draw. The idn generators delegated to the laxer non-idn hostname/email generators, whose length path emits a **one-character TLD** (`…@x.y`) and, for the hostname, a **single dotless label** for short lengths. But the idn checkers require a dot plus a **≥2-character** TLD (`_isFormatIdnHostname`: `(…\.)+[a-z¡-￿]{2,}`; `_isFormatIdnEmail`: `(…\.)+[^…]{2,}`). Generator and validator — two owners of one contract — disagreed. Regression from #2189/#2192, same class as #2204/#2045.

## Fix

`packages/typia/src/internal/`:

- **`_randomFormatIdnEmail.ts`** — own length-aware body instead of delegating: reserve a fixed `@<domain(1)>.<tld(2)>` (overhead 5) and let the local part absorb the requested length, so the TLD is always ≥2 chars.
- **`_randomFormatIdnHostname.ts`** — own length-aware body: reserve a fixed `.<tld(2)>` and realize the rest as dot-joined leading labels (each ≤63), guaranteeing a dot and a ≥2-char TLD at any satisfiable length. Its `minLength` floor is the idn minimum `x.yy` (4); an unsatisfiable window throws per #2192/#2204.
- **`_randomFormatHostname.ts`** — the label splitter (`ofLength`) is exported as `_randomHostnameLabels` so the idn hostname generator reuses it. The non-idn hostname generator's behavior is byte-identical.

The non-idn `email`/`hostname` generators are **not** modified, so their accepted set (including a 1-char TLD and dotless single-label hostnames, and the tight `MaxLength` windows they satisfy) is preserved.

## Verification

`pnpm --filter ./tests/test-typia-schema start --include random` — all 16 random feature tests pass.

Added `random`→`is` round trips (1000 draws each) to `test_random_string_pattern_format_length.ts` for the gap that hid this: length-tagged `idn-hostname`/`idn-email` (minLength, min+max, multi-label, short window, exact length), the unconstrained idn controls, and unsatisfiable idn windows that must throw.

Direct `is(random())` sweep, 1000 draws/case:

| case | before | after |
| --- | --- | --- |
| `idn-hostname & MinLength<40>` | 1000/1000 fail | 0/1000 fail |
| `idn-hostname & [4,8]` | 1000/1000 fail | 0/1000 fail |
| `idn-hostname & exact 12` | 1000/1000 fail | 0/1000 fail |
| `idn-email & MinLength<40>` | 1000/1000 fail | 0/1000 fail |
| `idn-email & [6,9]` | 1000/1000 fail | 0/1000 fail |
| `idn-email & exact 12` | 1000/1000 fail | 0/1000 fail |
| unconstrained idn (both) | 0/1000 fail | 0/1000 fail |
| non-idn `email`/`hostname` + length | 0/1000 fail | 0/1000 fail |
| `idn-email & MaxLength<5>` (unsat) | emits non-matching | throws |
| `idn-hostname & MaxLength<3>` (unsat) | emits non-matching | throws |

No `package.json` version bump; no `packages/interface/src` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy