### PR TITLE
fix(native): preserve template-literal union membership

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/compare_template_literal_union_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/compare_template_literal_union_transform_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCompareTemplateLiteralUnionTransform verifies template-literal object
+// union members retain their runtime domains during equality dispatch.
+//
+// The #2225 first-match fallback must use the same structural template
+// membership decision as is and clone. Weakening both template domains to
+// `typeof string` routes valid `b_*` values through the `a_*` comparator and
+// drops `b`.
+//
+//  1. Transform direct and factory is, clone, and equals calls for a tag-free
+//     template-literal object union and the same union nested in an object.
+//  2. Prove is accepts both witnesses and clone selects the `b_*` member while
+//     preserving their different `b` values.
+//  3. Exercise equal, cross-member, invalid-discriminator, nested, literal-
+//     discriminated, non-discriminable, and non-union controls at runtime.
+func TestCompareTemplateLiteralUnionTransform(t *testing.T) {
+  project := compareTemplateLiteralUnionProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("compare template-literal union transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  compareTemplateLiteralUnionRunRuntimeCases(t, project, out)
+}
+
+func compareTemplateLiteralUnionProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "compare-template-literal-union-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(compareTemplateLiteralUnionTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(compareTemplateLiteralUnionSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func compareTemplateLiteralUnionRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "throw-type-guard-error-stub.cjs"), []byte(compareTemplateLiteralUnionThrowStub), 0o644); err != nil {
+    t.Fatalf("write throw stub: %v", err)
+  }
+  js = strings.ReplaceAll(js, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(compareTemplateLiteralUnionRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("compare template-literal union runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const compareTemplateLiteralUnionTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const compareTemplateLiteralUnionThrowStub = `module.exports._throwTypeGuardError = (props) => {
+  const error = new Error("guard: " + props.expected);
+  error.name = "TypeGuardError";
+  throw error;
+};
+`
+
+const compareTemplateLiteralUnionSource = `import typia from "typia";
+
+type TemplateUnion =
+  | { kind: ` + "`a_${string}`" + `; common: string }
+  | { kind: ` + "`b_${string}`" + `; common: string; b?: string };
+type Nested = { value: TemplateUnion };
+
+export const isTemplate = typia.createIs<TemplateUnion>();
+export const cloneTemplate = typia.plain.createClone<TemplateUnion>();
+export const eqTemplateFactory = typia.compare.createEquals<TemplateUnion>();
+export const eqTemplateDirect = (x: TemplateUnion, y: TemplateUnion) =>
+  typia.compare.equals<TemplateUnion>(x, y);
+
+export const isNested = typia.createIs<Nested>();
+export const cloneNested = typia.plain.createClone<Nested>();
+export const eqNestedFactory = typia.compare.createEquals<Nested>();
+export const eqNestedDirect = (x: Nested, y: Nested) =>
+  typia.compare.equals<Nested>(x, y);
+
+export const eqLiteral = typia.compare.createEquals<
+  { kind: "a"; value: number } | { kind: "b"; value: string }
+>();
+export const eqOptional = typia.compare.createEquals<
+  { a?: number } | { b?: string }
+>();
+export const eqPlain = typia.compare.createEquals<{
+  kind: string;
+  common: string;
+  b?: string;
+}>();
+`
+
+const compareTemplateLiteralUnionRuntimeRunner = `const mod = require("./main.cjs");
+
+let failures = 0;
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    console.log("FAIL " + label + ": expected " + expected + ", got " + actual);
+    failures++;
+  }
+};
+const expectJson = (label, actual, expected) =>
+  expect(label, JSON.stringify(actual), JSON.stringify(expected));
+
+const left = { kind: "b_x", common: "same", b: "left" };
+const right = { kind: "b_x", common: "same", b: "right" };
+expect("is left b member", mod.isTemplate(left), true);
+expect("is right b member", mod.isTemplate(right), true);
+expectJson("clone left preserves b", mod.cloneTemplate(left), left);
+expectJson("clone right preserves b", mod.cloneTemplate(right), right);
+expect("factory different b", mod.eqTemplateFactory(left, right), false);
+expect("direct different b", mod.eqTemplateDirect(left, right), false);
+
+expect("factory equal b", mod.eqTemplateFactory(
+  { kind: "b_x", common: "same", b: "same" },
+  { kind: "b_x", common: "same", b: "same" },
+), true);
+expect("direct equal b", mod.eqTemplateDirect(
+  { kind: "b_x", common: "same", b: "same" },
+  { kind: "b_x", common: "same", b: "same" },
+), true);
+expect("a member different common", mod.eqTemplateFactory(
+  { kind: "a_x", common: "left" },
+  { kind: "a_x", common: "right" },
+), false);
+expect("a member equal", mod.eqTemplateFactory(
+  { kind: "a_x", common: "same" },
+  { kind: "a_x", common: "same" },
+), true);
+expect("a versus b", mod.eqTemplateFactory(
+  { kind: "a_x", common: "same" },
+  { kind: "b_x", common: "same" },
+), false);
+
+const invalidLeft = { kind: "c_x", common: "same" };
+const invalidRight = { kind: "c_x", common: "same" };
+expect("is rejects invalid discriminator", mod.isTemplate(invalidLeft), false);
+expect("factory rejects invalid discriminator", mod.eqTemplateFactory(invalidLeft, invalidRight), false);
+expect("direct rejects invalid discriminator", mod.eqTemplateDirect(invalidLeft, invalidRight), false);
+
+const nestedLeft = { value: left };
+const nestedRight = { value: right };
+expect("nested is left", mod.isNested(nestedLeft), true);
+expect("nested is right", mod.isNested(nestedRight), true);
+expectJson("nested clone left preserves b", mod.cloneNested(nestedLeft), nestedLeft);
+expectJson("nested clone right preserves b", mod.cloneNested(nestedRight), nestedRight);
+expect("nested factory different b", mod.eqNestedFactory(nestedLeft, nestedRight), false);
+expect("nested direct different b", mod.eqNestedDirect(nestedLeft, nestedRight), false);
+expect("nested factory equal b", mod.eqNestedFactory(
+  { value: { kind: "b_x", common: "same", b: "same" } },
+  { value: { kind: "b_x", common: "same", b: "same" } },
+), true);
+expect("nested invalid discriminator", mod.eqNestedFactory(
+  { value: invalidLeft },
+  { value: invalidRight },
+), false);
+
+expect("literal member different", mod.eqLiteral(
+  { kind: "a", value: 1 },
+  { kind: "a", value: 2 },
+), false);
+expect("literal cross member", mod.eqLiteral(
+  { kind: "a", value: 1 },
+  { kind: "b", value: "1" },
+), false);
+expect("optional member different", mod.eqOptional({ a: 1 }, { a: 2 }), false);
+expect("optional second payload follows first match", mod.eqOptional({ b: "left" }, { b: "right" }), true);
+expect("plain different", mod.eqPlain(
+  { kind: "b_x", common: "same", b: "left" },
+  { kind: "b_x", common: "same", b: "right" },
+), false);
+expect("plain equal", mod.eqPlain(
+  { kind: "b_x", common: "same", b: "same" },
+  { kind: "b_x", common: "same", b: "same" },
+), true);
+
+if (failures > 0) {
+  throw new Error(failures + " assertion(s) failed");
+}
+console.log("all compare template-literal union cases passed");
+`

--- a/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
+++ b/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
@@ -12,6 +12,7 @@ import (
   nativefactories "github.com/samchon/typia/packages/typia/native/core/factories"
   nativehelpers "github.com/samchon/typia/packages/typia/native/core/programmers/helpers"
   nativeinternal "github.com/samchon/typia/packages/typia/native/core/programmers/internal"
+  nativeiterate "github.com/samchon/typia/packages/typia/native/core/programmers/iterate"
   schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
 )
 
@@ -307,9 +308,8 @@ func (g *compareEqualProgrammerGenerator) objectCall(object *schemametadata.Meta
   return fmt.Sprintf("_eo%d(%s, %s)", object.Index, g.wrap(x), g.wrap(y))
 }
 
-// objectFlatBranch renders one member of an object union as a guarded member
-// comparator (the pre-discrimination form). It is used for a single-object
-// "union" and as the fallback for a union no supported predicate can split.
+// objectFlatBranch renders a single object member as a guarded comparator. A
+// multi-object union always uses objectUnion's member dispatch instead.
 func (g *compareEqualProgrammerGenerator) objectFlatBranch(object *schemametadata.MetadataObjectType, natives []*schemametadata.MetadataNative, x string, y string) string {
   // Guard the object branch against the sibling native instances. `_eo` admits
   // any `typeof === "object" && !Array.isArray` value, so a native (a Date is
@@ -439,8 +439,8 @@ func (g *compareEqualProgrammerGenerator) matchCall(object *schemametadata.Metad
 // may be absent), and every extra key a dynamic index signature declares must
 // hold a value of the signature's type. It mirrors the `_io` checkers `is`
 // emits, at the abstraction level the rest of this programmer works at — shape
-// and typeof, not the value constraints (`typia.tags.*`, template patterns)
-// `compare` deliberately ignores.
+// and typeof, plus structural template patterns. It deliberately ignores
+// `typia.tags.*` constraints.
 func (g *compareEqualProgrammerGenerator) matchObject(object *schemametadata.MetadataObjectType, v string) string {
   checks := []string{}
   regularKeys := []string{}
@@ -504,7 +504,7 @@ func (g *compareEqualProgrammerGenerator) match(metadata *schemametadata.Metadat
     branches = append(branches, g.typeof(v, atomic.Type))
   }
   if len(metadata.Templates) != 0 {
-    branches = append(branches, g.typeof(v, "string"))
+    branches = append(branches, g.and(g.typeof(v, "string"), g.template(metadata.Templates, v)))
   }
   if len(metadata.Functions) != 0 {
     branches = append(branches, g.typeof(v, "function"))
@@ -763,6 +763,19 @@ func (g *compareEqualProgrammerGenerator) dynamicKey(metadata *schemametadata.Me
   }
   if len(checks) == 0 {
     return "true"
+  }
+  return g.or(checks...)
+}
+
+// template renders the structural membership test shared with the authoritative
+// runtime template checker. Compare still ignores typia tag predicates when it
+// compares values, but it must retain the template-literal domain while routing
+// an object union to a declared member.
+func (g *compareEqualProgrammerGenerator) template(templates []*schemametadata.MetadataTemplate, input string) string {
+  checks := make([]string, 0, len(templates))
+  for _, template := range templates {
+    pattern := nativeiterate.TemplateRuntimePattern(template.Row)
+    checks = append(checks, fmt.Sprintf("RegExp(%s).test(%s)", strconv.Quote(pattern), g.wrap(input)))
   }
   return g.or(checks...)
 }

--- a/packages/typia/native/core/programmers/iterate/template_runtime_pattern.go
+++ b/packages/typia/native/core/programmers/iterate/template_runtime_pattern.go
@@ -25,6 +25,17 @@ type templateCapture struct {
   Atomic *nativemetadata.MetadataAtomic
 }
 
+// TemplateRuntimePattern returns the structural regular-expression pattern the
+// runtime template checker uses for one template-literal row.
+//
+// Consumers that only need template membership can share the checker's exact
+// pattern without duplicating its lowering. Runtime tag conditions remain owned
+// by Check_template because they require the checker context and capture map.
+func TemplateRuntimePattern(row []*nativemetadata.MetadataSchema) string {
+  pattern, _ := template_runtime_pattern(row)
+  return pattern
+}
+
 // template_runtime_pattern builds the structural regex of a template literal for
 // the runtime checker and, alongside it, the capture map of every constrained
 // interpolation placeholder.

--- a/tests/test-typia-schema/src/features/compare/test_compare_equals_object_union_template_literal.ts
+++ b/tests/test-typia-schema/src/features/compare/test_compare_equals_object_union_template_literal.ts
@@ -1,0 +1,152 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+type ITemplateUnion =
+  | { kind: `a_${string}`; common: string }
+  | { kind: `b_${string}`; common: string; b?: string };
+type INested = { value: ITemplateUnion };
+
+/**
+ * Verifies compare.equals preserves template-literal object-union membership.
+ *
+ * The non-discriminable fallback introduced for samchon/typia#2225 once
+ * weakened a template-literal property to `typeof string`. Valid `b_*` values
+ * then resolved to the `a_*` member, so a difference in `b` disappeared even
+ * though is and clone selected the later member and preserved that property.
+ *
+ * 1. Prove is accepts two `b_*` witnesses and clone preserves their distinct `b`
+ *    values.
+ * 2. Exercise different and equal `b_*` values, `a_*` values, cross-member values,
+ *    and invalid discriminators through factory and direct equals.
+ * 3. Repeat the membership controls with the union nested in an object.
+ */
+export const test_compare_equals_object_union_template_literal = (): void => {
+  const is = typia.createIs<ITemplateUnion>();
+  const clone = typia.plain.createClone<ITemplateUnion>();
+  const equals = typia.compare.createEquals<ITemplateUnion>();
+  const direct = (x: ITemplateUnion, y: ITemplateUnion): boolean =>
+    typia.compare.equals<ITemplateUnion>(x, y);
+
+  const left = {
+    kind: "b_x",
+    common: "same",
+    b: "left",
+  } satisfies ITemplateUnion;
+  const right = {
+    kind: "b_x",
+    common: "same",
+    b: "right",
+  } satisfies ITemplateUnion;
+  TestValidator.equals("is accepts left b member", true, is(left));
+  TestValidator.equals("is accepts right b member", true, is(right));
+  TestValidator.equals<ITemplateUnion>(
+    "clone preserves left b member",
+    left,
+    clone(left),
+  );
+  TestValidator.equals<ITemplateUnion>(
+    "clone preserves right b member",
+    right,
+    clone(right),
+  );
+  TestValidator.equals(
+    "factory compares different b",
+    false,
+    equals(left, right),
+  );
+  TestValidator.equals(
+    "direct compares different b",
+    false,
+    direct(left, right),
+  );
+
+  const equalLeft = {
+    kind: "b_x",
+    common: "same",
+    b: "same",
+  } satisfies ITemplateUnion;
+  const equalRight = { ...equalLeft } satisfies ITemplateUnion;
+  TestValidator.equals(
+    "factory compares equal b",
+    true,
+    equals(equalLeft, equalRight),
+  );
+  TestValidator.equals(
+    "direct compares equal b",
+    true,
+    direct(equalLeft, equalRight),
+  );
+  TestValidator.equals(
+    "a member compares declared properties",
+    false,
+    equals({ kind: "a_x", common: "left" }, { kind: "a_x", common: "right" }),
+  );
+  TestValidator.equals(
+    "equal a members",
+    true,
+    equals({ kind: "a_x", common: "same" }, { kind: "a_x", common: "same" }),
+  );
+  TestValidator.equals(
+    "a and b members differ",
+    false,
+    equals({ kind: "a_x", common: "same" }, { kind: "b_x", common: "same" }),
+  );
+
+  const invalidLeft = { kind: "c_x", common: "same" } as any;
+  const invalidRight = { kind: "c_x", common: "same" } as any;
+  TestValidator.equals(
+    "is rejects invalid discriminator",
+    false,
+    is(invalidLeft),
+  );
+  TestValidator.equals(
+    "factory rejects invalid discriminator",
+    false,
+    equals(invalidLeft, invalidRight),
+  );
+  TestValidator.equals(
+    "direct rejects invalid discriminator",
+    false,
+    direct(invalidLeft, invalidRight),
+  );
+
+  const nestedIs = typia.createIs<INested>();
+  const nestedClone = typia.plain.createClone<INested>();
+  const nestedEquals = typia.compare.createEquals<INested>();
+  const nestedDirect = (x: INested, y: INested): boolean =>
+    typia.compare.equals<INested>(x, y);
+  const nestedLeft: INested = { value: left };
+  const nestedRight: INested = { value: right };
+  TestValidator.equals("nested is accepts left", true, nestedIs(nestedLeft));
+  TestValidator.equals("nested is accepts right", true, nestedIs(nestedRight));
+  TestValidator.equals(
+    "nested clone preserves left",
+    nestedLeft,
+    nestedClone(nestedLeft),
+  );
+  TestValidator.equals(
+    "nested clone preserves right",
+    nestedRight,
+    nestedClone(nestedRight),
+  );
+  TestValidator.equals(
+    "nested factory compares different b",
+    false,
+    nestedEquals(nestedLeft, nestedRight),
+  );
+  TestValidator.equals(
+    "nested direct compares different b",
+    false,
+    nestedDirect(nestedLeft, nestedRight),
+  );
+  TestValidator.equals(
+    "nested factory compares equal b",
+    true,
+    nestedEquals({ value: equalLeft }, { value: equalRight }),
+  );
+  TestValidator.equals(
+    "nested rejects invalid discriminator",
+    false,
+    nestedEquals({ value: invalidLeft }, { value: invalidRight }),
+  );
+};


### PR DESCRIPTION
## Summary

Preserve structural template-literal domains when `compare.equals` resolves a fallback object-union member. Both operands now reach the same declared member as the `is`/`plain.clone` structural template path before equality compares that member's fields.

Fixes #2234

## Root cause and impact

The first-match fallback added for non-discriminable object unions represented every template bucket as only `typeof value === "string"`. For

```ts
{ kind: `a_${string}`; common: string }
  | { kind: `b_${string}`; common: string; b?: string }
```

both `_ui` matchers accepted any string `kind`. A valid `b_*` value therefore resolved to the earlier `a_*` member, whose comparator does not declare `b`; distinct `b` values compared equal. The same weakening also routed two identical invalid `c_*` discriminators to an arbitrary member.

## Implementation

- Expose the structural pattern already owned by the runtime template checker without exposing its capture/tag machinery.
- Retain that pattern only in the fallback member matcher that had weakened template metadata.
- Leave union specialization, dynamic-key equality, and compare's established `typia.tags.*` policy unchanged.
- Add one tag-free native transform/runtime regression and one matching function-per-file TypeScript regression.

No package version, `packages/interface/src`, workflow, dependency, or provider claim changes are included. The rebased branch preserves upstream `typia` version `13.1.19`.

## Emitted evidence

Before, both member matchers accepted every string discriminator:

```js
const _ui0 = (v) => typeof v.kind === "string" && typeof v.common === "string";
const _ui1 = (v) => typeof v.kind === "string" && typeof v.common === "string" && (v.b === undefined || typeof v.b === "string");
```

After, the same matchers preserve their declared structural domains:

```js
const _ui0 = (v) => typeof v.kind === "string" && RegExp("^a_(.*)").test(v.kind) && typeof v.common === "string";
const _ui1 = (v) => typeof v.kind === "string" && RegExp("^b_(.*)").test(v.kind) && typeof v.common === "string" && (v.b === undefined || typeof v.b === "string");
```

An unrelated non-union `compare.equals<{ kind: string; common: string; b?: string }>` export was byte-identical before and after: SHA-256 `f2a311c5577a6393c03a521d2d2024a3987dd83ce4e0474d6381833534db0a19`.

## Regression coverage

The native and TypeScript cases prove:

- both `b_*` operands are `is`-valid;
- clone resolves both to the later member and preserves different `b` values;
- direct and factory equals reject different `b` values and accept equal ones;
- `a_*` values compare their declared fields, while `a_*` and `b_*` differ;
- invalid discriminators are rejected instead of routed arbitrarily;
- direct/factory behavior holds for the same union nested in an object; and
- literal-discriminated (#2214), non-discriminable (#2225), and non-union controls remain unchanged.

## Local verification

Final rebased HEAD `2494e19cb477243cd0e195e0df8dbae29d52567f` is based directly on `643446af098866eba95ba672551d59d7f3890177`.

- PASS red-to-green `TestCompareTemplateLiteralUnionTransform` (current master produced 7 intended runtime assertion failures before the fix).
- PASS `go -C packages/typia/native test -p=1 ./cmd/ttsc-typia -run '^TestCompare(TemplateLiteralUnion|NonDiscriminableUnion|UnionDiscrimination)Transform$' -count=1` after Self-Review tightening and again after rebase.
- PASS `go -C packages/typia/test test -p=1 ../native/...` (full native suite; 360.7 seconds).
- PASS `go -C packages/typia/test vet -p=1 ../native/...`.
- PASS `pnpm --filter ./tests/test-typia-schema start -- --include compare_equals_object_union_template_literal` after rebase, including a fresh source-plugin build for the `13.1.19` cache key.
- PASS `pnpm --filter ./tests/test-typia-schema start` after rebase.
- PASS `pnpm --filter ./tests/test-feature-identity start`.
- PASS `git diff --check`, targeted Prettier check, filename/export identity, and en-US spelling sweep.

The full native suite and vet preceded Self-Review's removal of two unrelated emit expansions; the final fallback-only implementation was rerun through the focused native/adjacent tests and both schema commands. The already-passing D9 combined gate and repository-wide `pnpm build` were not rerun. Per campaign policy, `pnpm format` was not run.

## Pre-PR Self-Review chronology

The PR follows implementation, so these findings were resolved locally before the PR existed:

1. Round 1 removed unverified template-pattern changes from specialization and dynamic-key equality. `MetadataSchema_intersects` deliberately keeps template-vs-template/literal/string properties out of specialization, while dynamic keys were outside #2234's evidence.
2. Round 2 removed a diagnostic-only emit environment hook and narrowed comments to the structural template invariant actually implemented.
3. Round 3 reviewed the complete source/test/consequence surface from scratch and was clean.

Campaign CI is intentionally not used as a verification substitute. The push exact-SHA gate polled twice and observed no runs; the same gate will run again immediately after draft PR creation.
