### PR TITLE
feat(mcp): accept an explicit server version

### DIFF
--- a/experiments/mcp/README.md
+++ b/experiments/mcp/README.md
@@ -24,9 +24,9 @@ npm test          # MCP client <-> server over stdio (spawns lib/server.js)
 node lib/interop.js   # guards the rollup esmExternals fix against CJS externals
 ```
 
-`npm test` performs a real MCP handshake, lists the tools, and calls them with
-valid, coerced (`"40"` → `40`), invalid (validation feedback), and
-exception-raising arguments.
+`npm test` performs a real MCP handshake, verifies the explicit server version,
+lists the tools, and calls them with valid, coerced (`"40"` → `40`), invalid
+(validation feedback), and exception-raising arguments.
 
 ## Drive it with Claude Code
 

--- a/experiments/mcp/src/server.ts
+++ b/experiments/mcp/src/server.ts
@@ -37,5 +37,6 @@ class Calculator {
 
 const server = createMcpServer(
   typia.llm.controller<Calculator>("calc", new Calculator()),
+  { version: "2.3.4" },
 );
 await server.connect(new StdioServerTransport());

--- a/experiments/mcp/src/test.ts
+++ b/experiments/mcp/src/test.ts
@@ -32,6 +32,10 @@ const main = async (): Promise<void> => {
     const info = client.getServerVersion();
     assert("handshake reports server name 'calc'", info?.name === "calc");
     assert(
+      "handshake reports server version '2.3.4'",
+      info?.version === "2.3.4",
+    );
+    assert(
       "instructions reflect the class JSDoc",
       (client.getInstructions() ?? "").includes("Arithmetic tools"),
     );

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -30,7 +30,7 @@ Build with `ttsc`, or run TypeScript directly with `ttsx`.
 
 ## Usage
 
-`createMcpServer(controller, options?)` — pass a `typia.llm.controller` (or an `HttpLlm.controller` over an OpenAPI document), connect a transport. Every method of the class becomes an MCP tool; the controller's `name` is the server name and its class JSDoc becomes the handshake instructions. The handshake version is the OpenAPI `info.version` for HTTP controllers, `"1.0.0"` otherwise.
+`createMcpServer(controller, options?)` — pass a `typia.llm.controller` (or an `HttpLlm.controller` over an OpenAPI document), connect a transport. Every method of the class becomes an MCP tool; the controller's `name` is the server name and its class JSDoc becomes the handshake instructions. Pass the deployed application's version through `options.version`; when omitted, the handshake version is the OpenAPI `info.version` for HTTP controllers and `"1.0.0"` otherwise.
 
 ```typescript
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -47,6 +47,7 @@ class Calculator {
 
 const server = createMcpServer(
   typia.llm.controller<Calculator>("calculator", new Calculator()),
+  { version: "2.3.4" },
 );
 await server.connect(new StdioServerTransport());
 ```

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,6 +6,17 @@ import { McpControllerRegistrar } from "./internal/McpControllerRegistrar";
 /** Options of {@link createMcpServer}. */
 export interface IMcpServerOptions {
   /**
+   * Version of the MCP server implementation announced in the handshake.
+   *
+   * Set this to the version of the application that assembles and deploys the
+   * server. When omitted, an HTTP controller inherits its OpenAPI
+   * `info.version`, while a class controller keeps the `"1.0.0"` fallback.
+   *
+   * @default OpenAPI info.version or "1.0.0"
+   */
+  version?: string | undefined;
+
+  /**
    * Whether to add a serialized JSON text block next to `structuredContent` in
    * every tool result.
    *
@@ -29,12 +40,16 @@ export interface IMcpServerOptions {
  * Every method of the `controller`'s class becomes an MCP tool, with its input
  * schema, `outputSchema` / `structuredContent`, and argument validation all
  * reflected from the TypeScript types and JSDoc. No hand-written JSON schema.
- * The controller's `name` becomes the server name, and the class JSDoc
- * (`application.description`) becomes the MCP handshake instructions.
+ * The controller's `name` becomes the server name,
+ * {@link IMcpServerOptions.version} can identify the deployed implementation,
+ * and the class JSDoc (`application.description`) becomes the MCP handshake
+ * instructions.
  *
  * An {@link IHttpLlmController} from `HttpLlm.controller()` works the same way:
  * every OpenAPI operation becomes an MCP tool that calls the actual endpoint,
- * and the document's `info.version` becomes the handshake version.
+ * and the document's `info.version` becomes the default handshake version. An
+ * explicit {@link IMcpServerOptions.version} takes precedence when the MCP
+ * implementation and served API have different release versions.
  *
  * Every tool call is validated by typia. If the LLM provides invalid arguments,
  * it receives an {@link IValidation.IFailure} formatted by
@@ -79,9 +94,11 @@ export function createMcpServer<Class extends object = any>(
       ? undefined
       : controller.application.description?.trim() || undefined;
   const version: string =
+    options?.version ??
     (controller.protocol === "http"
       ? controller.application.version
-      : undefined) ?? "1.0.0";
+      : undefined) ??
+    "1.0.0";
   const server: McpServer = new McpServer(
     { name: controller.name, version },
     {

--- a/tests/test-mcp/src/features/test_mcp_create_server_explicit_version.ts
+++ b/tests/test-mcp/src/features/test_mcp_create_server_explicit_version.ts
@@ -1,0 +1,43 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TestValidator } from "@nestia/e2e";
+import { createMcpServer } from "@typia/mcp";
+import typia from "typia";
+
+import { Greeter } from "../structures/Greeter";
+
+/**
+ * Verifies a class-controller host can announce its implementation version.
+ *
+ * The controller owns reflected tools, but the application assembling the MCP
+ * server owns the deployed implementation version. Without a public option,
+ * every class-backed release announced the same `"1.0.0"` identity.
+ *
+ * 1. Create a class-backed server with an explicit implementation version.
+ * 2. Connect an SDK client through the public in-memory transport.
+ * 3. Assert the initialize handshake returns the controller name and supplied
+ *    version.
+ */
+export const test_mcp_create_server_explicit_version =
+  async (): Promise<void> => {
+    const server: McpServer = createMcpServer(
+      typia.llm.controller<Greeter>("greeter", new Greeter()),
+      { version: "2.3.4" },
+    );
+    const client: Client = new Client({ name: "version-test", version: "1.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      TestValidator.equals(
+        "explicit implementation version reaches the handshake",
+        client.getServerVersion(),
+        { name: "greeter", version: "2.3.4" },
+      );
+    } finally {
+      await Promise.allSettled([client.close(), server.close()]);
+    }
+  };

--- a/tests/test-mcp/src/features/test_mcp_create_server_version.ts
+++ b/tests/test-mcp/src/features/test_mcp_create_server_version.ts
@@ -1,3 +1,5 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TestValidator } from "@nestia/e2e";
 import { createMcpServer } from "@typia/mcp";
@@ -8,21 +10,32 @@ import { Greeter } from "../structures/Greeter";
 /**
  * Verifies a class controller announces the fixed `"1.0.0"` handshake version.
  *
- * `IMcpServerOptions` intentionally carries no version knob: an HTTP controller
- * inherits the OpenAPI `info.version`, and a class controller has no version
- * source, so the handshake pins the `"1.0.0"` default. A regression would
- * announce `undefined` and break the SDK's `Implementation` contract.
+ * An HTTP controller can inherit OpenAPI `info.version`, but a class controller
+ * has no inferred version source. When the caller omits an explicit version,
+ * the handshake therefore preserves the backward-compatible `"1.0.0"` fallback
+ * rather than announcing `undefined`.
  *
  * 1. Create a server over a class controller.
- * 2. Assert the underlying SDK server's `serverInfo.version` is `"1.0.0"`.
+ * 2. Connect an SDK client through the public in-memory transport.
+ * 3. Assert the initialize handshake announces the `"1.0.0"` fallback.
  */
 export const test_mcp_create_server_version = async (): Promise<void> => {
   const server: McpServer = createMcpServer(
     typia.llm.controller<Greeter>("greeter", new Greeter()),
   );
-  TestValidator.equals(
-    "class controller should announce the 1.0.0 default",
-    ((server.server as any)._serverInfo as { version: string }).version,
-    "1.0.0",
-  );
+  const client: Client = new Client({ name: "version-test", version: "1.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    TestValidator.equals(
+      "class controller should announce the 1.0.0 default",
+      client.getServerVersion(),
+      { name: "greeter", version: "1.0.0" },
+    );
+  } finally {
+    await Promise.allSettled([client.close(), server.close()]);
+  }
 };

--- a/tests/test-mcp/src/features/test_mcp_http_controller_version.ts
+++ b/tests/test-mcp/src/features/test_mcp_http_controller_version.ts
@@ -1,3 +1,5 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TestValidator } from "@nestia/e2e";
 import { IHttpLlmController } from "@typia/interface";
@@ -17,8 +19,8 @@ import { CalculatorApi } from "../structures/CalculatorApi";
  * `"1.0.0"` class-controller default.
  *
  * 1. Build an HTTP controller from a document whose `info.version` is known.
- * 2. Create a server over it.
- * 3. Assert the SDK server's `serverInfo.version` matches the document.
+ * 2. Connect an SDK client through the public in-memory transport.
+ * 3. Assert the initialize handshake inherits the document version.
  */
 export const test_mcp_http_controller_version = async (): Promise<void> => {
   const controller: IHttpLlmController = HttpLlm.controller({
@@ -27,9 +29,19 @@ export const test_mcp_http_controller_version = async (): Promise<void> => {
     connection: { host: "http://localhost:0" },
   });
   const server: McpServer = createMcpServer(controller);
-  TestValidator.equals(
-    "handshake version should mirror the document info.version",
-    ((server.server as any)._serverInfo as { version: string }).version,
-    CalculatorApi.VERSION,
-  );
+  const client: Client = new Client({ name: "version-test", version: "1.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    TestValidator.equals(
+      "handshake version should mirror the document info.version",
+      client.getServerVersion(),
+      { name: "calculator", version: CalculatorApi.VERSION },
+    );
+  } finally {
+    await Promise.allSettled([client.close(), server.close()]);
+  }
 };

--- a/tests/test-mcp/src/features/test_mcp_http_controller_version_override.ts
+++ b/tests/test-mcp/src/features/test_mcp_http_controller_version_override.ts
@@ -1,0 +1,47 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TestValidator } from "@nestia/e2e";
+import { IHttpLlmController } from "@typia/interface";
+import { createMcpServer } from "@typia/mcp";
+import { HttpLlm } from "@typia/utils";
+
+import { CalculatorApi } from "../structures/CalculatorApi";
+
+/**
+ * Verifies an explicit implementation version overrides OpenAPI inference.
+ *
+ * OpenAPI `info.version` remains the useful default for an HTTP controller, but
+ * it describes the served API rather than necessarily the deployed MCP server.
+ * A host-supplied implementation identity must therefore take precedence.
+ *
+ * 1. Build an HTTP controller whose document carries a known API version.
+ * 2. Create the MCP server with a different explicit implementation version.
+ * 3. Assert the public initialize handshake announces the explicit version.
+ */
+export const test_mcp_http_controller_version_override =
+  async (): Promise<void> => {
+    const controller: IHttpLlmController = HttpLlm.controller({
+      name: "calculator",
+      document: CalculatorApi.document(),
+      connection: { host: "http://localhost:0" },
+    });
+    const server: McpServer = createMcpServer(controller, {
+      version: "9.8.7",
+    });
+    const client: Client = new Client({ name: "version-test", version: "1.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      TestValidator.equals(
+        "explicit version overrides OpenAPI info.version",
+        client.getServerVersion(),
+        { name: "calculator", version: "9.8.7" },
+      );
+    } finally {
+      await Promise.allSettled([client.close(), server.close()]);
+    }
+  };

--- a/website/src/content/docs/utilization/mcp.mdx
+++ b/website/src/content/docs/utilization/mcp.mdx
@@ -20,6 +20,7 @@ export function createMcpServer<Class extends object = any>(
 ): McpServer;
 
 export interface IMcpServerOptions {
+  version?: string;
   textFallback?: boolean; // default false
 }
 ```
@@ -35,9 +36,12 @@ import { BbsArticleService } from "./BbsArticleService";
 
 const server = createMcpServer(
   typia.llm.controller<BbsArticleService>("bbs", new BbsArticleService()),
+  { version: "2.3.4" },
 );
 await server.connect(new StdioServerTransport());
 ```
+
+`version` identifies the deployed MCP server implementation in the initialize handshake. Supply the host application's release version when it has one. Without this option, an HTTP controller inherits OpenAPI `info.version` and a class controller keeps the backward-compatible `"1.0.0"` fallback.
 
 ## Setup
 
@@ -112,7 +116,7 @@ const server = createMcpServer(
 );
 ```
 
-The handshake version is the document's `info.version` (a class controller announces `"1.0.0"`). Argument validation, structured output, and error feedback behave exactly as with class controllers.
+The handshake version defaults to the document's `info.version` (a class controller defaults to `"1.0.0"`). An explicit `options.version` takes precedence when the deployed MCP server version differs from the served API version. Argument validation, structured output, and error feedback behave exactly as with class controllers.
 
 ## Server instructions
 


### PR DESCRIPTION
## Summary

- restore a public `IMcpServerOptions.version` override for class-backed MCP servers
- preserve the existing default precedence: explicit option, HTTP OpenAPI `info.version`, then `1.0.0`
- verify all four class/HTTP default/override cases through the public MCP initialize handshake
- exercise the explicit version through the npm-tarball stdio consumer and document the contract

This is the upstream prerequisite for samchon/automovie#1284, whose packaged server currently has no supported way to announce its real application version.

Closes #2022

## Verification

- `pnpm format` (completed; unrelated Windows line-ending refresh was excluded from the topic diff)
- `pnpm build`
- `pnpm --filter ./packages/mcp build`
- `pnpm --filter ./tests/test-mcp start` (22/22)
- `pnpm run test:toolchain`
- `pnpm package:tgz`
- fresh npm install + build + test + interop in `experiments/mcp`
- fresh npm install + build + test in `experiments/esm`
- `pnpm --dir website build`
- solo Self-Review after the final edit

`pnpm test` reaches one pre-existing Windows-only failure group in `test-typia-generate`: `parent directory links terminate` and `repeated directory aliases are rejected`. Both fail identically on a clean, current `master` worktree; the MCP suite and every other locally completed gate above pass.