### PR TITLE
fix(json): guard the toJSON call rather than leaving it to the arm

### DIFF
--- a/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
+++ b/packages/typia/native/core/programmers/json/JsonStringifyProgrammer.go
@@ -278,7 +278,34 @@ func jsonStringifyProgrammer_decode(props struct {
       Value: func() *shimast.Node {
         next := props
         next.Metadata = metadata
-        return jsonStringifyProgrammer_decode_to_json(next)
+        resolved := jsonStringifyProgrammer_decode_to_json(next)
+        if isDate {
+          return resolved
+        }
+        // The arm's own test is `typeof input.toJSON === "function"`, but an arm
+        // test is not always emitted — a sole arm needs no choice, and a final
+        // arm is the else — while this value *calls* `toJSON`. Leaving the call
+        // to be guarded by the arm meant a value whose `toJSON` is not callable
+        // threw `input.toJSON is not a function` from inside the serializer,
+        // including under `isStringify` and `validateStringify`, whose contract
+        // is to answer rather than throw (samchon/typia#2271).
+        //
+        // The guard therefore belongs to the call. `JSON.stringify` ignores a
+        // non-callable `toJSON` and serializes the object itself, and the
+        // metadata already carries that shape, so the fallback describes the
+        // original rather than inventing an answer. `Date` keeps the plain form:
+        // its arm is `instanceof Date`, and a real Date's `toJSON` is callable.
+        original := props
+        original.Metadata = props.Metadata.Escaped.Original
+        return nativefactories.ExpressionFactory.Conditional(
+          nativeprogrammers.IsProgrammer.Decode_to_json(struct {
+            Input     *shimast.Expression
+            CheckNull bool
+          }{Input: props.Input, CheckNull: false}),
+          resolved,
+          jsonStringifyProgrammer_decode(original),
+          props.Context.Emit,
+        )
       },
     })
   } else if len(props.Metadata.Functions) != 0 {

--- a/tests/test-typia-schema/src/features/json.isStringify/test_json_is_stringify_non_callable_to_json.ts
+++ b/tests/test-typia-schema/src/features/json.isStringify/test_json_is_stringify_non_callable_to_json.ts
@@ -1,0 +1,71 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { IValidation } from "typia";
+
+interface IJsonable {
+  keep: number;
+  value: {
+    toJSON: () => string;
+  };
+}
+
+/**
+ * Verifies a non-callable `toJSON` is answered, never thrown on.
+ *
+ * Serializing a `toJSON`-bearing type means calling `toJSON`, and the emitted
+ * union arm that does so carries its own `typeof input.toJSON === "function"`
+ * test. When that arm was the only one, the surrounding code dropped the test
+ * along with the choice — there is nothing to choose between — and left the call
+ * unguarded. A value whose `toJSON` is a non-function then threw
+ * `input.value.toJSON is not a function` from inside the serializer, so
+ * `isStringify` and `validateStringify`, whose whole purpose is to answer for
+ * untrusted input without a `try`/`catch`, threw on exactly the input they exist
+ * to handle.
+ *
+ * `JSON.stringify` ignores a non-callable `toJSON` and serializes the object
+ * itself, which is what the guard now falls back to.
+ *
+ * `typia.is` is deliberately not asserted here: under default options it does
+ * not validate function members — that is what `functional` is for — so it
+ * answers `true`, and the JSON path cannot inherit that leniency because it has
+ * to perform the call.
+ *
+ * 1. Take a value whose nested `toJSON` is a number rather than a function.
+ * 2. Require `stringify` to answer, and its answer to be JSON. The answer
+ *    describes the declared shape, so the function member is omitted and the
+ *    result is `{}` rather than native `JSON.stringify`'s `{"toJSON":1}` — typia
+ *    does not emit a member the type does not declare.
+ * 3. Require `isStringify` and `validateStringify` to answer rather than throw.
+ * 4. Keep the positive twin passing: a real `toJSON` still serializes through
+ *    its return value.
+ */
+export const test_json_is_stringify_non_callable_to_json = (): void => {
+  const invalid: IJsonable = { keep: 1, value: { toJSON: 1 } } as never;
+  const valid: IJsonable = { keep: 1, value: { toJSON: () => "x" } };
+
+  const text: string = typia.json.stringify<IJsonable>(invalid);
+  TestValidator.equals("stringify answers with JSON", JSON.parse(text), {
+    keep: 1,
+    value: {},
+  });
+
+  const guarded: string | null = typia.json.isStringify<IJsonable>(invalid);
+  TestValidator.equals(
+    "isStringify answers instead of throwing",
+    guarded === null || typeof guarded === "string",
+    true,
+  );
+
+  const validated: IValidation<string> =
+    typia.json.validateStringify<IJsonable>(invalid);
+  TestValidator.equals(
+    "validateStringify answers instead of throwing",
+    typeof validated.success,
+    "boolean",
+  );
+
+  TestValidator.equals(
+    "the twin serializes through toJSON",
+    JSON.parse(typia.json.stringify<IJsonable>(valid)),
+    JSON.parse(JSON.stringify(valid)),
+  );
+};


### PR DESCRIPTION
Closes #2271.

## Problem

`typia.json.isStringify` and `validateStringify` threw `TypeError: input.value.toJSON is not a function` on a value whose declared `toJSON` member is not callable. Throwing is a contract violation regardless of what the right answer is: those entry points exist so a caller can hand them untrusted input without a `try`/`catch`.

## Cause, located

Serializing a `toJSON`-bearing type means calling `toJSON`, and the union arm that does so carries its own `typeof input.toJSON === "function"` test. But an arm test is not always emitted — a sole arm needs no choice, and a final arm is the else — so the call went out unguarded.

Validation does not stop it either: `typia.is` under default options deliberately does not validate function members (that is what `functional` is for), so it answers `true` for this value and `isStringify`, being validate-then-serialize, hands it straight to the serializer.

An earlier attempt guarded the *checker* instead; it was reverted because the failing path never reaches that checker, and shipping it would have changed the emit for every escaped type while leaving the symptom exactly as it was.

## Change

The guard belongs to the call, not to the arm. `JSON.stringify` ignores a non-callable `toJSON` and serializes the object itself, and the metadata already carries that shape as `Escaped.Original`, so the fallback describes the original rather than inventing an answer.

`Date` keeps the plain form: its arm is `instanceof Date`, and a real `Date`'s `toJSON` is always callable.

## Verification

Probe before and after, on the same input:

```
before:  stringify(invalid) THREW: input.value.toJSON is not a function
after:   stringify(invalid) = {"keep":1,"value":{}}
```

The fallback serializes the **declared** shape, so the function member is omitted — native `JSON.stringify` answers `{"keep":1,"value":{"toJSON":1}}` because it serializes the runtime value, and typia does not emit a member the type does not declare. The regression asserts typia's answer rather than native parity for that reason, and keeps the positive twin serializing through `toJSON`.

- `test_json_is_stringify_non_callable_to_json` pins `stringify`, `isStringify`, and `validateStringify`.
- `pnpm --filter ./tests/test-typia-schema start` passes.
- The whole `packages/typia/native/...` tree passes.

The plugin cache was cleared and rebuilt from source during diagnosis, so the before/after difference is not a stale-emit artefact.

## Note on the branch name

The branch is named for #2276, which was where this investigation started; the intersection work is not in this change and #2276 stays open.
