### PR TITLE
fix(native): preserve Node buffer Blob and File identity

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/node_buffer_native_exports_is_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/node_buffer_native_exports_is_transform_test.go
@@ -1,0 +1,526 @@
+package main
+
+import (
+  "fmt"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestNodeBufferNativeExportsIsTransform preserves runtime-native identity for
+// the authoritative Blob and File exports from Node's buffer modules (#1568).
+//
+// Node's module-exported types and its equivalent bare globals have distinct
+// checker symbols even though they describe the same runtime constructors. A
+// name-only or global-pointer-only classifier can therefore confuse either the
+// authoritative exports or unrelated package declarations with structural
+// lookalikes.
+//
+//  1. Transform validators for Blob and File imported from both Node module
+//     spellings, plus their bare-global controls, with DOM libraries excluded.
+//  2. Require every validator to emit a runtime-native identity check rather
+//     than structural Blob/File property checks.
+//  3. Execute real instances and full plain lookalikes through all six emitted
+//     validators, requiring exactly twelve runtime outcomes.
+//  4. Transform ordinary package and user ambient Blob/File declarations and
+//     require their structural members and eight negative-control outcomes.
+//  5. Exclude Node types and prove a user-authored counterfeit of the exact
+//     node:buffer/buffer module names remains structural in eight more cases,
+//     even when its path mimics node_modules/@types/node without package data.
+func TestNodeBufferNativeExportsIsTransform(t *testing.T) {
+  project := nodeBufferNativeExportsProject(t)
+  transform := func(file string) string {
+    t.Helper()
+    js, errText, code := ttscTypiaTestCapture(func() int {
+      return runTransform([]string{
+        "--cwd", project,
+        "--tsconfig", "tsconfig.json",
+        "--file", file,
+        "--output", "js",
+      })
+    })
+    if code != 0 {
+      t.Fatalf("Node buffer native export transform %s failed: code=%d stderr=\n%s", file, code, errText)
+    }
+    return js
+  }
+  js := transform("src/input.ts")
+  controlsJS := transform("src/controls.ts")
+  spoofProject := nodeBufferNativeExportsSpoofProject(t)
+  spoofJS, spoofErrText, spoofCode := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", spoofProject,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/input.ts",
+      "--output", "js",
+    })
+  })
+  if spoofCode != 0 {
+    t.Fatalf("counterfeit Node buffer module transform failed: code=%d stderr=\n%s", spoofCode, spoofErrText)
+  }
+
+  failures := []string{}
+  for _, expected := range []struct {
+    check string
+    count int
+  }{
+    {check: "instanceof Blob", count: 4},
+    {check: "instanceof File", count: 4},
+  } {
+    if actual := strings.Count(js, expected.check); actual != expected.count {
+      failures = append(failures, fmt.Sprintf(
+        "emit contains %q %d times; expected %d runtime-native validators",
+        expected.check,
+        actual,
+        expected.count,
+      ))
+    }
+  }
+  for _, structural := range []string{"webkitRelativePath", ".lastModified", ".size", ".type"} {
+    if strings.Contains(js, structural) {
+      failures = append(failures, fmt.Sprintf("emit retained structural Blob/File member %q", structural))
+    }
+  }
+  for _, retained := range []string{"nodeBlobOk", "nodeFileOk"} {
+    if !strings.Contains(js, retained) {
+      failures = append(failures, fmt.Sprintf("native intersection union dropped control arm %q", retained))
+    }
+  }
+  for _, pruned := range []string{"blobLabel", "fileLabel"} {
+    if strings.Contains(js, pruned) {
+      failures = append(failures, fmt.Sprintf("native intersection union retained pruned member %q", pruned))
+    }
+  }
+  for _, structural := range []string{"packageBrand", "ambientBrand"} {
+    if !strings.Contains(controlsJS, structural) {
+      failures = append(failures, fmt.Sprintf("structural package/ambient control dropped member %q", structural))
+    }
+  }
+  for _, native := range []string{"instanceof Blob", "instanceof File"} {
+    if strings.Contains(controlsJS, native) {
+      failures = append(failures, fmt.Sprintf("structural package/ambient control was promoted to %q", native))
+    }
+  }
+  if !strings.Contains(spoofJS, "spoofBrand") {
+    failures = append(failures, "counterfeit Node buffer modules dropped their structural brand")
+  }
+  for _, native := range []string{"instanceof Blob", "instanceof File"} {
+    if strings.Contains(spoofJS, native) {
+      failures = append(failures, fmt.Sprintf("counterfeit Node buffer module was promoted to %q", native))
+    }
+  }
+
+  output, runtimeErr := nodeBufferNativeExportsRun(t, project, js, controlsJS)
+  if runtimeErr != nil {
+    failures = append(failures, fmt.Sprintf("runtime matrix failed: %v\n%s", runtimeErr, output))
+  }
+  for _, expectedCases := range []string{"RAN 12 CASES", "RAN 10 INTERSECTION CASES", "RAN 8 CONTROL CASES"} {
+    if !strings.Contains(output, expectedCases) {
+      failures = append(failures, fmt.Sprintf("runtime runner did not report %q; got:\n%s", expectedCases, output))
+    }
+  }
+  spoofOutput, spoofRuntimeErr := nodeBufferNativeExportsSpoofRun(t, spoofProject, spoofJS)
+  if spoofRuntimeErr != nil {
+    failures = append(failures, fmt.Sprintf("counterfeit runtime matrix failed: %v\n%s", spoofRuntimeErr, spoofOutput))
+  }
+  const expectedSpoofCases = "RAN 8 COUNTERFEIT CASES"
+  if !strings.Contains(spoofOutput, expectedSpoofCases) {
+    failures = append(failures, fmt.Sprintf("counterfeit runner did not report %q; got:\n%s", expectedSpoofCases, spoofOutput))
+  }
+  if len(failures) != 0 {
+    t.Fatalf(
+      "Node buffer native export mismatches:\n%s\n\nnative emit:\n%s\n\ncontrol emit:\n%s\n\ncounterfeit emit:\n%s",
+      strings.Join(failures, "\n"),
+      js,
+      controlsJS,
+      spoofJS,
+    )
+  }
+}
+
+func nodeBufferNativeExportsProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "node-buffer-native-exports-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+
+  src := filepath.Join(dir, "src")
+  dependency := filepath.Join(dir, "node_modules", "native-buffer-lookalike")
+  for _, path := range []string{src, dependency} {
+    if err := os.MkdirAll(path, 0o755); err != nil {
+      t.Fatalf("mkdir fixture path %s: %v", path, err)
+    }
+  }
+  for path, content := range map[string]string{
+    filepath.Join(dir, "tsconfig.json"):       nodeBufferNativeExportsTSConfig,
+    filepath.Join(src, "input.ts"):            nodeBufferNativeExportsSource,
+    filepath.Join(src, "controls.ts"):         nodeBufferNativeExportsControlSource,
+    filepath.Join(src, "node-buffer-augmentation.d.ts"): nodeBufferNativeExportsAugmentation,
+    filepath.Join(src, "user-ambient.d.ts"):   nodeBufferNativeExportsAmbientDeclarations,
+    filepath.Join(dependency, "package.json"): nodeBufferNativeExportsPackageJSON,
+    filepath.Join(dependency, "index.d.ts"):   nodeBufferNativeExportsPackageDeclarations,
+  } {
+    if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+      t.Fatalf("write fixture file %s: %v", path, err)
+    }
+  }
+  return dir
+}
+
+func nodeBufferNativeExportsSpoofProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "node-buffer-native-exports-spoof-")
+  if err != nil {
+    t.Fatalf("create counterfeit fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+
+  src := filepath.Join(dir, "src")
+  fakeNodeRoot := filepath.Join(src, "node_modules", "@types", "node")
+  for _, path := range []string{src, fakeNodeRoot} {
+    if err := os.MkdirAll(path, 0o755); err != nil {
+      t.Fatalf("mkdir counterfeit source %s: %v", path, err)
+    }
+  }
+  for path, content := range map[string]string{
+    filepath.Join(dir, "tsconfig.json"):       nodeBufferNativeExportsSpoofTSConfig,
+    filepath.Join(fakeNodeRoot, "buffer.d.ts"): nodeBufferNativeExportsSpoofDeclarations,
+    filepath.Join(src, "input.ts"):             nodeBufferNativeExportsSpoofSource,
+  } {
+    if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+      t.Fatalf("write counterfeit fixture file %s: %v", path, err)
+    }
+  }
+  return dir
+}
+
+func nodeBufferNativeExportsRun(t *testing.T, project string, js string, controlsJS string) (string, error) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+    return "", nil
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  for name, content := range map[string]string{
+    "input.cjs":    ttscTypiaTestRewriteCommonJS(t, js),
+    "controls.cjs": ttscTypiaTestRewriteCommonJS(t, controlsJS),
+    "run.cjs":      nodeBufferNativeExportsRuntimeRunner,
+  } {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write runtime file %s: %v", name, err)
+    }
+  }
+  cmd := exec.Command(node, filepath.Join(runtimeDir, "run.cjs"))
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  return string(output), err
+}
+
+func nodeBufferNativeExportsSpoofRun(t *testing.T, project string, js string) (string, error) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+    return "", nil
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir counterfeit runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  for name, content := range map[string]string{
+    "input.cjs": ttscTypiaTestRewriteCommonJS(t, js),
+    "run.cjs":   nodeBufferNativeExportsSpoofRuntimeRunner,
+  } {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write counterfeit runtime file %s: %v", name, err)
+    }
+  }
+  cmd := exec.Command(node, filepath.Join(runtimeDir, "run.cjs"))
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  return string(output), err
+}
+
+const nodeBufferNativeExportsTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const nodeBufferNativeExportsSource = `import typia from "typia";
+import type { Blob as NodeBlob, File as NodeFile } from "node:buffer";
+import type { Blob as LegacyBlob, File as LegacyFile } from "buffer";
+
+declare const nodeBlobBrand: unique symbol;
+declare const nodeFileBrand: unique symbol;
+type BrandedNodeBlob = NodeBlob & { readonly [nodeBlobBrand]?: never };
+type BrandedNodeFile = NodeFile & { readonly [nodeFileBrand]?: never };
+type NodeBlobIntersectionUnion =
+  | (NodeBlob & { blobLabel: string })
+  | { nodeBlobOk: boolean };
+type NodeFileIntersectionUnion =
+  | (NodeFile & { fileLabel: string })
+  | { nodeFileOk: boolean };
+
+export const isNodeBlob = typia.createIs<NodeBlob>();
+export const isNodeFile = typia.createIs<NodeFile>();
+export const isLegacyBlob = typia.createIs<LegacyBlob>();
+export const isLegacyFile = typia.createIs<LegacyFile>();
+export const isGlobalBlob = typia.createIs<Blob>();
+export const isGlobalFile = typia.createIs<File>();
+export const isBrandedNodeBlob = typia.createIs<BrandedNodeBlob>();
+export const isBrandedNodeFile = typia.createIs<BrandedNodeFile>();
+export const isNodeBlobIntersectionUnion =
+  typia.createIs<NodeBlobIntersectionUnion>();
+export const isNodeFileIntersectionUnion =
+  typia.createIs<NodeFileIntersectionUnion>();
+`
+
+const nodeBufferNativeExportsPackageJSON = `{
+  "name": "native-buffer-lookalike",
+  "version": "1.0.0",
+  "types": "index.d.ts"
+}
+`
+
+const nodeBufferNativeExportsSpoofTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "lib": ["ES2022"],
+    "types": [],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "files": [
+    "src/input.ts",
+    "src/node_modules/@types/node/buffer.d.ts"
+  ]
+}
+`
+
+const nodeBufferNativeExportsPackageDeclarations = `export interface Blob {
+  packageBrand: string;
+  size: number;
+  type: string;
+}
+export interface File extends Blob {
+  lastModified: number;
+  name: string;
+  webkitRelativePath: string;
+}
+`
+
+const nodeBufferNativeExportsAmbientDeclarations = `declare module "user-buffer-lookalike" {
+  export interface Blob {
+    ambientBrand: string;
+    size: number;
+    type: string;
+  }
+  export interface File extends Blob {
+    lastModified: number;
+    name: string;
+    webkitRelativePath: string;
+  }
+}
+`
+
+const nodeBufferNativeExportsAugmentation = `import "node:buffer";
+
+declare module "node:buffer" {
+  interface Blob {
+    readonly __typiaNodeBufferAugmentation?: never;
+  }
+  interface File {
+    readonly __typiaNodeBufferAugmentation?: never;
+  }
+}
+`
+
+const nodeBufferNativeExportsControlSource = `import typia from "typia";
+import type { Blob as PackageBlob, File as PackageFile } from "native-buffer-lookalike";
+import type { Blob as AmbientBlob, File as AmbientFile } from "user-buffer-lookalike";
+
+export const isPackageBlob = typia.createIs<PackageBlob>();
+export const isPackageFile = typia.createIs<PackageFile>();
+export const isAmbientBlob = typia.createIs<AmbientBlob>();
+export const isAmbientFile = typia.createIs<AmbientFile>();
+`
+
+const nodeBufferNativeExportsSpoofDeclarations = `declare module "node:buffer" {
+  export interface Blob {
+    spoofBrand: string;
+    size: number;
+    type: string;
+  }
+  export interface File extends Blob {
+    lastModified: number;
+    name: string;
+    webkitRelativePath: string;
+  }
+}
+declare module "buffer" {
+  export * from "node:buffer";
+}
+`
+
+const nodeBufferNativeExportsSpoofSource = `import typia from "typia";
+import type { Blob as NodeBlob, File as NodeFile } from "node:buffer";
+import type { Blob as LegacyBlob, File as LegacyFile } from "buffer";
+
+export const isNodeBlob = typia.createIs<NodeBlob>();
+export const isNodeFile = typia.createIs<NodeFile>();
+export const isLegacyBlob = typia.createIs<LegacyBlob>();
+export const isLegacyFile = typia.createIs<LegacyFile>();
+`
+
+const nodeBufferNativeExportsRuntimeRunner = `const validators = require("./input.cjs");
+const controls = require("./controls.cjs");
+const node = require("node:buffer");
+const legacy = require("buffer");
+
+const blobPlain = { size: 1, type: "text/plain" };
+const filePlain = {
+  lastModified: 0,
+  name: "x.txt",
+  size: 1,
+  type: "text/plain",
+  webkitRelativePath: "",
+};
+
+const cases = [
+  ["node:buffer Blob real", validators.isNodeBlob(new node.Blob(["x"], { type: "text/plain" })), true],
+  ["node:buffer Blob plain", validators.isNodeBlob(blobPlain), false],
+  ["node:buffer File real", validators.isNodeFile(new node.File(["x"], "x.txt", { lastModified: 0, type: "text/plain" })), true],
+  ["node:buffer File plain", validators.isNodeFile(filePlain), false],
+  ["buffer Blob real", validators.isLegacyBlob(new legacy.Blob(["x"], { type: "text/plain" })), true],
+  ["buffer Blob plain", validators.isLegacyBlob(blobPlain), false],
+  ["buffer File real", validators.isLegacyFile(new legacy.File(["x"], "x.txt", { lastModified: 0, type: "text/plain" })), true],
+  ["buffer File plain", validators.isLegacyFile(filePlain), false],
+  ["global Blob real", validators.isGlobalBlob(new Blob(["x"], { type: "text/plain" })), true],
+  ["global Blob plain", validators.isGlobalBlob(blobPlain), false],
+  ["global File real", validators.isGlobalFile(new File(["x"], "x.txt", { lastModified: 0, type: "text/plain" })), true],
+  ["global File plain", validators.isGlobalFile(filePlain), false],
+];
+
+const intersectionCases = [
+  ["branded Node Blob real", validators.isBrandedNodeBlob(new node.Blob(["x"])), true],
+  ["branded Node Blob plain", validators.isBrandedNodeBlob(blobPlain), false],
+  ["branded Node File real", validators.isBrandedNodeFile(new node.File(["x"], "x.txt")), true],
+  ["branded Node File plain", validators.isBrandedNodeFile(filePlain), false],
+  ["Node Blob intersection pruned", validators.isNodeBlobIntersectionUnion(Object.assign(new node.Blob(["x"]), { blobLabel: "x" })), false],
+  ["Node Blob intersection plain", validators.isNodeBlobIntersectionUnion({ ...blobPlain, blobLabel: "x" }), false],
+  ["Node Blob intersection other", validators.isNodeBlobIntersectionUnion({ nodeBlobOk: true }), true],
+  ["Node File intersection pruned", validators.isNodeFileIntersectionUnion(Object.assign(new node.File(["x"], "x.txt"), { fileLabel: "x" })), false],
+  ["Node File intersection plain", validators.isNodeFileIntersectionUnion({ ...filePlain, fileLabel: "x" }), false],
+  ["Node File intersection other", validators.isNodeFileIntersectionUnion({ nodeFileOk: true }), true],
+];
+
+const packageBlob = { packageBrand: "package", size: 1, type: "text/plain" };
+const packageFile = {
+  ...packageBlob,
+  lastModified: 0,
+  name: "x.txt",
+  webkitRelativePath: "",
+};
+const ambientBlob = { ambientBrand: "ambient", size: 1, type: "text/plain" };
+const ambientFile = {
+  ...ambientBlob,
+  lastModified: 0,
+  name: "x.txt",
+  webkitRelativePath: "",
+};
+const controlCases = [
+  ["package Blob structural", controls.isPackageBlob(packageBlob), true],
+  ["package Blob rejects native", controls.isPackageBlob(new node.Blob(["x"])), false],
+  ["package File structural", controls.isPackageFile(packageFile), true],
+  ["package File rejects native", controls.isPackageFile(new node.File(["x"], "x.txt")), false],
+  ["ambient Blob structural", controls.isAmbientBlob(ambientBlob), true],
+  ["ambient Blob rejects native", controls.isAmbientBlob(new node.Blob(["x"])), false],
+  ["ambient File structural", controls.isAmbientFile(ambientFile), true],
+  ["ambient File rejects native", controls.isAmbientFile(new node.File(["x"], "x.txt")), false],
+];
+
+const failures = [];
+for (const [name, actual, expected] of [...cases, ...intersectionCases, ...controlCases]) {
+  if (actual !== expected) {
+    failures.push(name + ": expected " + expected + " but got " + actual);
+  }
+}
+console.log("RAN " + cases.length + " CASES");
+console.log("RAN " + intersectionCases.length + " INTERSECTION CASES");
+console.log("RAN " + controlCases.length + " CONTROL CASES");
+if (failures.length !== 0) {
+  throw new Error("MISMATCHES:\n" + failures.join("\n"));
+}
+`
+
+const nodeBufferNativeExportsSpoofRuntimeRunner = `const validators = require("./input.cjs");
+const node = require("node:buffer");
+
+const blob = { spoofBrand: "fake", size: 1, type: "text/plain" };
+const file = {
+  ...blob,
+  lastModified: 0,
+  name: "x.txt",
+  webkitRelativePath: "",
+};
+const cases = [
+  ["counterfeit node:buffer Blob structural", validators.isNodeBlob(blob), true],
+  ["counterfeit node:buffer Blob rejects native", validators.isNodeBlob(new node.Blob(["x"])), false],
+  ["counterfeit node:buffer File structural", validators.isNodeFile(file), true],
+  ["counterfeit node:buffer File rejects native", validators.isNodeFile(new node.File(["x"], "x.txt")), false],
+  ["counterfeit buffer Blob structural", validators.isLegacyBlob(blob), true],
+  ["counterfeit buffer Blob rejects native", validators.isLegacyBlob(new node.Blob(["x"])), false],
+  ["counterfeit buffer File structural", validators.isLegacyFile(file), true],
+  ["counterfeit buffer File rejects native", validators.isLegacyFile(new node.File(["x"], "x.txt")), false],
+];
+
+const failures = [];
+for (const [name, actual, expected] of cases) {
+  if (actual !== expected) {
+    failures.push(name + ": expected " + expected + " but got " + actual);
+  }
+}
+console.log("RAN " + cases.length + " COUNTERFEIT CASES");
+if (failures.length !== 0) {
+  throw new Error("MISMATCHES:\n" + failures.join("\n"));
+}
+`

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -353,6 +353,44 @@ func metadata_symbol_is_global_type(checker *nativechecker.Checker, symbol *nati
   return checker.ResolveName(name, nil, nativeast.SymbolFlagsType, false) == symbol
 }
 
+// metadata_symbol_is_runtime_native_type applies the shared identity boundary
+// for simple runtime-native classes. Most natives are the exact symbol resolved
+// from the checker's global type table. Node's Blob and File module exports are
+// a second symbol for those same runtime constructors, so their declarations
+// qualify through the value-bearing shape shared by the supported Node type
+// definitions (#1568, #2239).
+func metadata_symbol_is_runtime_native_type(checker *nativechecker.Checker, symbol *nativeast.Symbol, name string) bool {
+  return metadata_symbol_is_global_type(checker, symbol, name) ||
+    metadata_symbol_is_node_buffer_native_export(symbol, name)
+}
+
+func metadata_symbol_is_node_buffer_native_export(symbol *nativeast.Symbol, name string) bool {
+  if symbol == nil || symbol.ValueDeclaration == nil || (name != "Blob" && name != "File") {
+    return false
+  }
+  declaration := symbol.ValueDeclaration
+  if declaration.Kind != nativeast.KindClassDeclaration && declaration.Kind != nativeast.KindVariableDeclaration {
+    return false
+  }
+  // @types/node 18/20 declare these constructor values as classes and 25
+  // declares merged interface/var pairs. The value declaration and exact core
+  // module together distinguish those runtime constructors from structural
+  // same-name interfaces without depending on node_modules placement, custom
+  // typeRoots, symlink targets, or virtualized package paths.
+  for node := declaration; node != nil; node = node.Parent {
+    if node.Kind == nativeast.KindModuleDeclaration && node.Name() != nil {
+      module := strings.Trim(node.Name().Text(), "\"'")
+      if module == "node:buffer" || module == "buffer" {
+        return true
+      }
+    }
+    if node.Kind == nativeast.KindSourceFile {
+      break
+    }
+  }
+  return false
+}
+
 func metadata_is_default_lib_file_name(fileName string) bool {
   slash := strings.ReplaceAll(fileName, "\\", "/")
   base := slash

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
@@ -485,7 +485,7 @@ func iterate_metadata_intersection_is_removable_object_constraint(
     return false
   }
   name, symbol := iterate_metadata_intersection_type_name_and_symbol(checker, typ)
-  if _, ok := iterate_metadata_native_simples[name]; ok && metadata_symbol_is_global_type(checker, symbol, name) {
+  if _, ok := iterate_metadata_native_simples[name]; ok && metadata_symbol_is_runtime_native_type(checker, symbol, name) {
     return false
   }
   for _, generic := range iterate_metadata_native_generics {
@@ -523,7 +523,7 @@ type iterate_metadata_intersection_identity struct {
 
 // iterate_metadata_intersection_type_name_and_symbol keeps the normalized name
 // paired with the symbol that supplied it, including the apparent-type fallback.
-// Intersection classifiers can then apply the same global-symbol identity gate
+// Intersection classifiers can then apply the same runtime-native identity gate
 // as direct native metadata without re-resolving either half independently.
 func iterate_metadata_intersection_type_name_and_symbol(
   checker *nativechecker.Checker,
@@ -578,7 +578,7 @@ func iterate_metadata_intersection_identify(
       return iterate_metadata_intersection_identity{Kind: "tag"}
     }
   }
-  if _, ok := iterate_metadata_native_simples[name]; ok && metadata_symbol_is_global_type(checker, symbol, name) {
+  if _, ok := iterate_metadata_native_simples[name]; ok && metadata_symbol_is_runtime_native_type(checker, symbol, name) {
     return iterate_metadata_intersection_identity{Kind: "native", Name: name}
   }
   for _, generic := range iterate_metadata_native_generics {
@@ -690,7 +690,7 @@ func iterate_metadata_intersection_is_plain_object_only(
   }
 
   name, symbol := iterate_metadata_intersection_type_name_and_symbol(checker, typ)
-  if _, ok := iterate_metadata_native_simples[name]; ok && metadata_symbol_is_global_type(checker, symbol, name) {
+  if _, ok := iterate_metadata_native_simples[name]; ok && metadata_symbol_is_runtime_native_type(checker, symbol, name) {
     return false
   }
   for _, generic := range iterate_metadata_native_generics {
@@ -996,7 +996,7 @@ func iterate_metadata_intersection_category(
   if name == "Array" || name == "ReadonlyArray" {
     return "array"
   }
-  if _, ok := iterate_metadata_native_simples[name]; ok && metadata_symbol_is_global_type(checker, symbol, name) {
+  if _, ok := iterate_metadata_native_simples[name]; ok && metadata_symbol_is_runtime_native_type(checker, symbol, name) {
     return "native:" + name
   }
   for _, generic := range iterate_metadata_native_generics {

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
@@ -26,8 +26,11 @@ func Iterate_metadata_native(props IMetadataIteratorProps) bool {
     // Match the built-in only when the checker resolves this exact symbol from
     // the global type table. A colliding package declaration then falls through
     // to its structural members regardless of whether it was authored in `.ts`
-    // or published through `.d.ts` (#2200, #2239).
-    if !metadata_symbol_is_global_type(props.Checker, symbol, name) {
+    // or published through `.d.ts` (#2200, #2239). Node's authoritative Blob
+    // and File module exports are distinct symbols for the same runtime globals,
+    // so admit only their value-bearing exact core-module declaration shape as
+    // the second identity path (#1568).
+    if !metadata_symbol_is_runtime_native_type(props.Checker, symbol, name) {
       return false
     }
     iterate_metadata_native_take(props.Metadata, name)
@@ -62,6 +65,11 @@ func iterate_metadata_native_take(metadata *schemametadata.MetadataSchema, name 
 func iterate_metadata_native_getNativeName(name string) string {
   if index := strings.Index(name, "<"); index != -1 {
     name = name[:index]
+  }
+  for _, module := range []string{"node:buffer.", "buffer."} {
+    if strings.HasPrefix(name, module) {
+      return strings.TrimPrefix(name, module)
+    }
   }
   if strings.HasPrefix(name, "\"") && strings.Contains(name, "\".") {
     if index := strings.Index(name[1:], "\"."); index != -1 {


### PR DESCRIPTION
## Intent

Preserve runtime-native constructor identity for the authoritative `Blob` and `File` exports from both `node:buffer` and `buffer` in the supported transformer runtime.

## Invariants

- Authoritative Node module exports and their bare-global controls accept real instances and reject structural lookalikes on the exercised Node 22 runtime.
- Ordinary package declarations, user ambient interfaces, and exact interface-only counterfeits of the Node module names remain structural.
- Direct, branded, and intersection-union classification apply the same identity boundary.

## Scope and mechanism

- Exact global-symbol identity remains the primary native boundary.
- The second path requires `Blob` or `File` to have a class/variable `ValueDeclaration` under the exact `node:buffer` or `buffer` core module. Installed Node 18/20 definitions use classes; Node 25 uses merged interface/var declarations.
- Classification does not infer package ownership from a filesystem path or filename. It therefore does not depend on `node_modules` placement, while structural interfaces have no constructor value declaration.
- Only the current unquoted `node:buffer.` and `buffer.` compiler names are normalized.
- Direct and all four native-intersection decisions use the same predicate.
- No version, public interface, dependency, provider, or workflow changes.

## Falsified hypotheses

- Module text alone is insufficient: with Node types excluded, a user declaration can own the exact `node:buffer` name and a `buffer` re-export.
- `/node_modules/@types/node/` is not package ownership: moving that same interface-only counterfeit to `src/node_modules/@types/node/buffer.d.ts` made the earlier path predicate promote all four validators. The committed regression preserves that path mutation without a package.json.
- Requiring the `buffer.d.ts` basename adds a renamed/vendor false negative but does not reject a deliberately value-bearing mimic, so filename provenance is not used.

## Runtime boundary

The positive runtime matrix executes on Node `v22.21.0`. The required transformer peer `ttsc@0.19.2` declares Node `>=22.15.0`, and repository build/test workflows use Node 24. This is transformer/CI evidence, not a blanket Node engine promise for the `typia` package, which declares no Node engine.

A separate Node `v18.20.8` probe established that `require("node:buffer").File` exists while `globalThis.File` is undefined. The current native metadata retains only the normalized name, so generated `instanceof File` throws `ReferenceError` there. This PR does not claim support for deploying already-generated validators on Node 18. Faithful module-aware Node 18 emit would require preserving constructor provenance across metadata and every native consumer; that interface expansion is outside this issue.

## Delivery chronology

- The implementation-free claim was first published as `c4014f37db2aa769da1cf131e0e646bffa11c1de`; run `29664630611` was cancelled by exact SHA.
- The claim was replayed unchanged as `a0cf22ad3f60d697be23d8b78623e75991a22d5a` onto base `b4ad0cf3ca8870fb7688b182ce27e739aaa4f934`.
- Initial implementation head `f37f30e66c8de4bf91f54c53afffc3b81c2fffd1` had six exact-SHA runs cancelled before final review.
- Final-review remediation head `11178c789281e77a1cf8d1d2ca0ac69e1cdfbdd6` replaced the path predicate and hardened the counterfeit fixture. Runs `29667179416`, `29667179419`, `29667179420`, `29667179430`, `29667179456`, and `29667179490` were all cancelled and polled to terminal status by exact SHA.
- The exact-SHA gate was rerun after this PR body mutation and enumerated only terminal runs. The PR remains draft and is not merged.

## Verification

- Path-mutated counterfeit: focused RED under the superseded path predicate, then green under the value-declaration predicate.
- `go test -p=1 ./cmd/ttsc-typia -run '^(TestNodeBufferNativeExportsIsTransform|TestPackageDeclarationNativeIdentityIsTransform|TestNativeNameCollisionIsTransform|TestNativeCollectionIdentityIsTransform|TestNativeGenericNameGuardIsTransform|TestNativeNamedIntersectionUnionTransform)$' -count=1 -v`
- Real-transform/runtime matrix: 12 direct cases, 10 intersection cases, 8 package/ambient controls, and 8 path-mutated exact-module counterfeit controls.
- `go test -p=1 -count=1 ./...`
- `go vet -p=1 ./...`
- `pnpm --filter ./tests/test-typia-schema start`
- Node 18.20.8 compatibility probe reproduced the excluded bare-`File` `ReferenceError`.
- Solo diff review, Lore trailer parsing, and `git diff --check`.

Custom `typeRoots`, symlink, and PnP layouts were assessed but not executed; the final predicate performs no path matching. Root `pnpm test`/build was not repeated, and the already-verified D9 batch was not rerun.

Fixes #1568
