### PR TITLE
fix(native): stabilize dynamic-key schema emit

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/json_schema_dynamic_key_determinism_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_schema_dynamic_key_determinism_transform_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+  "bytes"
+  "crypto/sha256"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestJsonSchemaDynamicKeyDeterminismTransform verifies dynamic-key schemas emit deterministically.
+//
+// Multiple template and numeric index signatures used to reach a Go map before
+// their value metadata was merged. Repeating one unchanged transform therefore
+// has to compare the complete output bytes, while runtime checks ensure a stable
+// order is not achieved by losing, duplicating, or broadening schema branches.
+//
+//  1. Transform unchanged tag-free dynamic-key fixtures repeatedly to TypeScript and JavaScript.
+//  2. Require every complete emit to match the first emit byte for byte.
+//  3. Execute the JavaScript and assert branch completeness plus unrelated ordering controls.
+func TestJsonSchemaDynamicKeyDeterminismTransform(t *testing.T) {
+  project := jsonSchemaDynamicKeyDeterminismProject(t)
+  var javascript string
+  for _, output := range []string{"ts", "js"} {
+    baseline := jsonSchemaDynamicKeyDeterminismTransform(t, project, output)
+    for iteration := 1; iteration < 32; iteration++ {
+      current := jsonSchemaDynamicKeyDeterminismTransform(t, project, output)
+      if bytes.Equal([]byte(current), []byte(baseline)) == false {
+        t.Fatalf(
+          "%s emit %d changed for unchanged input: baseline=%x current=%x first-difference=%d",
+          output,
+          iteration+1,
+          sha256.Sum256([]byte(baseline)),
+          sha256.Sum256([]byte(current)),
+          jsonSchemaDynamicKeyDeterminismFirstDifference(baseline, current),
+        )
+      }
+    }
+    t.Logf("%s emit remained byte-identical across 32 transforms: sha256=%x", output, sha256.Sum256([]byte(baseline)))
+    if output == "js" {
+      javascript = baseline
+    }
+  }
+  jsonSchemaDynamicKeyDeterminismRunRuntimeCases(t, project, javascript)
+}
+
+func jsonSchemaDynamicKeyDeterminismProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "json-schema-dynamic-key-determinism-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(jsonSchemaDynamicKeyDeterminismTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonSchemaDynamicKeyDeterminismSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func jsonSchemaDynamicKeyDeterminismTransform(t *testing.T, project string, output string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", output,
+    })
+  })
+  if code != 0 {
+    t.Fatalf("dynamic-key schema transform failed: output=%s code=%d stderr=\n%s", output, code, errText)
+  }
+  return out
+}
+
+func jsonSchemaDynamicKeyDeterminismFirstDifference(x string, y string) int {
+  limit := len(x)
+  if len(y) < limit {
+    limit = len(y)
+  }
+  for i := 0; i < limit; i++ {
+    if x[i] != y[i] {
+      return i
+    }
+  }
+  return limit
+}
+
+func jsonSchemaDynamicKeyDeterminismRunRuntimeCases(t *testing.T, project string, javascript string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, javascript)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(jsonSchemaDynamicKeyDeterminismRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("dynamic-key schema runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const jsonSchemaDynamicKeyDeterminismTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const jsonSchemaDynamicKeyDeterminismSource = `import typia from "typia";
+
+interface DynamicComposite {
+  id: string;
+  name: string;
+  [index: number]: number;
+  [key: ` + "`prefix_${string}`" + `]: string;
+  [key: ` + "`${string}_postfix`" + `]: string;
+  [key: ` + "`value_${number}`" + `]: boolean | string | number;
+  [key: ` + "`between_${string}_and_${number}`" + `]: boolean;
+}
+
+interface DynamicTemplate {
+  [key: ` + "`prefix_${string}`" + `]: string;
+  [key: ` + "`${string}_postfix`" + `]: string;
+  [key: ` + "`value_${number}`" + `]: number;
+  [key: ` + "`between_${string}_and_${number}`" + `]: boolean;
+}
+
+interface DynamicUnion {
+  [key: number | ` + "`prefix_${string}`" + ` | ` + "`${string}_postfix`" + `]: string;
+  [key: ` + "`value_between_${number}_and_${number}`" + `]: number;
+}
+
+interface LiteralOnly {
+  z: string;
+  a: number;
+}
+
+interface SingleDynamic {
+  [key: ` + "`only_${string}`" + `]: string;
+}
+
+type OrdinaryUnion = string | number;
+
+export const schemas = typia.json.schemas<[
+  DynamicComposite,
+  DynamicTemplate,
+  DynamicUnion,
+  LiteralOnly,
+  SingleDynamic,
+  OrdinaryUnion,
+]>();
+`
+
+const jsonSchemaDynamicKeyDeterminismRuntimeRunner = `const unit = require("./main.cjs").schemas;
+
+const components = unit.components?.schemas ?? {};
+const assertTypes = (name, expected) => {
+  const additional = components[name]?.additionalProperties;
+  const actual = Array.isArray(additional?.oneOf)
+    ? additional.oneOf.map((schema) => schema.type)
+    : [additional?.type];
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(name + " branches were " + JSON.stringify(actual) + ", expected " + JSON.stringify(expected));
+  }
+};
+
+assertTypes("DynamicComposite", ["number", "string", "boolean"]);
+assertTypes("DynamicTemplate", ["string", "number", "boolean"]);
+assertTypes("DynamicUnion", ["string", "number"]);
+
+const literal = components.LiteralOnly;
+const literalShape = {
+  type: literal?.type,
+  propertyKeys: Object.keys(literal?.properties ?? {}),
+  propertyTypes: Object.values(literal?.properties ?? {}).map((schema) => schema.type),
+  required: literal?.required,
+  additionalProperties: literal?.additionalProperties,
+};
+const expectedLiteralShape = {
+  type: "object",
+  propertyKeys: ["z", "a"],
+  propertyTypes: ["string", "number"],
+  required: ["z", "a"],
+  additionalProperties: false,
+};
+if (JSON.stringify(literalShape) !== JSON.stringify(expectedLiteralShape)) {
+  throw new Error("zero-dynamic literal schema changed: " + JSON.stringify(literalShape));
+}
+if (components.SingleDynamic?.additionalProperties?.type !== "string") {
+  throw new Error("single dynamic-key schema changed: " + JSON.stringify(components.SingleDynamic));
+}
+const ordinaryTypes = components.OrdinaryUnion?.oneOf?.map((schema) => schema.type) ?? [];
+if (JSON.stringify(ordinaryTypes) !== JSON.stringify(["string", "number"])) {
+  throw new Error("ordinary union branches changed: " + JSON.stringify(ordinaryTypes));
+}
+
+const refs = unit.schemas.map((schema) => schema.$ref);
+const expectedRefs = [
+  "#/components/schemas/DynamicComposite",
+  "#/components/schemas/DynamicTemplate",
+  "#/components/schemas/DynamicUnion",
+  "#/components/schemas/LiteralOnly",
+  "#/components/schemas/SingleDynamic",
+  "#/components/schemas/OrdinaryUnion",
+];
+if (JSON.stringify(refs) !== JSON.stringify(expectedRefs)) {
+  throw new Error("schema order changed: " + JSON.stringify(refs));
+}
+`

--- a/packages/typia/native/core/programmers/iterate/json_schema_object.go
+++ b/packages/typia/native/core/programmers/iterate/json_schema_object.go
@@ -111,7 +111,7 @@ func json_schema_create_object_schema(props struct {
       if pattern == nativeutils.PatternUtil.STRING {
         extraMeta.additionalProperties = &pair
       } else {
-        extraMeta.patternProperties[pattern] = pair
+        extraMeta.setPatternProperty(pattern, pair)
       }
     }
   }
@@ -152,8 +152,8 @@ func json_schema_join(props struct {
   extra      json_schema_superfluous
 }) JsonSchema {
   elements := []json_schema_metadata_schema_pair{}
-  for _, value := range props.extra.patternProperties {
-    elements = append(elements, value)
+  for _, key := range props.extra.patternPropertyKeys {
+    elements = append(elements, props.extra.patternProperties[key])
   }
   if props.extra.additionalProperties != nil {
     elements = append(elements, *props.extra.additionalProperties)
@@ -179,6 +179,16 @@ func json_schema_join(props struct {
 type json_schema_superfluous struct {
   additionalProperties *json_schema_metadata_schema_pair
   patternProperties    map[string]json_schema_metadata_schema_pair
+  // patternPropertyKeys preserves the first-insertion order of the map while
+  // later assignments to an existing pattern replace its value in place.
+  patternPropertyKeys []string
+}
+
+func (superfluous *json_schema_superfluous) setPatternProperty(pattern string, pair json_schema_metadata_schema_pair) {
+  if _, exists := superfluous.patternProperties[pattern]; exists == false {
+    superfluous.patternPropertyKeys = append(superfluous.patternPropertyKeys, pattern)
+  }
+  superfluous.patternProperties[pattern] = pair
 }
 
 type json_schema_metadata_schema_pair struct {

--- a/packages/typia/native/core/programmers/iterate/json_schema_pattern_property_order_test.go
+++ b/packages/typia/native/core/programmers/iterate/json_schema_pattern_property_order_test.go
@@ -1,0 +1,44 @@
+package iterate
+
+import (
+  "slices"
+  "testing"
+
+  nativemetadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestJsonSchemaPatternPropertyOrderPreservesFirstPosition verifies repeated patterns keep one ordered slot.
+//
+// The legacy TypeScript producer stored pairs in a plain object: assigning an
+// existing pattern replaced its value without moving or duplicating its first
+// insertion position. The Go order record must preserve that overwrite contract.
+//
+//  1. Insert two patterns, then replace the first pattern with new metadata and schema values.
+//  2. Assert the ordered keys remain unique and the map retains the replacement pair.
+func TestJsonSchemaPatternPropertyOrderPreservesFirstPosition(t *testing.T) {
+  first := &nativemetadata.MetadataSchema{}
+  replacement := &nativemetadata.MetadataSchema{}
+  extra := json_schema_superfluous{
+    patternProperties: map[string]json_schema_metadata_schema_pair{},
+  }
+  extra.setPatternProperty("first", json_schema_metadata_schema_pair{
+    metadata: first,
+    schema:   JsonSchema{"type": "string"},
+  })
+  extra.setPatternProperty("second", json_schema_metadata_schema_pair{
+    metadata: &nativemetadata.MetadataSchema{},
+    schema:   JsonSchema{"type": "boolean"},
+  })
+  extra.setPatternProperty("first", json_schema_metadata_schema_pair{
+    metadata: replacement,
+    schema:   JsonSchema{"type": "number"},
+  })
+
+  if slices.Equal(extra.patternPropertyKeys, []string{"first", "second"}) == false {
+    t.Fatalf("pattern property order was %v", extra.patternPropertyKeys)
+  }
+  pair := extra.patternProperties["first"]
+  if pair.metadata != replacement || pair.schema["type"] != "number" {
+    t.Fatalf("replacement pair was not retained: %#v", pair)
+  }
+}


### PR DESCRIPTION
## Intent

Make JSON schema emission byte-deterministic for objects with multiple numeric or template index signatures, without changing schema meaning or unrelated stable ordering.

Fixes #2233

## Root cause and scope

The Go migration retained dynamic pattern/value pairs in a map and ranged that map before `MetadataSchema_merge`. The legacy TypeScript producer used `Object.values`, whose string-key enumeration preserves first insertion order, so the migration made the resulting `oneOf` order depend on Go map iteration.

This change records each pattern's first insertion position beside the map and merges values in that order. Reassigning an existing pattern keeps its original slot and replaces its value, matching the earlier plain-object contract. The producer boundary feeds `json.schema`, `json.schemas`, `json.application`, the OpenAPI 3.0 downgrade, and the LLM schema/parameters/application consumers.

No package version, `packages/interface/src` declaration, workflow, dependency, or provider-specific behavior changes are included.

## Regression and emit evidence

On exact base `5fce10b93dfe3807423312b447d55f7b2265f5c6`, the new real-transform regression failed on the second unchanged TypeScript emit:

- baseline SHA-256: `b5d99f1f0c464b44482539e17eab0146698829e111053ee1e6c25c890265edd2`
- current SHA-256: `154e56197d98f94b5d260293643476a3c03db718cd8d05465ded335468ec8c52`
- first differing byte: `1374`

After the fix and rebase onto `643446af098866eba95ba672551d59d7f3890177`, 32 TypeScript and 32 JavaScript transforms were byte-identical:

- TypeScript SHA-256: `a87c4778bf525478e2bdc1e786b80f0c2da5a7cc346d49d520f3af6b5b51d6d9`
- JavaScript SHA-256: `8b49c22648563ab643862c509bf3c2ba28e28e4e1bfa614cf1f6bfa9fc40001b`

The runtime oracle pins the intended declaration-order stabilization and branch completeness:

- `DynamicComposite`: `[number, string, boolean]`
- `DynamicTemplate`: `[string, number, boolean]`
- `DynamicUnion`: `[string, number]`

It also preserves literal property order, component/schema order, a single dynamic signature, and an ordinary union. A separate unit negative control verifies that a repeated pattern keeps one ordered slot while retaining the replacement value.

## Local verification

- `go -C packages/typia/native test ./cmd/ttsc-typia -run '^TestJsonSchemaDynamicKeyDeterminismTransform$' -count=1 -v`
- `go -C packages/typia/native test ./core/programmers/iterate -run '^TestJsonSchemaPatternPropertyOrderPreservesFirstPosition$' -count=1 -v`
- `go -C packages/typia/native test ./core/programmers/iterate ./core/programmers/json ./core/programmers/llm -count=1`
- `go -C packages/typia/native test -p=1 -count=1 ./...`
- `go -C packages/typia/native vet -p=1 ./...`
- `pnpm --filter ./tests/test-typia-schema start` before and after rebase
- `git diff origin/master...HEAD --check`
- en-US spelling sweep over every added line

The first unprovisioned full-native attempt exposed the documented tag-type degradation and concurrent linker memory pressure. After `pnpm install --frozen-lockfile`, the serialized `-p=1` full suite passed in 141.5 seconds.

## Self-Review chronology

The handoff required PR creation after implementation, so solo Self-Review ran locally first. One complete whole-diff and consequence-surface round finished clean with no remediation findings. The final rebase changed no native path; focused and schema-consumer verification then passed again.

## Skipped checks

- Repository-wide `pnpm format` was not run because campaign implementation branches reserve it for Post-Campaign Cleanup; the targeted Go formatter handled only this diff.
- The already-passing D9 combined build/vet/three-fix gate was not repeated.
- Campaign Actions are cancelled by exact SHA after each remote mutation; local verification is the implementation gate.
