### PR TITLE
fix(native): preserve function semantics for call-only and construct-only interfaces

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/callable_interface_function_semantics_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/callable_interface_function_semantics_transform_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+  "fmt"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCallableInterfaceFunctionSemanticsTransform verifies declaration-syntax
+// parity for pure callable and constructable types (#2238).
+//
+// TypeScript considers the call-only and construct-only interfaces in this
+// fixture mutually assignable with their function-type aliases. Typia must
+// therefore apply the same default and `functional: true` validator semantics
+// to both spellings. Hybrid interfaces are a deliberate negative boundary:
+// their data members must remain represented rather than disappearing through
+// an over-broad signature check. The global `Function` type is the adjacent
+// positive control for the pre-existing function-interface path.
+//
+//  1. Transform one source under the default and functional plugin options.
+//  2. Exercise direct and factory validators at top level and inside holders.
+//  3. Require alias parity, hybrid-member preservation, and global Function
+//     behavior with an exact runtime case count.
+func TestCallableInterfaceFunctionSemanticsTransform(t *testing.T) {
+  project := compareEqualCoverProject(t, "callable-interface-function-semantics-", callableInterfaceFunctionSemanticsSource)
+  defaultJS := callableInterfaceFunctionSemanticsTransform(t, project, false)
+  functionalJS := callableInterfaceFunctionSemanticsTransform(t, project, true)
+
+  failures := []string{}
+  for name, js := range map[string]string{
+    "default":    defaultJS,
+    "functional": functionalJS,
+  } {
+    for _, member := range []string{"label", "kind", "inheritedCallableLabel", "inheritedConstructableKind"} {
+      if !strings.Contains(js, member) {
+        failures = append(failures, fmt.Sprintf("%s emit erased hybrid member %q", name, member))
+      }
+    }
+  }
+
+  output, runtimeErr := callableInterfaceFunctionSemanticsRun(t, project, defaultJS, functionalJS)
+  if runtimeErr != nil {
+    failures = append(failures, fmt.Sprintf("runtime matrix failed: %v\n%s", runtimeErr, output))
+  }
+  const expected = "RAN 104 CASES"
+  if !strings.Contains(output, expected) {
+    failures = append(failures, fmt.Sprintf("runtime runner did not report %q; got:\n%s", expected, output))
+  }
+  if len(failures) != 0 {
+    t.Fatalf(
+      "callable-interface function-semantics mismatches:\n%s\n\ndefault emit:\n%s\n\nfunctional emit:\n%s",
+      strings.Join(failures, "\n"),
+      defaultJS,
+      functionalJS,
+    )
+  }
+}
+
+func callableInterfaceFunctionSemanticsTransform(t *testing.T, project string, functional bool) string {
+  t.Helper()
+  option := ""
+  if functional {
+    option = `,"functional":true`
+  }
+  payload := `[{"config":{"transform":"typia/lib/transform"` + option + `},"name":"typia","stage":"transform"}]`
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+      "--plugins-json", payload,
+    })
+  })
+  if code != 0 {
+    t.Fatalf("callable-interface transform (functional=%t) failed: code=%d stderr=\n%s", functional, code, errText)
+  }
+  return out
+}
+
+func callableInterfaceFunctionSemanticsRun(t *testing.T, project string, defaultJS string, functionalJS string) (string, error) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+    return "", nil
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  modules := map[string]string{
+    "default.cjs":    ttscTypiaTestRewriteCommonJS(t, defaultJS),
+    "functional.cjs": ttscTypiaTestRewriteCommonJS(t, functionalJS),
+    "run.cjs":        callableInterfaceFunctionSemanticsRuntimeRunner,
+  }
+  for name, content := range modules {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write runtime file %s: %v", name, err)
+    }
+  }
+  cmd := exec.Command(node, filepath.Join(runtimeDir, "run.cjs"))
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  return string(output), err
+}
+
+const callableInterfaceFunctionSemanticsSource = `import typia from "typia";
+
+interface CallableInterface {
+  (value: number): string;
+}
+interface ConstructableInterface {
+  new (value: number): { value: number };
+}
+type CallableAlias = (value: number) => string;
+type ConstructableAlias = new (value: number) => { value: number };
+
+type Assert<T extends true> = T;
+type Same<X, Y> = [X] extends [Y]
+  ? [Y] extends [X]
+    ? true
+    : false
+  : false;
+type _CallableSpellingsAreEquivalent = Assert<Same<CallableInterface, CallableAlias>>;
+type _ConstructableSpellingsAreEquivalent = Assert<Same<ConstructableInterface, ConstructableAlias>>;
+
+interface InterfaceHolder {
+  callable: CallableInterface;
+  constructable: ConstructableInterface;
+}
+interface AliasHolder {
+  callable: CallableAlias;
+  constructable: ConstructableAlias;
+}
+
+interface HybridCallable {
+  (value: number): string;
+  label: string;
+}
+interface HybridConstructable {
+  new (value: number): { value: number };
+  kind: string;
+}
+
+interface IndexedCallable {
+  (value: number): string;
+  [key: string]: unknown;
+}
+interface IndexedConstructable {
+  new (value: number): { value: number };
+  [key: string]: unknown;
+}
+
+interface InheritedCallableMembers {
+  inheritedCallableLabel: string;
+}
+interface InheritedConstructableMembers {
+  inheritedConstructableKind: string;
+}
+interface InheritedIndexMembers {
+  [key: string]: unknown;
+}
+interface InheritedNamedCallable extends InheritedCallableMembers {
+  (value: number): string;
+}
+interface InheritedNamedConstructable extends InheritedConstructableMembers {
+  new (value: number): { value: number };
+}
+interface InheritedIndexedCallable extends InheritedIndexMembers {
+  (value: number): string;
+}
+interface InheritedIndexedConstructable extends InheritedIndexMembers {
+  new (value: number): { value: number };
+}
+
+export const directCallableInterface = (input: unknown): boolean => typia.is<CallableInterface>(input);
+export const factoryCallableInterface = typia.createIs<CallableInterface>();
+export const directConstructableInterface = (input: unknown): boolean => typia.is<ConstructableInterface>(input);
+export const factoryConstructableInterface = typia.createIs<ConstructableInterface>();
+
+export const directCallableAlias = (input: unknown): boolean => typia.is<CallableAlias>(input);
+export const factoryCallableAlias = typia.createIs<CallableAlias>();
+export const directConstructableAlias = (input: unknown): boolean => typia.is<ConstructableAlias>(input);
+export const factoryConstructableAlias = typia.createIs<ConstructableAlias>();
+
+export const directInterfaceHolder = (input: unknown): boolean => typia.is<InterfaceHolder>(input);
+export const factoryInterfaceHolder = typia.createIs<InterfaceHolder>();
+export const directAliasHolder = (input: unknown): boolean => typia.is<AliasHolder>(input);
+export const factoryAliasHolder = typia.createIs<AliasHolder>();
+
+export const directHybridCallable = (input: unknown): boolean => typia.is<HybridCallable>(input);
+export const factoryHybridCallable = typia.createIs<HybridCallable>();
+export const directHybridConstructable = (input: unknown): boolean => typia.is<HybridConstructable>(input);
+export const factoryHybridConstructable = typia.createIs<HybridConstructable>();
+
+export const directIndexedCallable = (input: unknown): boolean => typia.is<IndexedCallable>(input);
+export const factoryIndexedCallable = typia.createIs<IndexedCallable>();
+export const directIndexedConstructable = (input: unknown): boolean => typia.is<IndexedConstructable>(input);
+export const factoryIndexedConstructable = typia.createIs<IndexedConstructable>();
+
+export const directInheritedNamedCallable = (input: unknown): boolean => typia.is<InheritedNamedCallable>(input);
+export const factoryInheritedNamedCallable = typia.createIs<InheritedNamedCallable>();
+export const directInheritedNamedConstructable = (input: unknown): boolean => typia.is<InheritedNamedConstructable>(input);
+export const factoryInheritedNamedConstructable = typia.createIs<InheritedNamedConstructable>();
+export const directInheritedIndexedCallable = (input: unknown): boolean => typia.is<InheritedIndexedCallable>(input);
+export const factoryInheritedIndexedCallable = typia.createIs<InheritedIndexedCallable>();
+export const directInheritedIndexedConstructable = (input: unknown): boolean => typia.is<InheritedIndexedConstructable>(input);
+export const factoryInheritedIndexedConstructable = typia.createIs<InheritedIndexedConstructable>();
+
+export const directGlobalFunction = (input: unknown): boolean => typia.is<Function>(input);
+export const factoryGlobalFunction = typia.createIs<Function>();
+export const directGlobalFunctionHolder = (input: unknown): boolean => typia.is<{ fn: Function }>(input);
+export const factoryGlobalFunctionHolder = typia.createIs<{ fn: Function }>();
+`
+
+const callableInterfaceFunctionSemanticsRuntimeRunner = `const defaults = require("./default.cjs");
+const functional = require("./functional.cjs");
+
+let ran = 0;
+const failures = [];
+const eq = (name, actual, expected) => {
+  ran += 1;
+  if (actual !== expected) {
+    failures.push(name + ": expected " + expected + " but got " + actual);
+  }
+};
+
+const callable = (value) => String(value);
+class Constructable {
+  constructor(value) {
+    this.value = value;
+  }
+}
+const holder = { callable, constructable: Constructable };
+const placeholders = { callable: {}, constructable: {} };
+
+const topLevelRows = [
+  ["directCallableInterface", callable, {}],
+  ["factoryCallableInterface", callable, {}],
+  ["directConstructableInterface", Constructable, {}],
+  ["factoryConstructableInterface", Constructable, {}],
+  ["directCallableAlias", callable, {}],
+  ["factoryCallableAlias", callable, {}],
+  ["directConstructableAlias", Constructable, {}],
+  ["factoryConstructableAlias", Constructable, {}],
+];
+for (const [name, real, placeholder] of topLevelRows) {
+  eq("default " + name + " real", defaults[name](real), true);
+  eq("default " + name + " placeholder", defaults[name](placeholder), true);
+  eq("functional " + name + " real", functional[name](real), true);
+  eq("functional " + name + " placeholder", functional[name](placeholder), false);
+}
+
+for (const name of [
+  "directInterfaceHolder",
+  "factoryInterfaceHolder",
+  "directAliasHolder",
+  "factoryAliasHolder",
+]) {
+  eq("default " + name + " real", defaults[name](holder), true);
+  eq("default " + name + " placeholders", defaults[name](placeholders), true);
+  eq("functional " + name + " real", functional[name](holder), true);
+  eq("functional " + name + " placeholders", functional[name](placeholders), false);
+}
+
+// Hybrid interfaces stay outside the pure-function classification. A real
+// function or constructor missing the declared data member and a plain object
+// carrying only that member are both incomplete values. Keeping both negative
+// twins prevents a signature-based fix from erasing the member or the callable
+// side of the TypeScript shape.
+for (const mod of [defaults, functional]) {
+  for (const name of ["directHybridCallable", "factoryHybridCallable"]) {
+    eq(name + " callable missing data member", mod[name](callable), false);
+    eq(name + " data member without callability", mod[name]({ label: "kept" }), false);
+  }
+  for (const name of ["directHybridConstructable", "factoryHybridConstructable"]) {
+    eq(name + " constructor missing data member", mod[name](Constructable), false);
+    eq(name + " data member without constructability", mod[name]({ kind: "kept" }), false);
+  }
+}
+
+// Index signatures are an independent hybrid boundary, and both named and
+// indexed boundaries can arrive through interface inheritance. These valid
+// function/class values intentionally omit the full hybrid shape, so existing
+// structural handling rejects them. If either boundary is erased and the type
+// is over-classified as a pure function, default mode skips it and functional
+// mode accepts its typeof-function value.
+const hybridBoundaryRows = [
+  ["directIndexedCallable", callable],
+  ["factoryIndexedCallable", callable],
+  ["directIndexedConstructable", Constructable],
+  ["factoryIndexedConstructable", Constructable],
+  ["directInheritedNamedCallable", callable],
+  ["factoryInheritedNamedCallable", callable],
+  ["directInheritedNamedConstructable", Constructable],
+  ["factoryInheritedNamedConstructable", Constructable],
+  ["directInheritedIndexedCallable", callable],
+  ["factoryInheritedIndexedCallable", callable],
+  ["directInheritedIndexedConstructable", Constructable],
+  ["factoryInheritedIndexedConstructable", Constructable],
+];
+for (const [mode, mod] of [["default", defaults], ["functional", functional]]) {
+  for (const [name, value] of hybridBoundaryRows) {
+    eq(mode + " " + name + " incomplete hybrid", mod[name](value), false);
+  }
+}
+
+// The existing global Function path remains the positive interface control.
+for (const name of ["directGlobalFunction", "factoryGlobalFunction"]) {
+  eq("default " + name + " real", defaults[name](callable), true);
+  eq("default " + name + " placeholder", defaults[name]({}), true);
+  eq("functional " + name + " real", functional[name](callable), true);
+  eq("functional " + name + " placeholder", functional[name]({}), false);
+}
+for (const name of ["directGlobalFunctionHolder", "factoryGlobalFunctionHolder"]) {
+  eq("default " + name + " real", defaults[name]({ fn: callable }), true);
+  eq("default " + name + " placeholder", defaults[name]({ fn: {} }), true);
+  eq("functional " + name + " real", functional[name]({ fn: callable }), true);
+  eq("functional " + name + " placeholder", functional[name]({ fn: {} }), false);
+}
+
+console.log("RAN " + ran + " CASES");
+if (failures.length !== 0) {
+  throw new Error("MISMATCHES:\n" + failures.join("\n"));
+}
+`

--- a/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
+++ b/packages/typia/native/core/factories/internal/metadata/MetadataHelper.go
@@ -139,7 +139,7 @@ func metadata_get_type_arguments(checker *nativechecker.Checker, typ *nativechec
   return checker.GetTypeArguments(typ)
 }
 
-func metadata_get_function_node(typ *nativechecker.Type) *nativeast.Node {
+func metadata_get_function_node(checker *nativechecker.Checker, typ *nativechecker.Type) *nativeast.Node {
   if typ == nil {
     return nil
   }
@@ -164,6 +164,9 @@ func metadata_get_function_node(typ *nativechecker.Type) *nativeast.Node {
   // already uses for `() => void` members: a lenient pass under default options
   // and a signature-based check under `functional`.
   if metadata_is_global_function_interface(symbol, node) {
+    return node
+  }
+  if metadata_is_pure_function_interface(checker, typ, node) {
     return node
   }
   if nativeast.IsPropertyAssignment(node) {
@@ -287,8 +290,7 @@ func metadata_node_type_js_doc_tags(symbol *nativeast.Symbol) []schemametadata.I
 // first declaration is an `InterfaceDeclaration`, and that declaration lives in a
 // `lib.*.d.ts` — so it recognizes only the lib `Function` and never a
 // user-declared `interface Function`, a `function Function()` value, or any
-// other callable object type (a hybrid `interface Foo { (): void; x: number }`
-// keeps its data properties). See metadata_get_function_node for why the lib
+// other callable object type. See metadata_get_function_node for why the lib
 // `Function` must be treated as a function type (#2178).
 func metadata_is_global_function_interface(symbol *nativeast.Symbol, node *nativeast.Node) bool {
   if symbol == nil || symbol.Name != "Function" {
@@ -298,6 +300,29 @@ func metadata_is_global_function_interface(symbol *nativeast.Symbol, node *nativ
     return false
   }
   return metadata_symbol_from_default_lib(symbol)
+}
+
+// metadata_is_pure_function_interface reports whether an interface describes
+// only call and/or construct signatures. TypeScript augments every callable
+// object's apparent properties with the global Function members, so the raw
+// properties and index infos are the boundary: a hybrid interface keeps its
+// declared data shape, while a property-free callable or constructable
+// interface follows the same metadata path as its mutually assignable function
+// type alias (#2238).
+func metadata_is_pure_function_interface(
+  checker *nativechecker.Checker,
+  typ *nativechecker.Type,
+  node *nativeast.Node,
+) bool {
+  if checker == nil || typ == nil || node == nil || node.Kind != nativeast.KindInterfaceDeclaration {
+    return false
+  }
+  if len(nativechecker.Checker_getPropertiesOfType(checker, typ)) != 0 ||
+    len(nativechecker.Checker_getIndexInfosOfType(checker, typ)) != 0 {
+    return false
+  }
+  return len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 ||
+    len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindConstruct)) != 0
 }
 
 // metadata_symbol_from_default_lib reports whether the symbol's first locatable

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_function.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_function.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Iterate_metadata_function(props IMetadataIteratorProps) bool {
-  declaration := metadata_get_function_node(props.Type)
+  declaration := metadata_get_function_node(props.Checker, props.Type)
   if declaration == nil {
     return false
   }

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
@@ -481,7 +481,7 @@ func iterate_metadata_intersection_is_removable_object_constraint(
   if nativechecker.IsTupleType(typ) || nativechecker.Checker_isArrayType(checker, typ) {
     return false
   }
-  if metadata_get_function_node(typ) != nil || len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 {
+  if metadata_get_function_node(checker, typ) != nil || len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 {
     return false
   }
   name, symbol := iterate_metadata_intersection_type_name_and_symbol(checker, typ)
@@ -685,7 +685,7 @@ func iterate_metadata_intersection_is_plain_object_only(
   if nativechecker.IsTupleType(typ) || nativechecker.Checker_isArrayType(checker, typ) {
     return false
   }
-  if metadata_get_function_node(typ) != nil || len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 {
+  if metadata_get_function_node(checker, typ) != nil || len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 {
     return false
   }
 
@@ -1007,7 +1007,7 @@ func iterate_metadata_intersection_category(
   if name == "Map" || name == "ReadonlyMap" || name == "Set" || name == "ReadonlySet" {
     return "object"
   }
-  if metadata_get_function_node(typ) != nil || len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 {
+  if metadata_get_function_node(checker, typ) != nil || len(checker.GetSignaturesOfType(typ, nativechecker.SignatureKindCall)) != 0 {
     return "object"
   }
   if typ.Flags()&nativechecker.TypeFlagsObject != 0 {


### PR DESCRIPTION
## Intent

Make pure call-only and construct-only interfaces follow the same function metadata semantics as their mutually assignable function aliases. Interface declaration syntax must not change default or `functional: true` validator behavior.

Closes #2238.

## Implementation

- Pass the TypeScript checker into the shared function-node classifier.
- Recognize an `InterfaceDeclaration` as a pure function type only when it has at least one call or construct signature and has neither named properties nor index infos.
- Keep the existing global `Function` default-library gate first, and keep named-property/index-signature hybrids outside the new path.
- Pass the checker through the three existing intersection helper call sites without changing #2247's type-name/global-symbol identity logic.
- Add one real-transform regression that executes direct and factory validators, top-level and nested types, call-only and construct-only spellings, default and functional modes, alias controls, hybrid boundaries, and global `Function` controls.
- Independently pin own index-signature and inherited named/index hybrid boundaries for both callable and constructable interfaces, so either exclusion or inheritance handling cannot disappear unnoticed.

Final base: `7ac9c4b78002abdddf8c8335c8b26e5b5203979b`. Current head: `a43ca4a9b6055a9b0b46d878c3dbf94b7215f7ad`.

## RED and GREEN evidence

The focused regression first ran on then-current master `e4d98f6ca416591dfd008d3c5f1753a419df5fcc` before the production change. It executed its original 80 cases and failed with exactly 18 interface-only mismatches:

- Direct and factory top-level callable/constructable interfaces rejected real functions/classes in both modes and rejected the default-mode placeholders that equivalent aliases skip.
- Direct and factory nested interface holders showed the same three mismatches per entry point.
- All alias, hybrid-boundary, and global `Function` controls passed.
- Emit expanded callable/newable apparent `Function` members (`length`, `name`, `caller`) behind a `typeof === "object"` gate, while aliases emitted default `true` and functional `typeof === "function"` behavior.

After rebasing onto interim base `99acd9cbc911033e7b619fa726860df1bf571dbc`, the implementation produced GREEN. Independent review then identified that the oracle covered direct named-property hybrids but not the separate index-info exclusion or inheritance. A test-only amendment added 24 cases: own-index, inherited-named, and inherited-index callable/constructable interfaces through direct and factory validators in both modes. The final runner requires an exact 104-case count.

After #2248 merged, the two Lore commits were rebased with the empty claim preserved onto final master `7ac9c4b78002abdddf8c8335c8b26e5b5203979b`. `git range-diff` reports both commits patch-identical, and a direct old-head/new-head comparison reports every #2238 test and production byte unchanged. #2248 changed a different metadata production file. The focused 104 cases and adjacent seven transforms both remain GREEN on the final base.

## Final local verification

- Focused `TestCallableInterfaceFunctionSemanticsTransform`: pass, exact 104 runtime cases after final rebase (42.0s command time).
- Global `Function` and current intersection adjacent transform set: 7 tests pass after final rebase (8.8s).
- Full native tree: `go test -p=1 -count=1 ./...` passed on the same reviewed #2238 production blob before the final base-only rebase (203.6s).
- Native vet: `go vet ./...` passed on the same reviewed #2238 production blob (2.3s).
- `test-typia-automated --include Functional`: harness prestart plus 153 selected direct/factory validator cases pass (369.4s).
- Full `test-typia-schema`: pass (2,251ms reported test time; 9.6s command time).
- `git diff --check`, final-base merge-base/readback, old/new `git range-diff`, exact four-file byte comparison, and both rebased Lore trailer parses: pass.
- Solo Self-Review round 1 was clean. Round 2 recorded the independent test-oracle finding before editing, then recorded the 104-case remediation as clean.

The full native and vet commands were not repeated after the test-only 80-to-104 expansion or the final rebase. The expansion changed only the regression file; the later rebase kept all #2238 bytes patch-identical, and the newly merged #2248 had its own verification. The focused and adjacent suites were rerun on the combined final base as listed above.

## Claim chronology and exact-SHA correction

The worktree was assigned before the missing remote reservation step was identified. The regression, focused RED, production hypothesis, and local GREEN/full verification therefore preceded the claim. The local changes were stashed, an implementation-free Lore claim was committed and pushed, draft PR #2250 was opened, the chronology was written to the campaign knowledge base, and only then were the changes restored and committed.

The original claim commit was `5a5db3940d526ff442796103ac08d5aff4007dec`; its patch-identical rebased commit is `6a92079e02a388f41891e88b79ae58fdec521b2c`. The first post-push/post-PR gate commands mistakenly expanded the correct original short prefix to the nonexistent full SHA `5a5db3940d3ae989f285a7c5cb949ab782ea27a2`, so their no-run readbacks were not valid. The corrective gate against the actual original claim SHA completed three polls and found pull-request spell-check run `29664745046` already terminal success, with no active run remaining. The error and correction are recorded in the PR thread and `pr-callable-interface-2238-ci-state.md`.

The original implementation SHA `f935f126aba8646d8a38c0c4896ff20682fda37a` had five cancelled runs and one spell-check run that raced to success. The 104-case test-only amendment `4e690cbf604ec89a8df3a4aea5ff0a65d79744df` had six cancelled runs. After the final base rebase, current SHA `a43ca4a9b6055a9b0b46d878c3dbf94b7215f7ad` passed a fresh exact-SHA gate: runs `29665339054`, `29665339037`, `29665339042`, `29665339038`, `29665339055`, and `29665339089` all completed cancelled, with no active run.

## Exclusions and remaining verification

- No package version bump; the maintainer owns campaign releases.
- No `@typia/interface`, dependency, lockfile, workflow, provider, generated baseline, or documentation change.
- No repository-wide format run; campaign cleanup owns it.
- Full repository `pnpm build` and `pnpm test` were not run. The native tree, relevant functional automated matrix, full schema workspace, and final-base focused/adjacent tests are green as listed above.
