### PR TITLE
fix(native): keep symbol index signatures out of string-key metadata

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/symbol_index_domain_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/symbol_index_domain_transform_test.go
@@ -1,0 +1,316 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestSymbolIndexDomainTransform verifies a symbol index signature stays out
+// of typia's string-keyed validation and JSON Schema shape (#2240).
+//
+// TypeScript keeps string and symbol index domains distinct, including when a
+// symbol index key is intersected with a nominal brand. This regression pins
+// that boundary through the real transform because treating every checker
+// IndexInfo as a JSON string index makes unrelated Object.keys values inherit a
+// symbol index's value constraint. An ordinary string index and the explicit
+// symbol-member behavior fixed by #2226 are adjacent controls.
+//
+//  1. Compile checker-level keyof assertions for symbol and string indexes.
+//  2. Execute validators over ordinary extras and symbol-valued properties.
+//  3. Compare the symbol-index schema exactly with a plain-object control while
+//     requiring a normal string index to retain additionalProperties.
+func TestSymbolIndexDomainTransform(t *testing.T) {
+  project := symbolIndexDomainProject(t)
+  js := symbolIndexDomainTransform(t, project)
+  symbolIndexDomainRunRuntimeCases(t, project, js)
+}
+
+func symbolIndexDomainProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "symbol-index-domain-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(symbolIndexDomainTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(symbolIndexDomainSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func symbolIndexDomainTransform(t *testing.T, project string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("symbol index domain transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func symbolIndexDomainRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(symbolIndexDomainRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  if output, err := cmd.CombinedOutput(); err != nil {
+    t.Fatalf("symbol index domain runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const symbolIndexDomainTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const symbolIndexDomainSource = `import typia from "typia";
+
+declare const explicitSymbol: unique symbol;
+
+interface SymbolIndex {
+  name: string;
+  [key: symbol]: number;
+}
+
+type BrandedSymbol = symbol & {
+  readonly __brand: unique symbol;
+};
+
+interface BrandedSymbolIndex {
+  name: string;
+  [key: BrandedSymbol]: number;
+}
+
+interface PlainObject {
+  name: string;
+}
+
+interface StringIndex {
+  name: string;
+  [key: string]: string;
+}
+
+interface ExplicitSymbolMember {
+  name: string;
+  [explicitSymbol]: number;
+}
+
+type Assert<T extends true> = T;
+type _SymbolIndexHasNoStringDomain = Assert<
+  string extends keyof SymbolIndex ? false : true
+>;
+type _SymbolIndexHasNoNumberDomain = Assert<
+  number extends keyof SymbolIndex ? false : true
+>;
+type _SymbolIndexHasSymbolDomain = Assert<
+  symbol extends keyof SymbolIndex ? true : false
+>;
+type _BrandedSymbolIndexHasNoStringDomain = Assert<
+  string extends keyof BrandedSymbolIndex ? false : true
+>;
+type _BrandedSymbolIndexHasNoNumberDomain = Assert<
+  number extends keyof BrandedSymbolIndex ? false : true
+>;
+type _BrandedSymbolIndexHasBrandedDomain = Assert<
+  BrandedSymbol extends keyof BrandedSymbolIndex ? true : false
+>;
+type _StringIndexHasStringDomain = Assert<
+  string extends keyof StringIndex ? true : false
+>;
+type _StringIndexHasNumberDomain = Assert<
+  number extends keyof StringIndex ? true : false
+>;
+type _StringIndexHasNoSymbolDomain = Assert<
+  symbol extends keyof StringIndex ? false : true
+>;
+type _ExplicitSymbolMemberIsPresent = Assert<
+  typeof explicitSymbol extends keyof ExplicitSymbolMember ? true : false
+>;
+
+export const isSymbolIndex = typia.createIs<SymbolIndex>();
+export const isBrandedSymbolIndex =
+  typia.createIs<BrandedSymbolIndex>();
+export const isPlainObject = typia.createIs<PlainObject>();
+export const isStringIndex = typia.createIs<StringIndex>();
+export const isExplicitSymbolMember =
+  typia.createIs<ExplicitSymbolMember>();
+export const schemas = typia.json.schemas<[
+  SymbolIndex,
+  BrandedSymbolIndex,
+  PlainObject,
+  StringIndex,
+  ExplicitSymbolMember,
+]>();
+`
+
+const symbolIndexDomainRuntimeRunner = `const mod = require("./main.cjs");
+
+const failures = [];
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    failures.push(
+      label +
+        ": expected " +
+        JSON.stringify(expected) +
+        " but got " +
+        JSON.stringify(actual),
+    );
+  }
+};
+
+expect("symbol index plain", mod.isSymbolIndex({ name: "x" }), true);
+expect(
+  "symbol index ignores a numeric string extra",
+  mod.isSymbolIndex({ name: "x", extra: 1 }),
+  true,
+);
+expect(
+  "symbol index ignores a string extra",
+  mod.isSymbolIndex({ name: "x", extra: "unrelated" }),
+  true,
+);
+expect(
+  "symbol index ignores a matching symbol value",
+  mod.isSymbolIndex({ name: "x", [Symbol("key")]: 1 }),
+  true,
+);
+expect(
+  "symbol index ignores a non-matching symbol value",
+  mod.isSymbolIndex({ name: "x", [Symbol("key")]: "outside-json-shape" }),
+  true,
+);
+expect("symbol index validates named properties", mod.isSymbolIndex({ name: 1 }), false);
+
+expect(
+  "branded symbol index plain",
+  mod.isBrandedSymbolIndex({ name: "x" }),
+  true,
+);
+expect(
+  "branded symbol index ignores a string extra",
+  mod.isBrandedSymbolIndex({ name: "x", extra: "unrelated" }),
+  true,
+);
+expect(
+  "branded symbol index ignores a matching symbol value",
+  mod.isBrandedSymbolIndex({ name: "x", [Symbol("key")]: 1 }),
+  true,
+);
+expect(
+  "branded symbol index ignores a non-matching symbol value",
+  mod.isBrandedSymbolIndex({ name: "x", [Symbol("key")]: "outside-json-shape" }),
+  true,
+);
+expect(
+  "branded symbol index validates named properties",
+  mod.isBrandedSymbolIndex({ name: 1 }),
+  false,
+);
+
+expect("plain object ignores a string extra", mod.isPlainObject({ name: "x", extra: 1 }), true);
+expect("plain object validates named properties", mod.isPlainObject({ name: 1 }), false);
+
+expect("string index accepts matching extra", mod.isStringIndex({ name: "x", extra: "ok" }), true);
+expect("string index rejects mismatching extra", mod.isStringIndex({ name: "x", extra: 1 }), false);
+
+expect(
+  "explicit symbol member remains outside the JSON shape",
+  mod.isExplicitSymbolMember({ name: "x", [Symbol("member")]: "ignored" }),
+  true,
+);
+expect(
+  "explicit symbol member validates named properties",
+  mod.isExplicitSymbolMember({ name: 1 }),
+  false,
+);
+
+const schemas = mod.schemas.components.schemas;
+const plain = {
+  type: "object",
+  properties: { name: { type: "string" } },
+  required: ["name"],
+  additionalProperties: false,
+};
+const stringIndex = {
+  type: "object",
+  properties: { name: { type: "string" } },
+  required: ["name"],
+  additionalProperties: { type: "string" },
+};
+expect(
+  "plain object exact schema",
+  JSON.stringify(schemas.PlainObject),
+  JSON.stringify(plain),
+);
+expect(
+  "symbol index exact schema",
+  JSON.stringify(schemas.SymbolIndex),
+  JSON.stringify(plain),
+);
+expect(
+  "branded symbol index exact schema",
+  JSON.stringify(schemas.BrandedSymbolIndex),
+  JSON.stringify(plain),
+);
+expect(
+  "explicit symbol member exact schema",
+  JSON.stringify(schemas.ExplicitSymbolMember),
+  JSON.stringify(plain),
+);
+expect(
+  "string index exact schema",
+  JSON.stringify(schemas.StringIndex),
+  JSON.stringify(stringIndex),
+);
+if (failures.length !== 0) {
+  throw new Error("MISMATCHES:\n" + failures.join("\n"));
+}
+`

--- a/packages/typia/native/core/factories/internal/metadata/emplace_metadata_object.go
+++ b/packages/typia/native/core/factories/internal/metadata/emplace_metadata_object.go
@@ -182,6 +182,14 @@ func Emplace_metadata_object(props IMetadataIteratorProps) *schemametadata.Metad
   }
 
   for _, index := range props.Components.IndexInfos(props.Checker, props.Type) {
+    // IndexInfo keeps union domains separate, but a branded symbol key remains
+    // an intersection. Only string/number domains can describe properties seen
+    // through Object.keys or JSON Schema additionalProperties; walk nested
+    // intersections so every symbol-only form stays outside typia's structural
+    // JSON shape, just like an explicit symbol-keyed member (#2240).
+    if emplace_metadata_object_is_symbol_index_key(index.KeyType()) {
+      continue
+    }
     analyzer := func(typ *nativechecker.Type) func(any) *schemametadata.MetadataSchema {
       return func(property any) *schemametadata.MetadataSchema {
         explore := MetadataFactory_IExplore{
@@ -679,6 +687,23 @@ func emplace_metadata_object_valid_dynamic_key(key *schemametadata.MetadataSchem
     }
   }
   return total == key.Size()
+}
+
+func emplace_metadata_object_is_symbol_index_key(key *nativechecker.Type) bool {
+  if key == nil {
+    return false
+  }
+  if key.Flags()&nativechecker.TypeFlagsESSymbolLike != 0 {
+    return true
+  }
+  if key.IsIntersection() {
+    for _, child := range key.Types() {
+      if emplace_metadata_object_is_symbol_index_key(child) {
+        return true
+      }
+    }
+  }
+  return false
 }
 
 func iterate_optional_coalesce(props struct {


### PR DESCRIPTION
## Intent

Keep TypeScript symbol index signatures outside typia's string-keyed structural JSON shape. A symbol index, including a branded/intersection symbol domain, must not constrain `Object.keys` values or become JSON Schema `additionalProperties`.

## Scope

- Exclude checker index entries whose key domain is symbol-like directly or through nested intersections before dynamic object metadata is created.
- Preserve string and number index entries on the existing dynamic-property path; TypeScript-Go already exposes union index domains as separate `IndexInfo` entries.
- Add a tag-free real-transform regression with bare and branded symbol indexes, compile-time `keyof` controls, validator runtime cases, exact JSON Schema controls, a normal string index, and the explicit symbol-member behavior from #2226.
- Leave the separate explicit symbol-member filter unchanged.

## Evidence

- Initial RED: a bare symbol index rejected an unrelated string extra and emitted `additionalProperties: { type: number }` instead of matching the plain-object schema.
- Reviewer hypothesis RED on the initial PR implementation: `symbol & { readonly __brand: unique symbol }` was accepted as an index key by the checker but failed both `typia.createIs` and `typia.json.schemas` transforms as unsupported.
- Temporary diagnostics identified the relevant checker representation: bare symbol key flags were `512` (`ESSymbolLike`), while the branded key flags were `268435456` (`Intersection`). This disproved the initial direct-flags-only mechanism.
- GREEN: recursive intersection inspection keeps both bare and branded symbol domains outside typia's structural JSON shape while string-index and explicit-symbol controls remain unchanged.

## Verification

- `go test ./cmd/ttsc-typia -run '^TestSymbolIndexDomainTransform$' -count=1 -v`
- `go test ./cmd/ttsc-typia -run '^(TestSymbolIndexDomainTransform|TestSymbolKeyMemberFilterTransform|TestIntersectionBrandTransform|TestJsonSchemaDynamicKeyDeterminismTransform)$' -count=1 -v`
- `go test -p=1 -count=1 ./...`
- `go vet -p=1 ./...`
- `pnpm --filter ./tests/test-typia-schema start`
- repository Go formatter and `git diff --check`
- Solo Self-Review completed with a clean full round after the branded-symbol remediation.

The full native suite passed in 98.7 seconds and the full schema workspace passed in 69.9 seconds. `pnpm install --frozen-lockfile` provisioned the worktree without changing the lockfile. The repository-wide `pnpm format` and full `pnpm test` were intentionally not run under the active issue-campaign policy; package-scoped native and schema verification is recorded above. No version bump is included because campaign releases remain maintainer-owned.

## Campaign chronology

This PR is implementation-first: the initial implementation commit and draft PR existed before the campaign's claim-first reservation and knowledge-base record. No empty claim commit was created later to manufacture the preferred chronology. The exact chronology, prior gates, amended head, and one corrected gate-script aggregation error are recorded in the campaign knowledge base.

Automatic Actions for this campaign commit are cancelled by exact SHA after every push and relevant pull-request mutation.

Fixes #2240