### PR TITLE
fix(generate): track canonical directory identities

### DIFF
--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -875,8 +875,11 @@ export namespace TypiaGenerateWizard {
     });
 
     const currentStat: fs.Stats = await fs.promises.stat(props.from);
-    const directoryIdentity: string = fileIdentityKey(currentStat, currentReal);
-    if (props.visitedDirectories.has(directoryIdentity)) {
+    const directoryIdentities: readonly string[] = directoryIdentityKeys(
+      currentStat,
+      currentReal,
+    );
+    if (directoryIdentities.some((key) => props.visitedDirectories.has(key))) {
       const lexicalStat: fs.Stats = await fs.promises.lstat(props.from);
       if (lexicalStat.isSymbolicLink()) {
         throw new URIError(
@@ -885,7 +888,7 @@ export namespace TypiaGenerateWizard {
       }
       return;
     }
-    props.visitedDirectories.add(directoryIdentity);
+    for (const key of directoryIdentities) props.visitedDirectories.add(key);
 
     props.policy.observe(
       await FileSystemIdentity.inspectDirectory(props.from),
@@ -907,7 +910,9 @@ export namespace TypiaGenerateWizard {
     entries.sort((x, y) => {
       const linkOrder: number =
         Number(x.stat.isSymbolicLink()) - Number(y.stat.isSymbolicLink());
-      return linkOrder !== 0 ? linkOrder : x.name.localeCompare(y.name);
+      return linkOrder !== 0
+        ? linkOrder
+        : Buffer.compare(Buffer.from(x.name), Buffer.from(y.name));
     });
 
     for (const entry of entries) {
@@ -1090,6 +1095,16 @@ export namespace TypiaGenerateWizard {
     return stat.ino === 0
       ? `path:${path.normalize(realpath)}`
       : `inode:${stat.dev}:${stat.ino}`;
+  }
+
+  function directoryIdentityKeys(
+    stat: fs.Stats,
+    realpath: string,
+  ): readonly string[] {
+    const canonical: string = `path:${path.normalize(realpath)}`;
+    return stat.ino === 0
+      ? [canonical]
+      : [`inode:${stat.dev}:${stat.ino}`, canonical];
   }
 
   function formatDiagnostics(diagnostics: ITtscCompilerDiagnostic[]): string {

--- a/tests/test-typia-generate/scripts/filesystem/repeated-directory-aliases.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/repeated-directory-aliases.test.cjs
@@ -10,8 +10,8 @@ const {
 /**
  * Verifies repeated directory aliases are rejected before transformation.
  *
- * Locks deterministic directory de-duplication so alias order cannot multiply
- * transformed output or choose different target trees between runs.
+ * Locks byte-lexical directory de-duplication so locale cannot choose a
+ * different alias or target tree between runs.
  *
  * 1. Add one real source directory and two links to that directory.
  * 2. Generate and assert aliases are rejected before output is created.
@@ -22,7 +22,7 @@ test("repeated directory aliases are rejected", () => {
     const actual = path.join(fixture.input, "actual");
     writeSource(path.join(actual, "source.ts"));
     linkDirectory(actual, path.join(fixture.input, "alias-a"));
-    linkDirectory(actual, path.join(fixture.input, "alias-b"));
+    linkDirectory(actual, path.join(fixture.input, "alias_a"));
     expectFailureWithoutOutput(
       fixture,
       /alias-a.*revisits|revisits.*alias-a/is,


### PR DESCRIPTION
Fixes #2082

Follow-up to the merged #2093 implementation. On Windows, a junction can expose the same physical directory with a different `stat.dev`, so the former inode-only traversal key accepted a parent junction cycle and emitted output. This candidate records both the inode identity and canonical realpath, and uses UTF-8 byte ordering for deterministic alias diagnostics.

Verification completed locally before this claim:

- Filesystem suite: 9 passed; source-file symlink case skipped only because Windows Developer Mode is unavailable.
- Parent/self/mutual junctions, external links, physical output aliases, and ordinary nested directories covered.
- Removing canonical identity makes the parent-cycle regression fail; restoring locale comparison makes the byte-order alias regression fail.

Campaign gate: this draft is not merge-ready until its current-base prospective gate and the exact merged-SHA gate both pass under the frozen manifest. Actions for this exact branch SHA are cancelled and recorded under the campaign policy.