### PR TITLE
fix(native): resolve a non-discriminable object union by is-match in compare.equals (#2225)

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/compare_nondiscriminable_union_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/compare_nondiscriminable_union_transform_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCompareNonDiscriminableUnionTransform pins compare.equals over an object
+// union no discriminant can split (issue #2225).
+//
+// #2214 discriminated the object unions UnionPredicator can specialize, but left
+// every other object union on the pre-#2214 flat OR of member comparators.
+// UnionPredicator.Object skips a key that is not required, so a union whose
+// distinguishing keys are all optional (`{ a?: number } | { b?: string }`)
+// produced no specialization and always took that fallback — which is the very
+// defect #2214 removed: the wrong member's comparator matches because the keys
+// it declares are absent from both operands and compare `undefined ===
+// undefined`, while the keys that actually differ are not declared by that
+// member at all. So `equals({ a: 1 }, { a: 2 })` and even `equals({ a: 1 }, {})`
+// were `true` for distinct references.
+//
+// The fix routes such a union through the first-is-match ladder that
+// clone/classify/prune reach via Decode_union_object: each operand resolves to
+// the first member it structurally matches, distinct members compare false, and
+// a shared member's comparator decides the rest. `equals` therefore agrees with
+// what `clone` produces for the same value.
+//
+// All fixtures compare DISTINCT references (fresh object literals) so the
+// `x === y` identity fast path never hides the flaw.
+//
+//  1. Transform is + compare.createEquals + plain.createClone over
+//     all-optional, shared-optional-key, three-member, empty-member,
+//     discriminable/non-discriminable mixed, nested, recursive, container-valued
+//     and native-bearing non-discriminable unions.
+//  2. Require distinct-but-different values to compare not-equal (a populated
+//     object never equals `{}`), distinct-but-identical values to compare equal.
+//  3. Require `equals` to agree with `clone` over every ordered sample pair of
+//     `is`-valid values, and to be false whenever either operand fails `is`.
+func TestCompareNonDiscriminableUnionTransform(t *testing.T) {
+  project := compareNonDiscriminableUnionProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("compare non-discriminable union transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  if strings.Contains(out, "_ui0") == false {
+    t.Fatalf("expected the is-match member matchers in the emit, got:\n%s", out)
+  }
+  compareNonDiscriminableUnionRunRuntimeCases(t, project, out)
+}
+
+func compareNonDiscriminableUnionProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "compare-union-nondisc-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(compareNonDiscriminableUnionTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(compareNonDiscriminableUnionSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func compareNonDiscriminableUnionRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "throw-type-guard-error-stub.cjs"), []byte(compareNonDiscriminableUnionThrowStub), 0o644); err != nil {
+    t.Fatalf("write throw stub: %v", err)
+  }
+  js = strings.ReplaceAll(js, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(compareNonDiscriminableUnionRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("compare non-discriminable union runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const compareNonDiscriminableUnionTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const compareNonDiscriminableUnionThrowStub = `module.exports._throwTypeGuardError = (props) => {
+  const error = new Error("guard: " + props.expected);
+  error.name = "TypeGuardError";
+  throw error;
+};
+`
+
+const compareNonDiscriminableUnionSource = `import typia from "typia";
+
+// 1. the canonical all-optional union: no member has a unique required key
+type Opt = { a?: number } | { b?: string };
+export const isOpt = typia.createIs<Opt>();
+export const eqOpt = typia.compare.createEquals<Opt>();
+export const cloneOpt = typia.plain.createClone<Opt>();
+
+// 2. a key shared by both members, still no required discriminant
+type Shared = { a?: number; c?: boolean } | { b?: string; c?: boolean };
+export const isShared = typia.createIs<Shared>();
+export const eqShared = typia.compare.createEquals<Shared>();
+export const cloneShared = typia.plain.createClone<Shared>();
+
+// 3. three all-optional members
+type Three = { a?: number } | { b?: string } | { c?: boolean };
+export const isThree = typia.createIs<Three>();
+export const eqThree = typia.compare.createEquals<Three>();
+export const cloneThree = typia.plain.createClone<Three>();
+
+// 4. a member that declares nothing, so it matches every object
+type WithEmpty = { a?: number } | { [key: string]: never };
+export const isWithEmpty = typia.createIs<WithEmpty>();
+export const eqWithEmpty = typia.compare.createEquals<WithEmpty>();
+
+// 5. a discriminable member alongside a non-discriminable pair
+type Mixed = { type: "a"; x: number } | { p?: number } | { q?: string };
+export const isMixed = typia.createIs<Mixed>();
+export const eqMixed = typia.compare.createEquals<Mixed>();
+export const cloneMixed = typia.plain.createClone<Mixed>();
+
+// 6. a nested non-discriminable union property
+type Nested = { wrap: { a?: number } | { b?: string } };
+export const isNested = typia.createIs<Nested>();
+export const eqNested = typia.compare.createEquals<Nested>();
+export const cloneNested = typia.plain.createClone<Nested>();
+
+// 7. container-valued members: the array and tuple checks in the matcher are
+//    what routes a value, since the two members share their only key
+type Container = { value?: number[] } | { value?: [number, string] };
+export const isContainer = typia.createIs<Container>();
+export const eqContainer = typia.compare.createEquals<Container>();
+export const cloneContainer = typia.plain.createClone<Container>();
+
+// 8. a recursive non-discriminable union (matcher must not recurse forever at
+//    generation time, and the comparator still receives its _vctx)
+type Rec = { child?: Rec; a?: number } | { b?: string };
+export const isRec = typia.createIs<Rec>();
+export const eqRec = typia.compare.createEquals<Rec>();
+
+// 9. a native alongside a non-discriminable object union (notNatives guard)
+type WithNative = Date | { a?: number } | { b?: string };
+export const eqWithNative = typia.compare.createEquals<WithNative>();
+
+// controls that must keep the discriminated / flat forms
+export const eqDisc = typia.compare.createEquals<
+  { type: "a"; x: number } | { type: "b"; y: string }
+>();
+export const eqPrim = typia.compare.createEquals<string | number>();
+export const eqArrUnion = typia.compare.createEquals<number[] | string[]>();
+export const eqObj = typia.compare.createEquals<{ a?: number; b?: string }>();
+`
+
+const compareNonDiscriminableUnionRuntimeRunner = `const mod = require("./main.cjs");
+
+let failures = 0;
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    console.log("FAIL " + label + ": expected " + expected + ", got " + actual);
+    failures++;
+  }
+};
+const copy = (v) => JSON.parse(JSON.stringify(v));
+// Serialize a clone so that a key the resolved member declares but the value
+// omits stays visible: JSON.stringify drops an undefined-valued key, which would
+// make two members that declare different keys look alike.
+const shape = (v) => JSON.stringify(v, (_key, value) => (value === undefined ? null : value));
+
+// --- 1. the reported defect: {a?:number} | {b?:string} ---
+expect("opt a different", mod.eqOpt({ a: 1 }, { a: 2 }), false);
+expect("opt populated vs empty", mod.eqOpt({ a: 1 }, {}), false);
+expect("opt empty vs populated", mod.eqOpt({}, { a: 1 }), false);
+expect("opt cross member", mod.eqOpt({ a: 1 }, { b: "p" }), false);
+expect("opt identical", mod.eqOpt({ a: 1 }, { a: 1 }), true);
+expect("opt both empty", mod.eqOpt({}, {}), true);
+// both values resolve to the first member, under which "b" is not declared:
+// exactly what clone keeps, so equals must agree with clone rather than with
+// the raw literals.
+expect("opt second-member payload follows clone", mod.eqOpt({ b: "p" }, { b: "q" }), JSON.stringify(mod.cloneOpt({ b: "p" })) === JSON.stringify(mod.cloneOpt({ b: "q" })));
+expect("opt member resolution follows clone", mod.eqOpt({}, { a: "x" }), false);
+expect("opt invalid operand", mod.eqOpt({ a: "x", b: 1 }, { a: "x", b: 1 }), false);
+
+// --- 2. shared optional key ---
+expect("shared c different", mod.eqShared({ c: true }, { c: false }), false);
+expect("shared c identical", mod.eqShared({ a: 1, c: true }, { a: 1, c: true }), true);
+expect("shared a different", mod.eqShared({ a: 1, c: true }, { a: 2, c: true }), false);
+expect("shared populated vs empty", mod.eqShared({ a: 1 }, {}), false);
+expect("shared c only vs empty", mod.eqShared({ c: true }, {}), false);
+
+// --- 3. three all-optional members ---
+expect("three a different", mod.eqThree({ a: 1 }, { a: 2 }), false);
+expect("three populated vs empty", mod.eqThree({ a: 1 }, {}), false);
+expect("three identical", mod.eqThree({ a: 1 }, { a: 1 }), true);
+expect("three cross member", mod.eqThree({ a: 1 }, { c: true }), false);
+
+// --- 4. member matching everything ---
+expect("withempty a different", mod.eqWithEmpty({ a: 1 }, { a: 2 }), false);
+expect("withempty populated vs empty", mod.eqWithEmpty({ a: 1 }, {}), false);
+expect("withempty identical", mod.eqWithEmpty({ a: 1 }, { a: 1 }), true);
+
+// --- 5. discriminable member beside a non-discriminable pair ---
+expect("mixed disc different", mod.eqMixed({ type: "a", x: 1 }, { type: "a", x: 2 }), false);
+expect("mixed disc identical", mod.eqMixed({ type: "a", x: 1 }, { type: "a", x: 1 }), true);
+expect("mixed disc vs optional", mod.eqMixed({ type: "a", x: 1 }, { p: 1 }), false);
+expect("mixed optional different", mod.eqMixed({ p: 1 }, { p: 2 }), false);
+expect("mixed optional vs empty", mod.eqMixed({ p: 1 }, {}), false);
+expect("mixed optional identical", mod.eqMixed({ p: 1 }, { p: 1 }), true);
+
+// --- 6. nested non-discriminable union property ---
+expect("nested inner different", mod.eqNested({ wrap: { a: 1 } }, { wrap: { a: 2 } }), false);
+expect("nested inner populated vs empty", mod.eqNested({ wrap: { a: 1 } }, { wrap: {} }), false);
+expect("nested inner identical", mod.eqNested({ wrap: { a: 1 } }, { wrap: { a: 1 } }), true);
+expect("nested cross member", mod.eqNested({ wrap: { a: 1 } }, { wrap: { b: "p" } }), false);
+
+// --- 7. container-valued members ---
+expect("container array different", mod.eqContainer({ value: [1, 2] }, { value: [1, 3] }), false);
+expect("container array identical", mod.eqContainer({ value: [1, 2] }, { value: [1, 2] }), true);
+expect("container array vs empty", mod.eqContainer({ value: [1] }, {}), false);
+expect("container tuple different", mod.eqContainer({ value: [1, "p"] }, { value: [1, "q"] }), false);
+expect("container tuple identical", mod.eqContainer({ value: [1, "p"] }, { value: [1, "p"] }), true);
+expect("container cross member", mod.eqContainer({ value: [1] }, { value: [1, "p"] }), false);
+
+// --- 8. recursive non-discriminable union ---
+const mkRec = () => ({ a: 1, child: { a: 2, child: { a: 3 } } });
+expect("rec identical", mod.eqRec(mkRec(), mkRec()), true);
+expect("rec deep different", mod.eqRec(mkRec(), { a: 1, child: { a: 2, child: { a: 9 } } }), false);
+expect("rec depth different", mod.eqRec(mkRec(), { a: 1, child: { a: 2 } }), false);
+expect("rec populated vs empty", mod.eqRec(mkRec(), {}), false);
+
+// --- 9. native beside the non-discriminable union ---
+expect("withnative same date", mod.eqWithNative(new Date(0), new Date(0)), true);
+expect("withnative diff date", mod.eqWithNative(new Date(0), new Date(5000)), false);
+expect("withnative date vs object", mod.eqWithNative(new Date(0), { a: 1 }), false);
+expect("withnative object different", mod.eqWithNative({ a: 1 }, { a: 2 }), false);
+expect("withnative object identical", mod.eqWithNative({ a: 1 }, { a: 1 }), true);
+expect("withnative populated vs empty", mod.eqWithNative({ a: 1 }, {}), false);
+
+// --- controls: the discriminated path and the non-union paths are untouched ---
+expect("disc different", mod.eqDisc({ type: "a", x: 1 }, { type: "a", x: 2 }), false);
+expect("disc identical", mod.eqDisc({ type: "a", x: 1 }, { type: "a", x: 1 }), true);
+expect("disc cross arm", mod.eqDisc({ type: "a", x: 1 }, { type: "b", y: "p" }), false);
+expect("prim different", mod.eqPrim(1, 2), false);
+expect("prim identical", mod.eqPrim("x", "x"), true);
+expect("arrunion different", mod.eqArrUnion([1, 2], [1, 3]), false);
+expect("arrunion identical", mod.eqArrUnion([1, 2], [1, 2]), true);
+expect("obj optional different", mod.eqObj({ a: 1 }, { a: 2 }), false);
+expect("obj optional vs empty", mod.eqObj({ a: 1 }, {}), false);
+expect("obj optional identical", mod.eqObj({ a: 1 }, { a: 1 }), true);
+
+// --- equals agrees with is and with the member clone resolves to ---
+// For every ordered pair of samples (distinct references throughout):
+//   * an operand is rejects is never equal to anything, and
+//   * two is-valid operands are equal exactly when their clones are, which is
+//     the statement "both resolved to the same member and agree on everything
+//     that member declares".
+const agree = (label, eq, is, clone, samples) => {
+  for (const a of samples)
+    for (const b of samples) {
+      const x = copy(a);
+      const y = copy(b);
+      const suffix = " " + JSON.stringify(a) + " | " + JSON.stringify(b);
+      if (is(x) === false || is(y) === false) {
+        expect(label + " invalid operand not equal" + suffix, eq(x, y), false);
+        continue;
+      }
+      expect(label + " equals agrees with clone" + suffix, eq(x, y), shape(clone(x)) === shape(clone(y)));
+    }
+};
+
+agree("opt", mod.eqOpt, mod.isOpt, mod.cloneOpt, [
+  {}, { a: 1 }, { a: 2 }, { b: "p" }, { b: "q" }, { a: 1, b: "p" }, { a: "x", b: 1 }, { a: "x" },
+]);
+agree("shared", mod.eqShared, mod.isShared, mod.cloneShared, [
+  {}, { a: 1 }, { c: true }, { c: false }, { a: 1, c: true }, { b: "p" }, { b: "p", c: true }, { a: "x", b: 1 },
+]);
+agree("three", mod.eqThree, mod.isThree, mod.cloneThree, [
+  {}, { a: 1 }, { b: "p" }, { c: true }, { c: false }, { a: 1, c: true }, { a: "x", b: 1, c: 2 },
+]);
+agree("mixed", mod.eqMixed, mod.isMixed, mod.cloneMixed, [
+  {}, { type: "a", x: 1 }, { type: "a", x: 2 }, { p: 1 }, { p: 2 }, { q: "z" },
+]);
+agree("nested", mod.eqNested, mod.isNested, mod.cloneNested, [
+  { wrap: {} }, { wrap: { a: 1 } }, { wrap: { a: 2 } }, { wrap: { b: "p" } },
+]);
+agree("container", mod.eqContainer, mod.isContainer, mod.cloneContainer, [
+  {}, { value: [] }, { value: [1] }, { value: [1, 2] }, { value: [1, "p"] }, { value: [2, "p"] },
+]);
+
+if (failures > 0) {
+  throw new Error(failures + " assertion(s) failed");
+}
+console.log("all compare-non-discriminable-union cases passed");
+`

--- a/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
+++ b/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
@@ -34,6 +34,10 @@ type compareEqualProgrammerGenerator struct {
   Config    CompareEqualProgrammer_IConfig
   Recursive bool
   Counter   int
+  // Member-resolution checkers (`_ui<index>`) emitted on demand for the object
+  // unions that need the is-match ladder, keyed by the object's collection index.
+  Matchers     []string
+  MatcherIndex map[int]bool
 }
 
 var compareEqualProgrammer_factory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
@@ -71,8 +75,9 @@ func (compareEqualProgrammerNamespace) Write(props CompareEqualProgrammer_IProps
   }
 
   generator := &compareEqualProgrammerGenerator{
-    Config:    props.Config,
-    Recursive: nativeinternal.FeatureProgrammer.CollectionRecursive(collection),
+    Config:       props.Config,
+    Recursive:    nativeinternal.FeatureProgrammer.CollectionRecursive(collection),
+    MatcherIndex: map[int]bool{},
   }
   body := generator.schema(result.Data, "x", "y")
   statements := []string{}
@@ -89,6 +94,12 @@ func (compareEqualProgrammerNamespace) Write(props CompareEqualProgrammer_IProps
       statements = append(statements, generator.tupleFunction(tuple))
     }
   }
+  // The member matchers are collected last because every generation step above
+  // may request one. They are `const` arrow functions in the same scope as the
+  // `_eo`/`_ea`/`_et` helpers and are only ever called after this IIFE returns,
+  // so declaring them at the end is free of temporal-dead-zone hazards — the
+  // same placement `is` uses for the `_io` checkers it appends after `_cu`.
+  statements = append(statements, generator.Matchers...)
   if generator.Recursive {
     statements = append(statements, "return (x, y) => { const _vctx = {}; return "+body+"; };")
   } else {
@@ -162,20 +173,17 @@ func (g *compareEqualProgrammerGenerator) schema(metadata *schemametadata.Metada
   // branch and its absent payload keys compare `undefined === undefined`. The
   // discrimination reuses the shared UnionPredicator specialization the sibling
   // programmers (is/clone/classify/...) route through, so `equals` agrees with
-  // `is` on which member a value is.
+  // `is` on which member a value is. A union no discriminant can split (every
+  // distinguishing key optional, e.g. `{ a?: number } | { b?: string }`) routes
+  // through the first-is-match ladder instead — never a flat OR, which admits
+  // the same spurious match through absent keys comparing
+  // `undefined === undefined` (issue #2225).
   if len(metadata.Objects) >= 2 {
-    if expr, ok := g.objectUnion(metadata.Objects, x, y); ok {
-      if guard := g.notNatives(metadata.Natives, x, y); guard != "" {
-        expr = g.and(guard, expr)
-      }
-      branches = append(branches, expr)
-    } else {
-      // Not discriminable by a supported predicate (e.g. an all-optional union
-      // with no unique required key): fall back to the prior per-member OR.
-      for _, object := range metadata.Objects {
-        branches = append(branches, g.objectFlatBranch(object.Type, metadata.Natives, x, y))
-      }
+    expr := g.objectUnion(metadata.Objects, x, y)
+    if guard := g.notNatives(metadata.Natives, x, y); guard != "" {
+      expr = g.and(guard, expr)
     }
+    branches = append(branches, expr)
   } else {
     for _, object := range metadata.Objects {
       branches = append(branches, g.objectFlatBranch(object.Type, metadata.Natives, x, y))
@@ -319,16 +327,48 @@ func (g *compareEqualProgrammerGenerator) objectFlatBranch(object *schemametadat
 
 // objectUnion renders a discriminated comparison for a union of two or more
 // object types. It mirrors the is/clone/classify discrimination: each operand is
-// routed to exactly one member through the shared UnionPredicator discriminants,
-// and only when both land on the same member does that member's comparator run.
-// This replaces the flat OR whose wrong-member comparator could match spuriously.
-// It returns ok=false when the members are not discriminable by a supported
-// predicate, leaving the caller to fall back to the prior flat OR.
-func (g *compareEqualProgrammerGenerator) objectUnion(objects []*schemametadata.MetadataObject, x string, y string) (string, bool) {
+// routed to exactly one member, and only when both land on the same member does
+// that member's comparator run. This replaces the flat OR whose wrong-member
+// comparator could match spuriously.
+//
+// Routing prefers the shared UnionPredicator discriminants (issue #2214). When
+// no discriminant splits the members — every distinguishing key is optional, so
+// UnionPredicator yields no specialization, or more than one member is left
+// unspecialized — routing falls back to the first-is-match ladder that
+// clone/classify/prune reach through Decode_union_object (issue #2225). There is
+// no flat-OR fallback: the flat OR is the defect both issues describe.
+func (g *compareEqualProgrammerGenerator) objectUnion(objects []*schemametadata.MetadataObject, x string, y string) string {
   types := make([]*schemametadata.MetadataObjectType, 0, len(objects))
   for _, object := range objects {
     types = append(types, object.Type)
   }
+  ladder, ok := g.discriminantLadder(types)
+  if ok == false {
+    ladder = g.matchLadder(types)
+  }
+
+  tag := g.local("utag")
+  tx := g.local("utx")
+  // Dispatch: with the shared member index, run only that member's comparator.
+  dispatch := "false"
+  for i := len(types) - 1; i >= 0; i-- {
+    dispatch = fmt.Sprintf("%s === %d ? %s : %s", tx, types[i].Index, g.objectCall(types[i], "x", "y"), dispatch)
+  }
+  body := fmt.Sprintf(
+    "((x, y) => { const %s = (v) => (%s) ? (%s) : -1; const %s = %s(x); return %s !== -1 && %s === %s(y) && (%s); })(%s, %s)",
+    tag, g.isObject("v"), ladder, tx, tag, tx, tx, tag, dispatch, g.wrap(x), g.wrap(y),
+  )
+  return body
+}
+
+// discriminantLadder renders the routing ternary from the shared UnionPredicator
+// specialization: `<discriminant of member i> ? <index of member i> : ...`,
+// ending in the lone unspecialized member (the unconditional else the
+// discriminant ladder leaves) or -1 for "no member". It reports ok=false when
+// the members carry no usable discriminant, when more than one member is left
+// unspecialized, or when a discriminant value cannot be rendered as a check —
+// the caller then routes by is-match instead.
+func (g *compareEqualProgrammerGenerator) discriminantLadder(types []*schemametadata.MetadataObjectType) (string, bool) {
   specs := nativehelpers.UnionPredicator.Object(types)
   if len(specs) == 0 {
     return "", false
@@ -344,15 +384,8 @@ func (g *compareEqualProgrammerGenerator) objectUnion(objects []*schemametadata.
     }
   }
   if len(remained) > 1 {
-    // A non-discriminable remainder needs the full is-check ladder the sibling
-    // programmers reach through Decode_union_object; that machinery is AST-only,
-    // so leave these members to the caller's flat OR.
     return "", false
   }
-
-  // Routing ladder: a ternary that returns the member's collection index, or -1
-  // when the value matches no member. The innermost fallback is the lone
-  // remainder (the unconditional else the discriminant ladder leaves) or -1.
   fallback := "-1"
   if len(remained) == 1 {
     fallback = strconv.Itoa(remained[0].Index)
@@ -365,19 +398,187 @@ func (g *compareEqualProgrammerGenerator) objectUnion(objects []*schemametadata.
     }
     ladder = fmt.Sprintf("%s ? %d : %s", check, specs[i].Object.Index, ladder)
   }
+  return ladder, true
+}
 
-  tag := g.local("utag")
-  tx := g.local("utx")
-  // Dispatch: with the shared member index, run only that member's comparator.
-  dispatch := "false"
-  for i := len(types) - 1; i >= 0; i-- {
-    dispatch = fmt.Sprintf("%s === %d ? %s : %s", tx, types[i].Index, g.objectCall(types[i], "x", "y"), dispatch)
+// matchLadder renders the routing ternary for a union no discriminant splits:
+// the first member the value is-matches wins, exactly as `clone`/`classify`/
+// `prune` resolve membership through Decode_union_object's `if (_io0(input))
+// return ...; if (_io1(input)) ...` ladder. A value matching no member yields
+// -1, which makes `equals` false rather than letting a wrong member's comparator
+// decide.
+func (g *compareEqualProgrammerGenerator) matchLadder(types []*schemametadata.MetadataObjectType) string {
+  calls := make([]string, 0, len(types))
+  for _, object := range types {
+    // Declared in member order so the emitted matchers read in the same order
+    // as the ladder that calls them; the ladder itself is folded back to front.
+    calls = append(calls, g.matchCall(object, "v"))
   }
-  body := fmt.Sprintf(
-    "((x, y) => { const %s = (v) => (%s) ? (%s) : -1; const %s = %s(x); return %s !== -1 && %s === %s(y) && (%s); })(%s, %s)",
-    tag, g.isObject("v"), ladder, tx, tag, tx, tx, tag, dispatch, g.wrap(x), g.wrap(y),
-  )
-  return body, true
+  ladder := "-1"
+  for i := len(types) - 1; i >= 0; i-- {
+    ladder = fmt.Sprintf("%s ? %d : %s", calls[i], types[i].Index, ladder)
+  }
+  return ladder
+}
+
+// matchCall returns a call to the member's `_ui<index>` matcher, declaring the
+// matcher on first request. The index is registered before the body is rendered
+// so a recursive member refers to its own matcher instead of recursing forever
+// at generation time.
+func (g *compareEqualProgrammerGenerator) matchCall(object *schemametadata.MetadataObjectType, v string) string {
+  name := fmt.Sprintf("_ui%d", object.Index)
+  if g.MatcherIndex[object.Index] == false {
+    g.MatcherIndex[object.Index] = true
+    g.Matchers = append(g.Matchers, fmt.Sprintf("const %s = (v) => %s;", name, g.matchObject(object, "v")))
+  }
+  return fmt.Sprintf("%s(%s)", name, g.wrap(v))
+}
+
+// matchObject renders the structural is-check of one object member: every
+// declared regular key must hold a value of its declared type (an optional key
+// may be absent), and every extra key a dynamic index signature declares must
+// hold a value of the signature's type. It mirrors the `_io` checkers `is`
+// emits, at the abstraction level the rest of this programmer works at — shape
+// and typeof, not the value constraints (`typia.tags.*`, template patterns)
+// `compare` deliberately ignores.
+func (g *compareEqualProgrammerGenerator) matchObject(object *schemametadata.MetadataObjectType, v string) string {
+  checks := []string{}
+  regularKeys := []string{}
+  dynamic := []*schemametadata.MetadataProperty{}
+  for _, property := range object.Properties {
+    if compareProgrammer_isMethod(property) {
+      continue // methods carry no comparable data, so they do not route either
+    }
+    if sole := property.Key.GetSoleLiteral(); sole != nil {
+      regularKeys = append(regularKeys, *sole)
+      checks = append(checks, g.matchSlot(property.Value, g.property(v, *sole)))
+    } else {
+      dynamic = append(dynamic, property)
+    }
+  }
+  if len(dynamic) != 0 {
+    key := g.local("key")
+    regularCheck := compareEqualProgrammer_regularKeyCheck(regularKeys)
+    conditions := []string{}
+    for _, property := range dynamic {
+      conditions = append(conditions, g.and(g.dynamicKey(property.Key, key), g.matchSlot(property.Value, g.index(v, key))))
+    }
+    checks = append(checks, fmt.Sprintf("Object.keys(%s).every((%s) => %s)", g.wrap(v), key, g.or(regularCheck(key), g.or(conditions...))))
+  }
+  return g.and(checks...)
+}
+
+// matchSlot renders the is-check of a value slot — an object property or a tuple
+// element — allowing the slot to be absent when it is optional.
+func (g *compareEqualProgrammerGenerator) matchSlot(metadata *schemametadata.MetadataSchema, v string) string {
+  check := g.match(metadata, v)
+  if metadata != nil && metadata.IsRequired() == false {
+    return g.or(g.same(v, "undefined"), check)
+  }
+  return check
+}
+
+// match renders the structural is-check of one metadata schema as the OR of its
+// buckets, the same bucket walk `schema` compares over. An unconstrained bucket
+// (anything the compare feature already rejects, or a bucket carrying no shape
+// to test) renders as "true", which keeps the ladder's first-match order the
+// deciding factor exactly as it is in `is`.
+func (g *compareEqualProgrammerGenerator) match(metadata *schemametadata.MetadataSchema, v string) string {
+  if metadata == nil {
+    return "true"
+  }
+  metadata = schemametadata.MetadataSchema_unalias(metadata)
+  if metadata.Any {
+    return "true"
+  }
+  branches := []string{}
+  if metadata.Nullable {
+    branches = append(branches, g.same(v, "null"))
+  }
+  for _, constant := range metadata.Constants {
+    for _, value := range constant.Values {
+      branches = append(branches, g.same(v, compareEqualProgrammer_literal(value.Value, constant.Type)))
+    }
+  }
+  for _, atomic := range metadata.Atomics {
+    branches = append(branches, g.typeof(v, atomic.Type))
+  }
+  if len(metadata.Templates) != 0 {
+    branches = append(branches, g.typeof(v, "string"))
+  }
+  if len(metadata.Functions) != 0 {
+    branches = append(branches, g.typeof(v, "function"))
+  }
+  for _, native := range metadata.Natives {
+    branches = append(branches, g.instanceof(v, native.Name))
+  }
+  for _, tuple := range metadata.Tuples {
+    branches = append(branches, g.matchTuple(tuple.Type, v))
+  }
+  for _, array := range metadata.Arrays {
+    elem := g.local("elem")
+    branches = append(branches, g.and(g.isArray(v), fmt.Sprintf("%s.every((%s) => %s)", g.wrap(v), elem, g.match(array.Type.Value, elem))))
+  }
+  if len(metadata.Objects) != 0 {
+    calls := []string{}
+    for _, object := range metadata.Objects {
+      calls = append(calls, g.matchCall(object.Type, v))
+    }
+    branches = append(branches, g.and(g.isObject(v), g.or(calls...)))
+  }
+  for _, alias := range metadata.Aliases {
+    branches = append(branches, g.match(alias.Type.Value, v))
+  }
+  if metadata.Escaped != nil {
+    branches = append(branches, g.match(metadata.Escaped.Original, v))
+  }
+  if metadata.Rest != nil {
+    branches = append(branches, g.match(metadata.Rest, v))
+  }
+  if len(branches) == 0 {
+    return "true"
+  }
+  return g.or(branches...)
+}
+
+// matchTuple renders the is-check of a tuple: the array gate, the length range
+// an omitted optional trailing element makes legal (the same range `tupleInline`
+// compares over), and each element's own check.
+func (g *compareEqualProgrammerGenerator) matchTuple(tuple *schemametadata.MetadataTupleType, v string) string {
+  fixed := len(tuple.Elements)
+  var rest *schemametadata.MetadataSchema
+  if fixed != 0 && tuple.Elements[fixed-1].Rest != nil {
+    rest = tuple.Elements[fixed-1].Rest
+    fixed--
+  }
+  checks := []string{g.isArray(v)}
+  length := g.access(v, "length")
+  if rest == nil {
+    required := 0
+    allRequired := true
+    for i := 0; i < fixed; i++ {
+      if tuple.Elements[i].Optional {
+        allRequired = false
+      } else {
+        required++
+      }
+    }
+    if allRequired {
+      checks = append(checks, g.same(length, strconv.Itoa(fixed)))
+    } else {
+      checks = append(checks, fmt.Sprintf("%d <= %s && %d >= %s", required, length, fixed, length))
+    }
+  } else {
+    checks = append(checks, fmt.Sprintf("%s >= %d", length, fixed))
+  }
+  for i := 0; i < fixed; i++ {
+    checks = append(checks, g.matchSlot(tuple.Elements[i], g.index(v, strconv.Itoa(i))))
+  }
+  if rest != nil {
+    elem := g.local("elem")
+    checks = append(checks, fmt.Sprintf("%s.slice(%d).every((%s) => %s)", g.wrap(v), fixed, elem, g.match(rest, elem)))
+  }
+  return g.and(checks...)
 }
 
 // discriminant renders the routing predicate for one specialized union member,

--- a/tests/test-typia-schema/src/features/compare/test_compare_equals_object_union_non_discriminable.ts
+++ b/tests/test-typia-schema/src/features/compare/test_compare_equals_object_union_non_discriminable.ts
@@ -1,0 +1,139 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+type IOptional = { a?: number } | { b?: string };
+type IShared = { a?: number; c?: boolean } | { b?: string; c?: boolean };
+type INested = { wrap: { a?: number } | { b?: string } };
+
+/**
+ * Verifies compare.equals resolves a non-discriminable object union to one
+ * member before comparing.
+ *
+ * A union whose distinguishing keys are all optional has no required
+ * discriminant, so UnionPredicator yields no specialization and `equals` used
+ * to fall back to a flat OR of the member comparators. The wrong member's
+ * comparator then matched on absent keys comparing `undefined === undefined`
+ * while the keys that actually differ were not declared by that member, so
+ * `equals({ a: 1 }, { a: 2 })` and even `equals({ a: 1 }, {})` were `true`
+ * (samchon/typia#2225). Each operand must instead resolve to the first member
+ * it matches — the resolution `plain.clone` already uses — so that operands
+ * landing on different members are unequal and the shared member decides the
+ * rest.
+ *
+ * 1. Compare distinct references that differ under the resolved member, including
+ *    a populated object against `{}`.
+ * 2. Compare distinct references that agree, and operands the type rejects.
+ * 3. Assert `equals` agrees with `plain.clone` over every ordered pair of samples:
+ *    two values are equal exactly when they clone to the same member with the
+ *    same declared payload.
+ */
+export const test_compare_equals_object_union_non_discriminable = (): void => {
+  const equals = typia.compare.createEquals<IOptional>();
+  const clone = typia.plain.createClone<IOptional>();
+  const is = typia.createIs<IOptional>();
+
+  TestValidator.equals(
+    "distinct values of the first member",
+    false,
+    equals({ a: 1 }, { a: 2 }),
+  );
+  TestValidator.equals(
+    "populated object against empty object",
+    false,
+    equals({ a: 1 }, {}),
+  );
+  TestValidator.equals(
+    "empty object against populated object",
+    false,
+    equals({}, { a: 1 }),
+  );
+  TestValidator.equals(
+    "values of different members",
+    false,
+    equals({ a: 1 }, { b: "p" }),
+  );
+  TestValidator.equals(
+    "identical values of distinct reference",
+    true,
+    equals({ a: 1 }, { a: 1 }),
+  );
+  TestValidator.equals("two empty objects", true, equals({}, {}));
+  TestValidator.equals(
+    "an operand the union rejects",
+    false,
+    equals({ a: "x", b: 1 } as any, { a: "x", b: 1 } as any),
+  );
+
+  // `equals` must agree with the member `clone` resolves to: two values are
+  // equal exactly when they clone to the same member with the same payload.
+  // `shape` keeps a declared-but-absent key visible, which plain JSON drops, so
+  // members declaring different keys never look alike.
+  const shape = (value: unknown): string =>
+    JSON.stringify(value, (_key, inner) =>
+      inner === undefined ? null : inner,
+    );
+  const samples: IOptional[] = [
+    {},
+    { a: 1 },
+    { a: 2 },
+    { b: "p" },
+    { b: "q" },
+    { a: 1, b: "p" } as IOptional,
+    { a: "x" } as any,
+    { a: "x", b: 1 } as any,
+  ];
+  for (const x of samples)
+    for (const y of samples) {
+      const left = JSON.parse(JSON.stringify(x));
+      const right = JSON.parse(JSON.stringify(y));
+      const title = `${JSON.stringify(x)} vs ${JSON.stringify(y)}`;
+      if (is(left) === false || is(right) === false)
+        TestValidator.equals(
+          `rejected operand is equal to nothing: ${title}`,
+          false,
+          equals(left, right),
+        );
+      else
+        TestValidator.equals(
+          `equals agrees with clone: ${title}`,
+          shape(clone(left)) === shape(clone(right)),
+          equals(left, right),
+        );
+    }
+
+  // A key both members share still compares within one resolved member.
+  const shared = typia.compare.createEquals<IShared>();
+  TestValidator.equals(
+    "shared key differs",
+    false,
+    shared({ c: true }, { c: false }),
+  );
+  TestValidator.equals(
+    "shared key with member payload",
+    false,
+    shared({ a: 1, c: true }, { a: 2, c: true }),
+  );
+  TestValidator.equals(
+    "shared key identical",
+    true,
+    shared({ a: 1, c: true }, { a: 1, c: true }),
+  );
+
+  // The same resolution applies to a nested union property.
+  const nested = typia.compare.createEquals<INested>();
+  TestValidator.equals(
+    "nested union differs",
+    false,
+    nested({ wrap: { a: 1 } }, { wrap: { a: 2 } }),
+  );
+  TestValidator.equals(
+    "nested union populated against empty",
+    false,
+    nested({ wrap: { a: 1 } }, { wrap: {} }),
+  );
+  TestValidator.equals(
+    "nested union identical",
+    true,
+    nested({ wrap: { a: 1 } }, { wrap: { a: 1 } }),
+  );
+};

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -244,6 +244,8 @@ namespace compare {
 
 Deep equality by the structure of `T`. Extra runtime properties outside `T` are not part of the comparison.
 
+When `T` is a union of object types, each value first resolves to a single member — by its discriminator, or by the first member it matches when no discriminator distinguishes them, exactly as `plain.clone` resolves it. Two values that land on different members are never equal, and the one member they share decides the rest.
+
 ```typescript copy
 typia.compare.equals<IPoint>(x, y); // true when every declared field matches
 ```


### PR DESCRIPTION
Fixes #2225 — the still-open half of #2214.

## Problem

`compare.equals` over a **non-discriminable** object union (two or more object members, none with a unique required distinguishing key — e.g. `{ a?: number } | { b?: string }`) fell back to the pre-#2214 flat OR of member comparators, which is unsound. On `master` (`dbf147b4bb`), with distinct references:

```
eq({a:1}, {a:2})   -> true   (expected false)
eq({a:1}, {})      -> true   (expected false — a populated object equals {})
eq({a:1}, {b:"p"}) -> false  (correct)
```

`_eo1` (member `{b?}`) never inspects `a`, and `x.b === y.b` is `undefined === undefined`, so the wrong member's comparator carries the OR.

`UnionPredicator.Object` skips a key whose metadata is not required (`helpers/UnionPredicator.go:53`), so an all-optional union yields no specialization, `objectUnion()` returned `ok=false`, and `schema()` took the flat-OR `else` branch.

## Fix

`CompareEqualProgrammer.go` — the flat-OR fallback is gone. Every object union of two or more members now routes each operand to exactly one member and compares only within the member both share:

- **Discriminable** unions keep the #2214 `UnionPredicator` ladder, byte-identical.
- **Non-discriminable** unions route through a **first-is-match ladder**, the same resolution `plain.clone` / `plain.classify` / `plain.prune` reach through `Decode_union_object`. Per-member matchers `_ui<index>` are emitted on demand and are the structural twin of the `_io<index>` checkers `is` emits.

```js
// { a?: number } | { b?: string }
const _ui0 = (v) => v.a === undefined || typeof v.a === "number";
const _ui1 = (v) => v.b === undefined || typeof v.b === "string";
return (x, y) =>
  x === y ||
  ((x, y) => {
    const _utag0 = (v) => (isObject(v) ? (_ui0(v) ? 0 : _ui1(v) ? 1 : -1) : -1);
    const _utx1 = _utag0(x);
    return (
      _utx1 !== -1 &&
      _utx1 === _utag0(y) &&
      (_utx1 === 0 ? _eo0(x, y) : _utx1 === 1 ? _eo1(x, y) : false)
    );
  })(x, y);
```

Operands resolving to different members are unequal, and a value matching no member is unequal to everything. `equals` therefore agrees with what `clone` keeps for the same value. Note that on `master` `clone({ b: "p" })` for `{a?}|{b?}` resolves to the **first** member and returns `{}` — so `equals({b:"p"}, {b:"q"})` staying `true` is that same resolution, not a second defect.

## Verification

- **Red → green:** the new `TestCompareNonDiscriminableUnionTransform` fails 92 assertions against `master`'s programmer and passes with the fix. Every fixture compares distinct references, so the `x === y` fast path never hides the flaw.
- **Coverage:** all-optional pair, shared-optional-key union, three all-optional members, a member matching every object, a discriminable member beside a non-discriminable pair, nested union property, array/tuple-valued members, a recursive non-discriminable union, a `Date` beside the union (`notNatives` guard), plus discriminable / primitive / array-union / non-union controls. Six oracle matrices assert, over every ordered sample pair, that `equals` is false when `is` rejects an operand and otherwise agrees exactly with the member `clone` resolves to.
- **Emit diff (before vs after)** over ten compare/clone/classify/prune fixtures: only the non-discriminable object-union comparators change. #2214's discriminated union, #2202's optional-tuple compare, cover, less, less-NaN, method delegation, native overmatch, prune overmatch and classify union are byte-identical, as is every `is` and `clone` output.
- `go -C packages/typia/native test ./...` — no new failure. `TestCompareUnionDiscriminationTransform` (#2214) and `TestTupleOptionalCompareCloneTransform` (#2202) pass.
- **New TypeScript coverage:** `compare` had no case in any `tests/*` suite, so this adds `tests/test-typia-schema/src/features/compare/test_compare_equals_object_union_non_discriminable.ts`. It fails on the current programmer (`Bug on distinct values of the first member: x false, y true`) and passes with the fix; `pnpm --filter ./tests/test-typia-schema start` is Success at 174 tests, and `test-feature-identity` is Success.
- `pnpm --filter ./tests/test-typia-automated start --include equals` — Success, 132 tests, though note that matrix covers the `typia.equals` validator rather than `typia.compare.equals`.

`website/src/content/docs/misc.mdx` gains one paragraph stating the union member-resolution rule under `compare.equals`.

No `packages/typia/package.json` version bump and no `packages/interface/src` edit, per the issue's coordination note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7AePEdpjaxHrmVffuSjy
