### PR TITLE
fix: resolve three campaign residual defects

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/compare_functional_union_membership_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/compare_functional_union_membership_transform_test.go
@@ -1,0 +1,434 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCompareFunctionalUnionMembershipTransform verifies that compare.equals
+// selects an object-union member with the same functional-property semantics as
+// typia.is and the plain member routers (samchon/typia#2252).
+//
+// Object comparison deliberately ignores function-valued properties after it
+// has selected a member. That must not make those properties invisible while
+// selecting a member when the active `functional: true` option makes them part
+// of membership. Otherwise a string-valued later member enters an earlier
+// function-bearing member, and equality or cover can ignore the later member's
+// distinguishing data. The default mode remains intentionally lenient for a
+// sole function-valued property.
+//
+//  1. Transform functional and default-option variants of direct/factory is,
+//     equals, cover, clone, prune, and nested equality calls over both union
+//     orders.
+//  2. Execute distinct valid, invalid, same-reference, reversed-order, nested,
+//     and actual-function-member controls against the emitted JavaScript. The
+//     order-symmetric pair makes the function member the later declaration and
+//     changes only its later-member label, so member routing rather than
+//     function identity decides the result.
+//  3. Require compare.less to retain its existing multi-object-union diagnostic.
+func TestCompareFunctionalUnionMembershipTransform(t *testing.T) {
+	project := compareFunctionalUnionMembershipProject(t)
+	functional := compareFunctionalUnionMembershipTransform(t, project, true)
+	defaultMode := compareFunctionalUnionMembershipTransform(t, project, false)
+	compareFunctionalUnionMembershipRunRuntimeCases(t, project, functional, defaultMode)
+	if strings.Contains(functional, `typeof v.handler === "function"`) == false {
+		t.Fatalf("functional equality emit did not retain the function membership guard:\n%s", functional)
+	}
+	compareFunctionalUnionMembershipRejectsLess(t, project)
+}
+
+func compareFunctionalUnionMembershipProject(t *testing.T) string {
+	t.Helper()
+	base := os.Getenv("TYPIA_TEST_TMPDIR")
+	if base == "" {
+		root := ttscTypiaTestRepoRoot(t)
+		base = filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+	}
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatalf("mkdir temp base: %v", err)
+	}
+	dir, err := os.MkdirTemp(base, "compare-functional-union-")
+	if err != nil {
+		t.Fatalf("create temp fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir fixture src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.main.json"), []byte(compareFunctionalUnionMembershipTSConfig("src/main.ts")), 0o644); err != nil {
+		t.Fatalf("write main tsconfig: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.less.json"), []byte(compareFunctionalUnionMembershipTSConfig("src/less.ts")), 0o644); err != nil {
+		t.Fatalf("write less tsconfig: %v", err)
+	}
+	compareFunctionalUnionMembershipWriteTypiaFixture(t, dir)
+	if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(compareFunctionalUnionMembershipSource), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "less.ts"), []byte(compareFunctionalUnionMembershipLessSource), 0o644); err != nil {
+		t.Fatalf("write less source: %v", err)
+	}
+	return dir
+}
+
+func compareFunctionalUnionMembershipWriteTypiaFixture(t *testing.T, project string) {
+	t.Helper()
+	root := filepath.Join(project, "node_modules", "typia")
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir typia fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "lib"), 0o755); err != nil {
+		t.Fatalf("mkdir typia fixture lib: %v", err)
+	}
+	files := map[string]string{
+		"package.json": `{
+  "name": "typia",
+  "version": "0.0.0-test",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./lib/transform": "./lib/transform.js"
+  },
+  "ttsc": {
+    "plugin": { "transform": "typia/lib/transform" }
+  }
+}
+`,
+		"src/index.ts":     compareFunctionalUnionMembershipTypiaIndex,
+		"src/module.ts":    compareFunctionalUnionMembershipTypiaModule,
+		"src/compare.ts":   compareFunctionalUnionMembershipTypiaCompare,
+		"src/plain.ts":     compareFunctionalUnionMembershipTypiaPlain,
+		"lib/transform.js": "module.exports = {};\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write typia fixture %s: %v", name, err)
+		}
+	}
+}
+
+func compareFunctionalUnionMembershipTransform(t *testing.T, project string, functional bool) string {
+	t.Helper()
+	payload := `[{"config":{"transform":"typia/lib/transform"},"name":"typia","stage":"transform"}]`
+	if functional {
+		payload = `[{"config":{"transform":"typia/lib/transform","functional":true},"name":"typia","stage":"transform"}]`
+	}
+	out, errText, code := ttscTypiaTestCapture(func() int {
+		return runTransform([]string{
+			"--cwd", project,
+			"--tsconfig", "tsconfig.main.json",
+			"--file", "src/main.ts",
+			"--output", "js",
+			"--plugins-json=" + payload,
+		})
+	})
+	if code != 0 {
+		t.Fatalf("functional=%t transform failed: code=%d stderr=\n%s", functional, code, errText)
+	}
+	return out
+}
+
+func compareFunctionalUnionMembershipRunRuntimeCases(t *testing.T, project string, functional string, defaultMode string) {
+	t.Helper()
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node executable not found")
+	}
+	runtimeDir := filepath.Join(project, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("mkdir runtime dir: %v", err)
+	}
+	ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+	if err := os.WriteFile(filepath.Join(runtimeDir, "throw-type-guard-error-stub.cjs"), []byte(compareFunctionalUnionMembershipThrowStub), 0o644); err != nil {
+		t.Fatalf("write throw type guard error stub: %v", err)
+	}
+	for _, output := range []struct {
+		name string
+		js   string
+	}{
+		{name: "functional.cjs", js: functional},
+		{name: "default.cjs", js: defaultMode},
+	} {
+		js := strings.ReplaceAll(output.js, `require("typia/lib/internal/_throwTypeGuardError")`, `require("./throw-type-guard-error-stub.cjs")`)
+		js = ttscTypiaTestRewriteCommonJS(t, js)
+		if err := os.WriteFile(filepath.Join(runtimeDir, output.name), []byte(js), 0o644); err != nil {
+			t.Fatalf("write %s: %v", output.name, err)
+		}
+	}
+	runner := filepath.Join(runtimeDir, "run.cjs")
+	if err := os.WriteFile(runner, []byte(compareFunctionalUnionMembershipRuntimeRunner), 0o644); err != nil {
+		t.Fatalf("write runtime runner: %v", err)
+	}
+	cmd := exec.Command(node, runner)
+	cmd.Dir = runtimeDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("functional union membership runtime cases failed: %v\n%s", err, output)
+	}
+	if strings.Contains(string(output), "RAN 52 CASES") == false {
+		t.Fatalf("functional union membership runner skipped cases:\n%s", output)
+	}
+}
+
+func compareFunctionalUnionMembershipRejectsLess(t *testing.T, project string) {
+	t.Helper()
+	payload := `[{"config":{"transform":"typia/lib/transform","functional":true},"name":"typia","stage":"transform"}]`
+	_, errText, code := ttscTypiaTestCapture(func() int {
+		return runTransform([]string{
+			"--cwd", project,
+			"--tsconfig", "tsconfig.less.json",
+			"--file", "src/less.ts",
+			"--output", "js",
+			"--plugins-json=" + payload,
+		})
+	})
+	if code == 0 || strings.Contains(errText, "unable to order a union of multiple object types") == false {
+		t.Fatalf("compare.less did not retain its object-union diagnostic: code=%d stderr=\n%s", code, errText)
+	}
+}
+
+func compareFunctionalUnionMembershipTSConfig(entry string) string {
+	return `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["` + entry + `"]
+}
+`
+}
+
+const compareFunctionalUnionMembershipTypiaIndex = `import * as typia from "./module";
+
+export default typia;
+export * from "./module";
+`
+
+const compareFunctionalUnionMembershipTypiaModule = `export * as compare from "./compare";
+export * as plain from "./plain";
+
+export declare function is<T>(input: unknown): input is T;
+export declare function createIs<T>(): (input: unknown) => input is T;
+`
+
+const compareFunctionalUnionMembershipTypiaCompare = `export type Cover<T> = T extends object
+  ? { [K in keyof T]?: Cover<T[K]> }
+  : T;
+
+export declare function equals<T>(x: T, y: T): boolean;
+export declare function cover<T>(x: T, y: Cover<T>): boolean;
+export declare function less<T>(x: T, y: T): boolean;
+export declare function createEquals<T>(): (x: T, y: T) => boolean;
+export declare function createCover<T>(): (x: T, y: Cover<T>) => boolean;
+`
+
+const compareFunctionalUnionMembershipTypiaPlain = `export declare function clone<T>(input: T): T;
+export declare function createClone<T>(): (input: T) => T;
+export declare function createPrune<T extends object>(): (input: T) => void;
+`
+
+const compareFunctionalUnionMembershipThrowStub = `module.exports._throwTypeGuardError = (props) => {
+  const error = new Error("guard: " + props.expected);
+  error.name = "TypeGuardError";
+  throw error;
+};
+`
+
+const compareFunctionalUnionMembershipSource = `import typia from "typia";
+
+type FunctionUnion =
+  | { handler: (value: number) => string; common: string }
+  | { handler: string; common: string; label: string };
+type StringFirstUnion =
+  | { handler: string; common: string; label: string }
+  | { handler: (value: number) => string; common: string };
+type FunctionSecondUnion =
+  | { handler: string; common: string }
+  | { handler: (value: number) => string; common: string; label: string };
+type CoverPartial = { common: string; label: string };
+type Nested = { value: FunctionUnion };
+type FunctionSecondNested = { value: FunctionSecondUnion };
+interface Delegated {
+  value: string;
+  equals(input: Delegated): boolean;
+}
+
+export const directIs = (input: unknown): input is FunctionUnion =>
+  typia.is<FunctionUnion>(input);
+export const factoryIs = typia.createIs<FunctionUnion>();
+export const directEquals = (x: unknown, y: unknown): boolean =>
+  typia.compare.equals<FunctionUnion>(x as FunctionUnion, y as FunctionUnion);
+export const factoryEquals = typia.compare.createEquals<FunctionUnion>();
+export const directCover = (x: FunctionUnion, y: unknown): boolean =>
+  typia.compare.cover<FunctionUnion>(x, y as typia.compare.Cover<FunctionUnion>);
+export const factoryCover = typia.compare.createCover<FunctionUnion>();
+export const directClone = (input: FunctionUnion) =>
+  typia.plain.clone<FunctionUnion>(input);
+export const factoryClone = typia.plain.createClone<FunctionUnion>();
+export const prune = typia.plain.createPrune<FunctionUnion>();
+
+export const reversedEquals = typia.compare.createEquals<StringFirstUnion>();
+export const functionSecondDirectIs = (input: unknown): input is FunctionSecondUnion =>
+  typia.is<FunctionSecondUnion>(input);
+export const functionSecondFactoryIs = typia.createIs<FunctionSecondUnion>();
+export const functionSecondDirectEquals = (x: FunctionSecondUnion, y: FunctionSecondUnion): boolean =>
+  typia.compare.equals<FunctionSecondUnion>(x, y);
+export const functionSecondFactoryEquals = typia.compare.createEquals<FunctionSecondUnion>();
+export const functionSecondDirectCover = (x: FunctionSecondUnion, y: unknown): boolean =>
+  typia.compare.cover<FunctionSecondUnion>(x, y as typia.compare.Cover<FunctionSecondUnion>);
+export const functionSecondFactoryCover = typia.compare.createCover<FunctionSecondUnion>();
+export const coverPartialDirect = (x: CoverPartial, y: unknown): boolean =>
+  typia.compare.cover<CoverPartial>(x, y as typia.compare.Cover<CoverPartial>);
+export const coverPartialFactory = typia.compare.createCover<CoverPartial>();
+export const functionSecondNestedDirectEquals = (x: FunctionSecondNested, y: FunctionSecondNested): boolean =>
+  typia.compare.equals<FunctionSecondNested>(x, y);
+export const functionSecondNestedFactoryEquals = typia.compare.createEquals<FunctionSecondNested>();
+export const delegatedDirectEquals = (x: Delegated, y: Delegated): boolean =>
+  typia.compare.equals<Delegated>(x, y);
+export const delegatedFactoryEquals = typia.compare.createEquals<Delegated>();
+export const nestedEquals = typia.compare.createEquals<Nested>();
+export const nestedDirectEquals = (x: Nested, y: Nested): boolean =>
+  typia.compare.equals<Nested>(x, y);
+`
+
+const compareFunctionalUnionMembershipLessSource = `import typia from "typia";
+
+type FunctionUnion =
+  | { handler: (value: number) => string; common: string }
+  | { handler: string; common: string; label: string };
+
+typia.compare.less<FunctionUnion>({} as FunctionUnion, {} as FunctionUnion);
+`
+
+const compareFunctionalUnionMembershipRuntimeRunner = `const functional = require("./functional.cjs");
+const defaults = require("./default.cjs");
+
+let ran = 0;
+const failures = [];
+const expect = (name, actual, expected) => {
+  ran += 1;
+  if (actual !== expected)
+    failures.push(name + ": expected " + expected + ", got " + actual);
+};
+const expectJson = (name, actual, expected) =>
+  expect(name, JSON.stringify(actual), JSON.stringify(expected));
+
+const left = { handler: "text", common: "same", label: "left" };
+const right = { handler: "text", common: "same", label: "right" };
+const equal = { handler: "text", common: "same", label: "left" };
+const invalidLeft = { handler: 1, common: "same", label: "left" };
+const invalidRight = { handler: 1, common: "same", label: "right" };
+
+// Functional mode must use handler while routing, then preserve equality's
+// established post-selection treatment of actual function-valued properties.
+expect("functional direct is accepts later member", functional.directIs(left), true);
+expect("functional factory is accepts later member", functional.factoryIs(right), true);
+expect("functional direct equals distinguishes later label", functional.directEquals(left, right), false);
+expect("functional factory equals distinguishes later label", functional.factoryEquals(left, right), false);
+expect("functional direct equals keeps equal later member", functional.directEquals(left, equal), true);
+expect("functional factory equals keeps equal later member", functional.factoryEquals(left, equal), true);
+expect("functional direct cover distinguishes later label", functional.directCover(left, right), false);
+expect("functional factory cover distinguishes later label", functional.factoryCover(left, right), false);
+expectJson("functional direct clone preserves later member", functional.directClone(left), left);
+expectJson("functional factory clone preserves later member", functional.factoryClone(right), right);
+
+const pruned = { ...left, extra: true };
+functional.prune(pruned);
+expectJson("functional prune retains selected later label", pruned, left);
+expect("functional reversed union distinguishes later label", functional.reversedEquals(left, right), false);
+expect("functional nested factory distinguishes later label", functional.nestedEquals({ value: left }, { value: right }), false);
+expect("functional nested direct distinguishes later label", functional.nestedDirectEquals({ value: left }, { value: right }), false);
+
+expect("functional direct is rejects invalid handler", functional.directIs(invalidLeft), false);
+expect("functional factory is rejects invalid handler", functional.factoryIs(invalidRight), false);
+expect("functional direct equals rejects distinct invalid operands", functional.directEquals(invalidLeft, invalidRight), false);
+expect("functional factory equals rejects distinct invalid operands", functional.factoryEquals(invalidLeft, invalidRight), false);
+expect("functional same invalid reference keeps identity fast path", functional.factoryEquals(invalidLeft, invalidLeft), true);
+
+const functionLeft = { handler: (value) => String(value), common: "same" };
+const functionRight = { handler: (value) => "#" + value, common: "same" };
+const functionDifferentCommon = { handler: (value) => String(value), common: "different" };
+expect("functional actual functions keep method identity ignored", functional.factoryEquals(functionLeft, functionRight), true);
+expect("functional actual function member still compares data", functional.factoryEquals(functionLeft, functionDifferentCommon), false);
+
+// This is the order-symmetric public-behavior control. The function arm follows
+// the strict string arm and alone owns label. The string matcher must reject an
+// actual function before the later arm is selected, then equality compares label.
+const functionSecondHandler = (value) => String(value);
+const functionSecondLeft = {
+  common: "same",
+  handler: functionSecondHandler,
+  label: "left",
+};
+const functionSecondRight = {
+  common: "same",
+  handler: functionSecondHandler,
+  label: "right",
+};
+const functionSecondEqual = {
+  common: "same",
+  handler: (value) => "!" + value,
+  label: "left",
+};
+const functionSecondString = { handler: "text", common: "same" };
+const functionSecondExtra = { ...functionSecondLeft, extra: "ignored" };
+const functionSecondInvalidLeft = { common: "same", handler: 1, label: "same" };
+const functionSecondInvalidRight = { common: "same", handler: 1, label: "same" };
+const coverPartialFull = { common: "same", label: "left" };
+const coverPartialOmitted = { common: "same" };
+const coverPartialUndefined = { common: "same", label: undefined };
+expect("functional second function arm direct is accepts", functional.functionSecondDirectIs(functionSecondLeft), true);
+expect("functional second function arm factory is accepts", functional.functionSecondFactoryIs(functionSecondRight), true);
+expect("functional second function arm direct is rejects invalid handler", functional.functionSecondDirectIs(functionSecondInvalidLeft), false);
+expect("functional second function arm factory is rejects invalid handler", functional.functionSecondFactoryIs(functionSecondInvalidRight), false);
+expect("functional second function arm direct equals compares label", functional.functionSecondDirectEquals(functionSecondLeft, functionSecondRight), false);
+expect("functional second function arm factory equals compares label", functional.functionSecondFactoryEquals(functionSecondLeft, functionSecondRight), false);
+expect("functional second function arm direct equals rejects invalid equal-label handlers", functional.functionSecondDirectEquals(functionSecondInvalidLeft, functionSecondInvalidRight), false);
+expect("functional second function arm factory equals rejects invalid equal-label handlers", functional.functionSecondFactoryEquals(functionSecondInvalidLeft, functionSecondInvalidRight), false);
+expect("functional second function arm direct cover compares label", functional.functionSecondDirectCover(functionSecondLeft, functionSecondRight), false);
+expect("functional second function arm factory cover compares label", functional.functionSecondFactoryCover(functionSecondLeft, functionSecondRight), false);
+expect("functional second function arm nested direct equals compares label", functional.functionSecondNestedDirectEquals({ value: functionSecondLeft }, { value: functionSecondRight }), false);
+expect("functional second function arm nested factory equals compares label", functional.functionSecondNestedFactoryEquals({ value: functionSecondLeft }, { value: functionSecondRight }), false);
+expect("functional second function arm direct equals keeps equal label", functional.functionSecondDirectEquals(functionSecondLeft, functionSecondEqual), true);
+expect("functional second function arm factory equals keeps equal label", functional.functionSecondFactoryEquals(functionSecondLeft, functionSecondEqual), true);
+expect("functional function-first direct cross-member equals rejects", functional.directEquals(functionLeft, left), false);
+expect("functional function-first factory cross-member equals rejects", functional.factoryEquals(functionLeft, left), false);
+expect("functional function-second direct cross-member equals rejects", functional.functionSecondDirectEquals(functionSecondLeft, functionSecondString), false);
+expect("functional function-second factory cross-member equals rejects", functional.functionSecondFactoryEquals(functionSecondLeft, functionSecondString), false);
+expect("functional direct cover accepts omitted right property", functional.coverPartialDirect(coverPartialFull, coverPartialOmitted), true);
+expect("functional factory cover accepts omitted right property", functional.coverPartialFactory(coverPartialFull, coverPartialOmitted), true);
+expect("functional direct cover accepts undefined right property", functional.coverPartialDirect(coverPartialFull, coverPartialUndefined), true);
+expect("functional factory cover accepts undefined right property", functional.coverPartialFactory(coverPartialFull, coverPartialUndefined), true);
+expect("functional second function arm direct equals ignores extra key", functional.functionSecondDirectEquals(functionSecondLeft, functionSecondExtra), true);
+expect("functional second function arm factory equals ignores extra key", functional.functionSecondFactoryEquals(functionSecondLeft, functionSecondExtra), true);
+
+const delegatedLeft = { value: "left", equals: () => true };
+const delegatedRight = { value: "right", equals: () => true };
+expect("functional direct equals delegates declared method", functional.delegatedDirectEquals(delegatedLeft, delegatedRight), true);
+expect("functional factory equals delegates declared method", functional.delegatedFactoryEquals(delegatedLeft, delegatedRight), true);
+
+// Default mode deliberately treats a sole function-valued member as lenient.
+// The option boundary must stay visible rather than changing compare globally.
+expect("default direct is keeps function member lenient", defaults.directIs(invalidLeft), true);
+expect("default factory is keeps function member lenient", defaults.factoryIs(invalidRight), true);
+expect("default equals keeps function member ignored", defaults.factoryEquals(invalidLeft, invalidRight), true);
+expect("default second function arm direct equals retains later label", defaults.functionSecondDirectEquals(functionSecondLeft, functionSecondRight), false);
+expect("default second function arm factory equals retains later label", defaults.functionSecondFactoryEquals(functionSecondLeft, functionSecondRight), false);
+
+if (failures.length !== 0)
+  throw new Error(failures.join("\n"));
+console.log("RAN " + ran + " CASES");
+`

--- a/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
+++ b/packages/typia/native/core/programmers/compare/CompareEqualProgrammer.go
@@ -32,9 +32,10 @@ type CompareEqualProgrammer_IProps struct {
 }
 
 type compareEqualProgrammerGenerator struct {
-  Config    CompareEqualProgrammer_IConfig
-  Recursive bool
-  Counter   int
+  Config     CompareEqualProgrammer_IConfig
+  Functional bool
+  Recursive  bool
+  Counter    int
   // Member-resolution checkers (`_ui<index>`) emitted on demand for the object
   // unions that need the is-match ladder, keyed by the object's collection index.
   Matchers     []string
@@ -77,6 +78,7 @@ func (compareEqualProgrammerNamespace) Write(props CompareEqualProgrammer_IProps
 
   generator := &compareEqualProgrammerGenerator{
     Config:       props.Config,
+    Functional:   nativehelpers.OptionPredicator.Functional(props.Context.Options),
     Recursive:    nativeinternal.FeatureProgrammer.CollectionRecursive(collection),
     MatcherIndex: map[int]bool{},
   }
@@ -439,16 +441,15 @@ func (g *compareEqualProgrammerGenerator) matchCall(object *schemametadata.Metad
 // may be absent), and every extra key a dynamic index signature declares must
 // hold a value of the signature's type. It mirrors the `_io` checkers `is`
 // emits, at the abstraction level the rest of this programmer works at — shape
-// and typeof, plus structural template patterns. It deliberately ignores
-// `typia.tags.*` constraints.
+// and typeof, plus structural template patterns. Function-valued properties
+// participate in this routing check whenever `is` makes them meaningful; they
+// remain excluded from object value comparison after a member is selected. It
+// deliberately ignores `typia.tags.*` constraints.
 func (g *compareEqualProgrammerGenerator) matchObject(object *schemametadata.MetadataObjectType, v string) string {
   checks := []string{}
   regularKeys := []string{}
   dynamic := []*schemametadata.MetadataProperty{}
   for _, property := range object.Properties {
-    if compareProgrammer_isMethod(property) {
-      continue // methods carry no comparable data, so they do not route either
-    }
     if sole := property.Key.GetSoleLiteral(); sole != nil {
       regularKeys = append(regularKeys, *sole)
       checks = append(checks, g.matchSlot(property.Value, g.property(v, *sole)))
@@ -506,7 +507,7 @@ func (g *compareEqualProgrammerGenerator) match(metadata *schemametadata.Metadat
   if len(metadata.Templates) != 0 {
     branches = append(branches, g.and(g.typeof(v, "string"), g.template(metadata.Templates, v)))
   }
-  if len(metadata.Functions) != 0 {
+  if len(metadata.Functions) != 0 && (g.Functional || metadata.Size() != 1) {
     branches = append(branches, g.typeof(v, "function"))
   }
   for _, native := range metadata.Natives {

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -907,7 +907,9 @@ export namespace TypiaGenerateWizard {
     entries.sort((x, y) => {
       const linkOrder: number =
         Number(x.stat.isSymbolicLink()) - Number(y.stat.isSymbolicLink());
-      return linkOrder !== 0 ? linkOrder : x.name.localeCompare(y.name);
+      return linkOrder !== 0
+        ? linkOrder
+        : Buffer.compare(Buffer.from(x.name), Buffer.from(y.name));
     });
 
     for (const entry of entries) {

--- a/packages/typia/src/internal/_ProtobufReader.ts
+++ b/packages/typia/src/internal/_ProtobufReader.ts
@@ -110,15 +110,19 @@ export class _ProtobufReader {
    * Advance by exactly one varint, which carries no length prefix.
    *
    * A varint terminates at its first byte without the continuation bit, and may
-   * occupy no more than {@link VARINT_MAX_BYTES}. Reading past that limit would
-   * accept a varint that `varint32` and `varint64` could not, making the limit
-   * depend on which method happens to consume the value.
+   * occupy no more than {@link VARINT_MAX_BYTES}. Its tenth byte is bounded
+   * twice over, by {@link lastVarintByte}: it may neither continue into an
+   * eleventh byte nor carry payload above bit 63. Skipping is where that is
+   * easiest to get wrong, because this path discards the bytes it reads and so
+   * never notices a value it could not have represented. Relaxing either bound
+   * here would accept a varint that `varint32` and `varint64` reject, making
+   * the limit depend on which method happens to consume the value.
    */
   public skipVarint(): void {
     this.atomic(() => {
-      for (let i: number = 0; i < VARINT_MAX_BYTES; ++i)
+      for (let i: number = 1; i < VARINT_MAX_BYTES; ++i)
         if ((this.u8() & 0x80) === 0) return;
-      throw error(`varint exceeds ${VARINT_MAX_BYTES} bytes.`);
+      this.lastVarintByte();
     });
   }
 
@@ -172,8 +176,7 @@ export class _ProtobufReader {
     if (this.u8() < 0x80) return value;
     if (this.u8() < 0x80) return value;
     if (this.u8() < 0x80) return value;
-    if (this.u8() < 0x80) return value;
-
+    this.lastVarintByte();
     return value;
   }
 
@@ -208,8 +211,26 @@ export class _ProtobufReader {
     value |= ((loaded = this.u8n()) & BigInt(0x7f)) << BigInt(56);
     if (loaded < BigInt(0x80)) return value;
 
-    value |= (this.u8n() & BigInt(0x01)) << BigInt(63);
+    value |= BigInt(this.lastVarintByte()) << BigInt(63);
     return BigInt.asUintN(64, value);
+  }
+
+  /**
+   * Read the only byte whose varint payload is limited to bit 63.
+   *
+   * Two distinct faults meet on this byte, and each is named for what it is. A
+   * continuation bit means the varint would occupy an eleventh byte, which no
+   * 64-bit value can reach. Any other payload bit means the varint terminates
+   * within its ten bytes but carries a value bit above 63. Reporting the
+   * second as a length fault would tell the caller something untrue about a
+   * payload that is exactly ten bytes long.
+   */
+  private lastVarintByte(): number {
+    const loaded: number = this.u8();
+    if ((loaded & 0x80) !== 0)
+      throw error(`varint exceeds ${VARINT_MAX_BYTES} bytes.`);
+    if (loaded > 0x01) throw error(`varint exceeds ${VARINT_MAX_BITS} bits.`);
+    return loaded;
   }
 
   private u8(): number {
@@ -262,11 +283,18 @@ const error = (message: string): Error =>
 /**
  * The most bytes a varint may occupy: a 64-bit value in seven-bit groups.
  *
- * `varint32` and `varint64` hold this same limit structurally, by reading no
- * further than their tenth byte. This constant is what a loop-driven consumer
- * holds it by.
+ * Every path reads no further than its tenth byte and accepts only bit 63 from
+ * that byte. This constant keeps the loop-driven skip path on the same limit.
  */
 const VARINT_MAX_BYTES = 10;
+
+/**
+ * The widest value a varint may carry: the 64-bit Protocol Buffer wire domain.
+ *
+ * The tenth byte reaches only bit 63, so a payload bit above it belongs to no
+ * representable value. This names the overflow fault apart from the length one.
+ */
+const VARINT_MAX_BITS = 64;
 
 const utf8 = new Singleton(
   () => new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }),

--- a/packages/typia/test/go.mod
+++ b/packages/typia/test/go.mod
@@ -5,11 +5,9 @@ go 1.26
 require (
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/samchon/typia/packages/typia/native v0.0.0
+	google.golang.org/protobuf v1.34.2
 )
 
-require (
-	golang.org/x/sync v0.20.0 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
-)
+require golang.org/x/sync v0.20.0 // indirect
 
 replace github.com/samchon/typia/packages/typia/native => ../native

--- a/packages/typia/test/protobuf_varint_corpus.json
+++ b/packages/typia/test/protobuf_varint_corpus.json
@@ -1,0 +1,256 @@
+{
+  "specification": "https://protobuf.dev/programming-guides/encoding/#varints",
+  "oracle": "google.golang.org/protobuf/encoding/protowire.ConsumeVarint",
+  "purpose": "Single source of truth for the Protobuf varint boundary. The Go test pins these verdicts against the reference Go parser; the TypeScript regressions read the same bytes through typia's runtime reader and generated decoders. Neither side may transcribe a byte string or a verdict of its own.",
+  "strictness": "The specification fixes the ten-byte maximum and says nothing about a tenth byte carrying payload above bit 63, and the runtimes disagree there: protowire rejects such a varint, while the Java runtime's CodedInputStream.readRawVarint64 accepts it and discards the excess bits. typia follows protowire, so it never accepts bytes that google.golang.org/protobuf would refuse. No encoder emits that form, so the stricter reading costs no interoperability.",
+  "consumers": [
+    "packages/typia/test/protobuf_varint_corpus_matches_protowire_test.go",
+    "tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_varint_bounds.ts",
+    "tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_varint_bounds.ts"
+  ],
+  "fields": {
+    "name": "Unique label, used as the Go subtest name and the TypeScript failure label.",
+    "bytes": "Lowercase hexadecimal varint bytes, standing alone at the start of a buffer.",
+    "consumed": "Bytes protowire.ConsumeVarint consumes: the varint width when it accepts, -1 when the buffer truncates it, -3 when it overflows the 64-bit wire domain.",
+    "value": "Decimal unsigned 64-bit value protowire decodes, as a string because it exceeds an IEEE-754 double. Null whenever the oracle rejects.",
+    "fault": "Null when the oracle accepts, otherwise the wire fault class both readers must report."
+  },
+  "faults": {
+    "truncated": "The buffer ends before the varint terminates.",
+    "overlong": "The tenth byte still carries the continuation bit, so the varint would occupy an eleventh.",
+    "overflow": "The tenth byte terminates but carries payload above bit 63, outside the 64-bit wire domain."
+  },
+  "entries": [
+    {
+      "name": "zero",
+      "bytes": "00",
+      "consumed": 1,
+      "value": "0",
+      "fault": null
+    },
+    {
+      "name": "single-byte maximum",
+      "bytes": "7f",
+      "consumed": 1,
+      "value": "127",
+      "fault": null
+    },
+    {
+      "name": "two-byte canonical three hundred",
+      "bytes": "ac02",
+      "consumed": 2,
+      "value": "300",
+      "fault": null
+    },
+    {
+      "name": "two-byte maximum",
+      "bytes": "ff7f",
+      "consumed": 2,
+      "value": "16383",
+      "fault": null
+    },
+    {
+      "name": "non-canonical two-byte zero",
+      "bytes": "8000",
+      "consumed": 2,
+      "value": "0",
+      "fault": null
+    },
+    {
+      "name": "three-byte maximum",
+      "bytes": "ffff7f",
+      "consumed": 3,
+      "value": "2097151",
+      "fault": null
+    },
+    {
+      "name": "four-byte maximum",
+      "bytes": "ffffff7f",
+      "consumed": 4,
+      "value": "268435455",
+      "fault": null
+    },
+    {
+      "name": "five-byte 32-bit maximum",
+      "bytes": "ffffffff0f",
+      "consumed": 5,
+      "value": "4294967295",
+      "fault": null
+    },
+    {
+      "name": "five-byte maximum",
+      "bytes": "ffffffff7f",
+      "consumed": 5,
+      "value": "34359738367",
+      "fault": null
+    },
+    {
+      "name": "six-byte maximum",
+      "bytes": "ffffffffff7f",
+      "consumed": 6,
+      "value": "4398046511103",
+      "fault": null
+    },
+    {
+      "name": "seven-byte maximum",
+      "bytes": "ffffffffffff7f",
+      "consumed": 7,
+      "value": "562949953421311",
+      "fault": null
+    },
+    {
+      "name": "eight-byte maximum",
+      "bytes": "ffffffffffffff7f",
+      "consumed": 8,
+      "value": "72057594037927935",
+      "fault": null
+    },
+    {
+      "name": "nine-byte maximum",
+      "bytes": "ffffffffffffffff7f",
+      "consumed": 9,
+      "value": "9223372036854775807",
+      "fault": null
+    },
+    {
+      "name": "non-canonical ten-byte zero",
+      "bytes": "80808080808080808000",
+      "consumed": 10,
+      "value": "0",
+      "fault": null
+    },
+    {
+      "name": "ten-byte bit sixty-three only",
+      "bytes": "80808080808080808001",
+      "consumed": 10,
+      "value": "9223372036854775808",
+      "fault": null
+    },
+    {
+      "name": "canonical 64-bit maximum",
+      "bytes": "ffffffffffffffffff01",
+      "consumed": 10,
+      "value": "18446744073709551615",
+      "fault": null
+    },
+    {
+      "name": "empty buffer",
+      "bytes": "",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after 1 continuation byte",
+      "bytes": "80",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after 2 continuation bytes",
+      "bytes": "8080",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after 3 continuation bytes",
+      "bytes": "808080",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after 4 continuation bytes",
+      "bytes": "80808080",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after 5 continuation bytes",
+      "bytes": "8080808080",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after 6 continuation bytes",
+      "bytes": "808080808080",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after 7 continuation bytes",
+      "bytes": "80808080808080",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after 8 continuation bytes",
+      "bytes": "8080808080808080",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after 9 continuation bytes",
+      "bytes": "808080808080808080",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "truncated after nine payload-carrying bytes",
+      "bytes": "ffffffffffffffffff",
+      "consumed": -1,
+      "value": null,
+      "fault": "truncated"
+    },
+    {
+      "name": "ten continuation bytes",
+      "bytes": "80808080808080808080",
+      "consumed": -3,
+      "value": null,
+      "fault": "overlong"
+    },
+    {
+      "name": "continuing tenth byte carrying payload",
+      "bytes": "80808080808080808082",
+      "consumed": -3,
+      "value": null,
+      "fault": "overlong"
+    },
+    {
+      "name": "eleven-byte varint",
+      "bytes": "8080808080808080808001",
+      "consumed": -3,
+      "value": null,
+      "fault": "overlong"
+    },
+    {
+      "name": "excess tenth payload",
+      "bytes": "80808080808080808002",
+      "consumed": -3,
+      "value": null,
+      "fault": "overflow"
+    },
+    {
+      "name": "payload-carrying prefix with excess tenth payload",
+      "bytes": "ffffffffffffffffff02",
+      "consumed": -3,
+      "value": null,
+      "fault": "overflow"
+    },
+    {
+      "name": "tenth byte carrying every payload bit",
+      "bytes": "8080808080808080807f",
+      "consumed": -3,
+      "value": null,
+      "fault": "overflow"
+    }
+  ]
+}

--- a/packages/typia/test/protobuf_varint_corpus_matches_protowire_test.go
+++ b/packages/typia/test/protobuf_varint_corpus_matches_protowire_test.go
@@ -1,0 +1,163 @@
+package typiatest
+
+import (
+  "encoding/hex"
+  "path/filepath"
+  "strconv"
+  "testing"
+
+  testutil "github.com/samchon/typia/packages/typia/test/internal/testutil"
+  "google.golang.org/protobuf/encoding/protowire"
+)
+
+// TestProtobufVarintCorpusMatchesProtowire verifies the shared varint corpus
+// still describes the reference Go Protobuf parser.
+//
+// `protowire` is the oracle, not every runtime. The specification fixes the
+// ten-byte maximum and is silent on a tenth byte carrying payload above bit
+// 63, where `protowire` rejects and the Java runtime discards the excess bits.
+// The corpus records that in its `strictness` field; typia follows `protowire`
+// so it never accepts bytes `google.golang.org/protobuf` would refuse.
+//
+// This test pins the third-party oracle, and only that. Go cannot execute
+// typia's TypeScript reader — the transform suites that run emitted JavaScript
+// stub every `typia/lib/internal` import away — so a Go test can never witness
+// a typia regression here, and this one does not claim to. The coupling lives
+// in `protobuf_varint_corpus.json` instead: this test proves the corpus still
+// matches `protowire`, and the `test_protobuf_reader_varint_bounds` and
+// `test_protobuf_decode_varint_bounds` regressions read the same bytes and the
+// same verdicts through typia's reader and generated decoders. A
+// `google.golang.org/protobuf` upgrade that changed a verdict therefore fails
+// the build here rather than leaving those expectations quietly stale.
+//
+//  1. Require every corpus entry to be internally consistent with the wire rule.
+//  2. Require protowire to return exactly the recorded width, value, and error code.
+//  3. Require the same verdict when the varint stands in a tag, a length prefix,
+//     and a whole field, so the fault belongs to the varint and not to a position.
+func TestProtobufVarintCorpusMatchesProtowire(t *testing.T) {
+  corpus := testutil.ReadJSON[protobufVarintCorpus](t, filepath.Join(
+    testutil.RepoRoot(t),
+    "packages", "typia", "test", "protobuf_varint_corpus.json",
+  ))
+  if len(corpus.Entries) == 0 {
+    t.Fatal("the shared varint corpus is empty, so this test proved nothing")
+  }
+
+  seen := map[string]bool{}
+  for _, entry := range corpus.Entries {
+    if seen[entry.Name] {
+      t.Fatalf("corpus entry %q is declared twice", entry.Name)
+    }
+    seen[entry.Name] = true
+
+    t.Run(entry.Name, func(t *testing.T) {
+      bytes, err := hex.DecodeString(entry.Bytes)
+      if err != nil {
+        t.Fatalf("corpus bytes %q are not hexadecimal: %v", entry.Bytes, err)
+      }
+      protobufVarintCorpusRequireConsistency(t, entry, bytes)
+
+      value, n := protowire.ConsumeVarint(bytes)
+      if n != entry.Consumed {
+        t.Fatalf("ConsumeVarint consumed %d instead of the recorded %d", n, entry.Consumed)
+      }
+      if entry.Fault == "" {
+        want, err := strconv.ParseUint(entry.Value, 10, 64)
+        if err != nil {
+          t.Fatalf("corpus value %q is not an unsigned 64-bit integer: %v", entry.Value, err)
+        }
+        if value != want {
+          t.Fatalf("ConsumeVarint decoded %d instead of the recorded %d", value, want)
+        }
+        return
+      }
+
+      // A rejected varint carries its fault into every framing position, so a
+      // consumer cannot launder it by reading the same bytes as a tag or as a
+      // length. Only the leading byte is replaced, and only by another
+      // continuation byte, so the varint keeps its recorded width.
+      if len(bytes) == 0 {
+        return
+      }
+      if bytes[0]&0x80 == 0 {
+        t.Fatalf("rejected corpus entry must open with a continuation byte, not %#02x", bytes[0])
+      }
+      tag := append([]byte{0x88}, bytes[1:]...)
+      if _, _, n := protowire.ConsumeTag(tag); n != entry.Consumed {
+        t.Fatalf("ConsumeTag consumed %d instead of the recorded %d", n, entry.Consumed)
+      }
+      if _, n := protowire.ConsumeBytes(bytes); n != entry.Consumed {
+        t.Fatalf("ConsumeBytes consumed %d instead of the recorded %d", n, entry.Consumed)
+      }
+      field := append([]byte{0x0a}, bytes...)
+      if _, _, n := protowire.ConsumeField(field); n != entry.Consumed {
+        t.Fatalf("ConsumeField consumed %d instead of the recorded %d", n, entry.Consumed)
+      }
+    })
+  }
+  t.Logf("executed %d corpus entries against protowire", len(corpus.Entries))
+}
+
+// protobufVarintCorpusRequireConsistency rejects a corpus entry whose recorded
+// fault disagrees with its own bytes.
+//
+// Without this the corpus could name a fault class the bytes do not exhibit,
+// and both readers would faithfully assert the wrong message. The wire rule is
+// that a varint occupies at most ten bytes and its tenth byte carries bit 63
+// alone, so the class is decided by that byte.
+func protobufVarintCorpusRequireConsistency(t *testing.T, entry protobufVarintEntry, bytes []byte) {
+  t.Helper()
+  switch entry.Fault {
+  case "":
+    if entry.Consumed != len(bytes) {
+      t.Fatalf("an accepted entry must consume all %d bytes, not %d", len(bytes), entry.Consumed)
+    }
+    if entry.Value == "" {
+      t.Fatal("an accepted entry must record the decoded value")
+    }
+    return
+  case "truncated":
+    if entry.Consumed != -1 {
+      t.Fatalf("a truncated entry must record -1, not %d", entry.Consumed)
+    }
+    if len(bytes) >= 10 {
+      t.Fatalf("a %d-byte entry is long enough to terminate, so it is not truncated", len(bytes))
+    }
+  case "overlong":
+    if entry.Consumed != -3 {
+      t.Fatalf("an overlong entry must record -3, not %d", entry.Consumed)
+    }
+    if len(bytes) < 10 || bytes[9]&0x80 == 0 {
+      t.Fatal("an overlong entry must carry the continuation bit in its tenth byte")
+    }
+  case "overflow":
+    if entry.Consumed != -3 {
+      t.Fatalf("an overflow entry must record -3, not %d", entry.Consumed)
+    }
+    if len(bytes) < 10 || bytes[9]&0x80 != 0 || bytes[9] <= 0x01 {
+      t.Fatal("an overflow entry must terminate on a tenth byte carrying payload above bit 63")
+    }
+  default:
+    t.Fatalf("unknown fault class %q", entry.Fault)
+  }
+  if entry.Value != "" {
+    t.Fatalf("a rejected entry must record no value, but records %q", entry.Value)
+  }
+}
+
+// protobufVarintCorpus mirrors `protobuf_varint_corpus.json`. Its prose fields
+// are deliberately absent: they document the file for its readers, and reading
+// them back here would assert nothing.
+type protobufVarintCorpus struct {
+  Entries []protobufVarintEntry `json:"entries"`
+}
+
+// protobufVarintEntry is one corpus row. `Value` and `Fault` are JSON `null`
+// where they do not apply, which unmarshals to the empty string.
+type protobufVarintEntry struct {
+  Name     string `json:"name"`
+  Bytes    string `json:"bytes"`
+  Consumed int    `json:"consumed"`
+  Value    string `json:"value"`
+  Fault    string `json:"fault"`
+}

--- a/tests/test-typia-generate/scripts/filesystem/repeated-directory-aliases.test.cjs
+++ b/tests/test-typia-generate/scripts/filesystem/repeated-directory-aliases.test.cjs
@@ -10,8 +10,8 @@ const {
 /**
  * Verifies repeated directory aliases are rejected before transformation.
  *
- * Locks deterministic directory de-duplication so alias order cannot multiply
- * transformed output or choose different target trees between runs.
+ * Locks byte-lexical directory de-duplication so locale cannot choose a
+ * different alias or target tree between runs.
  *
  * 1. Add one real source directory and two links to that directory.
  * 2. Generate and assert aliases are rejected before output is created.
@@ -22,7 +22,7 @@ test("repeated directory aliases are rejected", () => {
     const actual = path.join(fixture.input, "actual");
     writeSource(path.join(actual, "source.ts"));
     linkDirectory(actual, path.join(fixture.input, "alias-a"));
-    linkDirectory(actual, path.join(fixture.input, "alias-b"));
+    linkDirectory(actual, path.join(fixture.input, "alias_a"));
     expectFailureWithoutOutput(
       fixture,
       /alias-a.*revisits|revisits.*alias-a/is,

--- a/tests/test-typia-schema/src/features/protobuf.decode/ProtobufVarintCorpus.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/ProtobufVarintCorpus.ts
@@ -1,0 +1,165 @@
+import fs from "fs";
+import typia from "typia";
+
+import { TestGlobal } from "../../TestGlobal";
+
+/**
+ * Reader for the shared Protobuf varint corpus.
+ *
+ * `packages/typia/test/protobuf_varint_corpus.json` is the single source of
+ * truth for the varint boundary: every byte string that exercises it, and the
+ * verdict the reference Go Protobuf parser returns for it. The Go test
+ * `TestProtobufVarintCorpusMatchesProtowire` proves those verdicts still match
+ * `google.golang.org/protobuf`, and the regressions here read the very same
+ * rows through typia's runtime reader and generated decoders. Neither side
+ * transcribes a byte string or a verdict of its own, so the two cannot drift
+ * apart while both stay green.
+ *
+ * The corpus is `protowire`'s verdict rather than every runtime's, and its
+ * `strictness` field records where that matters: on a tenth byte carrying
+ * payload above bit 63 the specification is silent and the Java runtime is
+ * lenient, while `protowire` rejects. typia follows `protowire`.
+ *
+ * A fault class, not a message, is what the corpus records. The mapping from a
+ * class to the exact text typia raises lives in {@link message} — one table,
+ * in one place, rather than a string repeated across the regressions.
+ */
+export namespace ProtobufVarintCorpus {
+  /** The wire fault classes the corpus distinguishes. */
+  export type Fault = "truncated" | "overlong" | "overflow";
+
+  /** One corpus row. */
+  export interface IEntry {
+    /** Unique label, used as the failure label of every derived assertion. */
+    name: string;
+
+    /** Lowercase hexadecimal bytes, standing at the start of a buffer. */
+    bytes: string & typia.tags.Pattern<"^([0-9a-f]{2})*$">;
+
+    /**
+     * Bytes `protowire.ConsumeVarint` consumes: the varint width when it
+     * accepts, `-1` when the buffer truncates it, `-3` when it overflows.
+     */
+    consumed: number & typia.tags.Type<"int32">;
+
+    /**
+     * Decimal unsigned 64-bit value the oracle decodes, as a string because it
+     * exceeds an IEEE-754 double. `null` whenever the oracle rejects.
+     */
+    value: string | null;
+
+    /** `null` when the oracle accepts, otherwise the wire fault class. */
+    fault: Fault | null;
+  }
+
+  /** Every corpus row, in file order. */
+  export const entries = (): IEntry[] => document().entries;
+
+  /** Rows the oracle accepts, each carrying a decoded value. */
+  export const accepted = (): IEntry[] =>
+    entries().filter((entry) => entry.fault === null);
+
+  /**
+   * Rows the oracle rejects for leaving the wire domain rather than for running
+   * out of buffer, so no further byte could rescue them.
+   */
+  export const malformed = (): IEntry[] =>
+    entries().filter(
+      (entry) => entry.fault === "overlong" || entry.fault === "overflow",
+    );
+
+  /** Rows whose buffer ends before the varint terminates. */
+  export const truncated = (): IEntry[] =>
+    entries().filter((entry) => entry.fault === "truncated");
+
+  /** The row carrying `name`, or a failure naming the missing row. */
+  export const find = (name: string): IEntry => {
+    const entry: IEntry | undefined = entries().find(
+      (candidate) => candidate.name === name,
+    );
+    if (entry === undefined)
+      throw new Error(
+        `the shared varint corpus carries no entry named ${JSON.stringify(name)}.`,
+      );
+    return entry;
+  };
+
+  /** Corpus bytes as octets. */
+  export const bytes = (entry: IEntry): number[] =>
+    (entry.bytes.match(/../g) ?? []).map((pair) => Number.parseInt(pair, 16));
+
+  /**
+   * The same varint re-headed as the tag of field 17, wire type VARIANT.
+   *
+   * Only the leading byte is replaced, and only by another continuation byte,
+   * so the varint keeps its recorded width and therefore its recorded fault.
+   */
+  export const asTag = (entry: IEntry): number[] => {
+    const octets: number[] = bytes(entry);
+    if (octets.length === 0 || (octets[0]! & 0x80) === 0)
+      throw new Error(
+        `${entry.name} does not open with a continuation byte, so re-heading it would change its width.`,
+      );
+    return [0x88, ...octets.slice(1)];
+  };
+
+  /** The decoded value of an accepted row. */
+  export const value = (entry: IEntry): bigint => {
+    if (entry.value === null)
+      throw new Error(
+        `${entry.name} is rejected by the oracle, so it carries no value.`,
+      );
+    return BigInt(entry.value);
+  };
+
+  /** The exact error typia must raise for a rejected row. */
+  export const message = (entry: IEntry): string => {
+    if (entry.fault === null)
+      throw new Error(
+        `${entry.name} is accepted by the oracle, so it raises no error.`,
+      );
+    return MESSAGES[entry.fault];
+  };
+
+  /** The prefix every Protobuf wire error carries. */
+  export const PREFIX = "Error on typia.protobuf.decode(): ";
+
+  interface IDocument {
+    specification: string;
+    oracle: string;
+    purpose: string;
+    strictness: string;
+    consumers: string[];
+    fields: Record<string, string>;
+    faults: Record<string, string>;
+    entries: IEntry[];
+  }
+
+  /**
+   * Parse the corpus once, asserting its shape.
+   *
+   * The assertion is not ceremony: a corpus that lost a field, or gained a
+   * fault class no regression knows how to expect, must fail loudly here
+   * instead of silently narrowing what the regressions cover.
+   */
+  const document = (): IDocument => {
+    if (parsed === null) {
+      parsed = typia.assert<IDocument>(
+        JSON.parse(fs.readFileSync(LOCATION, "utf8")),
+      );
+      if (parsed.entries.length === 0)
+        throw new Error(`the shared varint corpus at ${LOCATION} is empty.`);
+    }
+    return parsed;
+  };
+
+  let parsed: IDocument | null = null;
+
+  const LOCATION = `${TestGlobal.ROOT}/../../packages/typia/test/protobuf_varint_corpus.json`;
+
+  const MESSAGES: Record<Fault, string> = {
+    truncated: `${PREFIX}buffer overflow.`,
+    overlong: `${PREFIX}varint exceeds 10 bytes.`,
+    overflow: `${PREFIX}varint exceeds 64 bits.`,
+  };
+}

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_varint_bounds.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_varint_bounds.ts
@@ -1,0 +1,320 @@
+import typia from "typia";
+
+import { ProtobufVarintCorpus } from "./ProtobufVarintCorpus";
+
+/**
+ * Verifies generated Protobuf decoders reject malformed varints before
+ * validation.
+ *
+ * The generated decoder shares `uint32` between scalar values, field tags, and
+ * every length-delimited frame, while all 64-bit scalar projections share the
+ * corresponding wide reader. Every raw, assertion, predicate, and validation
+ * wrapper must therefore surface the same wire error instead of returning a
+ * product-shaped value, `null`, or an `IValidation` result.
+ *
+ * Every byte string and every verdict below comes from
+ * `packages/typia/test/protobuf_varint_corpus.json`, which the Go test
+ * `TestProtobufVarintCorpusMatchesProtowire` holds against
+ * `google.golang.org/protobuf`. Nothing here is transcribed, so a decoder that
+ * disagreed with the reference Go parser could not also agree with this file.
+ *
+ * 1. Cross all eight direct and factory wrappers with every malformed corpus
+ *    row placed as a 32-bit, 64-bit, boolean, packed, map, and nested value.
+ * 2. Reject the same rows as top-level and group tags, as bytes, string,
+ *    packed, map, nested, unknown-field, and group-contained length prefixes,
+ *    and as the value of an unknown varint field the decoder only skips.
+ * 3. Preserve every accepted row's decoded value, trailing fields, and encoder
+ *    round trips.
+ */
+export const test_protobuf_decode_varint_bounds = (): void => {
+  const baseline: Uint8Array = typia.protobuf.encode<ISurface>({
+    uint32: 1,
+    int32: -1,
+    uint64: 1n,
+    int64: -1n,
+    boolean: false,
+    packed: [1n],
+    bytes: Uint8Array.of(1),
+    string: "x",
+    records: { key: 1n },
+    nested: { value: 1n, text: "x" },
+    state: State.ONE,
+    strings: ["x"],
+  });
+
+  //----
+  // EVERY MALFORMED ROW, EVERY PLACEMENT
+  //----
+  // a valid message follows each malformed varint, so a decoder that rejected
+  // the payload for running out of bytes rather than for the varint itself
+  // would report a different fault here
+  const malformed: ProtobufVarintCorpus.IEntry[] =
+    ProtobufVarintCorpus.malformed();
+  if (malformed.length === 0)
+    throw new Error("the shared varint corpus carries no malformed row.");
+  for (const entry of malformed) {
+    const bytes: number[] = ProtobufVarintCorpus.bytes(entry);
+    const expected: string = ProtobufVarintCorpus.message(entry);
+    const label = (what: string): string => `${what} of ${entry.name}`;
+
+    for (const field of VARINT_FIELDS)
+      assertAll(
+        label(`${field.name} scalar`),
+        Uint8Array.from([field.tag, ...bytes, ...baseline]),
+        expected,
+      );
+
+    assertAll(
+      label("packed uint64 value"),
+      Uint8Array.from([0x32, bytes.length, ...bytes, ...baseline]),
+      expected,
+    );
+    assertAll(
+      label("unpacked repeated uint64 value"),
+      Uint8Array.from([0x30, ...bytes, ...baseline]),
+      expected,
+    );
+    assertAll(
+      label("map uint64 value"),
+      Uint8Array.from([0x4a, bytes.length + 1, 0x10, ...bytes, ...baseline]),
+      expected,
+    );
+    assertAll(
+      label("map string key length"),
+      Uint8Array.from([0x4a, bytes.length + 1, 0x0a, ...bytes, ...baseline]),
+      expected,
+    );
+    assertAll(
+      label("nested uint64 value"),
+      Uint8Array.from([0x52, bytes.length + 1, 0x08, ...bytes, ...baseline]),
+      expected,
+    );
+    assertAll(
+      label("nested string length"),
+      Uint8Array.from([0x52, bytes.length + 1, 0x12, ...bytes, ...baseline]),
+      expected,
+    );
+
+    for (const [name, tag] of LENGTH_FIELDS)
+      assertAll(
+        label(`${name} length`),
+        Uint8Array.from([tag, ...bytes, ...baseline]),
+        expected,
+      );
+    assertAll(
+      label("unknown field length"),
+      Uint8Array.from([0x6a, ...bytes, ...baseline]),
+      expected,
+    );
+    // the skip path discards the bytes it reads, so it is the one consumer
+    // that could accept a varint no value reader would; #2139 pinned only its
+    // over-long half, and the tenth-byte payload half arrives with this fix
+    assertAll(
+      label("unknown varint field"),
+      Uint8Array.from([0x68, ...bytes, ...baseline]),
+      expected,
+    );
+    assertAll(
+      label("length inside a group"),
+      Uint8Array.from([0x6b, 0x72, ...bytes, 0x6c, ...baseline]),
+      expected,
+    );
+
+    const tag: number[] = ProtobufVarintCorpus.asTag(entry);
+    assertAll(
+      label("top-level field tag"),
+      Uint8Array.from([...tag, 0x01, ...baseline]),
+      expected,
+    );
+    assertAll(
+      label("field tag inside a group"),
+      Uint8Array.from([0x6b, ...tag, 0x01, 0x6c, ...baseline]),
+      expected,
+    );
+  }
+
+  //----
+  // EVERY TRUNCATED ROW
+  //----
+  // nothing follows a truncated varint, so the payload really does end inside
+  // it and the decoder must report the framing fault rather than a value
+  for (const entry of ProtobufVarintCorpus.truncated()) {
+    const bytes: number[] = ProtobufVarintCorpus.bytes(entry);
+    const expected: string = ProtobufVarintCorpus.message(entry);
+    assertAll(
+      `scalar ${entry.name}`,
+      Uint8Array.from([0x08, ...bytes]),
+      expected,
+    );
+    assertAll(
+      `length ${entry.name}`,
+      Uint8Array.from([0x3a, ...bytes]),
+      expected,
+    );
+    if (bytes.length !== 0)
+      assertAll(
+        `tag ${entry.name}`,
+        Uint8Array.from(ProtobufVarintCorpus.asTag(entry)),
+        expected,
+      );
+  }
+
+  //----
+  // EVERY ACCEPTED ROW STILL DECODES
+  //----
+  for (const [label, decode] of DECODERS) {
+    for (const entry of ProtobufVarintCorpus.accepted()) {
+      const decoded: typia.Resolved<ISurface> = decode(
+        Uint8Array.from([
+          ...baseline,
+          0x18,
+          ...ProtobufVarintCorpus.bytes(entry),
+        ]),
+      );
+      const expected: bigint = ProtobufVarintCorpus.value(entry);
+      if (decoded.uint64 !== expected)
+        throw new Error(
+          `${label} decoded ${entry.name} as ${decoded.uint64} instead of ${expected}.`,
+        );
+    }
+
+    // a trailing field behind an accepted varint is still read
+    const trailing: typia.Resolved<ISurface> = decode(
+      Uint8Array.from([
+        ...baseline,
+        0x08,
+        ...ProtobufVarintCorpus.bytes(
+          ProtobufVarintCorpus.find("non-canonical ten-byte zero"),
+        ),
+        0x28,
+        0x01,
+      ]),
+    );
+    if (trailing.uint32 !== 0 || trailing.boolean !== true)
+      throw new Error(
+        `${label} lost a valid non-canonical value or trailing field.`,
+      );
+
+    const maximum: typia.Resolved<ISurface> = decode(
+      Uint8Array.from([
+        ...baseline,
+        0x18,
+        ...ProtobufVarintCorpus.bytes(
+          ProtobufVarintCorpus.find("canonical 64-bit maximum"),
+        ),
+      ]),
+    );
+    const roundTrip: typia.Resolved<ISurface> = decode(
+      typia.protobuf.encode<ISurface>(maximum as ISurface),
+    );
+    if (roundTrip.uint64 !== maximum.uint64 || roundTrip.records.key !== 1n)
+      throw new Error(`${label} broke a valid encoder round trip.`);
+  }
+};
+
+interface ISurface {
+  uint32: number & typia.tags.Type<"uint32">;
+  int32: number & typia.tags.Type<"int32">;
+  uint64: bigint & typia.tags.Type<"uint64">;
+  int64: bigint & typia.tags.Type<"int64">;
+  boolean: boolean;
+  packed: Array<bigint & typia.tags.Type<"uint64">>;
+  bytes: Uint8Array;
+  string: string;
+  records: Record<string, bigint & typia.tags.Type<"uint64">>;
+  nested: {
+    value: bigint & typia.tags.Type<"uint64">;
+    text: string;
+  };
+  state: State;
+  strings: string[];
+}
+
+enum State {
+  ZERO,
+  ONE,
+}
+
+type Decoder = (input: Uint8Array) => typia.Resolved<ISurface>;
+
+const must = (
+  label: string,
+  value: typia.Resolved<ISurface> | null,
+): typia.Resolved<ISurface> => {
+  if (value === null) throw new Error(`${label} rejected a valid payload.`);
+  return value;
+};
+
+const unwrap = (
+  label: string,
+  validation: typia.IValidation<typia.Resolved<ISurface>>,
+): typia.Resolved<ISurface> => {
+  if (validation.success === false)
+    throw new Error(`${label} rejected a valid payload.`);
+  return validation.data;
+};
+
+const DECODERS: ReadonlyArray<readonly [string, Decoder]> = [
+  ["decode", (input) => typia.protobuf.decode<ISurface>(input)],
+  ["createDecode", typia.protobuf.createDecode<ISurface>()],
+  ["assertDecode", (input) => typia.protobuf.assertDecode<ISurface>(input)],
+  ["createAssertDecode", typia.protobuf.createAssertDecode<ISurface>()],
+  [
+    "isDecode",
+    (input) => must("isDecode", typia.protobuf.isDecode<ISurface>(input)),
+  ],
+  [
+    "createIsDecode",
+    (
+      (decode) => (input: Uint8Array) =>
+        must("createIsDecode", decode(input))
+    )(typia.protobuf.createIsDecode<ISurface>()),
+  ],
+  [
+    "validateDecode",
+    (input) =>
+      unwrap("validateDecode", typia.protobuf.validateDecode<ISurface>(input)),
+  ],
+  [
+    "createValidateDecode",
+    (
+      (decode) => (input: Uint8Array) =>
+        unwrap("createValidateDecode", decode(input))
+    )(typia.protobuf.createValidateDecode<ISurface>()),
+  ],
+];
+
+const assertAll = (
+  label: string,
+  input: Uint8Array,
+  expected: string,
+): void => {
+  for (const [decoder, decode] of DECODERS) {
+    try {
+      decode(input);
+    } catch (error) {
+      if (error instanceof Error && error.message === expected) continue;
+      throw new Error(
+        `${decoder} ${label} reported ${String(error)} instead of ${JSON.stringify(expected)}.`,
+      );
+    }
+    throw new Error(`${decoder} accepted ${label}.`);
+  }
+};
+
+const VARINT_FIELDS = [
+  { name: "uint32", tag: 0x08 },
+  { name: "int32", tag: 0x10 },
+  { name: "uint64", tag: 0x18 },
+  { name: "int64", tag: 0x20 },
+  { name: "boolean", tag: 0x28 },
+  { name: "enum-like value", tag: 0x58 },
+] as const;
+const LENGTH_FIELDS = [
+  ["packed", 0x32],
+  ["bytes", 0x3a],
+  ["string", 0x42],
+  ["map", 0x4a],
+  ["nested", 0x52],
+  ["repeated string", 0x62],
+] as const;

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_unknown_field_faults.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_unknown_field_faults.ts
@@ -10,9 +10,9 @@ import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
  * A reserved wire type must not report an anonymous error that leaves the
  * caller unable to attribute the failure, and a varint must not be consumed
  * past the ten bytes a 64-bit value can legally occupy merely because the skip
- * path discards the bytes it reads. `varint32` and `varint64` are already
- * structurally bounded at ten, so a skip that is not makes the limit depend on
- * which method happens to consume the varint.
+ * path discards the bytes it reads. Value and skip paths must enforce the same
+ * tenth-byte payload boundary so the limit does not depend on which method
+ * happens to consume the varint.
  *
  * 1. Reject every wire type that carries no skip semantics, including the reserved
  *    6 and 7 and a bare END_GROUP, directly, from a non-zero offset, and nested
@@ -20,7 +20,7 @@ import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
  * 2. Skip varints up to the ten-byte limit and reject the eleventh byte, while a
  *    varint the buffer truncates before that limit still reports overflow.
  * 3. Assert every fault carries the standard prefix and restores the reader, and
- *    that the legal wire types and `uint32` are left untouched.
+ *    that legal wire types and legal ten-byte values are left untouched.
  */
 export const test_protobuf_reader_unknown_field_faults = (): void => {
   //----
@@ -157,15 +157,22 @@ export const test_protobuf_reader_unknown_field_faults = (): void => {
     r.skipType(ProtobufWire.START_GROUP),
   );
 
-  // `varint32` keeps capping at ten bytes rather than throwing: the reader's
-  // value paths are unchanged, and only the skip path gained the limit it lacked
-  const capped: _ProtobufReader = new _ProtobufReader(
-    Uint8Array.from([...continuations(10), 0x01]),
+  const malformed: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.from(continuations(10)),
   );
-  if (capped.uint32() !== 0 || capped.index() !== 10)
+  const malformedError: Error = rejection(
+    "ten continuation bytes through uint32",
+    () => malformed.uint32(),
+  );
+  if (malformedError.message !== OVERLONG)
     throw new Error(
-      `uint32 stopped at index ${capped.index()} instead of its ten-byte cap.`,
+      `ten continuation bytes through uint32 reported ${JSON.stringify(malformedError.message)}.`,
     );
+  const maximum: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.from([...new Array(9).fill(0xff), 0x01]),
+  );
+  if (maximum.uint32() !== 0xffffffff || maximum.index() !== 10)
+    throw new Error("uint32 no longer accepts a legal ten-byte wire value.");
 };
 
 /** Bytes carrying only the continuation bit, so a varint never terminates. */

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_varint_bounds.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_varint_bounds.ts
@@ -1,0 +1,301 @@
+import { ProtobufWire } from "@typia/interface";
+import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
+
+import { ProtobufVarintCorpus } from "./ProtobufVarintCorpus";
+
+/**
+ * Verifies every runtime Protobuf varint reader matches the reference Go
+ * parser over the shared corpus.
+ *
+ * A ten-byte varint has room for only one payload bit in its final byte. The
+ * scalar readers, length readers, and unknown-field skipper must reject both a
+ * continuing tenth byte and a terminating tenth byte with any higher payload
+ * bit, instead of returning a truncated value or accepting a zero length.
+ *
+ * Rejecting is only half of it. The corpus also carries the canonical maximum
+ * that terminates at each width from one byte through ten, so every early
+ * return in `varint32` and `varint64` keeps a positive control. The nine-byte
+ * row matters most: it is the legal encoding of `9223372036854775807`, the
+ * very value the issue's malformed ten-byte witness used to fabricate.
+ *
+ * Every byte string and every verdict below comes from
+ * `packages/typia/test/protobuf_varint_corpus.json`, which the Go test
+ * `TestProtobufVarintCorpusMatchesProtowire` holds against
+ * `google.golang.org/protobuf`. Nothing here is transcribed, so this regression
+ * cannot quietly disagree with the oracle that justifies it.
+ *
+ * 1. Cross every public integer and boolean reader, and the unknown-field
+ *    skipper, with every corpus row.
+ * 2. Read the rejected rows again as byte, string, fork, unknown-field, and
+ *    group-contained lengths and as a group's field tag.
+ * 3. Preserve the decoded value of every accepted row, exact pointer
+ *    advancement, and the trailing byte behind it.
+ */
+export const test_protobuf_reader_varint_bounds = (): void => {
+  const entries: ProtobufVarintCorpus.IEntry[] = ProtobufVarintCorpus.entries();
+  if (entries.length === 0)
+    throw new Error("the shared varint corpus is empty, so nothing was read.");
+
+  //----
+  // EVERY VALUE READER, EVERY ROW
+  //----
+  for (const entry of entries) {
+    const octets: number[] = ProtobufVarintCorpus.bytes(entry);
+    for (const reader of VALUE_READERS)
+      if (entry.fault !== null)
+        assertFault(
+          `${reader.name} of ${entry.name}`,
+          octets,
+          ProtobufVarintCorpus.message(entry),
+          (r) => reader.read(r),
+        );
+      else assertAccepted(entry, reader, octets);
+
+    // the skipper consumes the same varint without decoding it, so it must
+    // agree on where the varint ends and on whether it exists at all
+    if (entry.fault !== null)
+      assertFault(
+        `skipVarint of ${entry.name}`,
+        octets,
+        ProtobufVarintCorpus.message(entry),
+        (r) => r.skipVarint(),
+      );
+    else assertAdvance(`skipVarint of ${entry.name}`, entry, octets);
+  }
+
+  //----
+  // THE SAME ROWS IN EVERY FRAMING POSITION
+  //----
+  // a malformed varint stays malformed wherever the decoder meets it, so a
+  // consumer cannot launder it by reading it as a length or as a tag
+  for (const entry of ProtobufVarintCorpus.malformed()) {
+    const octets: number[] = ProtobufVarintCorpus.bytes(entry);
+    const expected: string = ProtobufVarintCorpus.message(entry);
+    assertAtomicFault(`bytes length of ${entry.name}`, octets, expected, (r) =>
+      r.bytes(),
+    );
+    assertAtomicFault(`string length of ${entry.name}`, octets, expected, (r) =>
+      r.string(),
+    );
+    assertAtomicFault(`fork length of ${entry.name}`, octets, expected, (r) =>
+      r.fork(),
+    );
+    assertAtomicFault(
+      `unknown LEN length of ${entry.name}`,
+      octets,
+      expected,
+      (r) => r.skipType(ProtobufWire.LEN),
+    );
+    assertAtomicFault(
+      `unknown VARIANT value of ${entry.name}`,
+      octets,
+      expected,
+      (r) => r.skipType(ProtobufWire.VARIANT),
+    );
+    assertAtomicFault(
+      `length inside a group of ${entry.name}`,
+      [0x0a, ...octets, 0x0c],
+      expected,
+      (r) => r.skipType(ProtobufWire.START_GROUP),
+    );
+    assertAtomicFault(
+      `tag inside a group of ${entry.name}`,
+      [...ProtobufVarintCorpus.asTag(entry), 0x01, 0x0c],
+      expected,
+      (r) => r.skipType(ProtobufWire.START_GROUP),
+    );
+  }
+
+  //----
+  // WHAT MUST NOT CHANGE
+  //----
+  // the two rejections stay named apart. Both rows below are exactly ten bytes
+  // wide, so a single message naming a length would be untrue of one of them:
+  // one varint would continue into an eleventh byte, the other terminates and
+  // carries a value bit above 63. The loops above assert each row's own text,
+  // and this pins the distinction the corpus draws between them.
+  const overlong: ProtobufVarintCorpus.IEntry =
+    ProtobufVarintCorpus.find("ten continuation bytes");
+  const overflow: ProtobufVarintCorpus.IEntry =
+    ProtobufVarintCorpus.find("excess tenth payload");
+  if (
+    ProtobufVarintCorpus.bytes(overlong).length !==
+    ProtobufVarintCorpus.bytes(overflow).length
+  )
+    throw new Error(
+      "the two rejected rows no longer share a width, so they no longer isolate the fault from the length.",
+    );
+  if (
+    ProtobufVarintCorpus.message(overlong) ===
+    ProtobufVarintCorpus.message(overflow)
+  )
+    throw new Error(
+      "an over-long varint and an overflowing one report the same fault again.",
+    );
+
+  // `bool` decides on the 32-bit projection rather than on the decoded value,
+  // so the corpus value cannot supply its expectation; only its framing is
+  // corpus-derived above. The legal ten-byte maximum must still read as true.
+  const maximum: ProtobufVarintCorpus.IEntry = ProtobufVarintCorpus.find(
+    "canonical 64-bit maximum",
+  );
+  const subject: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.from([...ProtobufVarintCorpus.bytes(maximum), 0x7f]),
+  );
+  const flag: boolean = subject.bool();
+  if (flag !== true || subject.index() !== maximum.consumed)
+    throw new Error(
+      `bool of ${maximum.name} returned ${flag} at index ${subject.index()} instead of true at ${maximum.consumed}.`,
+    );
+};
+
+interface IValueReader {
+  /** Public reader method name, used in failure labels. */
+  name: string;
+
+  /** The call under test. */
+  read: (reader: _ProtobufReader) => number | bigint | boolean;
+
+  /**
+   * The value this reader must return for a decoded varint, or `null` when the
+   * corpus value cannot supply it.
+   */
+  project: ((value: bigint) => number | bigint | boolean) | null;
+}
+
+/**
+ * Every public varint consumer, with the projection the wire format demands.
+ *
+ * A field narrower than the varint keeps the low bits, which is what a
+ * Protocol Buffer parser does with a 64-bit varint on a 32-bit field, so each
+ * 32-bit expectation is the oracle value reduced rather than an independent
+ * guess. `bool` is excluded from the value column and covered separately.
+ */
+const VALUE_READERS: IValueReader[] = [
+  {
+    name: "uint32",
+    read: (reader) => reader.uint32(),
+    project: (value) => Number(BigInt.asUintN(32, value)),
+  },
+  {
+    name: "int32",
+    read: (reader) => reader.int32(),
+    project: (value) => Number(BigInt.asIntN(32, value)),
+  },
+  {
+    name: "sint32",
+    read: (reader) => reader.sint32(),
+    project: (value) => Number(zigzag(BigInt.asUintN(32, value))),
+  },
+  {
+    name: "uint64",
+    read: (reader) => reader.uint64(),
+    project: (value) => value,
+  },
+  {
+    name: "int64",
+    read: (reader) => reader.int64(),
+    project: (value) => BigInt.asIntN(64, value),
+  },
+  {
+    name: "sint64",
+    read: (reader) => reader.sint64(),
+    project: (value) => zigzag(value),
+  },
+  {
+    name: "bool",
+    read: (reader) => reader.bool(),
+    project: null,
+  },
+];
+
+/** ZigZag decoding, which maps an unsigned varint back onto a signed value. */
+const zigzag = (value: bigint): bigint =>
+  (value >> BigInt(1)) ^ -(value & BigInt(1));
+
+/**
+ * Require the reader to decode an accepted row exactly.
+ *
+ * A trailing byte follows the varint so that consuming one byte too many or
+ * too few is visible as a wrong index rather than as an accidental buffer end.
+ */
+const assertAccepted = (
+  entry: ProtobufVarintCorpus.IEntry,
+  reader: IValueReader,
+  octets: number[],
+): void => {
+  const subject: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.from([...octets, 0x7f]),
+  );
+  const actual: number | bigint | boolean = reader.read(subject);
+  const expected: number | bigint | boolean | null =
+    reader.project === null
+      ? null
+      : reader.project(ProtobufVarintCorpus.value(entry));
+  if (expected !== null && actual !== expected)
+    throw new Error(
+      `${reader.name} of ${entry.name} returned ${String(actual)} instead of ${String(expected)}.`,
+    );
+  if (subject.index() !== entry.consumed)
+    throw new Error(
+      `${reader.name} of ${entry.name} stopped at index ${subject.index()} instead of ${entry.consumed}.`,
+    );
+};
+
+/** Require a consumer to advance across an accepted row and no further. */
+const assertAdvance = (
+  label: string,
+  entry: ProtobufVarintCorpus.IEntry,
+  octets: number[],
+): void => {
+  const subject: _ProtobufReader = new _ProtobufReader(
+    Uint8Array.from([...octets, 0x7f]),
+  );
+  subject.skipVarint();
+  if (subject.index() !== entry.consumed)
+    throw new Error(
+      `${label} stopped at index ${subject.index()} instead of ${entry.consumed}.`,
+    );
+};
+
+const assertFault = (
+  label: string,
+  octets: number[],
+  expected: string,
+  read: (reader: _ProtobufReader) => unknown,
+): void => {
+  const subject: _ProtobufReader = new _ProtobufReader(Uint8Array.from(octets));
+  assertMessage(label, expected, () => read(subject));
+};
+
+/** Require the fault and the atomic restoration the framing readers promise. */
+const assertAtomicFault = (
+  label: string,
+  octets: number[],
+  expected: string,
+  read: (reader: _ProtobufReader) => unknown,
+): void => {
+  const subject: _ProtobufReader = new _ProtobufReader(Uint8Array.from(octets));
+  const size: number = subject.size();
+  assertMessage(label, expected, () => read(subject));
+  if (subject.index() !== 0 || subject.size() !== size)
+    throw new Error(
+      `${label} left index ${subject.index()} and size ${subject.size()} instead of restoring the reader.`,
+    );
+};
+
+const assertMessage = (
+  label: string,
+  expected: string,
+  closure: () => unknown,
+): void => {
+  try {
+    closure();
+  } catch (error) {
+    if (error instanceof Error && error.message === expected) return;
+    throw new Error(
+      `${label} reported ${String(error)} instead of ${JSON.stringify(expected)}.`,
+    );
+  }
+  throw new Error(`${label} accepted a malformed Protobuf varint.`);
+};


### PR DESCRIPTION
## Purpose

This consolidates the residual issue-campaign work into one pull request, replacing five separate campaign pull requests.

Two maintainer directives shaped it. First, the local machine ran out of resource headroom, so **all local building and testing was stopped** and verification is delegated to GitHub Actions CI. Second, the residual pull requests are to be combined into a single one. Accordingly the campaign's per-push exact-SHA CI cancellation rule is **suspended for this branch**: these runs must be allowed to finish, because they are now the verification.

Every commit here is a squashed net diff of one campaign unit, one commit per issue, so each issue keeps its own acceptance boundary, rollback unit, and failure attribution inside the shared pull request.

## What each commit closes

| Issue | Commit | Defect |
| --- | --- | --- |
| #2082 | `fix(generate): order traversal entries by bytes, not locale` | `gather` sorted directory entries with `localeCompare`. Traversal order decides which lexical alias wins the visited-directory dedup, so the emitted output tree and the diagnostic path were locale-dependent. |
| #2256 | `fix(protobuf): reject malformed varints across values and framing` | `_ProtobufReader` accepted over-long varints; a ten-byte encoding with payload above bit 63 silently wrapped into a different value. Now bounded across values, tags, length prefixes, framing, and the unknown-field skip. |
| #2200 | `fix(native): require a runtime provider for native identity` | `metadata_symbol_is_global_type` treated global-table resolution as proof that a runtime provides the constructor, so a project's own `declare global` `File`/`Blob` won the lookup. |
| #2238 | `fix(native): preserve function semantics across callable spellings` | The pure-callable predicate was gated on `KindInterfaceDeclaration`, so `type X = { (v: number): string }` and the anonymous type literal fell through to structural object metadata. |
| #2252 | `fix(compare): preserve functional union membership during equality routing` | Equality routing decided union membership by a rule that disagreed with the emitted validator's own function rule. |

#2238 and #2252 were previously serialized by a merge-order dependency. Consolidation removes it: the callable-spelling boundary and the routing rule that depends on it are now verified in one tree.

## Evidence status — read this before reviewing

The campaign's normal gates are local build, focused suite, mutation proof, Self-Review, independent verification, and a full integration gate. The resource stop landed mid-wave, so those are **not uniformly satisfied here**. Stated exactly:

| Unit | Executed locally before the stop | Never executed |
| --- | --- | --- |
| #2082 | Fail-before on unmodified master with the candidate test: `repeated directory aliases are rejected` failed with a real `ERR_ASSERTION`, not a timeout. Adjacent cycle controls passed. Junction/inode, stability, case-spelling, and replacement probes all executed. | The narrowed determinism-only combination now shipping. The `mutual-cycle` cell, which timed out under fleet load and is recorded `UNTESTED`. The five CLI-mode rows. |
| #2256 | Rebase verified byte-identical; `protowire` v1.34.2 source read; Java/Go divergence checked upstream. | The suites and the Go oracle on this base. |
| #2200 | Nothing. | Everything, including compilation. |
| #2238 | Nothing. | Everything, including compilation. The 14-shape matrix has never run one cell. |
| #2252 | Nothing on this base. An earlier 52-case proof and mutation witness exist against an older master and are **not** reused as evidence. | Everything on this base. |

Three commits contain Go that has never been compiled. CI is the first thing to compile or run them, and failures here are expected to be diagnosed and repaired in this pull request.

The #2238 invariant that #2252 builds on is stated in its commit message and is **derived from source reading, not from an executed matrix**. If CI contradicts it, the routing fix must be re-examined, not patched.

## Not included: #2253

#2253 (contextual `any`/`unknown` JSON serialization) is **excluded and stays open**. Its work is preserved on `fix/json-contextual-undefined` and described on #2254. It is not a salvageable implementation:

- the `_jsonStringifyArray` runtime helper is orphaned — `StringifyJoiner.Array` still emits `input.map(arrow).join(",")` and nothing imports or calls it;
- the object-property half has no implementation at all, while its tests assert it;
- the `undefined: false` oracle question is unresolved, and native `JSON.stringify` is not an unqualified oracle in a mode where typia may legitimately skip undefined checks.

Its root-cause analysis is worth keeping: the class is wider than the reported witness. A sparse `number[]` emits `[,3]`, and a required property whose `toJSON` returns undefined emits `{"k":undefined}` — text that is not valid JSON at all.

## Superseded pull requests

#2262, #2258, #2257, #2264, #2255 are superseded by this pull request. #2254 stays open for #2253.

## Defect candidates raised while implementing, deliberately kept out of this diff

Recorded so they are not silently deferred; each needs its own issue.

1. **Lossy inode identity.** `fileIdentityKey` builds identities from `fs.Stats.ino` as a JS number. In a 4000-directory probe, 1879 NTFS directory IDs exceeded 2^53, where the double ulp is 8. Two distinct directories can fold into one identity, silently skipping a real directory or raising a bogus revisit error. It also guards `ensureTargetFiles`' input/output overwrite check, which makes it a data-loss path. `{ bigint: true }` is necessary but not sufficient: it addresses neither `ino === 0` filesystems nor the win32 case-folding gap in the path fallback.
2. **`metadata_symbol_from_default_lib` decides default-library provenance from the `lib.*.d.ts` base name**, which `libReplacement` defeats — real lib files resolve to `node_modules/@typescript/lib-es2022/index.d.ts`. This pull request routes only its own new predicate around it via a checker-keyed registry; the old helper's other callers, including `metadata_is_global_function_interface`, keep the wrong answer.
3. **Support-or-diagnostic divergence** between spellings for member-carrying callable shapes whose only alias spelling is an intersection. Pinned as a declared boundary here rather than silently generalized.
4. **`tests/test-typia-generate` filesystem cases are a flaky oracle by construction.** Each of the 10 cases pays full `ttsx --no-plugins` startup with no reuse, so cost is dominated by compiler startup rather than the behaviour under test — two consecutive full runs took 570 s and 644 s. The 180 s per-case bound sits only ~2.5x above unloaded cost. The durable fix is to stop paying startup ten times, not to raise the bound.
