### PR TITLE
fix(native): distinguish package declarations from runtime natives

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/package_declaration_native_identity_is_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/package_declaration_native_identity_is_transform_test.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+  "fmt"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestPackageDeclarationNativeIdentityIsTransform pins runtime-native identity
+// across ordinary package declarations and the genuine global controls (#2239).
+//
+// A declaration file is a normal published TypeScript package surface, so its
+// source form cannot by itself establish that a Date/Map/Set/WeakMap symbol is
+// the JavaScript native. The package types below are checker-equivalent to local
+// structural controls and must keep their own members. Conversely, real global
+// Date/Map/Set/WeakMap/WeakSet and Node-provided File/Blob types must retain
+// their native checks.
+//
+//  1. Publish colliding structural declarations through a fixture package's
+//     index.d.ts and transform validators for them plus local controls.
+//  2. Transform genuine global validators with DOM libraries excluded, making
+//     File and Blob come from the installed @types/node declaration package.
+//  3. Inspect the emitted classification and execute all validators in Node,
+//     requiring an exact case count so an omitted branch cannot pass silently.
+func TestPackageDeclarationNativeIdentityIsTransform(t *testing.T) {
+  project := packageDeclarationNativeIdentityProject(t)
+  transform := func(file string) string {
+    t.Helper()
+    out, errText, code := ttscTypiaTestCapture(func() int {
+      return runTransform([]string{
+        "--cwd", project,
+        "--tsconfig", "tsconfig.json",
+        "--file", file,
+        "--output", "js",
+      })
+    })
+    if code != 0 {
+      t.Fatalf("package declaration native identity transform %s failed: code=%d stderr=\n%s", file, code, errText)
+    }
+    return out
+  }
+
+  packageJS := transform("src/package.ts")
+  nativeJS := transform("src/native.ts")
+  failures := []string{}
+  for _, member := range []string{"stamp", "brandMap", "brandSet", "brandWeakMap"} {
+    if !strings.Contains(packageJS, member) {
+      failures = append(failures, fmt.Sprintf("package declaration member %q was dropped", member))
+    }
+  }
+  for _, gone := range []string{"instanceof Date", "instanceof Map", "instanceof Set", "instanceof WeakMap"} {
+    if strings.Contains(packageJS, gone) {
+      failures = append(failures, fmt.Sprintf("package declaration collision kept %q", gone))
+    }
+  }
+  for _, kept := range []string{
+    "instanceof Date",
+    "instanceof Map",
+    "instanceof Set",
+    "instanceof WeakMap",
+    "instanceof WeakSet",
+    "instanceof File",
+    "instanceof Blob",
+  } {
+    if !strings.Contains(nativeJS, kept) {
+      failures = append(failures, fmt.Sprintf("genuine native path %q was dropped", kept))
+    }
+  }
+  output, runtimeErr := packageDeclarationNativeIdentityRun(t, project, packageJS, nativeJS)
+  if runtimeErr != nil {
+    failures = append(failures, fmt.Sprintf("runtime matrix failed: %v\n%s", runtimeErr, output))
+  }
+  const expected = "RAN 30 CASES"
+  if !strings.Contains(output, expected) {
+    failures = append(failures, fmt.Sprintf("runtime runner did not report %q; got:\n%s", expected, output))
+  }
+  if len(failures) != 0 {
+    t.Fatalf("package declaration native identity mismatches:\n%s\n\npackage emit:\n%s\n\nnative emit:\n%s", strings.Join(failures, "\n"), packageJS, nativeJS)
+  }
+}
+
+func packageDeclarationNativeIdentityProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "package-declaration-native-identity-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+
+  src := filepath.Join(dir, "src")
+  dependency := filepath.Join(dir, "node_modules", "native-name-package")
+  for _, path := range []string{src, dependency} {
+    if err := os.MkdirAll(path, 0o755); err != nil {
+      t.Fatalf("mkdir fixture path %s: %v", path, err)
+    }
+  }
+  files := map[string]string{
+    filepath.Join(dir, "tsconfig.json"):       packageDeclarationNativeIdentityTSConfig,
+    filepath.Join(dependency, "package.json"): packageDeclarationNativeIdentityPackageJSON,
+    filepath.Join(dependency, "index.d.ts"):   packageDeclarationNativeIdentityDeclarations,
+    filepath.Join(src, "package.ts"):          packageDeclarationNativeIdentitySource,
+    filepath.Join(src, "native.ts"):           packageDeclarationNativeIdentityNativeSource,
+  }
+  for path, content := range files {
+    if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+      t.Fatalf("write fixture file %s: %v", path, err)
+    }
+  }
+  return dir
+}
+
+func packageDeclarationNativeIdentityRun(t *testing.T, project string, packageJS string, nativeJS string) (string, error) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+    return "", nil
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  modules := map[string]string{
+    "package.cjs": ttscTypiaTestRewriteCommonJS(t, packageJS),
+    "native.cjs":  ttscTypiaTestRewriteCommonJS(t, nativeJS),
+    "run.cjs":     packageDeclarationNativeIdentityRuntimeRunner,
+  }
+  for name, content := range modules {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write runtime file %s: %v", name, err)
+    }
+  }
+  cmd := exec.Command(node, filepath.Join(runtimeDir, "run.cjs"))
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  return string(output), err
+}
+
+const packageDeclarationNativeIdentityTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const packageDeclarationNativeIdentityPackageJSON = `{
+  "name": "native-name-package",
+  "version": "1.0.0",
+  "types": "index.d.ts"
+}
+`
+
+const packageDeclarationNativeIdentityDeclarations = `export interface Date {
+  stamp: number;
+}
+export interface Map<K, V> {
+  brandMap: K;
+  valueMap: V;
+}
+export interface Set<T> {
+  brandSet: T;
+}
+export interface WeakMap<K extends object, V> {
+  brandWeakMap: K;
+  valueWeakMap: V;
+}
+`
+
+const packageDeclarationNativeIdentitySource = `import typia from "typia";
+import type {
+  Date as PackageDate,
+  Map as PackageMap,
+  Set as PackageSet,
+  WeakMap as PackageWeakMap,
+} from "native-name-package";
+
+interface LocalDate {
+  stamp: number;
+}
+interface LocalMap<K, V> {
+  brandMap: K;
+  valueMap: V;
+}
+interface LocalSet<T> {
+  brandSet: T;
+}
+interface LocalWeakMap<K extends object, V> {
+  brandWeakMap: K;
+  valueWeakMap: V;
+}
+
+type Assert<T extends true> = T;
+type Same<X, Y> = [X] extends [Y]
+  ? [Y] extends [X]
+    ? true
+    : false
+  : false;
+type _PackageDateIsLocal = Assert<Same<PackageDate, LocalDate>>;
+type _PackageMapIsLocal = Assert<Same<PackageMap<string, number>, LocalMap<string, number>>>;
+type _PackageSetIsLocal = Assert<Same<PackageSet<string>, LocalSet<string>>>;
+type _PackageWeakMapIsLocal = Assert<Same<PackageWeakMap<object, string>, LocalWeakMap<object, string>>>;
+
+export const isPackageDate = typia.createIs<PackageDate>();
+export const isPackageMap = typia.createIs<PackageMap<string, number>>();
+export const isPackageSet = typia.createIs<PackageSet<string>>();
+export const isPackageWeakMap = typia.createIs<PackageWeakMap<object, string>>();
+export const isLocalDate = typia.createIs<LocalDate>();
+export const isLocalMap = typia.createIs<LocalMap<string, number>>();
+export const isLocalSet = typia.createIs<LocalSet<string>>();
+export const isLocalWeakMap = typia.createIs<LocalWeakMap<object, string>>();
+`
+
+const packageDeclarationNativeIdentityNativeSource = `import typia from "typia";
+
+export const isNativeDate = typia.createIs<Date>();
+export const isNativeMap = typia.createIs<Map<string, number>>();
+export const isNativeSet = typia.createIs<Set<string>>();
+export const isNativeWeakMap = typia.createIs<WeakMap<object, string>>();
+export const isNativeWeakSet = typia.createIs<WeakSet<object>>();
+export const isNativeFile = typia.createIs<File>();
+export const isNativeBlob = typia.createIs<Blob>();
+`
+
+const packageDeclarationNativeIdentityRuntimeRunner = `const packageTypes = require("./package.cjs");
+const natives = require("./native.cjs");
+
+let ran = 0;
+const failures = [];
+const eq = (name, actual, expected) => {
+  ran += 1;
+  if (actual !== expected) {
+    failures.push(name + ": expected " + expected + " but got " + actual);
+  }
+};
+
+eq("package Date valid", packageTypes.isPackageDate({ stamp: 1 }), true);
+eq("package Date invalid", packageTypes.isPackageDate({}), false);
+eq("package Date rejects native", packageTypes.isPackageDate(new Date()), false);
+eq("package Map valid", packageTypes.isPackageMap({ brandMap: "x", valueMap: 1 }), true);
+eq("package Map invalid", packageTypes.isPackageMap({ brandMap: "x" }), false);
+eq("package Map rejects native", packageTypes.isPackageMap(new Map([["x", 1]])), false);
+eq("package Set valid", packageTypes.isPackageSet({ brandSet: "x" }), true);
+eq("package Set invalid", packageTypes.isPackageSet({}), false);
+eq("package Set rejects native", packageTypes.isPackageSet(new Set(["x"])), false);
+eq("package WeakMap valid", packageTypes.isPackageWeakMap({ brandWeakMap: {}, valueWeakMap: "x" }), true);
+eq("package WeakMap invalid", packageTypes.isPackageWeakMap({ brandWeakMap: {} }), false);
+eq("package WeakMap rejects native", packageTypes.isPackageWeakMap(new WeakMap()), false);
+
+eq("local Date control", packageTypes.isLocalDate({ stamp: 1 }), true);
+eq("local Map control", packageTypes.isLocalMap({ brandMap: "x", valueMap: 1 }), true);
+eq("local Set control", packageTypes.isLocalSet({ brandSet: "x" }), true);
+eq("local WeakMap control", packageTypes.isLocalWeakMap({ brandWeakMap: {}, valueWeakMap: "x" }), true);
+
+eq("native Date real", natives.isNativeDate(new Date()), true);
+eq("native Date plain", natives.isNativeDate({}), false);
+eq("native Map real", natives.isNativeMap(new Map([["x", 1]])), true);
+eq("native Map plain", natives.isNativeMap({}), false);
+eq("native Set real", natives.isNativeSet(new Set(["x"])), true);
+eq("native Set plain", natives.isNativeSet({}), false);
+eq("native WeakMap real", natives.isNativeWeakMap(new WeakMap()), true);
+eq("native WeakMap plain", natives.isNativeWeakMap({}), false);
+eq("native WeakSet real", natives.isNativeWeakSet(new WeakSet()), true);
+eq("native WeakSet plain", natives.isNativeWeakSet({}), false);
+eq("Node File real", natives.isNativeFile(new File(["x"], "x.txt")), true);
+eq("Node File plain", natives.isNativeFile({ name: "x.txt", size: 1 }), false);
+eq("Node Blob real", natives.isNativeBlob(new Blob(["x"])), true);
+eq("Node Blob plain", natives.isNativeBlob({ size: 1, type: "text/plain" }), false);
+
+console.log("RAN " + ran + " CASES");
+if (failures.length !== 0) {
+  throw new Error("MISMATCHES:\n" + failures.join("\n"));
+}
+`

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -315,26 +315,17 @@ func metadata_symbol_from_default_lib(symbol *nativeast.Symbol) bool {
   return false
 }
 
-// metadata_symbol_from_declaration_file reports whether the symbol's first
-// locatable declaration lives in a `.d.ts` declaration file. It widens
-// metadata_symbol_from_default_lib beyond the TypeScript default libraries
-// (lib.*.d.ts) to any ambient declaration file, because a built-in native can be
-// declared by an ambient package rather than a default lib — the `File` and
-// `Blob` globals Node adds through @types/node are declared in `.d.ts` files that
-// are not `lib.*.d.ts`. Native classification uses this to keep a real built-in
-// native (declared in a `.d.ts`, whichever library) native, while a user type
-// that merely shares a native's name — an `interface File { name; size }` in a
-// `.ts` module — is not a declaration and falls through to the structural object
-// path (#2200).
-func metadata_symbol_from_declaration_file(symbol *nativeast.Symbol) bool {
-  for _, node := range metadata_node_declarations(symbol) {
-    src := nativeast.GetSourceFileOfNode(node)
-    if src == nil {
-      continue
-    }
-    return src.IsDeclarationFile
+// metadata_symbol_is_global_type reports whether symbol is the type that the
+// checker resolves from its global symbol table under name. Pointer identity is
+// deliberate: default-library natives and ambient-package globals such as
+// Node's File and Blob resolve to that shared global symbol, while an exported
+// package declaration remains a distinct module symbol even when its name and
+// `.d.ts` source form are identical (#2239).
+func metadata_symbol_is_global_type(checker *nativechecker.Checker, symbol *nativeast.Symbol, name string) bool {
+  if checker == nil || symbol == nil || name == "" {
+    return false
   }
-  return false
+  return checker.ResolveName(name, nil, nativeast.SymbolFlagsType, false) == symbol
 }
 
 func metadata_is_default_lib_file_name(fileName string) bool {

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_map.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_map.go
@@ -10,13 +10,9 @@ func Iterate_metadata_map(props IMetadataIteratorProps) bool {
   if metadata_type_symbol_base_name(typ) != "Map" {
     return false
   }
-  // Classify the native Map only when the type actually is the built-in, not
-  // merely a user type of the same name. A real Map is declared in a `.d.ts`
-  // library, so a module-scoped user `interface Map<K, V> { brandMap; ... }` in a
-  // `.ts` module falls through to the structural object path and is validated
-  // against its own members instead of `input instanceof Map` — the collection
-  // half of the #2200 identity gate (#2212).
-  if !metadata_symbol_from_declaration_file(typ.Symbol()) {
+  // The native Map is the checker-resolved global type, not any same-named
+  // package declaration (#2212, #2239).
+  if !metadata_symbol_is_global_type(props.Checker, typ.Symbol(), "Map") {
     return false
   }
   generic := metadata_get_type_arguments(props.Checker, typ)

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
@@ -23,12 +23,11 @@ func Iterate_metadata_native(props IMetadataIteratorProps) bool {
   }
   name = iterate_metadata_native_getNativeName(name)
   if _, ok := iterate_metadata_native_simples[name]; ok {
-    // Match the built-in only when the type actually is the built-in, not merely
-    // a user type of the same name. A real native is declared in a `.d.ts`
-    // library, so a user `interface File { name; size }` in a `.ts` module falls
-    // through to the structural object path and is validated against its own
-    // members instead of `input instanceof File` (#2200).
-    if !metadata_symbol_from_declaration_file(symbol) {
+    // Match the built-in only when the checker resolves this exact symbol from
+    // the global type table. A colliding package declaration then falls through
+    // to its structural members regardless of whether it was authored in `.ts`
+    // or published through `.d.ts` (#2200, #2239).
+    if !metadata_symbol_is_global_type(props.Checker, symbol, name) {
       return false
     }
     iterate_metadata_native_take(props.Metadata, name)
@@ -36,14 +35,9 @@ func Iterate_metadata_native(props IMetadataIteratorProps) bool {
   }
   for _, generic := range iterate_metadata_native_generics {
     if name == generic.Name || strings.HasPrefix(name, generic.Name+"<") {
-      // Classify the native generic (WeakMap/WeakSet) only when the type
-      // actually is the built-in, not merely a user type of the same name. A
-      // real WeakMap/WeakSet is declared in a `.d.ts` library, so a module-scoped
-      // user `interface WeakMap<K, V> { brandWeak }` in a `.ts` module falls
-      // through to the structural object path — the same identity gate the
-      // simples path above uses (#2200), applied to the collection generics the
-      // `+"<"` arity guard (#2181) alone left ungated (#2212).
-      if !metadata_symbol_from_declaration_file(symbol) {
+      // Use the same global-symbol identity gate for WeakMap/WeakSet. The
+      // `+"<"` arity guard (#2181) and generic metadata remain unchanged.
+      if !metadata_symbol_is_global_type(props.Checker, symbol, generic.Name) {
         return false
       }
       iterate_metadata_native_take(props.Metadata, generic.Name)

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_set.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_set.go
@@ -10,13 +10,9 @@ func Iterate_metadata_set(props IMetadataIteratorProps) bool {
   if metadata_type_symbol_base_name(typ) != "Set" {
     return false
   }
-  // Classify the native Set only when the type actually is the built-in, not
-  // merely a user type of the same name. A real Set is declared in a `.d.ts`
-  // library, so a module-scoped user `interface Set<T> { brandSet; ... }` in a
-  // `.ts` module falls through to the structural object path and is validated
-  // against its own members instead of `input instanceof Set` — the collection
-  // half of the #2200 identity gate (#2212).
-  if !metadata_symbol_from_declaration_file(typ.Symbol()) {
+  // The native Set is the checker-resolved global type, not any same-named
+  // package declaration (#2212, #2239).
+  if !metadata_symbol_is_global_type(props.Checker, typ.Symbol(), "Set") {
     return false
   }
   generic := metadata_get_type_arguments(props.Checker, typ)


### PR DESCRIPTION
## Intent

Published `.d.ts` files are normal package surfaces, so declaration-file origin cannot prove that a same-named type is the JavaScript runtime native. This change keeps ordinary package declarations structural while preserving the genuine global native identities, including Node-provided `File` and `Blob`.

## Scope

- Replace declaration-file detection with pointer identity against the TypeScript checker's global type symbol.
- Apply that identity invariant to the simple native, `WeakMap`/`WeakSet`, `Map`, and `Set` classifiers.
- Add a tag-free command-level transform regression backed by an actual fixture package under `node_modules`.
- Execute emitted JavaScript across 30 package, local structural, default-library native, and `@types/node` native cases.

The shared helper is intentionally not wired into intersection analysis here; #2237 owns that separate composition-time path.

## Verification

- Red on pre-fix master: all four package types emitted `instanceof`; eight runtime expectations were inverted while all genuine native controls passed.
- `go test -p=1 ./cmd/ttsc-typia -run '^(TestPackageDeclarationNativeIdentityIsTransform|TestNativeNameCollisionIsTransform|TestNativeCollectionIdentityIsTransform)$' -count=1 -v`
- `go test -p=1 ./...`
- `go vet -p=1 ./...`
- `pnpm --filter ./tests/test-typia-schema start`
- Targeted Go formatting, added-line en-US/ASCII inspection, and `git diff --check`
- Solo Self-Review completed with a final clean round.

Root `pnpm test` and package build were not repeated; the campaign gate used the complete native suite and the relevant TypeScript validator workspace. Repository-wide `pnpm format` was intentionally not run during the active issue campaign. Automatic Actions for this implementation commit are cancelled only by exact SHA under the campaign protocol.

No package version, `packages/interface/src`, workflow, provider, dependency, or generated baseline changes are included.

Fixes #2239
