### PR TITLE
docs(skills): require campaign asset cleanup

### DIFF
--- a/.agents/skills/benchmark/SKILL.md
+++ b/.agents/skills/benchmark/SKILL.md
@@ -33,3 +33,14 @@ Benchmark READMEs and prose follow AGENTS.md `## Maintenance` and the documentat
 Every result table reported in chat or committed to the result archive must be preserved for the active pull request. When the user has authorized PR updates under the pull-request skill, maintain one sticky comment beginning with `<!-- typia-benchmark-results -->`; update it with the latest table, report paths, and known invalid or missing categories.
 
 If no pull request exists or no update is authorized, keep the result in the final report and mark the comment as pending. Post it only after the user creates or authorizes updating the pull request.
+
+## Campaign Cleanup
+
+When a benchmark campaign uses a disposable worktree or an isolated measurement root, finish cleanup before marking that assignment complete. Preserve the committed result archive and compact command evidence, but remove every disposable worktree and its assigned mutable roots: `GOCACHE`, `GOTMPDIR`, `TTSC_CACHE_DIR`, generated-program scratch tree, dependency install tree, and temporary consumer or report staging tree. Go temporary assets are never reusable campaign evidence.
+
+1. Record the measured commit, command, result paths and hashes, environment, and any retained published result archive.
+2. Confirm the worktree and mutable roots contain no unreported source or result artifact.
+3. Remove the mutable roots and, for an assigned disposable worktree, run `git worktree remove --force <path>` for its exact path.
+4. Verify every removed root and, when applicable, worktree path no longer exists, run `git worktree prune`, delete the associated disposable local topic branch when one was created, and confirm no worktree registration remains.
+
+If a measurement is abandoned or invalid, retain only the diagnostic record needed to explain it; remove its worktree and Go temporary assets by the same procedure.

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -103,14 +103,15 @@ After a pull request merges:
 
 1. Verify GitHub records it as merged into the intended target. This works for merge, squash, and rebase strategies.
 2. Confirm the worktree has no unpushed or uncommitted work worth preserving.
-3. Run `git worktree remove --force <path>` so ignored build artifacts are deleted too.
-4. Verify the directory no longer exists.
-5. Run `git worktree prune` and delete the local topic branch.
-6. Confirm `git worktree list --porcelain` contains no record of the removed path.
+3. Preserve compact command evidence and result hashes in the campaign knowledge base, then remove every disposable mutable root assigned to that worktree: `GOCACHE`, `GOTMPDIR`, `TTSC_CACHE_DIR`, generated-output root, tarballs, and clean-consumer install root. Never retain a Go temporary cache after its assignment ends; logs and recorded hashes are evidence, not a reason to retain compiled cache contents.
+4. Run `git worktree remove --force <path>` so ignored build artifacts are deleted too.
+5. Verify the worktree directory and every assigned Go temporary root no longer exist.
+6. Run `git worktree prune` and delete the local topic branch.
+7. Confirm `git worktree list --porcelain` contains no record of the removed path.
 
-If an assignment ends without a merge, first record retained evidence and confirm the remaining contents are disposable. Then remove its worktree and local branch by the same standard.
+If an assignment ends without a merge, first record retained evidence and confirm the remaining contents are disposable. Then remove its worktree, assigned Go temporary roots, and local branch by the same standard.
 
-Apply this rule to every campaign-created worktree, including one used for Post-Campaign Cleanup. Do not mark an assignment complete while its worktree remains on disk.
+Apply this rule to every campaign-created worktree, including one used for Post-Campaign Cleanup and every verifier or mutation worktree. Do not mark an assignment complete while its worktree or assigned Go temporary assets remain on disk.
 
 ## While Campaign CI Is Cancelled
 


### PR DESCRIPTION
## Intent

Require every issue and benchmark campaign assignment to remove its disposable worktree and assigned mutable assets, including Go temporary caches, before completion.

## Scope

- Record and remove every assigned campaign mutable root before removing a finished issue-campaign worktree.
- Apply the same completion rule to verifier and mutation worktrees.
- Define benchmark-campaign cleanup for disposable worktrees, mutable roots, Go temporary assets, and any associated disposable local branch.

## Deferred

This documentation-only pull request does not make #2262 ready, alter its prospective gate, or merge any campaign pull request.

## Local verification

- Re-read the complete `.agents/skills/issue-campaign/development.md` and `.agents/skills/benchmark/SKILL.md` contexts after editing.
- `git diff --check`
- `git show --check --stat 22c6c8ca67ffd67e496938c64af2ec1de3c6b907`

Campaign Actions are deliberately cancelled; the exact-SHA cancellation records are maintained in the campaign knowledge base.
