### PR TITLE
fix: make http declarations self-contained and keep bare global natives identifiable

### DIFF
--- a/packages/interface/src/http/IHttpConnection.ts
+++ b/packages/interface/src/http/IHttpConnection.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 /**
  * HTTP connection configuration for remote server communication.
  *
@@ -59,9 +57,43 @@ export interface IHttpConnection {
    *     fetch: fetch as any,
    *   };
    */
-  fetch?: typeof fetch;
+  fetch?: IHttpConnection.IFetch;
 }
 export namespace IHttpConnection {
+  /**
+   * The runtime's `fetch`, or a minimal stand-in where none is declared.
+   *
+   * This resolves to exactly `typeof globalThis.fetch` in any project that
+   * declares it — through the DOM library, `@types/node`, or a polyfill's own
+   * typings — so the member's type is unchanged wherever it was previously
+   * usable. Where nothing declares it, it degrades to a callable shape instead
+   * of failing to resolve.
+   *
+   * The indirection exists because this package's emitted declarations must be
+   * self-contained. Naming `fetch` directly required a `/// <reference
+   * lib="dom" />` that the declaration emit does not carry into `lib/**`, so
+   * consumers installed a declaration whose types could not resolve, and the
+   * repository's own transform fixtures silently loaded the DOM library while
+   * believing they had excluded it (samchon/typia#2267, samchon/typia#2268).
+   */
+  export type IFetch = typeof globalThis extends { fetch: infer T }
+    ? T
+    : (input: any, init?: any) => Promise<any>;
+
+  /**
+   * The runtime's `AbortSignal`, or a minimal stand-in where none is declared.
+   *
+   * Resolves to the real `AbortSignal` instance type wherever one is declared,
+   * so a value read from here stays assignable back to `RequestInit["signal"]`
+   * and a real signal stays assignable into it. See {@link IFetch} for why the
+   * indirection exists.
+   */
+  export type IAbortSignal = typeof globalThis extends {
+    AbortSignal: abstract new (...args: any) => infer T;
+  }
+    ? T
+    : { readonly aborted: boolean };
+
   /**
    * Fetch API request options.
    *
@@ -178,7 +210,7 @@ export namespace IHttpConnection {
      *   const options = { signal: controller.signal };
      *   // Later: controller.abort();
      */
-    signal?: AbortSignal | null;
+    signal?: IHttpConnection.IAbortSignal | null;
   }
 
   /**

--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -197,7 +197,7 @@ const ttscTypiaTestJsonStringifyElementStub = `module.exports._jsonStringifyElem
   text === undefined ? "null" : text;
 `
 
-// Deterministic rather than random: these runtimes assert observable behaviour
+// Deterministic rather than random: these runtimes assert observable behavior
 // of the emitted validators, so a generated string only has to satisfy the
 // declared bounds, and a stable one keeps a failure reproducible.
 const ttscTypiaTestRandomStringStub = `module.exports._randomString = (props) => {

--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -6,6 +6,7 @@ import (
   "os/exec"
   "path/filepath"
   "runtime"
+  "sort"
   "strings"
   "testing"
 )
@@ -71,6 +72,7 @@ func ttscTypiaTestWriteCommonRuntimeStubs(t *testing.T, runtimeDir string) {
     "json-stringify-array-stub.cjs":    ttscTypiaTestJsonStringifyArrayStub,
     "json-stringify-property-stub.cjs": ttscTypiaTestJsonStringifyPropertyStub,
     "json-stringify-element-stub.cjs":  ttscTypiaTestJsonStringifyElementStub,
+    "random-string-stub.cjs":           ttscTypiaTestRandomStringStub,
   }
   for name, content := range files {
     if err := os.WriteFile(filepath.Join(runtimeDir, name), []byte(content), 0o644); err != nil {
@@ -91,6 +93,7 @@ func ttscTypiaTestRewriteCommonJS(t *testing.T, js string) string {
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyArray")`, `require("./json-stringify-array-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyProperty")`, `require("./json-stringify-property-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyElement")`, `require("./json-stringify-element-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_randomString")`, `require("./random-string-stub.cjs")`)
   for _, helper := range []string{"_notationAssign", "_notationCamel", "_notationKebab", "_notationKeyCollision", "_notationPascal", "_notationSnake"} {
     runtimeJS = strings.ReplaceAll(
       runtimeJS,
@@ -99,9 +102,29 @@ func ttscTypiaTestRewriteCommonJS(t *testing.T, js string) string {
     )
   }
   for _, needle := range []string{`require("typia")`, `require('typia')`, `from "typia"`, `from 'typia'`, `typia/lib/internal/`} {
-    if strings.Contains(runtimeJS, needle) {
-      t.Fatalf("runtime module still contains unresolved typia import %q", needle)
+    if !strings.Contains(runtimeJS, needle) {
+      continue
     }
+    // Name the modules that are actually unmapped. Reporting only the needle
+    // makes every new internal helper look like the same failure and sends the
+    // reader hunting through the emit for it.
+    if needle == `typia/lib/internal/` {
+      unresolved := map[string]bool{}
+      for _, part := range strings.Split(runtimeJS, needle)[1:] {
+        end := strings.IndexAny(part, "\"')")
+        if end < 0 {
+          end = len(part)
+        }
+        unresolved[part[:end]] = true
+      }
+      names := make([]string, 0, len(unresolved))
+      for name := range unresolved {
+        names = append(names, name)
+      }
+      sort.Strings(names)
+      t.Fatalf("runtime module has no stub for typia internal helpers: %s", strings.Join(names, ", "))
+    }
+    t.Fatalf("runtime module still contains unresolved typia import %q", needle)
   }
   return runtimeJS
 }
@@ -172,6 +195,20 @@ const ttscTypiaTestJsonStringifyPropertyStub = `module.exports._jsonStringifyPro
 
 const ttscTypiaTestJsonStringifyElementStub = `module.exports._jsonStringifyElement = (text) =>
   text === undefined ? "null" : text;
+`
+
+// Deterministic rather than random: these runtimes assert observable behaviour
+// of the emitted validators, so a generated string only has to satisfy the
+// declared bounds, and a stable one keeps a failure reproducible.
+const ttscTypiaTestRandomStringStub = `module.exports._randomString = (props) => {
+  const minimum =
+    props.minLength !== undefined
+      ? props.minLength
+      : Math.min(props.maxLength !== undefined ? props.maxLength : 5, 5);
+  const maximum = props.maxLength !== undefined ? props.maxLength : minimum + 5;
+  const length = Math.max(minimum, Math.min(minimum, maximum));
+  return "a".repeat(length);
+};
 `
 
 const ttscTypiaTestStringLengthStub = `module.exports._stringLength = (value) => {

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_native.go
@@ -66,7 +66,21 @@ func iterate_metadata_native_getNativeName(name string) string {
   if index := strings.Index(name, "<"); index != -1 {
     name = name[:index]
   }
-  for _, module := range []string{"node:buffer.", "buffer."} {
+  // `global.` is the qualifier `metadata_symbol_name` produces for a symbol
+  // declared inside a `declare global` block, which is how @types/node declares
+  // the bare `Blob` and `File` globals. A project that includes the DOM library
+  // never showed it, because the DOM declares those names at file scope and the
+  // DOM declaration won the name; drop the DOM library — an ordinary Node
+  // service compiled with `"lib": ["ES2022"]` — and the only declaration left is
+  // the augmented one, so the name arrives as `global.Blob` and this lookup
+  // misses before any identity question is asked. Stripping the qualifier only
+  // restores the question; whether the declaration is a runtime-provided native
+  // or a same-named user global stays the identity gate's answer to give.
+  //
+  // An ambient module's qualifier is deliberately not stripped here: a lookalike
+  // published as `declare module "user-buffer-lookalike"` arrives as
+  // `user-buffer-lookalike.Blob` and must keep failing this lookup.
+  for _, module := range []string{"node:buffer.", "buffer.", "global."} {
     if strings.HasPrefix(name, module) {
       return strings.TrimPrefix(name, module)
     }


### PR DESCRIPTION
## Purpose

Three defects with one root, found while re-adjudicating #2200 after the consolidated campaign wave. They are in one pull request because none of them can be verified without the others: the first makes the second reachable, and the second is what let the third hide.

| Issue | Defect |
| --- | --- |
| #2267 | Published `@typia/interface` declarations name `fetch` and `AbortSignal` while the `/// <reference lib="dom" />` that resolves them is dropped by the declaration emit. |
| #2268 | In-repo fixtures resolve `typia` through the workspace `exports` to `src`, inherit that same directive, and therefore load `lib.dom.d.ts` no matter what their own `tsconfig` says. |
| #2272 | With the DOM library absent, bare global `Blob` and `File` lose native identity: the name arrives as `global.Blob` and misses the native lookup before the identity gate is asked. |

## What changed

**`IHttpConnection`** reaches `fetch` and `AbortSignal` through conditional types keyed on `globalThis` instead of naming them directly:

```ts
export type IFetch = typeof globalThis extends { fetch: infer T }
  ? T
  : (input: any, init?: any) => Promise<any>;
```

Wherever anything declares those names — the DOM library, `@types/node`, a polyfill's own typings — these resolve to exactly the runtime's own types, so a real `AbortSignal` stays assignable in and a value read back out stays assignable to `RequestInit["signal"]`. Where nothing declares them they degrade to a minimal shape instead of failing to resolve. `pnpm --filter ./packages/interface build` confirms the emitted `lib/http/IHttpConnection.d.ts` is now self-contained.

**`iterate_metadata_native_getNativeName`** strips a `global.` qualifier alongside the existing `node:buffer.` and `buffer.` ones. An ambient module's qualifier is still not stripped, so a lookalike published as `declare module "user-buffer-lookalike"` keeps failing the lookup. Stripping only restores the question; whether a declaration is a runtime-provided native or a same-named user global remains the identity gate's answer.

**Test harness:** the runtime rewrite now names the modules it has no stub for instead of reporting only the needle `typia/lib/internal/`, and gains a `_randomString` stub. The first change turned a blind failure into an immediate diagnosis while investigating this.

## Evidence

The fault was located by instrumenting `Iterate_metadata_native` in a DOM-free fixture:

```
[dbg] raw="Blob"                       derived="Blob"                       inSimples=true
[dbg] raw="node:buffer.Blob"           derived="Blob"                       inSimples=true
[dbg] raw="global.Blob"                derived="global.Blob"                inSimples=false
[dbg] raw="user-buffer-lookalike.Blob" derived="user-buffer-lookalike.Blob" inSimples=false
```

The identity gate answers correctly for every symbol it is asked about — the same `global.Blob` symbol reports `buffer=true` with declarations in `@types/node/buffer.d.ts`, while the lookalike reports `buffer=false`. It was simply never asked. All instrumentation was reverted.

`TestNodeBufferNativeExportsIsTransform` and `TestPackageDeclarationNativeIdentityIsTransform` fail with the first change alone and pass with the second, which is the mutation evidence for the qualifier strip. Their bare-global rows were previously measuring DOM behaviour under a Node name; `webkitRelativePath`, a DOM-only `File` member, appearing among the structural members they retained is the giveaway.

The whole `packages/typia/native/...` tree passes locally.

## Consequence for #2200

Two of #2200's three regressions flip from failing to passing on this branch:

```
--- PASS: TestDefaultLibrarySpoofNativeIdentityTransform
--- PASS: TestLibReplacementNativeIdentityTransform
```

The spoof case is the meaningful one: a `lib.*.d.ts`-named package declaration is now correctly refused native identity, which is what #2200's product change always claimed and could not previously demonstrate. That work stays on `fix/metadata-identity-residuals` and is re-adjudicated separately once this lands.

## Not included

`typia.llm.schema<File, "chatgpt">()` in #2200's fixture is malformed independently — the signature is `schema<T, Config = {}>($defs)`, so the model string lands in `Config`, which must be a literal object type. That correction belongs to #2200's own branch.
