### PR TITLE
fix(json): describe a function member the same way however it is spelled

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -72,6 +72,7 @@ func ttscTypiaTestWriteCommonRuntimeStubs(t *testing.T, runtimeDir string) {
     "json-stringify-array-stub.cjs":    ttscTypiaTestJsonStringifyArrayStub,
     "json-stringify-property-stub.cjs": ttscTypiaTestJsonStringifyPropertyStub,
     "json-stringify-element-stub.cjs":  ttscTypiaTestJsonStringifyElementStub,
+    "json-stringify-tail-stub.cjs":     ttscTypiaTestJsonStringifyTailStub,
     "random-string-stub.cjs":           ttscTypiaTestRandomStringStub,
   }
   for name, content := range files {
@@ -93,6 +94,7 @@ func ttscTypiaTestRewriteCommonJS(t *testing.T, js string) string {
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyArray")`, `require("./json-stringify-array-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyProperty")`, `require("./json-stringify-property-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyElement")`, `require("./json-stringify-element-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyTail")`, `require("./json-stringify-tail-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_randomString")`, `require("./random-string-stub.cjs")`)
   for _, helper := range []string{"_notationAssign", "_notationCamel", "_notationKebab", "_notationKeyCollision", "_notationPascal", "_notationSnake"} {
     runtimeJS = strings.ReplaceAll(
@@ -200,6 +202,10 @@ const ttscTypiaTestJsonStringifyElementStub = `module.exports._jsonStringifyElem
 // Deterministic rather than random: these runtimes assert observable behavior
 // of the emitted validators, so a generated string only has to satisfy the
 // declared bounds, and a stable one keeps a failure reproducible.
+const ttscTypiaTestJsonStringifyTailStub = `module.exports._jsonStringifyTail = (str) =>
+  str[str.length - 1] === "," ? str.substring(0, str.length - 1) : str;
+`
+
 const ttscTypiaTestRandomStringStub = `module.exports._randomString = (props) => {
   const minimum =
     props.minLength !== undefined

--- a/packages/typia/native/core/programmers/iterate/json_schema_object.go
+++ b/packages/typia/native/core/programmers/iterate/json_schema_object.go
@@ -55,10 +55,16 @@ func json_schema_create_object_schema(props struct {
   required := []string{}
 
   for _, property := range props.object.Type.Properties {
-    if len(property.Value.Functions) != 0 &&
-      property.Value.Nullable == false &&
-      property.Value.IsRequired() &&
-      property.Value.Size() == 0 {
+    // A member that is only a function has no JSON to describe, so the schema
+    // drops it exactly as the serializer does. The condition has to match the
+    // serializer's (`StringifyJoiner`) or the two disagree about the same type:
+    // `Size()` counts `Functions`, so a pure function member is size 1 and a
+    // `Size() == 0` test could never fire for the case it was written to catch,
+    // leaving the member described as a `$ref` to an empty component — a schema
+    // for a document `json.stringify` never produces. Optionality is not part of
+    // the question either; an optional function member has no JSON either
+    // (samchon/typia#2270).
+    if json_schema_object_function_only(property.Value) {
       continue
     }
     if json_schema_has_any_tag(property.JsDocTags, []string{"hidden", "ignore", "internal"}) {
@@ -194,4 +200,30 @@ func (superfluous *json_schema_superfluous) setPatternProperty(pattern string, p
 type json_schema_metadata_schema_pair struct {
   metadata *nativemetadata.MetadataSchema
   schema   JsonSchema
+}
+
+// json_schema_object_function_only reports whether a member has no JSON to
+// describe because it is only a function, so the schema drops it exactly as the
+// serializer does.
+//
+// The condition has to agree with the serializer's (`StringifyJoiner`) or the
+// two describe the same type differently. Two ways it disagreed: `Size()` counts
+// `Functions`, so a pure function member is size 1 and the previous
+// `Size() == 0` test could never fire for the case it was written to catch; and
+// a named alias of a function type carries `Aliases`, not `Functions`, so the
+// same type reached through `type Consumer = (v: number) => string` survived as
+// a `$ref` to an empty component while the interface spelling of it vanished —
+// two documents for one type, and neither `json.stringify` ever produces
+// (samchon/typia#2270).
+//
+// Optionality is deliberately not part of the question: an optional function
+// member has no JSON either.
+func json_schema_object_function_only(value *nativemetadata.MetadataSchema) bool {
+  if value == nil {
+    return false
+  }
+  resolved := nativemetadata.MetadataSchema_unalias(value)
+  return len(resolved.Functions) != 0 &&
+    resolved.Nullable == false &&
+    resolved.Size() == 1
 }

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_function_member_spelling_parity.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_function_member_spelling_parity.ts
@@ -35,7 +35,7 @@ interface AliasHolder {
  *    equal.
  * 3. Require the member itself to be absent, so the parity cannot be satisfied
  *    by all three describing it wrongly in the same way.
- * 4. Require the neighbouring data member to survive, so omission is confined to
+ * 4. Require the neighboring data member to survive, so omission is confined to
  *    the function.
  */
 export const test_json_schema_function_member_spelling_parity = (): void => {

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_function_member_spelling_parity.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_function_member_spelling_parity.ts
@@ -1,0 +1,75 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+interface CallableInterface {
+  (value: number): string;
+}
+type CallableAlias = (value: number) => string;
+
+interface InterfaceHolder {
+  keep: number;
+  fn: CallableInterface;
+}
+interface AliasHolder {
+  keep: number;
+  fn: CallableAlias;
+}
+
+/**
+ * Verifies a function member is described identically however it is spelled.
+ *
+ * A member that is only a function has no JSON, and `json.stringify` omits it.
+ * The schema's own skip test disagreed with the serializer twice: it required
+ * `Size() === 0`, which a pure function member never is because `Size()` counts
+ * functions, and it read the member's own metadata, which carries `Aliases`
+ * rather than `Functions` when the function type is reached through a name. So
+ * the interface spelling vanished from the document while the two alias
+ * spellings survived as a `$ref` to an empty component — two schemas for one
+ * type, and neither describing what the serializer produces.
+ *
+ * 1. Declare one call signature two ways: an interface and a function type
+ *    alias. The named-type-literal spelling of the same signature belongs to
+ *    samchon/typia#2238, which is what stops it being expanded structurally in
+ *    the first place, so it is pinned there rather than here.
+ * 2. Generate the schema for a holder of each and require the documents to be
+ *    equal.
+ * 3. Require the member itself to be absent, so the parity cannot be satisfied
+ *    by all three describing it wrongly in the same way.
+ * 4. Require the neighbouring data member to survive, so omission is confined to
+ *    the function.
+ */
+export const test_json_schema_function_member_spelling_parity = (): void => {
+  const shape = (
+    unit: ReturnType<typeof typia.json.schema<InterfaceHolder>>,
+  ): unknown => {
+    const components = JSON.parse(
+      JSON.stringify(unit.components),
+    ) as Record<string, Record<string, any>>;
+    const schemas = components.schemas ?? {};
+    // Keyed by the holder's own name, which necessarily differs between the two
+    // spellings, so compare the shapes rather than the map: the property set,
+    // what is required, and how many components the document needed at all. The
+    // last one is what catches a leftover component minted for the function.
+    const holder = Object.values(schemas)[0] as Record<string, any>;
+    return {
+      componentCount: Object.keys(schemas).length,
+      properties: Object.keys(holder?.properties ?? {}).sort(),
+      required: [...(holder?.required ?? [])].sort(),
+    };
+  };
+
+  TestValidator.equals(
+    "alias spelling agrees with interface",
+    shape(typia.json.schema<AliasHolder>()),
+    shape(typia.json.schema<InterfaceHolder>()),
+  );
+  TestValidator.equals(
+    "the function member is described by neither",
+    shape(typia.json.schema<InterfaceHolder>()),
+    {
+      componentCount: 1,
+      properties: ["keep"],
+      required: ["keep"],
+    },
+  );
+};


### PR DESCRIPTION
Closes #2270.

## Problem

`json.schema` described a function-typed member two different ways depending on how the function type was spelled:

```
interface spelling                   function-type alias
  properties: {},                      properties: { fn: { $ref: ".../Consumer" } },
  required: [],                        required: ["fn"],
                                       Consumer: {}
```

One type, two documents — and the surviving member describes something `json.stringify` never emits, because the serializer omits a member that is only a function.

## Cause

The schema's skip condition disagreed with the serializer's in three ways, and one of them made it dead code:

- it required `Size() == 0`, but `Size()` counts `Functions`, so a member that is only a function is size 1 and **the test could never fire for the case it was written to catch**;
- it read the member's own metadata, which carries `Aliases` rather than `Functions` once the function type has a name, so `type Consumer = (v: number) => string` never looked like a function at all;
- it required the member to be required, though an optional function member has no JSON either.

The serializer's equivalent condition in `StringifyJoiner` uses `Size() == 1` and no optionality test, and it works.

## Change

The condition resolves aliases through the existing `MetadataSchema_unalias` and then matches the serializer's, so schema and serializer answer the same question the same way.

## Verification

`test_json_schema_function_member_spelling_parity` compares the two spellings **by shape** rather than by component map — the map is keyed by each holder's own name, which necessarily differs between them, so a map comparison could never pass and would have hidden the real question. It asserts the property set, the required set, and the component count; the last is what catches a leftover component minted for the function.

- `pnpm --filter ./tests/test-typia-schema start` passes.
- The whole `packages/typia/native/...` tree passes.
- Mutation: reverting only the condition to its previous form while keeping the test turns it red on exactly the expected rows — `.componentCount`, `.properties[0..1]`, `.required[0..1]`.

## Scope

The named-type-literal spelling of the same signature — `type Consumer = { (v: number): string }` — is still expanded structurally through the apparent `Function` members, so its component is a full object of `prototype`, `length`, and friends rather than an empty one. That is #2238's subject and is pinned there; this change deliberately does not reach it, and the regression here says so.
