### PR TITLE
fix(packaging): keep LangChain and MCP peer types assignable under Node16/NodeNext ESM

### DIFF
--- a/experiments/esm/README.md
+++ b/experiments/esm/README.md
@@ -11,6 +11,8 @@ experiment runs sources through `ttsx` and never touches the built `.mjs`;
 this project exists precisely because a broken `.mjs` (lost named exports,
 facade chunks) once shipped while every source-level suite stayed green.
 
+The build also assigns the packed LangChain, MCP, and Vercel adapter results to their peer-owned public types under Node16 ESM, NodeNext ESM, Node16 CommonJS, and Bundler ESM. It verifies that the consumer and adapter resolve each peer from one physical installation before compiling the matrix.
+
 ```bash
 pnpm run package:tgz   # from the repository root
 npm install

--- a/experiments/esm/adapter_type_controls.mts
+++ b/experiments/esm/adapter_type_controls.mts
@@ -1,0 +1,27 @@
+/**
+ * Verifies packed adapter return types preserve their peer-package identity.
+ *
+ * LangChain and MCP expose nominal peer-owned types, so a declaration mode
+ * split can make one physical peer installation appear as unrelated types.
+ * Vercel is the adjacent structural control.
+ *
+ * 1. Import each peer-owned type from the consumer's resolution context.
+ * 2. Assign each packed adapter result to that consumer-owned type.
+ * 3. Compile the same source as Node ESM, Node CJS, and Bundler ESM.
+ */
+import type { DynamicStructuredTool } from "@langchain/core/tools";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toLangChainTools } from "@typia/langchain";
+import { createMcpServer } from "@typia/mcp";
+import { toVercelTools } from "@typia/vercel";
+import type { Tool } from "ai";
+
+declare const controller: Parameters<typeof createMcpServer>[0];
+
+const langchain: DynamicStructuredTool[] = toLangChainTools(controller);
+const mcp: McpServer = createMcpServer(controller);
+const vercel: Record<string, Tool> = toVercelTools(controller);
+
+void langchain;
+void mcp;
+void vercel;

--- a/experiments/esm/package.json
+++ b/experiments/esm/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "ttsc",
+    "build": "npm run test:types && ttsc",
     "start": "npm run build && npm test",
-    "test": "node lib/index.js"
+    "test": "node lib/index.js",
+    "test:types": "node test-adapter-peer-types.mjs"
   },
   "devDependencies": {
     "@langchain/core": "^1.1.31",

--- a/experiments/esm/test-adapter-peer-types.mjs
+++ b/experiments/esm/test-adapter-peer-types.mjs
@@ -1,0 +1,72 @@
+import cp from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const source = path.join(directory, "adapter_type_controls.mts");
+const commonjs = path.join(
+  directory,
+  `adapter_type_controls.${process.pid}.cts`,
+);
+const tsc = path.join(
+  path.dirname(require.resolve("typescript/package.json")),
+  "bin",
+  "tsc",
+);
+
+const resolveFromPackage = (packageName, dependency) => {
+  const packageJson = require.resolve(`${packageName}/package.json`);
+  return fs.realpathSync(createRequire(packageJson).resolve(dependency));
+};
+
+const assertSingleInstallation = (packageName, dependency) => {
+  const consumer = fs.realpathSync(require.resolve(dependency));
+  const adapter = resolveFromPackage(packageName, dependency);
+  if (consumer !== adapter)
+    throw new Error(
+      `${dependency} has multiple installations: consumer=${consumer}, adapter=${adapter}`,
+    );
+};
+
+const compile = (name, file, module, moduleResolution) => {
+  cp.execFileSync(
+    process.execPath,
+    [
+      tsc,
+      "--ignoreConfig",
+      "--noEmit",
+      "--target",
+      "ES2020",
+      "--module",
+      module,
+      "--moduleResolution",
+      moduleResolution,
+      "--types",
+      "node",
+      "--skipLibCheck",
+      file,
+    ],
+    { cwd: directory, stdio: "inherit" },
+  );
+  console.log(`adapter type identity: ${name} passed`);
+};
+
+assertSingleInstallation("@typia/langchain", "@langchain/core/tools");
+assertSingleInstallation(
+  "@typia/mcp",
+  "@modelcontextprotocol/sdk/server/mcp.js",
+);
+assertSingleInstallation("@typia/vercel", "ai");
+
+fs.copyFileSync(source, commonjs);
+try {
+  compile("Node16 ESM", source, "Node16", "Node16");
+  compile("NodeNext ESM", source, "NodeNext", "NodeNext");
+  compile("Node16 CJS", commonjs, "Node16", "Node16");
+  compile("Bundler ESM", source, "ESNext", "Bundler");
+} finally {
+  fs.rmSync(commonjs, { force: true });
+}

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -8,7 +8,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rimraf lib && ttsc && rolldown -c",
+    "build": "rimraf lib && ttsc && node ../../scripts/create-conditional-declarations.cjs lib/index.d.ts && rolldown -c",
     "dev": "ttsc --watch",
     "prepack": "pnpm run build"
   },
@@ -66,8 +66,15 @@
     "types": "lib/index.d.ts",
     "exports": {
       ".": {
+        "import": {
+          "types": "./lib/index.d.mts",
+          "default": "./lib/index.mjs"
+        },
+        "require": {
+          "types": "./lib/index.d.cts",
+          "default": "./lib/index.js"
+        },
         "types": "./lib/index.d.ts",
-        "import": "./lib/index.mjs",
         "default": "./lib/index.js"
       },
       "./package.json": "./package.json"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,7 +8,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rimraf lib && ttsc && rolldown -c",
+    "build": "rimraf lib && ttsc && node ../../scripts/create-conditional-declarations.cjs lib/index.d.ts && rolldown -c",
     "dev": "ttsc --watch",
     "prepack": "pnpm run build"
   },
@@ -66,8 +66,15 @@
     "types": "lib/index.d.ts",
     "exports": {
       ".": {
+        "import": {
+          "types": "./lib/index.d.mts",
+          "default": "./lib/index.mjs"
+        },
+        "require": {
+          "types": "./lib/index.d.cts",
+          "default": "./lib/index.js"
+        },
         "types": "./lib/index.d.ts",
-        "import": "./lib/index.mjs",
         "default": "./lib/index.js"
       },
       "./package.json": "./package.json"

--- a/scripts/create-conditional-declarations.cjs
+++ b/scripts/create-conditional-declarations.cjs
@@ -1,0 +1,17 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const entries = process.argv.slice(2);
+if (entries.length === 0)
+  throw new Error("At least one .d.ts entry declaration is required.");
+
+for (const entry of entries) {
+  if (entry.endsWith(".d.ts") === false)
+    throw new Error(`Not a .d.ts declaration: ${entry}`);
+
+  const source = path.resolve(entry);
+  const declaration = fs.readFileSync(source);
+  const stem = source.slice(0, -".d.ts".length);
+  fs.writeFileSync(`${stem}.d.mts`, declaration);
+  fs.writeFileSync(`${stem}.d.cts`, declaration);
+}


### PR DESCRIPTION
Fixes #2242.

## Intent

Keep `@typia/langchain` and `@typia/mcp` public peer-owned return types assignable to the corresponding peer types imported by Node16 and NodeNext ESM consumers. One physical peer installation must not acquire incompatible declaration identities because the adapter declaration is interpreted as CommonJS.

## Scope

- Generate explicit `.d.mts` and `.d.cts` entry declarations from each adapter's single emitted `index.d.ts`.
- Publish condition-specific `import.types` and `require.types` targets while preserving the legacy `types` fallback and all existing CJS/ESM runtime targets.
- Extend the tarball-installed ESM experiment with a physical-installation check and Node16 ESM, NodeNext ESM, Node16 CJS, and Bundler ESM assignment matrix.
- Leave `@typia/vercel` unchanged as the adjacent structural control.

No package version, dependency, lockfile, workflow, `packages/interface/src`, or runtime source changed.

## Verification

Before the fix, the current-master packed consumer produced the expected matrix: Node16 ESM `1`, NodeNext ESM `1`, Node16 CJS `0`, and Bundler ESM `0`. The two ESM failures were `TS2719` for LangChain and `TS2322` for MCP.

After the fix:

- `pnpm --filter ./packages/langchain build`
- `pnpm --filter ./packages/mcp build`
- root `pnpm package:tgz` — passed in 96.7 seconds
- clean `experiments/esm` `npm install` — 176 packages, zero audit findings
- packed type matrix — Node16 ESM, NodeNext ESM, Node16 CJS, and Bundler ESM all passed
- `--traceResolution` — ESM/Bundler adapters and consumers both selected peer ESM declarations through adapter `.d.mts`; CJS selected peer CJS declarations through adapter `.d.cts`
- packed declarations — `.d.ts`, `.d.mts`, and `.d.cts` were byte-identical within each package
- packed manifests — version `13.1.19`, every main/module/types/export target present, no `workspace:` protocol
- `npm ls @langchain/core @modelcontextprotocol/sdk ai --all` — one deduplicated peer version for each adapter
- packed ESM runtime — all 21 checks passed, including LangChain invocation, MCP construction, and Vercel execution
- packed CommonJS runtime — LangChain conversion, MCP construction, and Vercel conversion passed
- `@typia/test-langchain` — 17 cases passed
- `@typia/test-mcp` — 22 cases passed
- `@typia/test-vercel` — 24 cases passed
- root `pnpm build` — passed
- targeted Prettier checks for new TypeScript/JavaScript, JSON parse, `git diff --check`, and en-US spelling check — passed
- solo Self-Review — one final complete round produced no further improvement

## Campaign constraints

- `pnpm format` was not run; the campaign owns one post-campaign formatter pass.
- The package version remains `13.1.19`; release numbering stays with the maintainer.
- POSIX execution was not available on this Windows host.
- Automatic Actions are intentionally cancelled by exact commit SHA under the active issue campaign; local verification is the implementation gate.
