### PR TITLE
fix(native): slice by rune in the notation emit so a non-ASCII key is not corrupted (#2227)

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/notation_unicode_key_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/notation_unicode_key_transform_test.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestNotationUnicodeKeyTransform verifies the notation emit keeps a non-ASCII
+// key intact and agrees with the runtime helper.
+//
+// Issue #2227: the emit computed each renamed key by slicing one *byte*
+// (`value[:1]`) before case-converting it, so a multi-byte rune's lead byte was
+// handed to the case operation on its own, could not be decoded, and came back
+// as U+FFFD — `typia.notations.createPascal<{ "École": number }>()` emitted the
+// key `"��cole"`. The static path corrupted the key while the dynamic
+// (index-signature) path, which calls the runtime `_notationPascal`, did not, so
+// one object could carry two different renamings of the same character and the
+// emitted key did not match its declared `CamelCase<T>` / `PascalCase<T>` type.
+//
+// The same fix covers the second half of the divergence: JavaScript performs
+// Unicode *full* case conversion while Go's `strings.ToUpper`/`ToLower` perform
+// the *simple* per-rune mapping, so the emit also disagreed with the runtime on
+// `ß` -> `SS`, `İ` -> `i` + U+0307, and the word-final sigma `ΑΣ` -> `ας`. That
+// half reached `snake`/`kebab` too, which never sliced a byte.
+//
+// Every key and every expectation below is written with `\uXXXX` escapes so the
+// fixture cannot be silently renormalized (NFC/NFD) by an editor, and so the
+// combining-mark and surrogate-pair cases stay exactly what they claim to be.
+//
+//  1. Transform a fixture whose keys cover a multi-byte first character, a
+//     multi-byte character right after an underscore, a key that is a single
+//     multi-byte character, a combining mark (NFD), a surrogate pair, and the
+//     case-folding-sensitive `İ`, `ß`, and word-final sigma — plus two ASCII
+//     keys as a regression anchor.
+//  2. Require the emitted JavaScript to carry no U+FFFD at all.
+//  3. Execute each statically emitted converter and assert its key-to-value map
+//     equals the expectation derived from JavaScript's own case semantics.
+//  4. Execute the dynamic `Record` converter, which routes through the runtime
+//     `_notation*` helper, over the same keys and require an identical map, so
+//     the compile-time emit and the runtime helper are proven equal per key.
+func TestNotationUnicodeKeyTransform(t *testing.T) {
+  project := notationUnicodeKeyProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("unicode notation transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  // The printer escapes every non-ASCII code unit, so a corrupted key reaches
+  // the output as the escape text rather than as the replacement rune itself.
+  // Both forms are rejected; checking only the rune would never fire.
+  if strings.Contains(out, `\uFFFD`) || strings.ContainsRune(out, '�') {
+    t.Fatalf("emitted converter must not contain U+FFFD; a key was corrupted by byte slicing:\n%s", out)
+  }
+  // Pin the exact emitted assignments for the witnesses of each half of the
+  // defect: the multi-byte first character and the post-underscore segment that
+  // byte slicing destroyed, plus the two characters that the simple per-rune
+  // case mapping got wrong. The printer escapes every non-ASCII code unit, so
+  // these are the literal bytes of the emitted JavaScript.
+  for _, assignment := range []string{
+    `["\u00E9cole"]: input["\u00C9cole"]`,
+    `["Key\u00D6lig"]: input["key_\u00D6lig"]`,
+    `["SS"]: input["\u00DF"]`,
+    `["i\u0307stanbul"]: input["\u0130stanbul"]`,
+  } {
+    if !strings.Contains(out, assignment) {
+      t.Fatalf("emitted converter should contain the assignment %s:\n%s", assignment, out)
+    }
+  }
+  notationUnicodeKeyRunRuntimeCases(t, project, out)
+}
+
+func notationUnicodeKeyProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "notation-unicode-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(notationUnicodeKeyTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(notationUnicodeKeySource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func notationUnicodeKeyRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(notationUnicodeKeyRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("unicode notation runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const notationUnicodeKeyTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const notationUnicodeKeySource = `import typia from "typia";
+
+interface SourceRecord {
+  "\u00C9cole": number;
+  "\u00F6lwert": number;
+  "\u65E5\u672C\u8A9E": number;
+  "key_\u00D6lig": number;
+  "\u00D6": number;
+  "\u0130stanbul": number;
+  "\u00DF": number;
+  "\uD801\uDC28test": number;
+  "\u0391\u03A3_\u0391\u03A3": number;
+  "e\u0301cole": number;
+  "\u00FCber_Stra\u00DFe": number;
+  MAX_COUNT: number;
+  fooBar: number;
+}
+
+type DynamicRecord = Record<string, number>;
+
+export const toCamel = typia.notations.createCamel<SourceRecord>();
+export const toPascal = typia.notations.createPascal<SourceRecord>();
+export const toSnake = typia.notations.createSnake<SourceRecord>();
+export const toKebab = typia.notations.createKebab<SourceRecord>();
+
+export const toCamelDynamic = typia.notations.createCamel<DynamicRecord>();
+export const toPascalDynamic = typia.notations.createPascal<DynamicRecord>();
+export const toSnakeDynamic = typia.notations.createSnake<DynamicRecord>();
+export const toKebabDynamic = typia.notations.createKebab<DynamicRecord>();
+`
+
+const notationUnicodeKeyRuntimeRunner = `const mod = require("./main.cjs");
+
+// Every source key carries a distinct value, so comparing the whole
+// key-to-value map proves the per-key renaming rather than just the key set.
+const input = {
+  ["\u00C9cole"]: 1,
+  ["\u00F6lwert"]: 2,
+  ["\u65E5\u672C\u8A9E"]: 3,
+  ["key_\u00D6lig"]: 4,
+  ["\u00D6"]: 5,
+  ["\u0130stanbul"]: 6,
+  ["\u00DF"]: 7,
+  ["\uD801\uDC28test"]: 8,
+  ["\u0391\u03A3_\u0391\u03A3"]: 9,
+  ["e\u0301cole"]: 10,
+  ["\u00FCber_Stra\u00DFe"]: 11,
+  ["MAX_COUNT"]: 12,
+  ["fooBar"]: 13,
+};
+
+// Expectations are JavaScript's own case semantics, not a snapshot of the Go
+// emit: full case conversion (ß -> SS, İ -> i + U+0307, word-final
+// sigma ΑΣ -> ας) and UTF-16 code-unit indexing, under which
+// str[0] of an astral character is an uncased lone surrogate and stays put.
+const expected = {
+  camel: {
+    ["\u00E9cole"]: 1,
+    ["\u00F6lwert"]: 2,
+    ["\u65E5\u672C\u8A9E"]: 3,
+    ["key\u00D6lig"]: 4,
+    ["\u00F6"]: 5,
+    ["i\u0307stanbul"]: 6,
+    ["\u00DF"]: 7,
+    ["\uD801\uDC28test"]: 8,
+    ["\u03B1\u03C2\u0391\u03C3"]: 9,
+    ["e\u0301cole"]: 10,
+    ["\u00FCberStra\u00DFe"]: 11,
+    ["maxCount"]: 12,
+    ["fooBar"]: 13,
+  },
+  pascal: {
+    ["\u00C9cole"]: 1,
+    ["\u00D6lwert"]: 2,
+    ["\u65E5\u672C\u8A9E"]: 3,
+    ["Key\u00D6lig"]: 4,
+    ["\u00D6"]: 5,
+    ["\u0130stanbul"]: 6,
+    ["SS"]: 7,
+    ["\uD801\uDC28test"]: 8,
+    ["\u0391\u03C3\u0391\u03C3"]: 9,
+    ["E\u0301cole"]: 10,
+    ["\u00DCberStra\u00DFe"]: 11,
+    ["MaxCount"]: 12,
+    ["FooBar"]: 13,
+  },
+  snake: {
+    ["\u00E9cole"]: 1,
+    ["\u00F6lwert"]: 2,
+    ["\u65E5\u672C\u8A9E"]: 3,
+    ["key_\u00F6lig"]: 4,
+    ["\u00F6"]: 5,
+    ["i\u0307stanbul"]: 6,
+    ["\u00DF"]: 7,
+    ["\uD801\uDC28test"]: 8,
+    ["\u03B1\u03C2_\u03B1\u03C2"]: 9,
+    ["e\u0301cole"]: 10,
+    ["\u00FCber_stra\u00DFe"]: 11,
+    ["max_count"]: 12,
+    ["foo_bar"]: 13,
+  },
+  kebab: {
+    ["\u00E9cole"]: 1,
+    ["\u00F6lwert"]: 2,
+    ["\u65E5\u672C\u8A9E"]: 3,
+    ["key-\u00F6lig"]: 4,
+    ["\u00F6"]: 5,
+    ["i\u0307stanbul"]: 6,
+    ["\u00DF"]: 7,
+    ["\uD801\uDC28test"]: 8,
+    ["\u03B1\u03C2-\u03B1\u03C2"]: 9,
+    ["e\u0301cole"]: 10,
+    ["\u00FCber-stra\u00DFe"]: 11,
+    ["max-count"]: 12,
+    ["foo-bar"]: 13,
+  },
+};
+
+const normalize = (object) =>
+  JSON.stringify(
+    Object.entries(object)
+      .map(([key, value]) => [Array.from(key, (c) => c.charCodeAt(0)), value])
+      .sort((a, b) => (String(a) < String(b) ? -1 : 1)),
+  );
+
+const notations = ["camel", "pascal", "snake", "kebab"];
+const capitalize = (name) => name[0].toUpperCase() + name.substring(1);
+
+for (const notation of notations) {
+  const want = normalize(expected[notation]);
+
+  // The statically emitted converter: one property assignment per known key.
+  const staticResult = mod["to" + capitalize(notation)](input);
+  if (normalize(staticResult) !== want) {
+    throw new Error(
+      "static " + notation + " emit disagreed with JavaScript case semantics:\n" +
+        "  expected " + want + "\n" +
+        "  actual   " + normalize(staticResult),
+    );
+  }
+
+  // The dynamic converter: one runtime _notation* call per index-signature key.
+  const dynamicResult = mod["to" + capitalize(notation) + "Dynamic"](input);
+  if (normalize(dynamicResult) !== normalize(staticResult)) {
+    throw new Error(
+      "static " + notation + " emit disagreed with the runtime helper:\n" +
+        "  runtime " + normalize(dynamicResult) + "\n" +
+        "  emit    " + normalize(staticResult),
+    );
+  }
+
+  for (const key of Object.keys(staticResult)) {
+    if (key.includes("�")) {
+      throw new Error(
+        "renamed " + notation + " key contains U+FFFD: " + JSON.stringify(key),
+      );
+    }
+  }
+}
+`

--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -195,54 +195,96 @@ module.exports._accessExpressionAsString = (key) => {
 };
 `
 
-const ttscTypiaTestNotationStub = `const capitalize = (str) =>
-  str.length === 0 ? str : str[0].toUpperCase() + str.substring(1);
-const unsnake = ({ plain, snake }) => (str) => {
+// ttscTypiaTestNotationStub stands in for typia/lib/internal/_notation*, which
+// the emitted converter requires for dynamic (index-signature) keys.
+//
+// These tests assert that the statically emitted key and the runtime helper
+// agree, so this stub is that assertion's oracle and has to stay a faithful
+// transcription of packages/typia/src/internal/_notation{Camel,Pascal,Snake,
+// Kebab}.ts and private/__notationRename.ts — an approximation turns "emit ==
+// runtime" into "emit == whatever this file happens to say". Keep it a direct
+// transcription: same routing on underscore presence (not on segment count),
+// the same CamelizeSnakeString/PascalizeSnakeString recursions, and the same
+// per-segment case-boundary walk in snake. It deliberately uses string
+// concatenation rather than template literals because it is embedded in a Go
+// raw string literal, which is backtick-delimited.
+const ttscTypiaTestNotationStub = `const __notationRename = (props) => (str) => {
   let prefix = "";
   while (str.startsWith("_")) {
     prefix += "_";
     str = str.substring(1);
   }
-  const items = str.split("_").filter((item) => item.length !== 0);
-  if (items.length === 0) return prefix;
-  return prefix + (items.length === 1 ? plain(items[0]) : items.map(snake).join(""));
+  if (str.length === 0) return prefix;
+  return prefix + (str.includes("_") ? props.snake(str) : props.plain(str));
 };
-const snake = (source) => {
-  if (source.length === 0) return source;
-  let prefix = "";
-  while (source.startsWith("_")) {
-    prefix += "_";
-    source = source.substring(1);
-  }
-  const items = source.split("_");
-  if (items.length > 1) return prefix + items.map((item) => item.toLowerCase()).join("_");
+
+const _notationCamelSnake = (str) => {
+  while (str.startsWith("_")) str = str.substring(1);
+  if (str.length === 0) return "";
+  const index = str.indexOf("_");
+  if (index < 0) return str.toLowerCase();
+  const middle = str[index + 1];
+  if (middle === undefined) return str.toLowerCase();
+  return middle === "_"
+    ? _notationCamelSnake(str.substring(0, index) + "_" + str.substring(index + 2))
+    : str.substring(0, index).toLowerCase() +
+      middle.toUpperCase() +
+      _notationCamelSnake(str.substring(index + 2));
+};
+
+const _notationPascalSnake = (str) => {
+  while (str.startsWith("_")) str = str.substring(1);
+  if (str.length === 0) return "";
+  const index = str.indexOf("_");
+  return index < 0
+    ? str[0].toUpperCase() + str.substring(1).toLowerCase()
+    : str[0].toUpperCase() +
+      str.substring(1, index).toLowerCase() +
+      _notationPascalSnake(str.substring(index + 1));
+};
+
+const _notationSnakeWord = (str) => {
   const indexes = [];
-  for (let i = 0; i < source.length; i++) {
-    const code = source.charCodeAt(i);
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
     if (65 <= code && code <= 90) indexes.push(i);
   }
   for (let i = indexes.length - 1; i > 0; --i)
     if (indexes[i] - indexes[i - 1] === 1) indexes.splice(i, 1);
-  if (indexes[0] === 0) indexes.splice(0, 1);
-  if (indexes.length === 0) return prefix + source.toLowerCase();
-  let output = "";
+  if (indexes.length !== 0 && indexes[0] === 0) indexes.splice(0, 1);
+  if (indexes.length === 0) return str.toLowerCase();
+  let ret = "";
   for (let i = 0; i < indexes.length; i++) {
-    output += source.substring(i === 0 ? 0 : indexes[i - 1], indexes[i]).toLowerCase() + "_";
+    ret += str.substring(i === 0 ? 0 : indexes[i - 1], indexes[i]).toLowerCase();
+    ret += "_";
   }
-  return prefix + output + source.substring(indexes[indexes.length - 1]).toLowerCase();
+  ret += str.substring(indexes[indexes.length - 1]).toLowerCase();
+  return ret;
 };
 
-module.exports._notationCamel = unsnake({
-  plain: (str) => str === str.toUpperCase() ? str.toLowerCase() : str[0].toLowerCase() + str.substring(1),
-  snake: (str, index) => index === 0 ? str.toLowerCase() : capitalize(str.toLowerCase()),
+module.exports._notationCamel = __notationRename({
+  plain: (str) =>
+    str === str.toUpperCase()
+      ? str.toLowerCase()
+      : str[0].toLowerCase() + str.substring(1),
+  snake: _notationCamelSnake,
 });
-module.exports._notationPascal = unsnake({
-  plain: capitalize,
-  snake: (str) => capitalize(str.toLowerCase()),
+module.exports._notationPascal = __notationRename({
+  plain: (str) => str[0].toUpperCase() + str.substring(1),
+  snake: _notationPascalSnake,
 });
-module.exports._notationSnake = snake;
-module.exports._notationKebab = (source) => {
-  let snaked = snake(source);
+module.exports._notationSnake = (str) => {
+  if (str.length === 0) return str;
+  let prefix = "";
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === "_") prefix += "_";
+    else break;
+  }
+  if (prefix.length !== 0) str = str.substring(prefix.length);
+  return prefix + str.split("_").map(_notationSnakeWord).join("_");
+};
+module.exports._notationKebab = (str) => {
+  let snaked = module.exports._notationSnake(str);
   let prefix = "";
   while (snaked.startsWith("_")) {
     prefix += "_";

--- a/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
+++ b/packages/typia/native/core/programmers/notations/NotationGeneralProgrammer.go
@@ -3,6 +3,7 @@ package notations
 import (
   "fmt"
   "strings"
+  "unicode/utf8"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimchecker "github.com/microsoft/typescript-go/shim/checker"
@@ -14,6 +15,8 @@ import (
   nativeinternal "github.com/samchon/typia/packages/typia/native/core/programmers/internal"
   nativeiterate "github.com/samchon/typia/packages/typia/native/core/programmers/iterate"
   schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+  "golang.org/x/text/cases"
+  "golang.org/x/text/language"
 )
 
 type notationGeneralProgrammerNamespace struct{}
@@ -1339,6 +1342,67 @@ var NotationGeneralProgrammer_Pascal = NotationGeneralProgrammer_IRename{Name: "
 var NotationGeneralProgrammer_Snake = NotationGeneralProgrammer_IRename{Name: "snake", Func: notationGeneralProgrammer_snake}
 var NotationGeneralProgrammer_Kebab = NotationGeneralProgrammer_IRename{Name: "kebab", Func: notationGeneralProgrammer_kebab}
 
+// notationGeneralProgrammer_toUpper and notationGeneralProgrammer_toLower
+// reproduce JavaScript's `String.prototype.toUpperCase` / `toLowerCase`, which
+// is the case operation the runtime helpers (`_notationCamel`,
+// `_notationPascal`, `_notationSnake`) and the `CamelCase<T>` / `PascalCase<T>`
+// typings both apply. JavaScript performs Unicode *full* case conversion, while
+// `strings.ToUpper` / `strings.ToLower` perform the *simple* per-rune mapping,
+// so the two disagree wherever a code point maps to a different number of code
+// points or depends on context: `ß` -> `SS`, `İ` -> `i` + U+0307, `ﬁ` -> `FI`,
+// and the word-final sigma `ΑΣ` -> `ας`. Emitting a key through the simple
+// mapping would make the compile-time emit disagree with the runtime helper and
+// with the declared `*Case<T>` return type. `language.Und` selects the
+// locale-independent root mapping, matching JavaScript's locale-independent
+// `toUpperCase` / `toLowerCase` (as opposed to `toLocaleUpperCase`).
+//
+// A `cases.Caser` carries mutable state and must not be shared across
+// goroutines, so each call builds its own; notation renaming runs once per
+// object key at compile time, not on a hot path.
+func notationGeneralProgrammer_toUpper(str string) string {
+  return cases.Upper(language.Und).String(str)
+}
+
+func notationGeneralProgrammer_toLower(str string) string {
+  return cases.Lower(language.Und).String(str)
+}
+
+// notationGeneralProgrammer_head splits str after the character a JavaScript
+// `str[0]` expression addresses, returning that head and the remainder.
+//
+// The runtime helpers and the `*Case<T>` typings capitalize a key by indexing
+// its first character, so the emit has to slice at the same boundary. Slicing
+// by byte (`str[:1]`) instead splits a multi-byte UTF-8 rune and hands a lone
+// lead byte to the case operation, which cannot decode it and substitutes
+// U+FFFD — `École` was emitted as `��cole`.
+func notationGeneralProgrammer_head(str string) (string, string) {
+  _, size := utf8.DecodeRuneInString(str)
+  return str[:size], str[size:]
+}
+
+// notationGeneralProgrammer_upperHead and notationGeneralProgrammer_lowerHead
+// case-convert a head produced by notationGeneralProgrammer_head the way
+// `str[0].toUpperCase()` / `str[0].toLowerCase()` does.
+//
+// JavaScript indexes a string by UTF-16 code unit, so `str[0]` of an astral
+// character is its lone high surrogate, and no case mapping applies to an
+// unpaired surrogate. Such a head is therefore returned verbatim rather than
+// case-mapped, which is what keeps a Deseret or Adlam key stable across the
+// emit, the runtime helper, and the type.
+func notationGeneralProgrammer_upperHead(head string) string {
+  if r, _ := utf8.DecodeRuneInString(head); r > 0xFFFF {
+    return head
+  }
+  return notationGeneralProgrammer_toUpper(head)
+}
+
+func notationGeneralProgrammer_lowerHead(head string) string {
+  if r, _ := utf8.DecodeRuneInString(head); r > 0xFFFF {
+    return head
+  }
+  return notationGeneralProgrammer_toLower(head)
+}
+
 // notationGeneralProgrammer_rename is the shared outer walk for the
 // camel/pascal notations. It mirrors the `CamelCase<T>` / `PascalCase<T>`
 // typings: leading underscores are preserved verbatim, an all-underscore key
@@ -1363,10 +1427,11 @@ func notationGeneralProgrammer_rename(str string, plain func(string) string, sna
 
 func notationGeneralProgrammer_camel(str string) string {
   return notationGeneralProgrammer_rename(str, func(value string) string {
-    if value == strings.ToUpper(value) {
-      return strings.ToLower(value)
+    if value == notationGeneralProgrammer_toUpper(value) {
+      return notationGeneralProgrammer_toLower(value)
     }
-    return strings.ToLower(value[:1]) + value[1:]
+    head, tail := notationGeneralProgrammer_head(value)
+    return notationGeneralProgrammer_lowerHead(head) + tail
   }, notationGeneralProgrammer_camel_snake)
 }
 
@@ -1383,17 +1448,22 @@ func notationGeneralProgrammer_camel_snake(str string) string {
   }
   index := strings.IndexByte(str, '_')
   if index < 0 || index+1 >= len(str) {
-    return strings.ToLower(str)
+    return notationGeneralProgrammer_toLower(str)
   }
   if str[index+1] == '_' {
     return notationGeneralProgrammer_camel_snake(str[:index] + "_" + str[index+2:])
   }
-  return strings.ToLower(str[:index]) + strings.ToUpper(str[index+1:index+2]) + notationGeneralProgrammer_camel_snake(str[index+2:])
+  // The character after the underscore is one whole rune, not one byte; `_` is
+  // ASCII so it never falls inside a multi-byte sequence and `index` stays a
+  // valid boundary.
+  middle, rest := notationGeneralProgrammer_head(str[index+1:])
+  return notationGeneralProgrammer_toLower(str[:index]) + notationGeneralProgrammer_upperHead(middle) + notationGeneralProgrammer_camel_snake(rest)
 }
 
 func notationGeneralProgrammer_pascal(str string) string {
   return notationGeneralProgrammer_rename(str, func(value string) string {
-    return strings.ToUpper(value[:1]) + value[1:]
+    head, tail := notationGeneralProgrammer_head(value)
+    return notationGeneralProgrammer_upperHead(head) + tail
   }, notationGeneralProgrammer_pascal_snake)
 }
 
@@ -1407,11 +1477,14 @@ func notationGeneralProgrammer_pascal_snake(str string) string {
   if str == "" {
     return ""
   }
+  head, tail := notationGeneralProgrammer_head(str)
   index := strings.IndexByte(str, '_')
   if index < 0 {
-    return strings.ToUpper(str[:1]) + strings.ToLower(str[1:])
+    return notationGeneralProgrammer_upperHead(head) + notationGeneralProgrammer_toLower(tail)
   }
-  return strings.ToUpper(str[:1]) + strings.ToLower(str[1:index]) + notationGeneralProgrammer_pascal_snake(str[index+1:])
+  // `index` counts bytes from the start of `str`; the tail it delimits starts
+  // after the whole leading rune, hence the `len(head)` offset.
+  return notationGeneralProgrammer_upperHead(head) + notationGeneralProgrammer_toLower(tail[:index-len(head)]) + notationGeneralProgrammer_pascal_snake(str[index+1:])
 }
 
 // notationGeneralProgrammer_snake_word runs the case-boundary walk over one
@@ -1435,7 +1508,7 @@ func notationGeneralProgrammer_snake_word(str string) string {
     indexes = indexes[1:]
   }
   if len(indexes) == 0 {
-    return strings.ToLower(str)
+    return notationGeneralProgrammer_toLower(str)
   }
   ret := ""
   for i, last := range indexes {
@@ -1443,10 +1516,10 @@ func notationGeneralProgrammer_snake_word(str string) string {
     if i != 0 {
       first = indexes[i-1]
     }
-    ret += strings.ToLower(str[first:last])
+    ret += notationGeneralProgrammer_toLower(str[first:last])
     ret += "_"
   }
-  ret += strings.ToLower(str[indexes[len(indexes)-1]:])
+  ret += notationGeneralProgrammer_toLower(str[indexes[len(indexes)-1]:])
   return ret
 }
 

--- a/packages/typia/native/go.mod
+++ b/packages/typia/native/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/microsoft/typescript-go/shim/printer v0.0.0
 	github.com/microsoft/typescript-go/shim/scanner v0.0.0
 	github.com/samchon/ttsc/packages/ttsc v0.0.0
+	golang.org/x/text v0.36.0
 )
 
 require (
@@ -35,5 +36,4 @@ require (
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
 )

--- a/tests/test-interface/src/typings/test_notation_unicode_keys.ts
+++ b/tests/test-interface/src/typings/test_notation_unicode_keys.ts
@@ -1,0 +1,122 @@
+import { CamelCase, KebabCase, PascalCase, SnakeCase } from "@typia/interface";
+
+/**
+ * Pins the `*Case<T>` typings on non-ASCII keys.
+ *
+ * Issue #2227: the Go notation emit sliced one _byte_ off a key before case
+ * converting it, so a multi-byte rune's lead byte became U+FFFD and
+ * `PascalCase` of `École` was emitted as `��cole`; it also used Go's _simple_
+ * per-rune case mapping where JavaScript uses _full_ case conversion,
+ * disagreeing on `ß` -> `SS` and `İ` -> `i` + U+0307. These types are the
+ * declared return type of `typia.notations.camel/pascal/snake/kebab`, so this
+ * locks the exact keys the emit and the runtime helpers must both produce.
+ *
+ * Two cases are deliberately absent because the _type_ is the side that differs
+ * from the runtime helper, independently of the emit:
+ *
+ * - `PascalCase<{ "𐐨test": number }>`. `Capitalize` on an astral character
+ *   uppercases it under typescript-go but leaves it under `tsc` and under
+ *   JavaScript, where `str[0]` is an uncased lone surrogate.
+ * - `SnakeCase`/`KebabCase` of a word-final sigma. `SnakageStringRepeatedly`
+ *   applies `Lowercase` one character at a time, so `Σ` never sees the
+ *   preceding cased character that makes JavaScript's whole-string
+ *   `toLowerCase` produce `ς`. `CamelCase`/`PascalCase` lowercase whole
+ *   substrings and do agree, which is why the sigma battery below covers them.
+ *
+ * 1. Assert all four `*Case` typings over a battery of non-ASCII keys covering a
+ *    multi-byte first character, a multi-byte character after an underscore, a
+ *    single-character key, a combining mark, and full-case-conversion
+ *    characters.
+ * 2. Assert `CamelCase`/`PascalCase` over a word-final sigma key.
+ */
+export type NotationUnicodeKeysCases = [
+  Assert<IsEqual<CamelCase<Battery>, ExpectedCamel>>,
+  Assert<IsEqual<PascalCase<Battery>, ExpectedPascal>>,
+  Assert<IsEqual<SnakeCase<Battery>, ExpectedSnake>>,
+  Assert<IsEqual<KebabCase<Battery>, ExpectedKebab>>,
+  Assert<IsEqual<CamelCase<SigmaBattery>, ExpectedSigmaCamel>>,
+  Assert<IsEqual<PascalCase<SigmaBattery>, ExpectedSigmaPascal>>,
+];
+
+type Assert<T extends true> = T;
+
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;
+
+// Every key is written with `\uXXXX` escapes so an editor cannot silently
+// renormalize NFC into NFD, or the reverse, and change what is asserted.
+interface Battery {
+  "\u00C9cole": number; // multi-byte first character (NFC)
+  "\u00F6lwert": number; // multi-byte first character, lowercase
+  "\u65E5\u672C\u8A9E": number; // uncased script
+  "key_\u00D6lig": number; // multi-byte character right after an underscore
+  "\u00D6": number; // a key that is one multi-byte character
+  "\u0130stanbul": number; // lowercases to two code points
+  "\u00DF": number; // uppercases to two characters
+  "e\u0301cole": number; // combining mark (NFD)
+  "\u00FCber_Stra\u00DFe": number; // mixed
+}
+
+interface ExpectedCamel {
+  "\u00E9cole": number;
+  "\u00F6lwert": number;
+  "\u65E5\u672C\u8A9E": number;
+  "key\u00D6lig": number;
+  "\u00F6": number;
+  "i\u0307stanbul": number;
+  "\u00DF": number;
+  "e\u0301cole": number;
+  "\u00FCberStra\u00DFe": number;
+}
+
+interface ExpectedPascal {
+  "\u00C9cole": number;
+  "\u00D6lwert": number;
+  "\u65E5\u672C\u8A9E": number;
+  "Key\u00D6lig": number;
+  "\u00D6": number;
+  "\u0130stanbul": number;
+  SS: number;
+  "E\u0301cole": number;
+  "\u00DCberStra\u00DFe": number;
+}
+
+interface ExpectedSnake {
+  "\u00E9cole": number;
+  "\u00F6lwert": number;
+  "\u65E5\u672C\u8A9E": number;
+  "key_\u00F6lig": number;
+  "\u00F6": number;
+  "i\u0307stanbul": number;
+  "\u00DF": number;
+  "e\u0301cole": number;
+  "\u00FCber_stra\u00DFe": number;
+}
+
+interface ExpectedKebab {
+  "\u00E9cole": number;
+  "\u00F6lwert": number;
+  "\u65E5\u672C\u8A9E": number;
+  "key-\u00F6lig": number;
+  "\u00F6": number;
+  "i\u0307stanbul": number;
+  "\u00DF": number;
+  "e\u0301cole": number;
+  "\u00FCber-stra\u00DFe": number;
+}
+
+interface SigmaBattery {
+  "\u0391\u03A3_\u0391\u03A3": number; // word-final sigma
+}
+
+interface ExpectedSigmaCamel {
+  "\u03B1\u03C2\u0391\u03C3": number;
+}
+
+interface ExpectedSigmaPascal {
+  "\u0391\u03C3\u0391\u03C3": number;
+}

--- a/tests/test-typia-schema/src/features/notations/test_notation_unicode_keys.ts
+++ b/tests/test-typia-schema/src/features/notations/test_notation_unicode_keys.ts
@@ -1,0 +1,153 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+/**
+ * Verifies notation output equals the `*Case<T>` type on non-ASCII keys.
+ *
+ * Issue #2227: the Go compile-time emit computed each renamed key by slicing
+ * one _byte_ (`value[:1]`) before case converting it, so a multi-byte rune's
+ * lead byte could not be decoded and came back as U+FFFD — `pascal` of
+ * `\u00C9cole` produced a mojibake key. The static-key path (the emit) then
+ * disagreed with the dynamic-key path (the runtime `_notation*` helper) and
+ * with the declared return type, so one object could carry two renamings of the
+ * same character and reading a declared key returned `undefined`.
+ *
+ * This pins all three producers at once: assigning to `typia.*Case<T>` and
+ * reading each declared key checks the emit against the type, and comparing the
+ * `Record` conversion's key set checks the runtime helper against the emit.
+ *
+ * Every key is written with `\uXXXX` escapes so an editor cannot silently
+ * renormalize NFC into NFD, or the reverse, and change what is asserted.
+ *
+ * The battery deliberately holds only characters whose simple per-rune case
+ * mapping equals JavaScript's full case conversion. `ttsc` and `ttsx` ship in
+ * the same package but do not agree on the case-mapping intrinsics: `ttsc`
+ * computes `Capitalize<"\u00DF">` as `SS` and `Lowercase<"\u0130">` as `i` +
+ * U+0307 (full, matching JavaScript), while `ttsx` — which executes this suite
+ * — computes them as `\u00DF` and `i` (simple). Those characters are covered
+ * where the answer is unambiguous instead: `tests/test-interface` pins them
+ * against `ttsc`, and the transform test at
+ * `packages/typia/native/cmd/ttsc-typia/notation_unicode_key_transform_test.go`
+ * pins the emit against the runtime helper itself.
+ *
+ * 1. Convert a static-key object under each notation and read every declared key.
+ * 2. Convert the same keys through a `Record` (dynamic) and compare the key set.
+ */
+export const test_notation_unicode_keys = (): void => {
+  const value: Battery = {
+    "\u00C9cole": 1,
+    "\u00F6lwert": 2,
+    "\u65E5\u672C\u8A9E": 3,
+    "key_\u00D6lig": 4,
+    "\u00D6": 5,
+    "e\u0301cole": 6,
+    "\u00FCber_Stra\u00DFe": 7,
+  };
+
+  // ---- static keys: soundness against the declared *Case<T> type ----
+  const snaked: typia.SnakeCase<Battery> =
+    typia.notations.snake<Battery>(value);
+  TestValidator.equals("snake \u00E9cole", snaked["\u00E9cole"], 1);
+  TestValidator.equals("snake \u00F6lwert", snaked["\u00F6lwert"], 2);
+  TestValidator.equals(
+    "snake \u65E5\u672C\u8A9E",
+    snaked["\u65E5\u672C\u8A9E"],
+    3,
+  );
+  TestValidator.equals("snake key_\u00F6lig", snaked["key_\u00F6lig"], 4);
+  TestValidator.equals("snake \u00F6", snaked["\u00F6"], 5);
+  TestValidator.equals("snake e\u0301cole", snaked["e\u0301cole"], 6);
+  TestValidator.equals(
+    "snake \u00FCber_stra\u00DFe",
+    snaked["\u00FCber_stra\u00DFe"],
+    7,
+  );
+
+  const camelled: typia.CamelCase<Battery> =
+    typia.notations.camel<Battery>(value);
+  TestValidator.equals("camel \u00E9cole", camelled["\u00E9cole"], 1);
+  TestValidator.equals("camel \u00F6lwert", camelled["\u00F6lwert"], 2);
+  TestValidator.equals(
+    "camel \u65E5\u672C\u8A9E",
+    camelled["\u65E5\u672C\u8A9E"],
+    3,
+  );
+  TestValidator.equals("camel key\u00D6lig", camelled["key\u00D6lig"], 4);
+  TestValidator.equals("camel \u00F6", camelled["\u00F6"], 5);
+  TestValidator.equals("camel e\u0301cole", camelled["e\u0301cole"], 6);
+  TestValidator.equals(
+    "camel \u00FCberStra\u00DFe",
+    camelled["\u00FCberStra\u00DFe"],
+    7,
+  );
+
+  const pascalled: typia.PascalCase<Battery> =
+    typia.notations.pascal<Battery>(value);
+  TestValidator.equals("pascal \u00C9cole", pascalled["\u00C9cole"], 1);
+  TestValidator.equals("pascal \u00D6lwert", pascalled["\u00D6lwert"], 2);
+  TestValidator.equals(
+    "pascal \u65E5\u672C\u8A9E",
+    pascalled["\u65E5\u672C\u8A9E"],
+    3,
+  );
+  TestValidator.equals("pascal Key\u00D6lig", pascalled["Key\u00D6lig"], 4);
+  TestValidator.equals("pascal \u00D6", pascalled["\u00D6"], 5);
+  TestValidator.equals("pascal E\u0301cole", pascalled["E\u0301cole"], 6);
+  TestValidator.equals(
+    "pascal \u00DCberStra\u00DFe",
+    pascalled["\u00DCberStra\u00DFe"],
+    7,
+  );
+
+  const kebabbed: typia.KebabCase<Battery> =
+    typia.notations.kebab<Battery>(value);
+  TestValidator.equals("kebab \u00E9cole", kebabbed["\u00E9cole"], 1);
+  TestValidator.equals("kebab \u00F6lwert", kebabbed["\u00F6lwert"], 2);
+  TestValidator.equals(
+    "kebab \u65E5\u672C\u8A9E",
+    kebabbed["\u65E5\u672C\u8A9E"],
+    3,
+  );
+  TestValidator.equals("kebab key-\u00F6lig", kebabbed["key-\u00F6lig"], 4);
+  TestValidator.equals("kebab \u00F6", kebabbed["\u00F6"], 5);
+  TestValidator.equals("kebab e\u0301cole", kebabbed["e\u0301cole"], 6);
+  TestValidator.equals(
+    "kebab \u00FCber-stra\u00DFe",
+    kebabbed["\u00FCber-stra\u00DFe"],
+    7,
+  );
+
+  // ---- dynamic keys: the runtime _notation* helper over the whole matrix ----
+  const dynamic: Record<string, number> = { ...value };
+  const sortKeys = (input: object): string[] => Object.keys(input).sort();
+  TestValidator.equals(
+    "snake dynamic key set",
+    sortKeys(typia.notations.snake<Record<string, number>>(dynamic)),
+    sortKeys(snaked),
+  );
+  TestValidator.equals(
+    "camel dynamic key set",
+    sortKeys(typia.notations.camel<Record<string, number>>(dynamic)),
+    sortKeys(camelled),
+  );
+  TestValidator.equals(
+    "pascal dynamic key set",
+    sortKeys(typia.notations.pascal<Record<string, number>>(dynamic)),
+    sortKeys(pascalled),
+  );
+  TestValidator.equals(
+    "kebab dynamic key set",
+    sortKeys(typia.notations.kebab<Record<string, number>>(dynamic)),
+    sortKeys(kebabbed),
+  );
+};
+
+interface Battery {
+  "\u00C9cole": number; // multi-byte first character (NFC)
+  "\u00F6lwert": number; // multi-byte first character, lowercase
+  "\u65E5\u672C\u8A9E": number; // uncased script
+  "key_\u00D6lig": number; // multi-byte character right after an underscore
+  "\u00D6": number; // a key that is one multi-byte character
+  "e\u0301cole": number; // combining mark (NFD)
+  "\u00FCber_Stra\u00DFe": number; // mixed, with a lowercase-position sharp s
+}


### PR DESCRIPTION
Fixes #2227.

## Problem

`typia.notations.camel`/`pascal` corrupted a non-ASCII object key at compile time. The Go emit computed each renamed key by slicing one **byte** (`value[:1]`) before case converting it, so when the first character was a multi-byte UTF-8 rune the case operation received a lone lead byte, could not decode it, and substituted U+FFFD:

```js
// typia.notations.createPascal<{ "École": number; "ölwert": string }>()
_co0 = input => ({ ["��cole"]: input["École"], ["��lwert"]: input["ölwert"] });
```

The input key was read correctly but the **output** key was mojibake. The static path corrupted the key while the dynamic index-signature path — which calls the runtime `_notationPascal` — did not, so one object could carry two different renamings of the same character, and the emitted key did not match its declared `CamelCase<T>`/`PascalCase<T>` type.

## Fix

**1. Slice where JavaScript slices.** All five byte-slice sites (camel plain, the camel snake segment, pascal plain, and both pascal snake segments) now split at the boundary a JavaScript `str[0]` addresses.

**2. Case-convert the way JavaScript does.** Fixing only the slicing left a second divergence of the same root class: JavaScript performs Unicode *full* case conversion while `strings.ToUpper`/`strings.ToLower` perform the *simple* per-rune mapping, so the emit still disagreed with the runtime helper **and with `ttsc`'s own `*Case<T>` computation** on `ß` → `SS`, `İ` → `i` + U+0307, `ﬁ` → `FI`, and the word-final sigma `ΑΣ` → `ας`. That half also reached `snake`/`kebab`, which never sliced a byte. Every notation case operation now routes through `golang.org/x/text/cases` with `language.Und`, which reproduces JavaScript's locale-independent `toUpperCase`/`toLowerCase` — verified identical on all 14 probed code points.

An astral character keeps its case, because JavaScript indexes by UTF-16 code unit and `str[0]` of a surrogate pair is an uncased lone surrogate. That matches the runtime helper.

## Verification

**Emit diff over a 375-key corpus** (pre-fix vs post-fix rename output):

| | changed |
| --- | --- |
| 310 ASCII keys | **0 / 1248** comparisons — byte-identical |
| 65 non-ASCII keys | 92 / 200 comparisons, every one replacing mojibake or a wrong case mapping |

`snake`/`kebab` change only for the genuine case-folding cases (`İ` and word-final sigma).

**Three-way agreement.** Over the non-ASCII matrix the emit now equals the runtime helper on every key (0 mismatches / 260 comparisons; 92 before). Against the type as `ttsc` computes it, the emit agrees everywhere except the two pre-existing type-side cases listed below.

**Suites**

| suite | result |
| --- | --- |
| `go test ./...` (native) | pass, except `TestAnyArrayTypeTagsTransform`, which fails identically on pre-fix `master` — the documented no-`node_modules` `typia.tags` artifact |
| `tests/test-typia-schema` | 174 tests, Success |
| `tests/test-utils` | 305 tests, Success (includes `test_naming_convention_notation_parity`) |
| `tests/test-interface` | compile-only, clean |

**Tests added**

- `packages/typia/native/cmd/ttsc-typia/notation_unicode_key_transform_test.go` — transforms a matrix covering a multi-byte first character, a multi-byte character after an underscore, a single-character key, a combining mark (NFD), a surrogate pair, `İ`, `ß`, and word-final sigma; asserts the emitted key-to-value map equals JavaScript's own case semantics **and** equals the dynamic `Record` conversion, which routes through the runtime helper. Red before this change.
- `tests/test-interface/src/typings/test_notation_unicode_keys.ts` — pins the `*Case<T>` typings over the same matrix under `ttsc`.
- `tests/test-typia-schema/src/features/notations/test_notation_unicode_keys.ts` — end-to-end, pinning the emit against `typia.*Case<T>` by reading every declared key, and against the runtime helper by comparing the dynamic key set.

## Called out

- **`golang.org/x/text` is now a direct requirement** of the native module. It was already in the module graph as an indirect dependency and both hashes are in `go.sum`, so consumers building the plugin from source need nothing new.
- **`ttscTypiaTestNotationStub` was a stale oracle.** It stands in for the runtime helper in the transform tests, and it had drifted from `packages/typia/src/internal/_notation*.ts` on 12 inputs — 7 of them plain ASCII (`fooBar_baz`, `fooBar_`, `a_b_c`) — which made every "emit == runtime" assertion compare against a copy that was not the runtime. It is now a faithful transcription, and the existing tests still pass against it.
- **No version bump**, per the issue.

## Findings for follow-up (not fixed here)

1. **`ttsc` and `ttsx` disagree on the case-mapping intrinsics.** Same package, different answers: `ttsc` computes `Capitalize<"ß">` as `SS` and `Lowercase<"İ">` as `i` + U+0307 (full conversion, matching JavaScript), while `ttsx` computes them as `ß` and `i` (simple per-rune). The emit follows `ttsc` and the runtime. Because `ttsx` executes `tests/test-typia-schema`, that suite's battery is deliberately limited to characters where both agree, and the affected characters are pinned in `tests/test-interface` (compiled by `ttsc`) and in the Go transform test (against the runtime helper) instead. This is upstream of typia.
2. **`SnakeCase`/`KebabCase` and word-final sigma.** `SnakageStringRepeatedly` applies `Lowercase` one character at a time, so `Σ` never sees the preceding cased character that makes JavaScript's whole-string `toLowerCase` produce `ς`. The emit now matches the runtime helper and `@typia/utils` `NamingConvention` here; the type is the remaining outlier and would need a change in `packages/interface`, which this PR does not touch. `CamelCase`/`PascalCase` lowercase whole substrings and already agree.
3. **`Capitalize` on an astral character.** `ttsc` uppercases it (rune slicing) where JavaScript leaves it (`str[0]` is an uncased lone surrogate), so `PascalCase<{ "𐐨test": number }>` disagrees with the runtime helper upstream of typia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
