### PR TITLE
fix(native): carry a boolean's default through the OpenAPI 3.0 downgrade (#2217)

### DIFF
--- a/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader.go
+++ b/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader.go
@@ -83,12 +83,16 @@ func OpenApiV3Downgrader_downgrade_schema(collection *OpenApiV3Downgrader_ICompo
 
   var visit func(schema JsonSchema)
   visit = func(schema JsonSchema) {
-    if openApiV3Downgrader_is_boolean(schema) {
-      union = append(union, JsonSchema{"type": "boolean"})
-    } else if openApiV3Downgrader_is_integer(schema) ||
+    if openApiV3Downgrader_is_boolean(schema) ||
+      openApiV3Downgrader_is_integer(schema) ||
       openApiV3Downgrader_is_number(schema) ||
       openApiV3Downgrader_is_string(schema) ||
       openApiV3Downgrader_is_reference(schema) {
+      // A boolean carries the same declared keywords through the downgrade as
+      // the other primitives do (at minimum `default`, plus every attribute
+      // OpenApiV3.IJsonSchema.IBoolean allows); rebuilding it as
+      // `{"type": "boolean"}` dropped them. `omit_examples` keeps the legal
+      // 3.0 keys and strips only `examples`, which 3.0 does not define.
       union = append(union, openApiV3Downgrader_omit_examples(schema))
     } else if openApiV3Downgrader_is_array(schema) {
       next := openApiV3Downgrader_omit_examples(schema)

--- a/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader_boolean_default_test.go
+++ b/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader_boolean_default_test.go
@@ -1,0 +1,95 @@
+package iterate
+
+import (
+  "testing"
+)
+
+// TestOpenApiV3DowngraderCarriesBooleanKeywords verifies the 3.0 downgrade keeps
+// a boolean's declared keywords instead of rebuilding a bare `{"type":
+// "boolean"}`.
+//
+// The boolean branch used to append `{"type": "boolean"}` from scratch, dropping
+// `default` and every other keyword, while the number/string/reference branch
+// carried theirs through `omit_examples`. So a `boolean & Default<true>` kept
+// `default` under 3.1 but lost it under 3.0, contradicting
+// `OpenApiV3.IJsonSchema.IBoolean`, which declares `default` (and the shared
+// `title`/`description`/`deprecated` attributes). The expectations below come
+// from that declared type: only keys it allows may survive, and `examples` — the
+// one 3.0 does not define — must not.
+//
+// 1. Downgrade a boolean carrying `default`, and one also carrying attributes.
+// 2. Assert each keeps every declared keyword and drops only `examples`.
+// 3. Assert a keyword-less boolean still degrades to a bare `{"type": "boolean"}`
+//    and that a boolean inside a union keeps its `default`.
+func TestOpenApiV3DowngraderCarriesBooleanKeywords(t *testing.T) {
+  collection := OpenApiV3Downgrader_downgrade_components(&OpenApi_IComponents{})
+
+  cases := []struct {
+    label    string
+    input    JsonSchema
+    expected JsonSchema
+  }{
+    {
+      label:    "boolean carries its default",
+      input:    JsonSchema{"type": "boolean", "default": true},
+      expected: JsonSchema{"type": "boolean", "default": true},
+    },
+    {
+      label: "boolean carries default:false and shared attributes",
+      input: JsonSchema{
+        "type":        "boolean",
+        "default":     false,
+        "title":       "Enabled",
+        "description": "Whether the feature is enabled.",
+        "deprecated":  true,
+      },
+      expected: JsonSchema{
+        "type":        "boolean",
+        "default":     false,
+        "title":       "Enabled",
+        "description": "Whether the feature is enabled.",
+        "deprecated":  true,
+      },
+    },
+    {
+      // `examples` is the one attribute 3.0 does not define; the downgrade must
+      // drop it while keeping `default`.
+      label: "boolean drops examples but keeps default",
+      input: JsonSchema{
+        "type":     "boolean",
+        "default":  true,
+        "examples": map[string]any{"on": true},
+      },
+      expected: JsonSchema{"type": "boolean", "default": true},
+    },
+    {
+      label:    "keyword-less boolean stays bare",
+      input:    JsonSchema{"type": "boolean"},
+      expected: JsonSchema{"type": "boolean"},
+    },
+    {
+      label: "boolean default survives inside a union",
+      input: JsonSchema{
+        "oneOf": []JsonSchema{
+          {"type": "boolean", "default": true},
+          {"type": "number"},
+        },
+      },
+      expected: JsonSchema{
+        "oneOf": []JsonSchema{
+          {"type": "boolean", "default": true},
+          {"type": "number"},
+        },
+      },
+    },
+  }
+
+  for _, tc := range cases {
+    actual := OpenApiV3Downgrader_downgrade_schema(collection, tc.input)
+    if openApiV3DowngraderTestJSON(t, actual) != openApiV3DowngraderTestJSON(t, tc.expected) {
+      t.Fatalf("%s: got %s, want %s", tc.label,
+        openApiV3DowngraderTestJSON(t, actual),
+        openApiV3DowngraderTestJSON(t, tc.expected))
+    }
+  }
+}

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -243,9 +243,12 @@ export namespace OpenApiV3Downgrader {
         ),
       };
       const visit = (schema: OpenApi.IJsonSchema): void => {
-        if (OpenApiTypeChecker.isBoolean(schema))
-          union.push({ type: "boolean" });
-        else if (
+        if (
+          // A boolean carries its declared keywords (at minimum `default`,
+          // plus every attribute OpenApiV3.IJsonSchema.IBoolean allows) through
+          // the downgrade like the other primitives. Rebuilding it as a bare
+          // `{ type: "boolean" }` dropped them; `omitSchemaExamples` keeps the
+          // legal 3.0 keys and strips only `examples`, which 3.0 does not define.
           OpenApiTypeChecker.isBoolean(schema) ||
           OpenApiTypeChecker.isInteger(schema) ||
           OpenApiTypeChecker.isNumber(schema) ||

--- a/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_boolean_default.ts
+++ b/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_boolean_default.ts
@@ -1,0 +1,82 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiV3 } from "@typia/interface";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies the OpenAPI 3.0 downgrade keeps a boolean's declared keywords.
+ *
+ * The downgrader rebuilt a boolean as a bare `{ "type": "boolean" }`, dropping
+ * its `default` (and every other keyword) while number and string carried
+ * theirs through. So `boolean & Default<true>` emitted `default: true` under
+ * "3.1" but lost it under "3.0", contradicting
+ * `OpenApiV3.IJsonSchema.IBoolean`, which declares `default`. This pins the
+ * boolean branch against the keys that type allows, and against the 3.1 form it
+ * must agree with.
+ *
+ * 1. Emit a bare `boolean & Default<true>` under "3.1" and "3.0" and assert both
+ *    carry `default: true`.
+ * 2. Emit an object whose boolean properties carry `default`, title, description,
+ *    and `@deprecated`, and assert the 3.0 component keeps them while a
+ *    keyword-less boolean stays a bare `{ type: "boolean" }`.
+ * 3. Assert the 3.0 components validate as a legal `OpenApiV3.IComponents`, so no
+ *    key outside the declared boolean type leaked in.
+ */
+export const test_json_schemas_v3_0_boolean_default = (): void => {
+  const emended = typia.json.schemas<[boolean & tags.Default<true>], "3.1">();
+  const downgraded = typia.json.schemas<
+    [boolean & tags.Default<true>],
+    "3.0"
+  >();
+  TestValidator.equals("version", downgraded.version, "3.0");
+  // The 3.1 form already carried the keyword; the downgrade must not diverge.
+  TestValidator.equals("3.1 boolean default", clean(emended.schemas[0]), {
+    type: "boolean",
+    default: true,
+  });
+  TestValidator.equals("3.0 boolean default", clean(downgraded.schemas[0]), {
+    type: "boolean",
+    default: true,
+  });
+
+  interface IFlags {
+    /**
+     * Whether the feature is enabled.
+     *
+     * @deprecated
+     * @title Enabled
+     */
+    enabled: boolean & tags.Default<false>;
+    plain: boolean;
+  }
+  const object = typia.json.schemas<[IFlags], "3.0">();
+  const flags = clean(object.components).schemas
+    ?.IFlags as unknown as OpenApiV3.IJsonSchema.IObject;
+  TestValidator.equals(
+    "embedded boolean keeps keywords",
+    flags.properties?.enabled,
+    {
+      type: "boolean",
+      title: "Enabled",
+      description: "Whether the feature is enabled.",
+      default: false,
+      deprecated: true,
+    },
+  );
+  // Boundary: a boolean without a keyword stays a bare `{ type: "boolean" }`.
+  TestValidator.equals(
+    "keyword-less boolean stays bare",
+    flags.properties?.plain,
+    {
+      type: "boolean",
+    },
+  );
+
+  // The downgrade added no key the declared 3.0 boolean type disallows.
+  TestValidator.predicate(
+    "components validate against OpenApiV3.IComponents",
+    typia.validateEquals<OpenApiV3.IComponents>(clean(object.components))
+      .success,
+  );
+};
+
+const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));

--- a/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_parity_converter.ts
+++ b/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_parity_converter.ts
@@ -44,6 +44,12 @@ export const test_json_schemas_v3_0_parity_converter = (): void => {
     literal: "alpha" | "beta";
     mixedLiteral: 1 | 2 | "three";
     booleanValue: boolean;
+    /**
+     * A boolean keyword must survive the downgrade in both owners. Rebuilding a
+     * boolean as a bare `{ type: "boolean" }` dropped it and drifted the two
+     * owners apart wherever a boolean carried one.
+     */
+    booleanDefault: boolean & tags.Default<true>;
     tuple: [string, number];
     restTuple: [string, ...number[]];
     dictionary: Record<string, number>;


### PR DESCRIPTION
## Problem

Fixes #2217. Both owners of the OpenAPI 3.0 downgrade rebuilt a `boolean` as a bare `{"type":"boolean"}`, dropping its `default` (and every other keyword) while number, string, and integer carried theirs through. So `boolean & Default<true>` emitted `{type:"boolean",default:true}` under `"3.1"` but `{type:"boolean"}` under `"3.0"` — contradicting typia's own `OpenApiV3.IJsonSchema.IBoolean`, which declares `default`.

## Fix — both owners of the one downgrade contract

- **Native** (`packages/typia/native/core/programmers/iterate/openapi_v3_downgrader.go`): the boolean branch appended `{"type":"boolean"}` from scratch. Routed it through the same `omit_examples` branch the other primitives already use.
- **`@typia/utils`** (`packages/utils/src/converters/internal/OpenApiV3Downgrader.ts`): the identical twin defect. Its standalone `if (isBoolean) push({ type: "boolean" })` shadowed the `isBoolean` already sitting (as dead code) in the keyword-carrying `else if`. Removing the standalone push lets a boolean flow through `omitSchemaExamples`, so the two owners agree again.

`omit_examples` / `omitSchemaExamples` shallow-copies every key except `examples` (the one attribute 3.0 does not define), so the boolean keeps exactly the keys `OpenApiV3.IJsonSchema.IBoolean` allows (`type`, `default`, `enum`, `nullable`, and the shared `title`/`description`/`deprecated`/`example`/`readOnly`/`writeOnly` attributes). The change stops dropping; it invents nothing.

## Why the parity oracle was blind — now fixed

The 3.0↔`@typia/utils` parity test (`test_json_schemas_v3_0_parity_converter.ts`) compares the two owners, but its fixture used only a keyword-less `boolean`, so both agreed on the lossy shape and the class stayed invisible. The fixture now carries a `boolean & Default<true>`: **before** the utils fix it FAILS (native carries `default`, utils drops it — divergent at `.properties.booleanDefault.default`), **after** both carry it and it passes.

## Verification

- **Red → green (Go):** new `openapi_v3_downgrader_boolean_default_test.go` — failed with `{"type":"boolean"}` before, passes carrying `default` after.
- **Red → green (native schema):** new `test_json_schemas_v3_0_boolean_default.ts` asserts the 3.0 boolean keeps `default` (and title/description/deprecated), a keyword-less boolean stays bare, the 3.1 form is unchanged, and the components pass `validateEquals<OpenApiV3.IComponents>` (no illegal key leaked).
- **Red → green (parity oracle):** strengthened `test_json_schemas_v3_0_parity_converter.ts` fails before the utils fix, passes after.
- **Regression:** full native Go tree (`go -C packages/typia/native test ./...`), full `test-typia-schema`, and full `test-utils` suites all green. Native and utils now agree on `boolean & Default`.

## Notes

- No `packages/typia/package.json` version bump; no `packages/interface/src` edit (the `IBoolean` declaration is authoritative and correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy