### PR TITLE
fix(json): keep contextual any and unknown serialization valid

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/json_stringify_contextual_undefined_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_stringify_contextual_undefined_transform_test.go
@@ -1,0 +1,556 @@
+package main
+
+import (
+  "fmt"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestJsonStringifyContextualUndefinedTransform pins every json stringify family
+// against ECMAScript JSON.stringify wherever a child serialization evaluates to
+// JavaScript undefined (#2253).
+//
+// A child can serialize to undefined while the value itself is present: `any`
+// and `unknown` delegate to JSON.stringify, which answers undefined for a
+// function, a symbol, and a toJSON that returns undefined; a property typed
+// `undefined` has nothing to serialize; and an array hole reads as undefined at
+// any element type. The object joiner decided omission from a test on the input
+// and the array joiner joined the mapped results, so those children concatenated
+// the token `undefined` into a static property, produced `{"k":undefined}` for a
+// dynamic one, and left an empty array slot - text that fails JSON.parse, which
+// the is/assert/validate families then reported as success.
+//
+//  1. Transform one fixture that exports the direct and factory forms of
+//     stringify, isStringify, assertStringify, and validateStringify for `any`
+//     and `unknown` in static, optional, dynamic, array, tuple, rest, and nested
+//     positions, plus the toJSON, sparse-array, and typed controls beside them.
+//  2. Execute the emitted serializers in Node and compare every success payload
+//     with native JSON.stringify of the same input, parsing both so the
+//     comparison is contextual equivalence rather than the current emit.
+//  3. Require the guarded families to reject each one-axis invalid twin, run the
+//     whole matrix again under `undefined: false`, and report the exact executed
+//     case count so a runner that silently skipped cells cannot pass as green.
+func TestJsonStringifyContextualUndefinedTransform(t *testing.T) {
+  for _, row := range jsonStringifyContextualUndefinedRows() {
+    t.Run(row.name, func(t *testing.T) {
+      project := jsonStringifyContextualUndefinedProject(t)
+      js := jsonStringifyContextualUndefinedTransform(t, project, row.payload())
+      jsonStringifyContextualUndefinedRunRuntime(t, project, js, row)
+    })
+  }
+}
+
+type jsonStringifyContextualUndefinedRow struct {
+  name string
+  // config is the JSON fragment appended to typia's resolved plugin entry.
+  config string
+  // strict marks the row where `undefined: false` makes the checkers reject an
+  // explicitly undefined optional property. The serialized text of everything
+  // the checkers still accept must not move.
+  strict bool
+}
+
+func (row jsonStringifyContextualUndefinedRow) payload() string {
+  return `[{"config":{"transform":"typia/lib/transform"` + row.config + `},"name":"typia","stage":"transform"}]`
+}
+
+func jsonStringifyContextualUndefinedRows() []jsonStringifyContextualUndefinedRow {
+  return []jsonStringifyContextualUndefinedRow{
+    {name: "default options", config: ``, strict: false},
+    {name: "undefined false", config: `,"undefined":false`, strict: true},
+  }
+}
+
+// jsonStringifyContextualUndefinedTypes names every fixture type the runner
+// drives. The Go side owns the list so the exported symbol names and the
+// runner's lookup keys cannot drift apart.
+var jsonStringifyContextualUndefinedTypes = []struct{ Key, TS string }{
+  {"anyProperty", "IAnyProperty"},
+  {"unknownProperty", "IUnknownProperty"},
+  {"undefinedProperty", "IUndefinedProperty"},
+  {"optionalAny", "IOptionalAny"},
+  {"recordAny", "IRecordAny"},
+  {"recordUnknown", "IRecordUnknown"},
+  {"mixedRecord", "IMixedRecord"},
+  {"anyArray", "IAnyArray"},
+  {"unknownArray", "IUnknownArray"},
+  {"numberArray", "INumberArray"},
+  {"tuple", "ITuple"},
+  {"restTuple", "IRestTuple"},
+  {"nested", "INested"},
+  {"jsonableProperty", "IJsonableProperty"},
+  {"maybeJsonableProperty", "IMaybeJsonableProperty"},
+}
+
+func jsonStringifyContextualUndefinedProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "json-stringify-contextual-undefined-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(jsonStringifyContextualUndefinedTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonStringifyContextualUndefinedSource()), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func jsonStringifyContextualUndefinedTransform(t *testing.T, project string, payload string) string {
+  t.Helper()
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+      "--plugins-json", payload,
+    })
+  })
+  if code != 0 {
+    t.Fatalf("json stringify contextual-undefined transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  return out
+}
+
+func jsonStringifyContextualUndefinedRunRuntime(t *testing.T, project string, js string, row jsonStringifyContextualUndefinedRow) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime-"+strings.ReplaceAll(row.name, " ", "-"))
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  stubs := map[string]string{
+    "json-stringify-number-stub.cjs":  jsonStringifyContextualUndefinedNumberStub,
+    "json-stringify-string-stub.cjs":  jsonStringifyContextualUndefinedStringStub,
+    "json-stringify-tail-stub.cjs":    jsonStringifyContextualUndefinedTailStub,
+    "json-stringify-rest-stub.cjs":    jsonStringifyContextualUndefinedRestStub,
+    "throw-type-guard-error-stub.cjs": jsonStringifyContextualUndefinedThrowStub,
+  }
+  for name, content := range stubs {
+    if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  runtimeJS := js
+  for from, to := range map[string]string{
+    `require("typia/lib/internal/_jsonStringifyNumber")`: `require("./json-stringify-number-stub.cjs")`,
+    `require("typia/lib/internal/_jsonStringifyString")`: `require("./json-stringify-string-stub.cjs")`,
+    `require("typia/lib/internal/_jsonStringifyTail")`:   `require("./json-stringify-tail-stub.cjs")`,
+    `require("typia/lib/internal/_jsonStringifyRest")`:   `require("./json-stringify-rest-stub.cjs")`,
+    `require("typia/lib/internal/_throwTypeGuardError")`: `require("./throw-type-guard-error-stub.cjs")`,
+  } {
+    runtimeJS = strings.ReplaceAll(runtimeJS, from, to)
+  }
+  runtimeJS = ttscTypiaTestRewriteCommonJS(t, runtimeJS)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  prelude := fmt.Sprintf("const STRICT_UNDEFINED = %v;\n", row.strict)
+  if err := os.WriteFile(runner, []byte(prelude+jsonStringifyContextualUndefinedRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("json stringify contextual-undefined runtime failed (%s): %v\n%s", row.name, err, output)
+  }
+  // The count is asserted rather than the exit code so a row that silently stops
+  // running cannot pass as a row that ran and agreed with the oracle. 59 value
+  // rows x 6 executions each: direct and factory forms across stringify,
+  // isStringify, assertStringify, and validateStringify, minus the two guarded
+  // entry points for rows whose contract is rejection.
+  const expected = "RAN 354 CASES"
+  if !strings.Contains(string(output), expected) {
+    t.Fatalf("json stringify contextual-undefined runner did not report %q (%s); got:\n%s", expected, row.name, output)
+  }
+}
+
+const jsonStringifyContextualUndefinedTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+const jsonStringifyContextualUndefinedDeclarations = `import typia from "typia";
+
+interface IAnyProperty {
+  keep: number;
+  value: any;
+}
+interface IUnknownProperty {
+  keep: number;
+  value: unknown;
+}
+interface IUndefinedProperty {
+  keep: number;
+  value: undefined;
+}
+interface IOptionalAny {
+  keep: number;
+  value?: any;
+}
+type IRecordAny = Record<string, any>;
+type IRecordUnknown = Record<string, unknown>;
+interface IMixedRecord {
+  keep: number;
+  [key: string]: any;
+}
+type IAnyArray = any[];
+type IUnknownArray = unknown[];
+type INumberArray = number[];
+type ITuple = [any, unknown, number];
+type IRestTuple = [number, ...any[]];
+interface INested {
+  outer: { inner: any }[];
+}
+interface IJsonable {
+  toJSON(): string;
+}
+interface IMaybeJsonable {
+  toJSON(): string | undefined;
+}
+interface IJsonableProperty {
+  keep: number;
+  value: IJsonable;
+}
+interface IMaybeJsonableProperty {
+  keep: number;
+  value: IMaybeJsonable;
+}
+
+`
+
+// jsonStringifyContextualUndefinedSource emits the direct and factory form of
+// all four stringify families for every fixture type, so one transform covers
+// the whole family x form axis of the matrix.
+func jsonStringifyContextualUndefinedSource() string {
+  var builder strings.Builder
+  builder.WriteString(jsonStringifyContextualUndefinedDeclarations)
+  for _, entry := range jsonStringifyContextualUndefinedTypes {
+    for _, family := range []string{"stringify", "isStringify", "assertStringify", "validateStringify"} {
+      creator := "create" + strings.ToUpper(family[:1]) + family[1:]
+      fmt.Fprintf(
+        &builder,
+        "export const factory_%s_%s = typia.json.%s<%s>();\n",
+        family, entry.Key, creator, entry.TS,
+      )
+      fmt.Fprintf(
+        &builder,
+        "export const direct_%s_%s = (input: %s) => typia.json.%s<%s>(input);\n",
+        family, entry.Key, entry.TS, family, entry.TS,
+      )
+    }
+    builder.WriteString("\n")
+  }
+  return builder.String()
+}
+
+const jsonStringifyContextualUndefinedNumberStub = `module.exports._jsonStringifyNumber = (value) => (Number.isFinite(value) ? value : null);
+`
+
+const jsonStringifyContextualUndefinedStringStub = `module.exports._jsonStringifyString = (value) => JSON.stringify(value);
+`
+
+// The tail and rest stubs are transcriptions of
+// packages/typia/src/internal/_jsonStringifyTail.ts and _jsonStringifyRest.ts.
+const jsonStringifyContextualUndefinedTailStub = `module.exports._jsonStringifyTail = (str) =>
+  str[str.length - 1] === "," ? str.substring(0, str.length - 1) : str;
+`
+
+const jsonStringifyContextualUndefinedRestStub = `module.exports._jsonStringifyRest = (str) =>
+  str.length === 2 ? "" : "," + str.substring(1, str.length - 1);
+`
+
+const jsonStringifyContextualUndefinedThrowStub = `module.exports._throwTypeGuardError = (props) => {
+  const error = new Error(props.expected);
+  Object.assign(error, props);
+  throw error;
+};
+`
+
+const jsonStringifyContextualUndefinedRunner = `const mod = require("./main.cjs");
+
+// deepEqual compares two JSON.parse results. Objects are compared by key set and
+// value, never by text, because typia is free to order the properties it emits
+// differently from ECMAScript while still producing an equivalent document.
+const deepEqual = (x, y) => {
+  if (x === y) return true;
+  if (x === null || y === null) return false;
+  if (typeof x !== "object" || typeof y !== "object") return false;
+  if (Array.isArray(x) !== Array.isArray(y)) return false;
+  if (Array.isArray(x)) {
+    if (x.length !== y.length) return false;
+    return x.every((v, i) => deepEqual(v, y[i]));
+  }
+  const xk = Object.keys(x).sort();
+  const yk = Object.keys(y).sort();
+  if (xk.length !== yk.length) return false;
+  if (!xk.every((k, i) => k === yk[i])) return false;
+  return xk.every((k) => deepEqual(x[k], y[k]));
+};
+
+const sparse = (assign) => {
+  const array = [];
+  assign(array);
+  return array;
+};
+
+const CASES = [
+  // Static any property: every value whose serialization is undefined must
+  // vanish exactly the way ECMAScript drops it, and the valid neighbors beside
+  // it must survive.
+  ["anyProperty", "function value", () => ({ keep: 1, value: () => 0 })],
+  ["anyProperty", "symbol value", () => ({ keep: 1, value: Symbol("s") })],
+  ["anyProperty", "undefined value", () => ({ keep: 1, value: undefined })],
+  ["anyProperty", "null value", () => ({ keep: 1, value: null })],
+  ["anyProperty", "number value", () => ({ keep: 1, value: 2 })],
+  ["anyProperty", "nested function member", () => ({
+    keep: 1,
+    value: { a: 1, b: () => 0, c: Symbol("x"), d: undefined },
+  })],
+  ["anyProperty", "nested array member", () => ({
+    keep: 1,
+    value: [() => 0, 1, Symbol("y"), undefined],
+  })],
+  ["anyProperty", "toJSON returning undefined", () => ({
+    keep: 1,
+    value: { toJSON: () => undefined },
+  })],
+  ["anyProperty", "toJSON returning a value", () => ({
+    keep: 1,
+    value: { toJSON: () => 3 },
+  })],
+  ["anyProperty", "invalid keep twin", () => ({ keep: "x", value: 1 }), "reject"],
+
+  // unknown must behave exactly like any.
+  ["unknownProperty", "function value", () => ({ keep: 1, value: () => 0 })],
+  ["unknownProperty", "symbol value", () => ({ keep: 1, value: Symbol("s") })],
+  ["unknownProperty", "undefined value", () => ({ keep: 1, value: undefined })],
+  ["unknownProperty", "number value", () => ({ keep: 1, value: 2 })],
+  ["unknownProperty", "invalid keep twin", () => ({ keep: "x", value: 1 }), "reject"],
+
+  // A required property typed undefined has nothing to serialize at all.
+  ["undefinedProperty", "undefined value", () => ({ keep: 1, value: undefined })],
+
+  // Optional any: absent, explicitly undefined, and present.
+  ["optionalAny", "absent", () => ({ keep: 1 })],
+  ["optionalAny", "explicit undefined", () => ({ keep: 1, value: undefined }), "strictReject"],
+  ["optionalAny", "function value", () => ({ keep: 1, value: () => 0 })],
+  ["optionalAny", "number value", () => ({ keep: 1, value: 2 })],
+
+  // Dynamic (index signature) properties.
+  ["recordAny", "mixed omitted and kept", () => ({
+    keep: 1,
+    omit: () => 0,
+    sym: Symbol("s"),
+    nil: null,
+    undef: undefined,
+  })],
+  ["recordAny", "every entry omitted", () => ({ omit: () => 0, sym: Symbol("s") })],
+  ["recordAny", "empty object", () => ({})],
+  ["recordUnknown", "mixed omitted and kept", () => ({
+    keep: 1,
+    omit: () => 0,
+    sym: Symbol("s"),
+    nil: null,
+  })],
+  ["mixedRecord", "static neighbor with omitted dynamic", () => ({
+    keep: 1,
+    omit: () => 0,
+    sym: Symbol("s"),
+    nil: null,
+  })],
+  ["mixedRecord", "static neighbor only", () => ({ keep: 1 })],
+
+  // Arrays: a serialization of undefined is null in array context, and a hole
+  // reads as undefined at every element type.
+  ["anyArray", "leading function", () => [() => 0, 1]],
+  ["anyArray", "all element kinds", () => [() => 0, 1, Symbol("s"), undefined, null]],
+  ["anyArray", "single function", () => [() => 0]],
+  ["anyArray", "empty", () => []],
+  ["anyArray", "sparse tail", () => sparse((a) => {
+    a[0] = 1;
+    a[3] = 4;
+  })],
+  ["unknownArray", "leading function", () => [() => 0, 1]],
+  ["numberArray", "dense control", () => [1, 2, 3]],
+  ["numberArray", "sparse leading holes", () => sparse((a) => {
+    a[2] = 3;
+  })],
+
+  // Tuples and rest tuples.
+  ["tuple", "function and symbol elements", () => [() => 0, Symbol("s"), 1]],
+  ["tuple", "undefined elements", () => [undefined, undefined, 1]],
+  ["tuple", "valid control", () => [1, 2, 3]],
+  ["tuple", "invalid last element twin", () => [1, 2, "x"], "reject"],
+  ["restTuple", "function inside rest", () => [1, () => 0, 2]],
+  ["restTuple", "empty rest", () => [1]],
+
+  // Nested containers.
+  ["nested", "function inside nested object", () => ({
+    outer: [{ inner: () => 0 }, { inner: 1 }],
+  })],
+
+  // toJSON controls: present, inherited, returning undefined, and non-callable.
+  ["jsonableProperty", "own toJSON", () => ({ keep: 1, value: { toJSON: () => "x" } })],
+  ["jsonableProperty", "inherited toJSON", () => {
+    class Jsonable {
+      toJSON() {
+        return "x";
+      }
+    }
+    return { keep: 1, value: new Jsonable() };
+  }],
+  // A non-callable toJSON twin belongs here by shape but not by cause: the
+  // checker fails to reject it and the serializer then throws
+  // "input.value.toJSON is not a function", so isStringify and validateStringify
+  // throw where their contract is to answer. That is a callability rule, not the
+  // contextual "decide omission from the serialized result" rule this regression
+  // pins, and fixing it here would mix two root causes into one diff. It is
+  // tracked separately and keeps its own twin there.
+  ["maybeJsonableProperty", "toJSON returning undefined", () => ({
+    keep: 1,
+    value: { toJSON: () => undefined },
+  })],
+  ["maybeJsonableProperty", "toJSON returning a value", () => ({
+    keep: 1,
+    value: { toJSON: () => "x" },
+  })],
+];
+
+let ran = 0;
+const failures = [];
+
+const fail = (label, message) => failures.push(label + ": " + message);
+
+const parse = (label, text) => {
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch (error) {
+    fail(label, "produced text that is not JSON: " + JSON.stringify(text));
+    return { ok: false };
+  }
+};
+
+const compare = (label, text, oracle) => {
+  if (typeof text !== "string") {
+    fail(label, "produced " + String(text) + " instead of JSON text");
+    return;
+  }
+  const parsed = parse(label, text);
+  if (parsed.ok !== true) return;
+  if (!deepEqual(parsed.value, oracle.value))
+    fail(
+      label,
+      "produced " + text + " but JSON.stringify produced " + oracle.text,
+    );
+};
+
+const run = (fn, argument) => {
+  try {
+    return { thrown: false, value: fn(argument) };
+  } catch (error) {
+    return { thrown: true, error };
+  }
+};
+
+for (const [key, label, make, kind] of CASES) {
+  const reject = kind === "reject";
+  const strictReject = kind === "strictReject" && STRICT_UNDEFINED === true;
+  const oracleText = JSON.stringify(make());
+  const oracle = { text: oracleText, value: undefined };
+  if (reject !== true) {
+    if (typeof oracleText !== "string")
+      throw new Error(key + " / " + label + ": oracle produced no text");
+    oracle.value = JSON.parse(oracleText);
+  }
+  for (const form of ["factory", "direct"]) {
+    const name = key + " / " + label + " / " + form;
+
+    // json.stringify never validates, so its text must match the oracle for
+    // every statically accepted input, in both option rows.
+    if (reject !== true) {
+      ran += 1;
+      const raw = run(mod[form + "_stringify_" + key], make());
+      if (raw.thrown === true)
+        fail(name + " / stringify", "threw " + String(raw.error && raw.error.message));
+      else compare(name + " / stringify", raw.value, oracle);
+    }
+
+    // json.isStringify: null means rejected.
+    ran += 1;
+    const is = run(mod[form + "_isStringify_" + key], make());
+    if (is.thrown === true)
+      fail(name + " / isStringify", "threw " + String(is.error && is.error.message));
+    else if (reject === true) {
+      if (is.value !== null)
+        fail(name + " / isStringify", "accepted an invalid value: " + String(is.value));
+    } else if (is.value === null) {
+      if (strictReject !== true)
+        fail(name + " / isStringify", "rejected a valid value");
+    } else compare(name + " / isStringify", is.value, oracle);
+
+    // json.assertStringify: a throw means rejected.
+    ran += 1;
+    const asserted = run(mod[form + "_assertStringify_" + key], make());
+    if (reject === true) {
+      if (asserted.thrown !== true)
+        fail(name + " / assertStringify", "accepted an invalid value: " + String(asserted.value));
+    } else if (asserted.thrown === true) {
+      if (strictReject !== true)
+        fail(name + " / assertStringify", "rejected a valid value: " + String(asserted.error && asserted.error.message));
+    } else compare(name + " / assertStringify", asserted.value, oracle);
+
+    // json.validateStringify: success must never carry malformed text.
+    ran += 1;
+    const validated = run(mod[form + "_validateStringify_" + key], make());
+    if (validated.thrown === true)
+      fail(name + " / validateStringify", "threw " + String(validated.error && validated.error.message));
+    else if (reject === true) {
+      if (validated.value.success !== false)
+        fail(name + " / validateStringify", "accepted an invalid value: " + JSON.stringify(validated.value));
+    } else if (validated.value.success === false) {
+      if (strictReject !== true)
+        fail(name + " / validateStringify", "rejected a valid value: " + JSON.stringify(validated.value.errors));
+    } else compare(name + " / validateStringify", validated.value.data, oracle);
+  }
+}
+
+if (failures.length !== 0) {
+  for (const line of failures) console.log(line);
+  throw new Error(failures.length + " contextual serialization failures");
+}
+console.log("RAN " + ran + " CASES");
+`

--- a/packages/typia/native/cmd/ttsc-typia/json_stringify_contextual_undefined_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_stringify_contextual_undefined_transform_test.go
@@ -439,7 +439,7 @@ const CASES = [
   // throw where their contract is to answer. That is a callability rule, not the
   // contextual "decide omission from the serialized result" rule this regression
   // pins, and fixing it here would mix two root causes into one diff. It is
-  // tracked separately and keeps its own twin there.
+  // tracked in samchon/typia#2271 and keeps its own twin there.
   ["maybeJsonableProperty", "toJSON returning undefined", () => ({
     keep: 1,
     value: { toJSON: () => undefined },

--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -68,6 +68,9 @@ func ttscTypiaTestWriteCommonRuntimeStubs(t *testing.T, runtimeDir string) {
     "access-expression-stub.cjs": ttscTypiaTestAccessExpressionStub,
     "string-length-stub.cjs":     ttscTypiaTestStringLengthStub,
     "notation-stub.cjs":          ttscTypiaTestNotationStub,
+    "json-stringify-array-stub.cjs":    ttscTypiaTestJsonStringifyArrayStub,
+    "json-stringify-property-stub.cjs": ttscTypiaTestJsonStringifyPropertyStub,
+    "json-stringify-element-stub.cjs":  ttscTypiaTestJsonStringifyElementStub,
   }
   for name, content := range files {
     if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
@@ -85,6 +88,9 @@ func ttscTypiaTestRewriteCommonJS(t *testing.T, js string) string {
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_functionalTypeGuardErrorFactory")`, `require("./functional-error-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_accessExpressionAsString")`, `require("./access-expression-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_stringLength")`, `require("./string-length-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyArray")`, `require("./json-stringify-array-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyProperty")`, `require("./json-stringify-property-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyElement")`, `require("./json-stringify-element-stub.cjs")`)
   for _, helper := range []string{"_notationAssign", "_notationCamel", "_notationKebab", "_notationKeyCollision", "_notationPascal", "_notationSnake"} {
     runtimeJS = strings.ReplaceAll(
       runtimeJS,
@@ -140,6 +146,32 @@ const ttscTypiaTestAssertGuardStub = `module.exports._assertGuard = (exceptionab
 
 const ttscTypiaTestFunctionalErrorStub = `module.exports._functionalTypeGuardErrorFactory = (props) =>
   Object.assign(new Error(props.expected), props);
+`
+
+// The two JSON stringify stubs mirror packages/typia/src/internal exactly. They
+// are runtime doubles for the emit these tests execute; the shipped helpers
+// themselves are exercised by the TypeScript suites against the real package.
+const ttscTypiaTestJsonStringifyArrayStub = `module.exports._jsonStringifyArray = (elements, mapper) => {
+  const length = Math.min(
+    Math.max(Math.trunc(elements.length) || 0, 0),
+    Number.MAX_SAFE_INTEGER,
+  );
+  let output = "";
+  for (let i = 0; i < length; ++i) {
+    const elem = elements[i];
+    const text = elem === undefined ? undefined : mapper(elem, i);
+    output += (i === 0 ? "" : ",") + (text === undefined ? "null" : text);
+  }
+  return output;
+};
+`
+
+const ttscTypiaTestJsonStringifyPropertyStub = `module.exports._jsonStringifyProperty = (head, text, tail) =>
+  text === undefined ? "" : head + text + tail;
+`
+
+const ttscTypiaTestJsonStringifyElementStub = `module.exports._jsonStringifyElement = (text) =>
+  text === undefined ? "null" : text;
 `
 
 const ttscTypiaTestStringLengthStub = `module.exports._stringLength = (value) => {

--- a/packages/typia/native/core/programmers/helpers/StringifyJoinder.go
+++ b/packages/typia/native/core/programmers/helpers/StringifyJoinder.go
@@ -22,9 +22,10 @@ type StringifyJoiner_ObjectProps struct {
 }
 
 type StringifyJoiner_ArrayProps struct {
-  Input *shimast.Expression
-  Arrow *shimast.Expression
-  Emit  *shimprinter.EmitContext
+  Context nativecontext.ITypiaContext
+  Input   *shimast.Expression
+  Arrow   *shimast.Expression
+  Emit    *shimprinter.EmitContext
 }
 
 type StringifyJoiner_TupleProps struct {
@@ -49,17 +50,22 @@ func (stringifyJoinerNamespace) Object(props StringifyJoiner_ObjectProps) *shima
       dynamic = append(dynamic, entry)
     }
   }
-  expressions := stringifyJoiner_regular_properties(regular, dynamic, props.Context.Emit)
+  expressions := stringifyJoiner_regular_properties(props.Context, regular, dynamic, props.Context.Emit)
   if len(dynamic) != 0 {
     keys := make([]string, 0, len(regular))
     for _, entry := range regular {
       keys = append(keys, *entry.Key.GetSoleLiteral())
     }
-    expressions = append(expressions, stringifyJoiner_dynamic_properties(dynamic, keys, props.Context.Emit))
+    expressions = append(expressions, stringifyJoiner_dynamic_properties(props.Context, dynamic, keys, props.Context.Emit))
   }
 
+  // The tail helper removes the separator left behind when the last written
+  // member drops out at runtime, so it may only be skipped when the last regular
+  // member cannot drop. Required is not the same as cannot-drop: a required
+  // `any` member is omitted whenever its value serializes to `undefined`, which
+  // without this produced a trailing comma before `}` (#2253).
   filtered := expressions
-  if !((len(regular) != 0 && regular[len(regular)-1].Meta.IsRequired() && len(dynamic) == 0) ||
+  if !((len(regular) != 0 && !stringifyJoiner_entry_omittable(regular[len(regular)-1]) && len(dynamic) == 0) ||
     (len(regular) == 0 && len(dynamic) != 0)) {
     filtered = []*shimast.Node{
       f.NewCallExpression(
@@ -79,27 +85,26 @@ func (stringifyJoinerNamespace) Object(props StringifyJoiner_ObjectProps) *shima
   return nativefactories.TemplateFactory.Generate(output, props.Context.Emit)
 }
 
+// Array serializes elements through the `_jsonStringifyArray` helper rather than
+// `input.map(...).join(",")`.
+//
+// `map` never visits a hole and leaves one behind, and `join` renders both a
+// hole and a mapped `undefined` as empty text, so the two cases ECMAScript's
+// SerializeJSONArray answers with `null` were emitted as nothing at all: a
+// sparse array produced the malformed text `[,1]`, and an element serializing to
+// `undefined` — a function, a symbol, or a `toJSON` returning nothing in an
+// `any` or `unknown` slot — silently collapsed its position. A hole exists at
+// runtime whatever the element type declares, so this is not confined to `any`
+// (#2253).
 func (stringifyJoinerNamespace) Array(props StringifyJoiner_ArrayProps) *shimast.Node {
   f := nativecontext.EmitFactoryOf(stringifyJoiner_factory, props.Emit)
   return nativefactories.TemplateFactory.Generate([]*shimast.Node{
     f.NewStringLiteral("[", shimast.TokenFlagsNone),
     f.NewCallExpression(
-      nativefactories.IdentifierFactory.Access(
-        nil,
-        f.NewCallExpression(
-          nativefactories.IdentifierFactory.Access(nil, props.Input, "map"),
-          nil,
-          nil,
-          f.NewNodeList([]*shimast.Node{props.Arrow}),
-          shimast.NodeFlagsNone,
-        ),
-        "join",
-      ),
+      stringifyJoiner_internal(props.Context, "jsonStringifyArray"),
       nil,
       nil,
-      f.NewNodeList([]*shimast.Node{
-        f.NewStringLiteral(",", shimast.TokenFlagsNone),
-      }),
+      f.NewNodeList([]*shimast.Node{props.Input, props.Arrow}),
       shimast.NodeFlagsNone,
     ),
     f.NewStringLiteral("]", shimast.TokenFlagsNone),
@@ -132,7 +137,7 @@ func (stringifyJoinerNamespace) Tuple(props StringifyJoiner_TupleProps) *shimast
   return nativefactories.TemplateFactory.Generate(expressions, props.Emit)
 }
 
-func stringifyJoiner_regular_properties(regular []IExpressionEntry, dynamic []IExpressionEntry, emit ...*shimprinter.EmitContext) []*shimast.Node {
+func stringifyJoiner_regular_properties(context nativecontext.ITypiaContext, regular []IExpressionEntry, dynamic []IExpressionEntry, emit ...*shimprinter.EmitContext) []*shimast.Node {
   f := nativecontext.EmitFactoryOf(stringifyJoiner_factory, emit...)
   output := []*shimast.Node{}
   sort.Slice(regular, func(i int, j int) bool {
@@ -149,19 +154,44 @@ func stringifyJoiner_regular_properties(regular []IExpressionEntry, dynamic []IE
     // re-escape the JSON bytes for the template-literal context: otherwise `\"`
     // decays to `"`, `\\` to `\`, a control-char escape's backslash is dropped, a
     // raw backtick closes the template, and `${` starts a live interpolation.
+    separator := ""
+    if index != len(regular)-1 || len(dynamic) != 0 {
+      separator = ","
+    }
     base := []*shimast.Node{
       f.NewStringLiteral(stringifyJoiner_escape_template(string(encoded))+":", shimast.TokenFlagsNone),
       entry.Expression,
     }
-    if index != len(regular)-1 || len(dynamic) != 0 {
-      base = append(base, f.NewStringLiteral(",", shimast.TokenFlagsNone))
+    if separator != "" {
+      base = append(base, f.NewStringLiteral(separator, shimast.TokenFlagsNone))
     }
     empty := (!entry.Meta.IsRequired() && !entry.Meta.Nullable && entry.Meta.Size() == 0) ||
       (len(entry.Meta.Functions) != 0 && !entry.Meta.Nullable && entry.Meta.Size() == 1)
     if empty {
       continue
     }
-    if !entry.Meta.IsRequired() || len(entry.Meta.Functions) != 0 || entry.Meta.Any {
+    if stringifyJoiner_result_undefinable(entry.Meta) {
+      // An `any` or `unknown` member is serialized by JSON.stringify, which
+      // answers `undefined` for a function, a symbol, and a `toJSON` returning
+      // nothing while the value itself is present. Only the serialized result
+      // distinguishes those from a value that has text, so the member is written
+      // through the helper that reads that result — once, because a `toJSON` may
+      // answer differently on a second call (#2253). The input tests below stay
+      // for members whose serializer must not run on a missing value at all.
+      output = append(output, f.NewCallExpression(
+        stringifyJoiner_internal(context, "jsonStringifyProperty"),
+        nil,
+        nil,
+        f.NewNodeList([]*shimast.Node{
+          f.NewStringLiteral(string(encoded)+":", shimast.TokenFlagsNone),
+          entry.Expression,
+          f.NewStringLiteral(separator, shimast.TokenFlagsNone),
+        }),
+        shimast.NodeFlagsNone,
+      ))
+      continue
+    }
+    if !entry.Meta.IsRequired() || len(entry.Meta.Functions) != 0 {
       output = append(output, nativefactories.ExpressionFactory.Conditional(
         stringifyJoiner_regular_condition(entry, emit...),
         f.NewStringLiteral("", shimast.TokenFlagsNone),
@@ -173,6 +203,39 @@ func stringifyJoiner_regular_properties(regular []IExpressionEntry, dynamic []IE
     }
   }
   return output
+}
+
+// stringifyJoiner_entry_omittable reports whether a member can be absent from
+// the emitted object at runtime, which is exactly the set of members that are
+// written through a conditional or through the property helper.
+func stringifyJoiner_entry_omittable(entry IExpressionEntry) bool {
+  return !entry.Meta.IsRequired() || len(entry.Meta.Functions) != 0 ||
+    stringifyJoiner_result_undefinable(entry.Meta)
+}
+
+// stringifyJoiner_result_undefinable reports whether a value that is present can
+// still serialize to nothing, which is the case an input test cannot see.
+//
+// `any` and `unknown` are serialized by JSON.stringify, which answers
+// `undefined` for a function, a symbol, and a `toJSON` returning nothing. A
+// declared `toJSON` is the same case without `any`: the member's text is its
+// return value, so a return type that admits `undefined` admits a member with no
+// text (#2253).
+// StringifyJoiner_ResultUndefinable exposes the same question to the element
+// positions the joiner does not build itself, so a tuple slot and an object
+// member classify a value identically.
+func StringifyJoiner_ResultUndefinable(meta *nativemetadata.MetadataSchema) bool {
+  return stringifyJoiner_result_undefinable(meta)
+}
+
+func stringifyJoiner_result_undefinable(meta *nativemetadata.MetadataSchema) bool {
+  if meta == nil {
+    return false
+  }
+  if meta.Any {
+    return true
+  }
+  return meta.Escaped != nil && meta.Escaped.Returns != nil && !meta.Escaped.Returns.IsRequired()
 }
 
 func stringifyJoiner_regular_condition(entry IExpressionEntry, emit ...*shimprinter.EmitContext) *shimast.Node {
@@ -199,7 +262,7 @@ func stringifyJoiner_regular_condition(entry IExpressionEntry, emit ...*shimprin
   return stringifyJoiner_reduce(conditions, shimast.KindBarBarToken, emit...)
 }
 
-func stringifyJoiner_dynamic_properties(dynamic []IExpressionEntry, regular []string, emit ...*shimprinter.EmitContext) *shimast.Node {
+func stringifyJoiner_dynamic_properties(context nativecontext.ITypiaContext, dynamic []IExpressionEntry, regular []string, emit ...*shimprinter.EmitContext) *shimast.Node {
   f := nativecontext.EmitFactoryOf(stringifyJoiner_factory, emit...)
   statements := []*shimast.Node{
     f.NewIfStatement(
@@ -298,7 +361,7 @@ func stringifyJoiner_dynamic_properties(dynamic []IExpressionEntry, regular []st
   }
   simple := len(dynamic) == 1 && dynamic[0].Key.Size() == 1 && len(dynamic[0].Key.Atomics) != 0 && dynamic[0].Key.Atomics[0].Type == "string"
   if simple {
-    statements = append(statements, stringifyJoiner_stringify(dynamic[0], emit...))
+    statements = append(statements, stringifyJoiner_stringify(context, dynamic[0], emit...))
     return output()
   }
   for _, entry := range dynamic {
@@ -313,7 +376,7 @@ func stringifyJoiner_dynamic_properties(dynamic []IExpressionEntry, regular []st
         f.NewNodeList([]*shimast.Node{f.NewIdentifier("key")}),
         shimast.NodeFlagsNone,
       ),
-      stringifyJoiner_stringify(entry, emit...),
+      stringifyJoiner_stringify(context, entry, emit...),
       nil,
     ))
   }
@@ -321,20 +384,39 @@ func stringifyJoiner_dynamic_properties(dynamic []IExpressionEntry, regular []st
   return output()
 }
 
-func stringifyJoiner_stringify(entry IExpressionEntry, emit ...*shimprinter.EmitContext) *shimast.Node {
+func stringifyJoiner_stringify(context nativecontext.ITypiaContext, entry IExpressionEntry, emit ...*shimprinter.EmitContext) *shimast.Node {
   f := nativecontext.EmitFactoryOf(stringifyJoiner_factory, emit...)
+  head := nativefactories.TemplateFactory.Generate([]*shimast.Node{
+    f.NewCallExpression(
+      f.NewIdentifier("JSON.stringify"),
+      nil,
+      f.NewNodeList(nil),
+      f.NewNodeList([]*shimast.Node{f.NewIdentifier("key")}),
+      shimast.NodeFlagsNone,
+    ),
+    f.NewStringLiteral(":", shimast.TokenFlagsNone),
+  }, emit...)
+  if entry.Meta.Any {
+    // An index-signature member takes the same contextual decision a static one
+    // takes: `any` and `unknown` values are serialized by JSON.stringify, which
+    // answers `undefined` for a present function, symbol, or empty `toJSON`.
+    // Returning the empty string hands the surrounding filter the same sentinel
+    // it already uses for a missing value, so the member and its separator drop
+    // together instead of rendering the literal `undefined` (#2253).
+    return f.NewReturnStatement(f.NewCallExpression(
+      stringifyJoiner_internal(context, "jsonStringifyProperty"),
+      nil,
+      nil,
+      f.NewNodeList([]*shimast.Node{
+        head,
+        entry.Expression,
+        f.NewStringLiteral("", shimast.TokenFlagsNone),
+      }),
+      shimast.NodeFlagsNone,
+    ))
+  }
   return f.NewReturnStatement(
-    nativefactories.TemplateFactory.Generate([]*shimast.Node{
-      f.NewCallExpression(
-        f.NewIdentifier("JSON.stringify"),
-        nil,
-        f.NewNodeList(nil),
-        f.NewNodeList([]*shimast.Node{f.NewIdentifier("key")}),
-        shimast.NodeFlagsNone,
-      ),
-      f.NewStringLiteral(":", shimast.TokenFlagsNone),
-      entry.Expression,
-    }, emit...),
+    nativefactories.TemplateFactory.Generate([]*shimast.Node{head, entry.Expression}, emit...),
   )
 }
 

--- a/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
@@ -697,9 +697,10 @@ func jsonStringifyProgrammer_decode_array_inline(props jsonStringifyProgrammer_d
       Arrow *shimast.Node
     }) *shimast.Node {
       return nativehelpers.StringifyJoiner.Array(nativehelpers.StringifyJoiner_ArrayProps{
-        Input: next.Input,
-        Arrow: next.Arrow,
-        Emit:  props.Context.Emit,
+        Context: props.Context,
+        Input:   next.Input,
+        Arrow:   next.Arrow,
+        Emit:    props.Context.Emit,
       })
     },
     Array:   props.Array,
@@ -772,7 +773,7 @@ func jsonStringifyProgrammer_decode_tuple_inline(props jsonStringifyProgrammer_d
     } else {
       explore.Postfix = fmt.Sprintf("\"[%d]\"", index)
     }
-    elements = append(elements, jsonStringifyProgrammer_decode(struct {
+    code := jsonStringifyProgrammer_decode(struct {
       Context   nativecontext.ITypiaContext
       Config    nativeinternal.FeatureProgrammer_IConfig
       Functor   *nativehelpers.FunctionProgrammer
@@ -788,7 +789,20 @@ func jsonStringifyProgrammer_decode_tuple_inline(props jsonStringifyProgrammer_d
       Metadata:  elem,
       Explore:   explore,
       Validated: props.Validated,
-    }))
+    })
+    if nativehelpers.StringifyJoiner_ResultUndefinable(elem) {
+      // A tuple slot holds its position, so an element that serializes to
+      // nothing is `null` rather than omitted; without this its text was the
+      // literal `undefined` (#2253).
+      code = f.NewCallExpression(
+        jsonStringifyProgrammer_internal(props.Context, "jsonStringifyElement"),
+        nil,
+        nil,
+        f.NewNodeList([]*shimast.Node{code}),
+        shimast.NodeFlagsNone,
+      )
+    }
+    elements = append(elements, code)
   }
   var rest *shimast.Node
   if len(props.Tuple.Elements) != 0 {

--- a/packages/typia/src/internal/_jsonStringifyArray.ts
+++ b/packages/typia/src/internal/_jsonStringifyArray.ts
@@ -1,0 +1,50 @@
+/**
+ * Serializes the elements of an array the way ECMAScript `JSON.stringify` does.
+ *
+ * `SerializeJSONArray` walks index `0` to `LengthOfArrayLike(value) - 1` and
+ * writes `null` wherever the element serializes to `undefined`. Neither
+ * `Array.prototype.map` nor `Array.prototype.join` reproduces that:
+ *
+ * - `map` never visits a hole and leaves one behind, and `join` renders a hole
+ *   as empty text, so a sparse array joined into malformed text such as
+ *   `[,1]`. A hole exists at runtime whatever the element type declares, so
+ *   this is not an `any` concern.
+ * - `join` renders a mapped `undefined` as empty text too, which is what an
+ *   `any` or `unknown` element holding a function, a symbol, or a `toJSON`
+ *   that returns nothing serializes to.
+ *
+ * The length is converted with `ToLength` and read once, which is both what
+ * `JSON.stringify` does and what `Array.prototype.every` - the traversal
+ * typia's own array checkers emit - does, so the checker and the serializer
+ * walk one index range rather than two that merely usually coincide.
+ *
+ * @param elements Array being serialized.
+ * @param mapper Serializer of one element, emitted by the transform.
+ * @returns Comma separated element text, without the enclosing brackets.
+ * @internal
+ */
+export const _jsonStringifyArray = <T>(
+  elements: ArrayLike<T>,
+  mapper: (elem: T, index: number) => string,
+): string => {
+  const length: number = Math.min(
+    Math.max(Math.trunc(elements.length) || 0, 0),
+    Number.MAX_SAFE_INTEGER,
+  );
+  let output: string = "";
+  for (let i: number = 0; i < length; ++i) {
+    const elem: T | undefined = elements[i];
+    // A hole and an explicit `undefined` are answered without calling the
+    // mapper, because the mapper is the element type's own serializer and a
+    // typed one has no answer for a missing value. Everything else is answered
+    // from the mapper's *result*: an element that is present but serializes to
+    // nothing — a function, a symbol, or a `toJSON` returning nothing in an
+    // `any` slot — is `null` in an array position, exactly as
+    // SerializeJSONArray specifies, and testing the input instead would let its
+    // text become the literal `undefined`.
+    const text: string | undefined =
+      elem === undefined ? undefined : mapper(elem, i);
+    output += (i === 0 ? "" : ",") + (text === undefined ? "null" : text);
+  }
+  return output;
+};

--- a/packages/typia/src/internal/_jsonStringifyElement.ts
+++ b/packages/typia/src/internal/_jsonStringifyElement.ts
@@ -1,0 +1,19 @@
+/**
+ * Writes one array or tuple element the way ECMAScript `JSON.stringify` writes
+ * it.
+ *
+ * `SerializeJSONArray` writes `null` wherever an element serializes to
+ * `undefined`, because an array position cannot be omitted without shifting
+ * every element after it. A present value with no serialization — a function, a
+ * symbol, or a `toJSON` returning nothing — is therefore `null`, not the literal
+ * text `undefined` and not an empty slot.
+ *
+ * This is the fixed-position counterpart of `_jsonStringifyArray`, which answers
+ * the same question while walking an array's own index range.
+ *
+ * @param text Serialized element value, or `undefined` when it has none.
+ * @returns Element text, or `null` when the element has no serialization.
+ * @internal
+ */
+export const _jsonStringifyElement = (text: string | undefined): string =>
+  text === undefined ? "null" : text;

--- a/packages/typia/src/internal/_jsonStringifyProperty.ts
+++ b/packages/typia/src/internal/_jsonStringifyProperty.ts
@@ -1,0 +1,29 @@
+/**
+ * Writes one object member the way ECMAScript `JSON.stringify` writes it.
+ *
+ * `SerializeJSONObject` serializes each member first and drops the member
+ * entirely when that result is `undefined`. Deciding omission from the *input*
+ * instead cannot reach the same answer: a symbol and a `toJSON` returning
+ * nothing are both present, non-`undefined`, non-function values whose
+ * serialization is `undefined`, so the member's text became the literal
+ * `"k":undefined` — output that is not JSON at all.
+ *
+ * The serialized text is passed in already evaluated, so the member's value is
+ * serialized exactly once. Testing the input and then serializing would evaluate
+ * a `toJSON` twice, and a `toJSON` is free to answer differently each call.
+ *
+ * The trailing separator belongs to the member because a dropped member must
+ * take its comma with it; `_jsonStringifyTail` removes the one that is left
+ * behind when the last written member is the one that dropped.
+ *
+ * @param head Quoted key and colon, emitted by the transform.
+ * @param text Serialized member value, or `undefined` when it has none.
+ * @param tail Separator following this member, empty for the last one.
+ * @returns Member text, or an empty string when the member is omitted.
+ * @internal
+ */
+export const _jsonStringifyProperty = (
+  head: string,
+  text: string | undefined,
+  tail: string,
+): string => (text === undefined ? "" : head + text + tail);

--- a/tests/test-typia-schema/src/features/json.stringify/test_json_stringify_contextual_undefined.ts
+++ b/tests/test-typia-schema/src/features/json.stringify/test_json_stringify_contextual_undefined.ts
@@ -1,0 +1,199 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { IValidation } from "typia";
+
+interface IAnyProperty {
+  keep: number;
+  value: any;
+}
+interface IUnknownProperty {
+  keep: number;
+  value: unknown;
+}
+interface IUndefinedProperty {
+  keep: number;
+  value: undefined;
+}
+interface IMaybeJsonable {
+  toJSON(): string | undefined;
+}
+interface IMaybeJsonableProperty {
+  keep: number;
+  value: IMaybeJsonable;
+}
+interface INested {
+  outer: { inner: any }[];
+}
+
+/**
+ * Verifies typia.json stringify output stays JSON wherever a child serializes
+ * to undefined.
+ *
+ * `any` and `unknown` delegate to JSON.stringify, which answers JavaScript
+ * `undefined` for a function, a symbol, and a toJSON that returns nothing; a
+ * property typed `undefined` has nothing to serialize; and an array hole reads
+ * as undefined at every element type. Those children used to be concatenated
+ * verbatim, so the emitted text carried the token `undefined` or an empty array
+ * slot and failed JSON.parse, while isStringify / assertStringify /
+ * validateStringify reported that text as success.
+ *
+ * 1. Serialize each contextual value with the raw, is, assert, and validate
+ *    families.
+ * 2. Take the expected document from native `JSON.stringify` of the same input,
+ *    never from typia's own emit.
+ * 3. Assert every success payload parses and equals the oracle document.
+ */
+export const test_json_stringify_contextual_undefined = (): void => {
+  // Compare a typia payload with what ECMAScript JSON.stringify writes for the
+  // same input. Both sides are parsed, because typia may order the properties
+  // it emits differently while still producing an equivalent document.
+  const oracle = (label: string, actual: string, input: unknown): void => {
+    const expected: string = JSON.stringify(input) as string;
+    TestValidator.equals(label, JSON.parse(actual), JSON.parse(expected));
+  };
+
+  // Every family must agree with the oracle on one input.
+  const families = <T>(
+    label: string,
+    input: T,
+    raw: (input: T) => string,
+    guarded: (input: T) => string | null,
+    asserted: (input: T) => string,
+    validated: (input: T) => IValidation<string>,
+  ): void => {
+    oracle(`${label} / stringify`, raw(input), input);
+
+    const isText: string | null = guarded(input);
+    TestValidator.equals(`${label} / isStringify accepts`, isText !== null, true);
+    if (isText !== null) oracle(`${label} / isStringify`, isText, input);
+
+    oracle(`${label} / assertStringify`, asserted(input), input);
+
+    const result: IValidation<string> = validated(input);
+    TestValidator.equals(
+      `${label} / validateStringify accepts`,
+      result.success,
+      true,
+    );
+    if (result.success === true)
+      oracle(`${label} / validateStringify`, result.data, input);
+  };
+
+  const anyProperty = (label: string, value: any): void =>
+    families<IAnyProperty>(
+      `any property ${label}`,
+      { keep: 1, value },
+      (input) => typia.json.stringify<IAnyProperty>(input),
+      (input) => typia.json.isStringify<IAnyProperty>(input),
+      (input) => typia.json.assertStringify<IAnyProperty>(input),
+      (input) => typia.json.validateStringify<IAnyProperty>(input),
+    );
+
+  // Static `any` property: a function, a symbol, and a toJSON that returns
+  // nothing all serialize to undefined and must vanish with their comma.
+  anyProperty("function", () => 0);
+  anyProperty("symbol", Symbol("s"));
+  anyProperty("undefined", undefined);
+  anyProperty("toJSON returning undefined", { toJSON: () => undefined });
+  anyProperty("null", null);
+  anyProperty("number", 2);
+  anyProperty("nested members", { a: 1, b: () => 0, c: Symbol("x") });
+
+  // `unknown` must behave exactly like `any`.
+  families<IUnknownProperty>(
+    "unknown property function",
+    { keep: 1, value: () => 0 },
+    (input) => typia.json.stringify<IUnknownProperty>(input),
+    (input) => typia.json.isStringify<IUnknownProperty>(input),
+    (input) => typia.json.assertStringify<IUnknownProperty>(input),
+    (input) => typia.json.validateStringify<IUnknownProperty>(input),
+  );
+
+  // A required property typed `undefined` has nothing to serialize.
+  families<IUndefinedProperty>(
+    "undefined property",
+    { keep: 1, value: undefined },
+    (input) => typia.json.stringify<IUndefinedProperty>(input),
+    (input) => typia.json.isStringify<IUndefinedProperty>(input),
+    (input) => typia.json.assertStringify<IUndefinedProperty>(input),
+    (input) => typia.json.validateStringify<IUndefinedProperty>(input),
+  );
+
+  // A toJSON whose declared return admits undefined resolves to nothing.
+  families<IMaybeJsonableProperty>(
+    "maybe jsonable property",
+    { keep: 1, value: { toJSON: () => undefined } },
+    (input) => typia.json.stringify<IMaybeJsonableProperty>(input),
+    (input) => typia.json.isStringify<IMaybeJsonableProperty>(input),
+    (input) => typia.json.assertStringify<IMaybeJsonableProperty>(input),
+    (input) => typia.json.validateStringify<IMaybeJsonableProperty>(input),
+  );
+
+  // Dynamic (index signature) properties take the same contextual decision.
+  families<Record<string, any>>(
+    "record any",
+    { keep: 1, omit: () => 0, sym: Symbol("s"), nil: null, undef: undefined },
+    (input) => typia.json.stringify<Record<string, any>>(input),
+    (input) => typia.json.isStringify<Record<string, any>>(input),
+    (input) => typia.json.assertStringify<Record<string, any>>(input),
+    (input) => typia.json.validateStringify<Record<string, any>>(input),
+  );
+
+  // Array slots become `null`, never an empty slot.
+  families<any[]>(
+    "any array",
+    [() => 0, 1, Symbol("s"), undefined, null],
+    (input) => typia.json.stringify<any[]>(input),
+    (input) => typia.json.isStringify<any[]>(input),
+    (input) => typia.json.assertStringify<any[]>(input),
+    (input) => typia.json.validateStringify<any[]>(input),
+  );
+
+  // A hole reads as undefined whatever the element type declares, so a sparse
+  // typed array is the same contextual case as a function in an `any` slot.
+  const sparse: number[] = [];
+  sparse[2] = 3;
+  families<number[]>(
+    "sparse number array",
+    sparse,
+    (input) => typia.json.stringify<number[]>(input),
+    (input) => typia.json.isStringify<number[]>(input),
+    (input) => typia.json.assertStringify<number[]>(input),
+    (input) => typia.json.validateStringify<number[]>(input),
+  );
+
+  // Tuple and rest positions are array context too.
+  families<[any, unknown, number]>(
+    "tuple",
+    [() => 0, Symbol("s"), 1],
+    (input) => typia.json.stringify<[any, unknown, number]>(input),
+    (input) => typia.json.isStringify<[any, unknown, number]>(input),
+    (input) => typia.json.assertStringify<[any, unknown, number]>(input),
+    (input) => typia.json.validateStringify<[any, unknown, number]>(input),
+  );
+  families<[number, ...any[]]>(
+    "rest tuple",
+    [1, () => 0, 2],
+    (input) => typia.json.stringify<[number, ...any[]]>(input),
+    (input) => typia.json.isStringify<[number, ...any[]]>(input),
+    (input) => typia.json.assertStringify<[number, ...any[]]>(input),
+    (input) => typia.json.validateStringify<[number, ...any[]]>(input),
+  );
+
+  // Nested containers inherit the same decision at every depth.
+  families<INested>(
+    "nested",
+    { outer: [{ inner: () => 0 }, { inner: 1 }] },
+    (input) => typia.json.stringify<INested>(input),
+    (input) => typia.json.isStringify<INested>(input),
+    (input) => typia.json.assertStringify<INested>(input),
+    (input) => typia.json.validateStringify<INested>(input),
+  );
+
+  // Negative twin: a value the checkers must still reject, so the contextual
+  // relaxation above cannot be mistaken for "accept everything".
+  TestValidator.equals(
+    "invalid neighbor rejected",
+    typia.json.isStringify<IAnyProperty>({ keep: "x", value: 1 } as never),
+    null,
+  );
+};


### PR DESCRIPTION
Closes #2253.

This draft reserves the independently reproduced JSON contextual-serialization defect before implementation. The product invariant is that every child value accepted through `any` or `unknown` follows ECMAScript JSON context: object children that serialize to JavaScript `undefined` are omitted, while array and tuple children become `null`; successful text must parse as JSON.

Implementation has not started. The batch will add real-transform regressions across direct/factory and raw/is/assert/validate families, enumerate every shared joinder consumer, inspect emitted JavaScript, and mutation-prove the permanent oracle before the prospective and exact-merge integration gates.

Campaign constraints: no package version, tag, release, publication, or unrelated schema-interface change.
