### PR TITLE
docs(json): expose malformed parse exceptions

### DIFF
--- a/website/src/content/docs/json/parse.mdx
+++ b/website/src/content/docs/json/parse.mdx
@@ -17,13 +17,15 @@ namespace json {
 }
 ```
 
-Each function maps to one of the [runtime validators](/docs/validators/is):
+Each function maps to one of the [runtime validators](/docs/validators/is), but validation starts only after native `JSON.parse` succeeds:
 
-| Function | If JSON is valid AND matches `T` | If anything is wrong |
-|----------|----------------------------------|----------------------|
-| `json.isParse<T>` | returns the parsed value | returns `null` |
-| `json.assertParse<T>` | returns the parsed value | throws `TypeGuardError` |
-| `json.validateParse<T>` | returns `IValidation.ISuccess<T>` | returns `IValidation.IFailure` |
+| Function | Valid JSON matching `T` | Valid JSON not matching `T` | Malformed JSON |
+|----------|-------------------------|-----------------------------|----------------|
+| `json.isParse<T>` | returns the parsed value | returns `null` | throws `SyntaxError` |
+| `json.assertParse<T>` | returns the parsed value | throws `TypeGuardError` | throws `SyntaxError` |
+| `json.validateParse<T>` | returns `IValidation.ISuccess<T>` | returns `IValidation.IFailure` | throws `SyntaxError` |
+
+The factory functions `createIsParse`, `createAssertParse`, and `createValidateParse` produce parsers with the same outcomes.
 
 ## First example
 
@@ -37,7 +39,8 @@ interface User {
 
 const text: string = await fetch("/me").then((r) => r.text());
 const user = typia.json.assertParse<User>(text);
-// → parsed User, validated. Throws if either parse or validation fails.
+// → parsed User when text is valid JSON matching User.
+// Throws SyntaxError for malformed JSON or TypeGuardError for a type mismatch.
 ```
 
 <Tabs items={['TypeScript Source', 'Compiled JavaScript']}>


### PR DESCRIPTION
## Intent

The JSON parse guide grouped malformed JSON and post-parse type mismatches under one failure outcome. That implied `json.isParse` and `json.validateParse` never throw, although all generated parse variants preserve native `JSON.parse` syntax errors.

## Scope

- Split the guide's contract table into matching JSON, valid-but-type-invalid JSON, and malformed JSON.
- State the distinct `null`, `IValidation.IFailure`, `TypeGuardError`, and `SyntaxError` outcomes for all three parse variants.
- State that the direct and factory forms share the same contract.
- Clarify the `assertParse` example without changing runtime behavior or adding a generic transform pattern.

No runtime, package version, interface declaration, workflow, or unrelated guide changed.

## Contract evidence

The following transformed runtime matrix was captured before the edit and repeated after the final prose on exact base `5fce10b93dfe3807423312b447d55f7b2265f5c6`:

| Input class | `isParse` direct/factory | `validateParse` direct/factory | `assertParse` direct/factory |
| --- | --- | --- | --- |
| Valid JSON matching `T` | parsed value | `IValidation.ISuccess` with data | parsed value |
| Valid JSON not matching `T` | `null` | `IValidation.IFailure` with errors and data | `TypeGuardError` |
| Malformed JSON | `SyntaxError` | `SyntaxError` | `SyntaxError` |

Both malformed paths were `instanceof SyntaxError` and not `TypeGuardError`. The mismatch assertion method was `typia.json.assertParse` for the direct call and `typia.json.createAssertParse` for the factory. Native `JSON.parse` was the syntax-error control.

History was also checked: closed #1053 records the intentional caller-side exception boundary, while PR #1852 / merge `7c4f72e5f17` introduced the conflicting guide table. Per #2232, that history was treated as evidence rather than an implementation prescription; current direct and factory behavior was measured independently.

## Pre-PR chronology and Self-Review

- The first cold transformed probe reached its 15-minute timeout; the warmed retry completed in 11.8 seconds and produced the red matrix above.
- Root packaging first reached a 20-minute timeout during the cold `typia` prepack. A complete retry passed in 22 minutes 53 seconds and produced all six expected tarballs.
- The first website build reached the playground Wasm step and failed with `fatal error: out of memory allocating heap arena map` during concurrent Go linking. After the resource contention cleared, the same Wasm build passed in 24 minutes 43 seconds and the complete website build passed.
- Solo Self-Review inspected the complete one-file diff and consequence surface. The first full round was clean, so no remediation round was required.

## Verification

- `pnpm install` — passed (1 minute 49.6 seconds).
- `pnpm build` — passed (96.5 seconds).
- `pnpm package:tgz` — passed (22 minutes 53.4 seconds); `interface`, `langchain`, `mcp`, `typia`, `utils`, and `vercel` tarballs confirmed and left ignored.
- `node build/wasm.js` in `website/` — passed after resource contention cleared (24 minutes 43.4 seconds; 39.27 MiB).
- `pnpm build` in `website/` — passed (171.1 seconds); Next compiled, type-checked, generated 74/74 static pages including `/docs/json/parse`, exported, indexed, and generated the sitemap.
- Rendered `/docs/json/parse` HTML — confirmed the three input columns, all `SyntaxError` cells, factory parity sentence, and assertion distinction.
- Final transformed direct/factory runtime matrix — passed (5.1 seconds; all 18 paths matched the table).
- `typos v1.48.0 --config typos.toml website/src/content/docs/json/parse.mdx` — passed with en-US configuration.
- `git diff --check` — passed.

Skipped by campaign contract: repository-wide `pnpm format`, the full `pnpm test` suite for this documentation-only change, and the already-complete D9 combined checks. Campaign CI is cancelled per exact SHA; the push gate observed no runs after two polls.

Fixes #2235
