### PR TITLE
fix(native): unalias the property in json.application validation so an aliased malformed function is reported (#2216)

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/json_application_alias_function_validation_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_application_alias_function_validation_transform_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestJsonApplicationAliasFunctionValidation verifies that a function property
+// written through a `type` alias reaches the same #2195 guards as an inline one.
+//
+// `json.application` keeps the alias on the property value it validates but
+// unaliases the one it emits, so before #2216 the two disagreed: `Validate` read
+// `p.Value.Functions` (empty for an aliased member) and skipped every per-function
+// check, while `WriteApplication` unaliased and silently dropped the malformed
+// function. The mirror case rejected a valid aliased application with a spurious
+// "must have at least a function type." This pins both directions.
+//
+//  1. Reject an aliased union / optional / nullable function with its exact
+//     #2195 diagnostic, matching the inline sibling fixtures.
+//  2. Accept an aliased required single function (direct and through a deep
+//     alias chain), emitting it and reporting no "at least a function" error.
+func TestJsonApplicationAliasFunctionValidation(t *testing.T) {
+  for _, tt := range []struct {
+    name     string
+    source   string
+    fragment string
+  }{
+    {
+      name: "alias-union",
+      source: `import typia from "typia";
+type BadUnion = (() => number) | ((value: number) => string);
+typia.json.application<{ good(): number; bad: BadUnion; }>();
+`,
+      fragment: "JSON application's function type does not allow union type.",
+    },
+    {
+      name: "alias-optional",
+      source: `import typia from "typia";
+type BadFn = () => number;
+typia.json.application<{ good(): number; bad?: BadFn; }>();
+`,
+      fragment: "JSON application's function type must be required.",
+    },
+    {
+      name: "alias-nullable",
+      source: `import typia from "typia";
+type BadFn = () => number;
+typia.json.application<{ good(): number; bad: BadFn | null; }>();
+`,
+      fragment: "JSON application's function type must not be nullable.",
+    },
+  } {
+    jsonApplicationAliasExpectDiagnostic(t, tt.name, tt.source, tt.fragment)
+  }
+
+  for _, tt := range []struct {
+    name     string
+    source   string
+    function string
+  }{
+    {
+      name: "alias-required-single",
+      source: `import typia from "typia";
+type GoodFn = () => number;
+typia.json.application<{ only: GoodFn; }>();
+`,
+      function: "only",
+    },
+    {
+      name: "alias-deep-chain",
+      source: `import typia from "typia";
+type A = B;
+type B = () => number;
+typia.json.application<{ deep: A; }>();
+`,
+      function: "deep",
+    },
+  } {
+    jsonApplicationAliasExpectInclusion(t, tt.name, tt.source, tt.function)
+  }
+}
+
+func jsonApplicationAliasExpectDiagnostic(t *testing.T, name string, source string, fragment string) {
+  t.Helper()
+  project := jsonApplicationAliasProject(t, name, source)
+  _, errText, code := ttscTypiaTestCapture(func() int {
+    return runBuild([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--emit",
+      "--outDir", filepath.Join(project, "dist"),
+    })
+  })
+  if code != 3 {
+    t.Fatalf("%s aliased application build should fail with code 3, got %d\nstderr=%s", name, code, errText)
+  }
+  for _, want := range []string{"error TS(typia.json.application):", fragment} {
+    if !strings.Contains(errText, want) {
+      t.Fatalf("%s aliased application diagnostic missing %q:\n%s", name, want, errText)
+    }
+  }
+}
+
+func jsonApplicationAliasExpectInclusion(t *testing.T, name string, source string, function string) {
+  t.Helper()
+  project := jsonApplicationAliasProject(t, name, source)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("%s valid aliased application should transform, got code %d\nstderr=%s", name, code, errText)
+  }
+  if !strings.Contains(out, `name: "`+function+`"`) {
+    t.Fatalf("%s valid aliased application dropped its function %q:\n%s", name, function, out)
+  }
+  if strings.Contains(out, "at least a function") {
+    t.Fatalf("%s valid aliased application reported a spurious empty-application error:\n%s", name, out)
+  }
+}
+
+func jsonApplicationAliasProject(t *testing.T, name string, source string) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "json-application-alias-"+name+"-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(randomRecursiveMinItemsTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}

--- a/packages/typia/native/core/programmers/json/JsonApplicationProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonApplicationProgrammer.go
@@ -51,20 +51,30 @@ func (jsonApplicationProgrammerNamespace) Validate(props struct {
     }
     least := false
     for _, p := range object.Properties {
-      value := p.Value
+      // Resolve the function through any `type` alias exactly as
+      // WriteApplication does, so an aliased function is recognized as a
+      // function property here too. Otherwise `p.Value.Functions` is empty for
+      // an aliased member and every check below is skipped, letting
+      // WriteApplication silently drop the malformed function (issue #2216,
+      // reopening #2195 for aliased members).
+      value := jsonApplicationProgrammer_unaliasFunctions(p.Value)
       if len(value.Functions) != 0 {
         least = true
         // These per-function shape checks must run for every function
         // property, independent of the top-level `valid`: otherwise a
         // malformed function (union/optional/nullable) is silently dropped by
-        // WriteApplication with no diagnostic at all (issue #2195).
+        // WriteApplication with no diagnostic at all (issue #2195). The union
+        // shape comes from the unaliased value, while the reference-site
+        // optional/nullable modifiers stay on the raw property value: an
+        // optional or nullable alias is not unwrapped by MetadataSchema_unalias,
+        // so those two checks must read `p.Value`, not the unaliased schema.
         if len(value.Functions) != 1 || value.Size() != 1 {
           output = append(output, "JSON application's function type does not allow union type.")
         }
-        if value.IsRequired() == false {
+        if p.Value.IsRequired() == false {
           output = append(output, "JSON application's function type must be required.")
         }
-        if value.Nullable == true {
+        if p.Value.Nullable == true {
           output = append(output, "JSON application's function type must not be nullable.")
         }
       }
@@ -370,6 +380,28 @@ func jsonApplicationProgrammer_descriptionFromParam(tags []nativemetadata.IJsDoc
   }
   text := strings.TrimPrefix(*description, param.Name)
   return &text
+}
+
+// jsonApplicationProgrammer_unaliasFunctions resolves the metadata schema whose
+// `Functions` decide whether a property is a function slot and how that function
+// is shaped. WriteApplication reads `len(MetadataSchema_unalias(value).Functions)`
+// for the same decision, but MetadataSchema_unalias preserves a reference-site
+// optional or nullable modifier and so stops before an optional/nullable alias.
+// This peels a pure single-alias chain past those modifiers too (guarded by
+// Size == 1 so a union stays visible), so an aliased function that is optional,
+// nullable, or a union of functions is still recognized and reported instead of
+// being silently dropped (issue #2216). A non-function alias resolves to a
+// schema with no functions and is therefore ignored, exactly as before.
+func jsonApplicationProgrammer_unaliasFunctions(value *nativemetadata.MetadataSchema) *nativemetadata.MetadataSchema {
+  visited := map[*nativemetadata.MetadataSchema]struct{}{}
+  for len(value.Functions) == 0 && len(value.Aliases) == 1 && value.Size() == 1 {
+    if _, ok := visited[value]; ok {
+      break
+    }
+    visited[value] = struct{}{}
+    value = value.Aliases[0].Type.Value
+  }
+  return value
 }
 
 func jsonApplicationProgrammer_hidden(tags []nativemetadata.IJsDocTagInfo) bool {

--- a/tests/test-error/src/json/json.application.alias-nullable.ts
+++ b/tests/test-error/src/json/json.application.alias-nullable.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+// A NULLABLE FUNCTION PROPERTY WRITTEN THROUGH A `type` ALIAS MUST BE REJECTED,
+// NOT SILENTLY DROPPED (issue #2216, reopening #2195 for aliased members).
+type BadFn = () => number;
+typia.json.application<{
+  good(): number;
+  bad: BadFn | null;
+}>();

--- a/tests/test-error/src/json/json.application.alias-optional.ts
+++ b/tests/test-error/src/json/json.application.alias-optional.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+// AN OPTIONAL FUNCTION PROPERTY WRITTEN THROUGH A `type` ALIAS MUST BE REJECTED,
+// NOT SILENTLY DROPPED (issue #2216, reopening #2195 for aliased members).
+type BadFn = () => number;
+typia.json.application<{
+  good(): number;
+  bad?: BadFn;
+}>();

--- a/tests/test-error/src/json/json.application.alias-union.ts
+++ b/tests/test-error/src/json/json.application.alias-union.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+// A UNION-OF-FUNCTIONS PROPERTY WRITTEN THROUGH A `type` ALIAS MUST BE REJECTED,
+// NOT SILENTLY DROPPED (issue #2216, reopening #2195 for aliased members).
+type BadUnion = (() => number) | ((value: number) => string);
+typia.json.application<{
+  good(): number;
+  bad: BadUnion;
+}>();

--- a/tests/test-error/src/llm/llm.application.alias-nullable.ts
+++ b/tests/test-error/src/llm/llm.application.alias-nullable.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+// A NULLABLE FUNCTION PROPERTY WRITTEN THROUGH A `type` ALIAS MUST BE REJECTED,
+// NOT SILENTLY DROPPED (issue #2216, reopening #2195 for aliased members).
+type BadFn = (p: { value: string }) => void;
+typia.llm.application<{
+  good(p: { value: string }): void;
+  bad: BadFn | null;
+}>();

--- a/tests/test-error/src/llm/llm.application.alias-optional.ts
+++ b/tests/test-error/src/llm/llm.application.alias-optional.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+// AN OPTIONAL FUNCTION PROPERTY WRITTEN THROUGH A `type` ALIAS MUST BE REJECTED,
+// NOT SILENTLY DROPPED (issue #2216, reopening #2195 for aliased members).
+type BadFn = (p: { value: string }) => void;
+typia.llm.application<{
+  good(p: { value: string }): void;
+  bad?: BadFn;
+}>();

--- a/tests/test-error/src/llm/llm.application.alias-union.ts
+++ b/tests/test-error/src/llm/llm.application.alias-union.ts
@@ -1,0 +1,11 @@
+import typia from "typia";
+
+// A UNION-OF-FUNCTIONS PROPERTY WRITTEN THROUGH A `type` ALIAS MUST BE REJECTED,
+// NOT SILENTLY DROPPED (issue #2216, reopening #2195 for aliased members).
+type BadUnion =
+  | ((p: { value: string }) => void)
+  | ((p: { flag: boolean }) => void);
+typia.llm.application<{
+  good(p: { value: string }): void;
+  bad: BadUnion;
+}>();


### PR DESCRIPTION
## Problem

`typia.json.application` validated the **raw** property but emitted the **un-aliased** one, so a function property written through a `type` alias bypassed every per-function guard #2195 added. A `type`-aliased malformed function (optional / nullable / union) was silently dropped from the application with no diagnostic — the exact silent-loss #2195 closed, reopened for aliased members. The mirror case (an all-aliased application) spuriously rejected a valid aliased function with "must have at least a function type."

## Root cause

In `JsonApplicationProgrammer.go`, `Validate` read `p.Value.Functions` (empty for an aliased member, so every per-function check was skipped and `least` stayed false), while `WriteApplication` unaliased with `MetadataSchema_unalias` and dropped the malformed function silently. The two owners disagreed on aliasing.

## Fix

`Validate` now resolves the function through any `type` alias before its per-function checks, matching `WriteApplication`:

- A new `jsonApplicationProgrammer_unaliasFunctions` peels a pure single-alias chain (guarded by `Size == 1` so a union stays visible) to recognize the aliased function. `MetadataSchema_unalias` alone is insufficient: it preserves a reference-site optional/nullable modifier and refuses to unwrap such an alias, which would leave the optional/nullable cases still silently dropped.
- The union shape is read from the unaliased value; the reference-site `optional`/`nullable` modifiers stay on the raw `p.Value` (an optional/nullable alias keeps those flags on the reference, not the unwrapped schema).

**LLM path — verified, not affected.** `llm.application` / `llm.controller` run their validate pass with `Absorb: true`, which resolves aliases before `LlmApplicationProgrammer.Validate` sees them (the property arrives with `Functions` already populated and no aliases). Every aliased malformed case already emits the correct #2195 diagnostic, so `LlmApplicationProgrammer.go` is unchanged.

## Verification

- Native regression test `TestJsonApplicationAliasFunctionValidation` (`packages/typia/native/cmd/ttsc-typia`): aliased union / optional / nullable each fail with their exact #2195 diagnostic; an aliased required single function and a deep alias chain are emitted with no spurious "at least a function". RED on master (aliased union built with exit 0, no diagnostic), GREEN after.
- `tests/test-error` fixtures for the aliased malformed cases on both the json and llm paths.
- Full native `go test ./...`, `test-error`, `test-typia-schema`, `test-mcp` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
