### PR TITLE
chore: apply the repository formatter after the campaign

### DIFF
--- a/packages/langchain/src/internal/LangChainParameterConverter.ts
+++ b/packages/langchain/src/internal/LangChainParameterConverter.ts
@@ -4,29 +4,31 @@ import { IHttpLlmFunction, ILlmFunction } from "@typia/interface";
 /**
  * A Standard JSON Schema view of one typia function's parameters.
  *
- * LangChain's tool `schema` fills two roles at once: `toJsonSchema(tool.schema)`
- * turns it into the parameters the model is shown, and `StructuredTool.call`
- * validates incoming arguments against it before the tool body runs. Handing
- * over a bare `ILlmSchema.IParameters` fills the first role but forfeits the
- * second — LangChain validates it with `@cfworker/json-schema`, which rejects
- * what typia would have coerced and reports the failure in its own words, so
- * typia's coercion and its correctable feedback both become unreachable.
+ * LangChain's tool `schema` fills two roles at once:
+ * `toJsonSchema(tool.schema)` turns it into the parameters the model is shown,
+ * and `StructuredTool.call` validates incoming arguments against it before the
+ * tool body runs. Handing over a bare `ILlmSchema.IParameters` fills the first
+ * role but forfeits the second — LangChain validates it with
+ * `@cfworker/json-schema`, which rejects what typia would have coerced and
+ * reports the failure in its own words, so typia's coercion and its correctable
+ * feedback both become unreachable.
  *
- * Standard JSON Schema separates the two roles. It carries a model-facing schema
- * under `~standard.jsonSchema` and, by declaring no `~standard.validate`, no
- * validator — which is exactly typia's position: show the model this schema, and
- * leave validation to `LlmJson.validateArguments` in the tool body. LangChain
- * reads the schema back through its own `toJsonSchema`, so the model sees the
- * same parameters document as before, byte for byte.
+ * Standard JSON Schema separates the two roles. It carries a model-facing
+ * schema under `~standard.jsonSchema` and, by declaring no
+ * `~standard.validate`, no validator — which is exactly typia's position: show
+ * the model this schema, and leave validation to `LlmJson.validateArguments` in
+ * the tool body. LangChain reads the schema back through its own
+ * `toJsonSchema`, so the model sees the same parameters document as before,
+ * byte for byte.
  *
- * `@typia/vercel` states the same contract to the AI SDK through `jsonSchema()`,
- * whose `validate` is likewise left undefined so that `safeValidateTypes`
- * short-circuits its own validation.
+ * `@typia/vercel` states the same contract to the AI SDK through
+ * `jsonSchema()`, whose `validate` is likewise left undefined so that
+ * `safeValidateTypes` short-circuits its own validation.
  *
  * Two version floors hold this together, and both are pinned in the package
  * manifest. `toJsonSchema` only reads `~standard.jsonSchema` from
- * `@langchain/core@1.1.30` onwards — older versions return the wrapper itself and
- * would advertise *that* to the model in place of the parameters — and
+ * `@langchain/core@1.1.30` onwards — older versions return the wrapper itself
+ * and would advertise _that_ to the model in place of the parameters — and
  * `StandardJSONSchemaV1` only exists from `@standard-schema/spec@1.1.0`.
  *
  * @see https://github.com/standard-schema/standard-schema

--- a/packages/typia/src/internal/_ProtobufReader.ts
+++ b/packages/typia/src/internal/_ProtobufReader.ts
@@ -221,9 +221,9 @@ export class _ProtobufReader {
    * Two distinct faults meet on this byte, and each is named for what it is. A
    * continuation bit means the varint would occupy an eleventh byte, which no
    * 64-bit value can reach. Any other payload bit means the varint terminates
-   * within its ten bytes but carries a value bit above 63. Reporting the
-   * second as a length fault would tell the caller something untrue about a
-   * payload that is exactly ten bytes long.
+   * within its ten bytes but carries a value bit above 63. Reporting the second
+   * as a length fault would tell the caller something untrue about a payload
+   * that is exactly ten bytes long.
    */
   private lastVarintByte(): number {
     const loaded: number = this.u8();
@@ -292,7 +292,8 @@ const VARINT_MAX_BYTES = 10;
  * The widest value a varint may carry: the 64-bit Protocol Buffer wire domain.
  *
  * The tenth byte reaches only bit 63, so a payload bit above it belongs to no
- * representable value. This names the overflow fault apart from the length one.
+ * representable value. This names the overflow fault apart from the length
+ * one.
  */
 const VARINT_MAX_BITS = 64;
 

--- a/packages/typia/src/internal/_jsonStringifyArray.ts
+++ b/packages/typia/src/internal/_jsonStringifyArray.ts
@@ -5,13 +5,13 @@
  * writes `null` wherever the element serializes to `undefined`. Neither
  * `Array.prototype.map` nor `Array.prototype.join` reproduces that:
  *
- * - `map` never visits a hole and leaves one behind, and `join` renders a hole
- *   as empty text, so a sparse array joined into malformed text such as
- *   `[,1]`. A hole exists at runtime whatever the element type declares, so
- *   this is not an `any` concern.
- * - `join` renders a mapped `undefined` as empty text too, which is what an
- *   `any` or `unknown` element holding a function, a symbol, or a `toJSON`
- *   that returns nothing serializes to.
+ * - `map` never visits a hole and leaves one behind, and `join` renders a hole as
+ *   empty text, so a sparse array joined into malformed text such as `[,1]`. A
+ *   hole exists at runtime whatever the element type declares, so this is not
+ *   an `any` concern.
+ * - `join` renders a mapped `undefined` as empty text too, which is what an `any`
+ *   or `unknown` element holding a function, a symbol, or a `toJSON` that
+ *   returns nothing serializes to.
  *
  * The length is converted with `ToLength` and read once, which is both what
  * `JSON.stringify` does and what `Array.prototype.every` - the traversal

--- a/packages/typia/src/internal/_jsonStringifyElement.ts
+++ b/packages/typia/src/internal/_jsonStringifyElement.ts
@@ -5,11 +5,11 @@
  * `SerializeJSONArray` writes `null` wherever an element serializes to
  * `undefined`, because an array position cannot be omitted without shifting
  * every element after it. A present value with no serialization — a function, a
- * symbol, or a `toJSON` returning nothing — is therefore `null`, not the literal
- * text `undefined` and not an empty slot.
+ * symbol, or a `toJSON` returning nothing — is therefore `null`, not the
+ * literal text `undefined` and not an empty slot.
  *
- * This is the fixed-position counterpart of `_jsonStringifyArray`, which answers
- * the same question while walking an array's own index range.
+ * This is the fixed-position counterpart of `_jsonStringifyArray`, which
+ * answers the same question while walking an array's own index range.
  *
  * @param text Serialized element value, or `undefined` when it has none.
  * @returns Element text, or `null` when the element has no serialization.

--- a/packages/typia/src/internal/_jsonStringifyProperty.ts
+++ b/packages/typia/src/internal/_jsonStringifyProperty.ts
@@ -2,15 +2,16 @@
  * Writes one object member the way ECMAScript `JSON.stringify` writes it.
  *
  * `SerializeJSONObject` serializes each member first and drops the member
- * entirely when that result is `undefined`. Deciding omission from the *input*
+ * entirely when that result is `undefined`. Deciding omission from the _input_
  * instead cannot reach the same answer: a symbol and a `toJSON` returning
  * nothing are both present, non-`undefined`, non-function values whose
  * serialization is `undefined`, so the member's text became the literal
  * `"k":undefined` — output that is not JSON at all.
  *
  * The serialized text is passed in already evaluated, so the member's value is
- * serialized exactly once. Testing the input and then serializing would evaluate
- * a `toJSON` twice, and a `toJSON` is free to answer differently each call.
+ * serialized exactly once. Testing the input and then serializing would
+ * evaluate a `toJSON` twice, and a `toJSON` is free to answer differently each
+ * call.
  *
  * The trailing separator belongs to the member because a dropped member must
  * take its comma with it; `_jsonStringifyTail` removes the one that is left

--- a/packages/typia/src/internal/_randomPattern.ts
+++ b/packages/typia/src/internal/_randomPattern.ts
@@ -2,7 +2,10 @@ import RandExp from "randexp";
 
 import { _ILengthProps } from "./_randomStringLength";
 
-export const _randomPattern = (regex: RegExp, props?: _ILengthProps): string => {
+export const _randomPattern = (
+  regex: RegExp,
+  props?: _ILengthProps,
+): string => {
   const r: RandExp = new RandExp(regex);
   const min: number | undefined = props?.minLength;
   const max: number | undefined = props?.maxLength;

--- a/packages/typia/src/internal/_randomStringLength.ts
+++ b/packages/typia/src/internal/_randomStringLength.ts
@@ -18,10 +18,10 @@ export interface _ILengthProps {
  * length `fixed + segment.length` lands inside the requested window.
  *
  * `fixed` is the number of characters the format always contributes around the
- * segment, `fallback` is the segment length used when the leaf is
- * unconstrained on that side, and `minimum` is the smallest segment the format
- * still validates with. Throws when the window cannot be satisfied by this
- * format's shape (e.g. `Format<"email"> & MaxLength<3>`).
+ * segment, `fallback` is the segment length used when the leaf is unconstrained
+ * on that side, and `minimum` is the smallest segment the format still
+ * validates with. Throws when the window cannot be satisfied by this format's
+ * shape (e.g. `Format<"email"> & MaxLength<3>`).
  */
 export const _randomSegmentLength = (
   props: _ILengthProps | undefined,

--- a/packages/typia/src/internal/private/__notationRename.ts
+++ b/packages/typia/src/internal/private/__notationRename.ts
@@ -9,10 +9,7 @@
  * collapsing it to the underscore-free `plain` path.
  */
 export const __notationRename =
-  (props: {
-    plain: (str: string) => string;
-    snake: (str: string) => string;
-  }) =>
+  (props: { plain: (str: string) => string; snake: (str: string) => string }) =>
   (str: string): string => {
     let prefix: string = "";
     while (str.startsWith("_")) {

--- a/packages/utils/src/utils/NamingConvention.ts
+++ b/packages/utils/src/utils/NamingConvention.ts
@@ -285,10 +285,7 @@ const RESTRICTED: Set<string> = new Set([
  * collapsing it to the underscore-free `plain` path.
  */
 const renameOuter =
-  (props: {
-    plain: (str: string) => string;
-    snake: (str: string) => string;
-  }) =>
+  (props: { plain: (str: string) => string; snake: (str: string) => string }) =>
   (str: string): string => {
     let prefix: string = "";
     while (str.startsWith("_")) {
@@ -300,7 +297,7 @@ const renameOuter =
   };
 
 /**
- * snake_case conversion of one underscore-free segment.
+ * Snake_case conversion of one underscore-free segment.
  *
  * Splits on case boundaries, collapsing an acronym run into a single word
  * (`XMLParser` → `xmlparser`, `toHTML` → `to_html`).
@@ -332,12 +329,13 @@ const snakeWord = (str: string): string => {
 };
 
 /**
- * camelCase conversion of a key that contains at least one underscore.
+ * CamelCase conversion of a key that contains at least one underscore.
  *
  * Uppercases the character after each underscore and lowercases the rest,
  * matching `CamelizeSnakeString`. A trailing underscore has no character to
- * uppercase, so it falls through to lowercasing the whole key (`foo_` → `foo_`),
- * and a doubled underscore collapses to a single one before continuing.
+ * uppercase, so it falls through to lowercasing the whole key (`foo_` →
+ * `foo_`), and a doubled underscore collapses to a single one before
+ * continuing.
  */
 const camelSnake = (str: string): string => {
   while (str.startsWith("_")) str = str.substring(1);

--- a/packages/utils/src/utils/internal/JsonDescriptor.ts
+++ b/packages/utils/src/utils/internal/JsonDescriptor.ts
@@ -16,7 +16,7 @@ export namespace JsonDescriptor {
    * a key owes the invariant that its dots are the type's own qualification and
    * nothing else.
    *
-   * typia's own producers keep it. `MetadataCollection.getName` joins a
+   * Typia's own producers keep it. `MetadataCollection.getName` joins a
    * duplicate's counter with `-o` and `MetadataCollection_replaceOpenApi`
    * rewrites a flattened nested type's dots, both in
    * `packages/typia/native/core/schemas/metadata/MetadataCollection.go`;

--- a/packages/utils/src/validators/internal/OpenApiIntegerValidator.ts
+++ b/packages/utils/src/validators/internal/OpenApiIntegerValidator.ts
@@ -56,15 +56,15 @@ export namespace OpenApiIntegerValidator {
   /**
    * Name the integer type a schema declares, in typia's tag notation.
    *
-   * Every bounds message used to hardcode `Type<"int32">`, so a plain
-   * `{ type: "integer", minimum: 0 }` reported a 32-bit width the schema never
-   * stated. The width has to come from the schema instead. OpenAPI spells it as
+   * Every bounds message used to hardcode `Type<"int32">`, so a plain `{ type:
+   * "integer", minimum: 0 }` reported a 32-bit width the schema never stated.
+   * The width has to come from the schema instead. OpenAPI spells it as
    * `format` (`"int32"` / `"int64"`), which the normalized schema type does not
-   * model for integers — typia's own emitter writes a bare
-   * `{ type: "integer" }` for `Type<"int32">` — but `OpenApiConverter` passes an
-   * external document's `format` straight through, so it does reach this
-   * validator at runtime. Read it defensively and echo only what is there,
-   * mirroring how {@link OpenApiStringValidator} reports a string's `format`.
+   * model for integers — typia's own emitter writes a bare `{ type: "integer"
+   * }` for `Type<"int32">` — but `OpenApiConverter` passes an external
+   * document's `format` straight through, so it does reach this validator at
+   * runtime. Read it defensively and echo only what is there, mirroring how
+   * {@link OpenApiStringValidator} reports a string's `format`.
    */
   const describeType = (schema: OpenApi.IJsonSchema.IInteger): string => {
     const format: unknown = (schema as { format?: unknown }).format;

--- a/tests/template/src/structures/ClassNonPublic.ts
+++ b/tests/template/src/structures/ClassNonPublic.ts
@@ -44,8 +44,9 @@ export namespace ClassNonPublic {
    * constructor-assigned `heritage` and `hidden`, but the declared type exposes
    * neither, so `typia.protobuf.message<ClassNonPublic>()` describes exactly
    * `implicit` and `shown` and a decode gives only those back. Declaring the
-   * projection lets the oracle demand that shape exactly: injecting a non-public
-   * member into the output now fails instead of being waved through.
+   * projection lets the oracle demand that shape exactly: injecting a
+   * non-public member into the output now fails instead of being waved
+   * through.
    */
   export const RESOLVE = (input: ClassNonPublic) => ({
     implicit: input.implicit,

--- a/tests/template/src/structures/TypeTagRange.ts
+++ b/tests/template/src/structures/TypeTagRange.ts
@@ -65,9 +65,10 @@ export namespace TypeTagRange {
    * Boundary spoilers, one step outside each tag's bound.
    *
    * Every spoiled value is the nearest integer a correct validator must never
-   * accept: `3` against `ExclusiveMinimum<3>`, `7` against `ExclusiveMaximum<7>`,
-   * and `9` against the `equal` pair. A validator that compares with the wrong
-   * strictness passes the ordinary generated value and fails only here.
+   * accept: `3` against `ExclusiveMinimum<3>`, `7` against
+   * `ExclusiveMaximum<7>`, and `9` against the `equal` pair. A validator that
+   * compares with the wrong strictness passes the ordinary generated value and
+   * fails only here.
    */
   export const SPOILERS: Spoiler<TypeTagRange>[] = [
     (input) => {

--- a/tests/test-feature-identity/src/FeatureIdentity.ts
+++ b/tests/test-feature-identity/src/FeatureIdentity.ts
@@ -14,10 +14,9 @@ import { Git } from "./Git";
  * name, and two files exporting the same name inside one suite report two
  * indistinguishable executions.
  *
- * This namespace turns that contract into a checkable invariant.
- * {@link collect} gathers the tracked feature files, {@link parse} extracts
- * the `test_*` declarations each one exports, and {@link diagnose} reports
- * every violation.
+ * This namespace turns that contract into a checkable invariant. {@link collect}
+ * gathers the tracked feature files, {@link parse} extracts the `test_*`
+ * declarations each one exports, and {@link diagnose} reports every violation.
  */
 export namespace FeatureIdentity {
   /** A single tracked feature-tree source file. */
@@ -40,14 +39,14 @@ export namespace FeatureIdentity {
    *
    * The invariant has two halves:
    *
-   * 1. **Identity** — a `test_`-named file exports exactly one `test_*`
-   *    function, and that name equals the file's basename. A file *not* named
-   *    `test_*` is a helper and must export no `test_*` function at all,
-   *    because `DynamicExecutor` would otherwise run a test that no file name
+   * 1. **Identity** — a `test_`-named file exports exactly one `test_*` function,
+   *    and that name equals the file's basename. A file _not_ named `test_*` is
+   *    a helper and must export no `test_*` function at all, because
+   *    `DynamicExecutor` would otherwise run a test that no file name
    *    announces.
-   * 2. **Uniqueness** — no two files in the **same suite** export the same
-   *    name. Suites run as separate processes with separate reports, so the
-   *    same name in two different suites is legal and is not reported.
+   * 2. **Uniqueness** — no two files in the **same suite** export the same name.
+   *    Suites run as separate processes with separate reports, so the same name
+   *    in two different suites is legal and is not reported.
    *
    * @param files Feature files to inspect.
    * @returns One human-readable diagnostic per violation; empty when the tree
@@ -149,9 +148,9 @@ export namespace FeatureIdentity {
    *
    * Deliberately recognizes only top-level `export const|let|var|function`
    * declarations, the form every feature file uses. An exotic export — a
-   * renamed re-export or a default export — yields no match, so
-   * {@link diagnose} reports the file as exporting nothing rather than passing
-   * it unchecked. The check fails closed.
+   * renamed re-export or a default export — yields no match, so {@link diagnose}
+   * reports the file as exporting nothing rather than passing it unchecked. The
+   * check fails closed.
    *
    * @param code TypeScript source text.
    * @returns Exported `test_*` names in source order.

--- a/tests/test-feature-identity/src/features/test_feature_identity_collect.ts
+++ b/tests/test-feature-identity/src/features/test_feature_identity_collect.ts
@@ -20,8 +20,8 @@ import { FeatureIdentity } from "../FeatureIdentity";
  *    helper, a declaration file, a file outside `features`, and a staged file
  *    deleted from the working tree.
  * 2. Assert the collector returns the three real sources and nothing else.
- * 3. Assert the non-ASCII file is parsed and its mismatch reported, so the
- *    quoting path stays wired end to end.
+ * 3. Assert the non-ASCII file is parsed and its mismatch reported, so the quoting
+ *    path stays wired end to end.
  */
 export const test_feature_identity_collect = (): void => {
   const root: string = fs.mkdtempSync(path.join(os.tmpdir(), "typia-fid-"));

--- a/tests/test-feature-identity/src/features/test_feature_identity_duplicate_export.ts
+++ b/tests/test-feature-identity/src/features/test_feature_identity_duplicate_export.ts
@@ -14,8 +14,7 @@ import { FeatureIdentity } from "../FeatureIdentity";
  *
  * 1. Assert one name exported by two files of the same suite is reported once,
  *    naming both files.
- * 2. Assert the same name exported by two files of different suites is
- *    silent.
+ * 2. Assert the same name exported by two files of different suites is silent.
  */
 export const test_feature_identity_duplicate_export = (): void => {
   // 1. SAME SUITE: A COLLISION

--- a/tests/test-feature-identity/src/features/test_feature_identity_helper_file.ts
+++ b/tests/test-feature-identity/src/features/test_feature_identity_helper_file.ts
@@ -9,7 +9,7 @@ import { FeatureIdentity } from "../FeatureIdentity";
  * Feature trees legitimately hold shared helpers —
  * `test-typia-schema/src/features/plain/PlainNativeClone.ts` is one — so the
  * rule must not demand that every file be a test. The converse still bites:
- * `DynamicExecutor` requires *every* module in the tree and runs *any*
+ * `DynamicExecutor` requires _every_ module in the tree and runs _any_
  * `test_`-prefixed export it finds, so a test hidden in a helper file would run
  * under a name no file announces, which is the same identity defect from the
  * other direction.

--- a/tests/test-feature-identity/src/features/test_feature_identity_repository.ts
+++ b/tests/test-feature-identity/src/features/test_feature_identity_repository.ts
@@ -3,8 +3,7 @@ import { TestValidator } from "@nestia/e2e";
 import { FeatureIdentity } from "../FeatureIdentity";
 
 /**
- * Verifies every tracked feature test file is named after the test it
- * exports.
+ * Verifies every tracked feature test file is named after the test it exports.
  *
  * This is the backstop for the whole class. `DynamicExecutor` keys its
  * `--include` / `--exclude` filter and its report entries on the **exported**
@@ -14,8 +13,8 @@ import { FeatureIdentity } from "../FeatureIdentity";
  * invisible today because every test body still runs; only this scan fails.
  *
  * 1. Collect every tracked `tests/<suite>/src/features` source file.
- * 2. Assert the scan actually reached the trees, so a broken collector cannot
- *    pass vacuously.
+ * 2. Assert the scan actually reached the trees, so a broken collector cannot pass
+ *    vacuously.
  * 3. Assert the tree yields no identity or uniqueness diagnostic.
  */
 export const test_feature_identity_repository = (): void => {

--- a/tests/test-feature-identity/src/features/test_feature_identity_source_parse.ts
+++ b/tests/test-feature-identity/src/features/test_feature_identity_source_parse.ts
@@ -14,8 +14,8 @@ import { FeatureIdentity } from "../FeatureIdentity";
  * contributor's `export function` is understood rather than condemned.
  *
  * 1. Assert each top-level declaration form is recognized.
- * 2. Assert an indented declaration, a comment, and a non-`test_` export are
- *    not mistaken for tests.
+ * 2. Assert an indented declaration, a comment, and a non-`test_` export are not
+ *    mistaken for tests.
  * 3. Assert a renamed re-export yields nothing, so the file fails closed.
  */
 export const test_feature_identity_source_parse = (): void => {

--- a/tests/test-feature-identity/src/features/test_feature_identity_workspace_name.ts
+++ b/tests/test-feature-identity/src/features/test_feature_identity_workspace_name.ts
@@ -59,7 +59,8 @@ interface IWorkspace {
  * scan in `FeatureIdentity` does: only a tracked manifest can mislead another
  * contributor, and reading git keeps the result independent of whichever suites
  * have run before this one. `tests/config` carries no manifest and is simply
- * not a workspace, so matching nothing there is correct rather than an omission.
+ * not a workspace, so matching nothing there is correct rather than an
+ * omission.
  */
 const collect = (root: string = Git.toplevel()): IWorkspace[] =>
   // Run from the repository root: `git ls-files -- tests` resolves its

--- a/tests/test-interface/src/typings/test_notation_underscore_boundary.ts
+++ b/tests/test-interface/src/typings/test_notation_underscore_boundary.ts
@@ -1,7 +1,8 @@
 import { CamelCase, KebabCase, PascalCase, SnakeCase } from "@typia/interface";
 
 /**
- * Pins the `*Case<T>` typings on keys mixing an underscore with a case boundary.
+ * Pins the `*Case<T>` typings on keys mixing an underscore with a case
+ * boundary.
  *
  * Issue #2190: the `snake`/`kebab` runtime and their Go compile-time twins
  * lowercased each underscore-delimited segment atomically (`fooBar_baz` ->

--- a/tests/test-langchain/src/features/test_langchain_class_controller_coercion.ts
+++ b/tests/test-langchain/src/features/test_langchain_class_controller_coercion.ts
@@ -13,9 +13,9 @@ import { Calculator } from "../structures/Calculator";
  * registrar runs the shared `LlmJson.validateArguments` (coerce, then validate)
  * and dispatches its coerced `data`. That coercion is unreachable whenever
  * LangChain validates the registered `schema` itself, because
- * `@cfworker/json-schema` rejects the string before the tool body runs and never
- * coerces. `@typia/mcp` and `@typia/vercel` both accept this exact input; this
- * pins `@typia/langchain` to the same answer.
+ * `@cfworker/json-schema` rejects the string before the tool body runs and
+ * never coerces. `@typia/mcp` and `@typia/vercel` both accept this exact input;
+ * this pins `@typia/langchain` to the same answer.
  *
  * 1. Build a class controller and convert it to LangChain tools.
  * 2. Invoke `add` with a stringified operand `{ x: "42", y: 5 }`.

--- a/tests/test-langchain/src/features/test_langchain_class_controller_validation.ts
+++ b/tests/test-langchain/src/features/test_langchain_class_controller_validation.ts
@@ -24,8 +24,8 @@ import { Calculator } from "../structures/Calculator";
  *
  * 1. Build a class controller and convert it to LangChain tools.
  * 2. Invoke `add` with a non-numeric operand.
- * 3. Assert the throw carries typia's annotated feedback for `$input.x` and
- *    never LangChain's schema message.
+ * 3. Assert the throw carries typia's annotated feedback for `$input.x` and never
+ *    LangChain's schema message.
  * 4. Assert valid arguments still execute.
  */
 export const test_langchain_class_controller_validation =

--- a/tests/test-langchain/src/features/test_langchain_http_controller_coercion.ts
+++ b/tests/test-langchain/src/features/test_langchain_http_controller_coercion.ts
@@ -10,10 +10,10 @@ import { HttpLlm } from "@typia/utils";
  * The class and HTTP controllers share one `createTool`, which dispatches the
  * `data` of `LlmJson.validateArguments` — the coerced arguments — rather than
  * what the model sent. Registering a schema LangChain validates itself defeats
- * that for both protocols at once: `@cfworker/json-schema` rejects a stringified
- * `"42"` before the tool body, so the request is never issued at all. Injecting
- * the controller's own `execute` observes the dispatched arguments without a
- * live server.
+ * that for both protocols at once: `@cfworker/json-schema` rejects a
+ * stringified `"42"` before the tool body, so the request is never issued at
+ * all. Injecting the controller's own `execute` observes the dispatched
+ * arguments without a live server.
  *
  * 1. Build an OpenAPI document whose request body needs two numbers.
  * 2. Inject an `execute` that records the arguments it receives.

--- a/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
+++ b/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
@@ -11,17 +11,16 @@ import { Calculator } from "../structures/Calculator";
  * Verifies a LangChain argument failure fences typia's feedback exactly once.
  *
  * `LlmJson.stringify` owns the markdown fence around its annotated JSON, so a
- * caller that wraps the return value in a second ```` ```json ```` fence hands
- * the model ```` ```json\n```json ```` — broken markdown, in the one payload
- * whose whole purpose is to be read back and corrected. Counting the fence is
- * what pins this, because asserting the feedback merely `includes("```json")`
- * passes with one fence or two; asserting the body is `LlmJson.stringify`'s
- * output verbatim additionally pins that the registrar wraps it in nothing at
- * all.
+ * caller that wraps the return value in a second ````json` fence hands the
+ * model ````json\n```json` — broken markdown, in the one payload whose whole
+ * purpose is to be read back and corrected. Counting the fence is what pins
+ * this, because asserting the feedback merely `includes("```json")` passes with
+ * one fence or two; asserting the body is `LlmJson.stringify`'s output verbatim
+ * additionally pins that the registrar wraps it in nothing at all.
  *
  * 1. Build a class controller and convert it to LangChain tools.
  * 2. Invoke `add` with a non-numeric operand to force typia's feedback.
- * 3. Assert the message opens exactly one ```` ```json ```` fence.
+ * 3. Assert the message opens exactly one ````json` fence.
  * 4. Assert the message is the registrar's title followed by `LlmJson.stringify`
  *    verbatim.
  */
@@ -52,9 +51,8 @@ export const test_langchain_tool_error_single_json_fence =
       1,
     );
 
-    const func: ILlmFunction | undefined = controller.application.functions.find(
-      (f) => f.name === "add",
-    );
+    const func: ILlmFunction | undefined =
+      controller.application.functions.find((f) => f.name === "add");
     if (func === undefined) throw new Error("Missing add function");
     const validation: IValidation<unknown> = LlmJson.validateArguments(
       func,

--- a/tests/test-langchain/src/features/test_langchain_tool_model_facing_schema.ts
+++ b/tests/test-langchain/src/features/test_langchain_tool_model_facing_schema.ts
@@ -16,14 +16,14 @@ import { Calculator } from "../structures/Calculator";
  * parameters the model is shown. Because typia validates arguments itself, the
  * registrar declines the first role by registering Standard JSON Schema — and
  * the whole point of that shape is that it does not cost the second. Nothing
- * else asserts the model-facing artifact, so a regression that traded the schema
- * away to reclaim validation would leave the model calling tools blind, with
- * every other test still green.
+ * else asserts the model-facing artifact, so a regression that traded the
+ * schema away to reclaim validation would leave the model calling tools blind,
+ * with every other test still green.
  *
  * 1. Build a class controller and convert it to LangChain tools.
  * 2. Assert `toJsonSchema` yields typia's parameters document unchanged.
- * 3. Assert the OpenAI tool definition LangChain sends carries the same
- *    document, with the properties and required list the model needs.
+ * 3. Assert the OpenAI tool definition LangChain sends carries the same document,
+ *    with the properties and required list the model needs.
  */
 export const test_langchain_tool_model_facing_schema =
   async (): Promise<void> => {
@@ -35,9 +35,8 @@ export const test_langchain_tool_model_facing_schema =
     const addTool: DynamicStructuredTool | undefined = tools.find(
       (t) => t.name === "add",
     );
-    const func: ILlmFunction | undefined = controller.application.functions.find(
-      (f) => f.name === "add",
-    );
+    const func: ILlmFunction | undefined =
+      controller.application.functions.find((f) => f.name === "add");
     if (addTool === undefined) throw new Error("Missing add tool");
     if (func === undefined) throw new Error("Missing add function");
 

--- a/tests/test-typia-automated/src/build/TestAutomationTemplate.ts
+++ b/tests/test-typia-automated/src/build/TestAutomationTemplate.ts
@@ -28,15 +28,14 @@ export interface TestAutomationTemplate {
   /**
    * Whether the `_test_*` internal returns a promise the case must be awaited
    * on. The generated function then declares `Promise<void>` so that a rejected
-   * oracle reaches `DynamicExecutor` instead of becoming an unhandled rejection.
+   * oracle reaches `DynamicExecutor` instead of becoming an unhandled
+   * rejection.
    */
   asynchronous?: true;
   programmer?: (create: boolean) => (structure: string) => string;
 }
 export namespace TestAutomationTemplate {
-  /**
-   * The public method a template's direct or factory half exercises.
-   */
+  /** The public method a template's direct or factory half exercises. */
   export const method = (
     tpl: TestAutomationTemplate,
     create: boolean,

--- a/tests/test-typia-automated/src/regressions/index.ts
+++ b/tests/test-typia-automated/src/regressions/index.ts
@@ -8,11 +8,11 @@ import { test_resolved_equal_to_oracle } from "./test_resolved_equal_to_oracle";
 /**
  * Runs the harness regressions that guard the generated matrix itself.
  *
- * These cases cannot live under `src/features`, which the controller deletes and
- * regenerates on every run, and they are not typia feature tests: they assert
- * that the harness generates what it claims and that its oracles can fail. The
- * suite's `prestart` runs them, so a broken harness stops the run before four
- * thousand generated cases report against it.
+ * These cases cannot live under `src/features`, which the controller deletes
+ * and regenerates on every run, and they are not typia feature tests: they
+ * assert that the harness generates what it claims and that its oracles can
+ * fail. The suite's `prestart` runs them, so a broken harness stops the run
+ * before four thousand generated cases report against it.
  */
 async function main(): Promise<void> {
   await test_process_fatal_events();

--- a/tests/test-typia-automated/src/regressions/test_direct_factory_matrix.ts
+++ b/tests/test-typia-automated/src/regressions/test_direct_factory_matrix.ts
@@ -5,17 +5,19 @@ import { TestAutomationController } from "../build/TestAutomationController";
 import { TestAutomationTemplate } from "../build/TestAutomationTemplate";
 
 /**
- * Verifies every eligible template generates both a direct and a factory matrix.
+ * Verifies every eligible template generates both a direct and a factory
+ * matrix.
  *
  * `TestAutomationController` asks for the direct visit of each runtime template
  * and then for its factory visit, but a `create === false` early return used to
  * discard the first request. Twenty public operation families therefore shipped
  * only their `createX` half, and nothing failed to say so. This backstop reads
- * the controller's real output, so the same suppression cannot return silently.
+ * the controller's real output, so the same suppression cannot return
+ * silently.
  *
  * 1. Drive the controller with a collecting, non-executing visit.
- * 2. Require both halves of every creatable template, and require the
- *    create-only Standard Schema family to still have no direct half.
+ * 2. Require both halves of every creatable template, and require the create-only
+ *    Standard Schema family to still have no direct half.
  * 3. Require the two halves of a family to cover an identical structure set.
  */
 export const test_direct_factory_matrix = async (): Promise<void> => {

--- a/tests/test-typia-automated/src/regressions/test_resolved_equal_to_async_oracle.ts
+++ b/tests/test-typia-automated/src/regressions/test_resolved_equal_to_async_oracle.ts
@@ -9,10 +9,10 @@ import { resolved_equal_to_async } from "../utils/resolved_equal_to_async";
  * The resolving oracle used to answer `x instanceof File ? y instanceof File :
  * true` for a blob, so two blobs of any size, media type, name, modification
  * time, and content compared equal. Metadata is now synchronous, and because
- * `Blob.arrayBuffer()` is not, byte equality lives in this asynchronous variant,
- * which the four FormData internals use. The last cases pin the projection a
- * real `FormData` performs, so the oracle cannot be tightened into rejecting
- * correct product output.
+ * `Blob.arrayBuffer()` is not, byte equality lives in this asynchronous
+ * variant, which the four FormData internals use. The last cases pin the
+ * projection a real `FormData` performs, so the oracle cannot be tightened into
+ * rejecting correct product output.
  *
  * 1. Reject a changed size, media type, name, and modification time.
  * 2. Reject same-size different bytes, which only the awaited pass can see.

--- a/tests/test-typia-automated/src/regressions/test_resolved_equal_to_oracle.ts
+++ b/tests/test-typia-automated/src/regressions/test_resolved_equal_to_oracle.ts
@@ -7,8 +7,8 @@ import { resolved_equal_to } from "../utils/resolved_equal_to";
  *
  * `resolved_equal_to` used to answer `true` whenever the fixture name contained
  * `Class` or either side was a function, and it walked only the input's own
- * keys. Whole fixture classes therefore executed with no oracle at all, while an
- * unexpected output property, a mismatched native brand, and same-length but
+ * keys. Whole fixture classes therefore executed with no oracle at all, while
+ * an unexpected output property, a mismatched native brand, and same-length but
  * different buffer bytes all passed. Each case below is a negative twin of a
  * positive one, so an oracle that answered `true` unconditionally, or one that
  * lost a branch, cannot survive the table.
@@ -42,7 +42,11 @@ export const test_resolved_equal_to_oracle = (): void => {
   // an ordinary bug in the helper satisfy this case.
   const blob: Blob = new Blob([Uint8Array.from([1])]);
   try {
-    resolved_equal_to(probe())({ part: blob }, { part: blob }, { silent: true });
+    resolved_equal_to(probe())(
+      { part: blob },
+      { part: blob },
+      { silent: true },
+    );
   } catch (exp) {
     const message: string = (exp as Error).message;
     if (message.includes("resolved_equal_to_async()") === true) return;

--- a/tests/test-typia-automated/src/utils/resolved_equal_to_async.ts
+++ b/tests/test-typia-automated/src/utils/resolved_equal_to_async.ts
@@ -11,10 +11,10 @@ import {
 /**
  * {@link resolved_equal_to} plus asynchronous `Blob` and `File` byte equality.
  *
- * `Blob.arrayBuffer()` is asynchronous, so a synchronous oracle can compare only
- * a blob's metadata. This variant exists for the `FormData` operations, the only
- * ones whose fixtures carry binary parts: it runs the same strict walk and then
- * awaits the content of every blob pair that walk collected.
+ * `Blob.arrayBuffer()` is asynchronous, so a synchronous oracle can compare
+ * only a blob's metadata. This variant exists for the `FormData` operations,
+ * the only ones whose fixtures carry binary parts: it runs the same strict walk
+ * and then awaits the content of every blob pair that walk collected.
  *
  * Keeping it separate keeps the fourteen synchronous consumers synchronous:
  * eight HTTP query and header internals, four plain-clone internals, and the

--- a/tests/test-typia-automated/src/utils/strict_equal_to.ts
+++ b/tests/test-typia-automated/src/utils/strict_equal_to.ts
@@ -9,13 +9,13 @@
  *
  * The walk is deliberately strict:
  *
- * - own enumerable keys are compared symmetrically, so an unexpected output
+ * - Own enumerable keys are compared symmetrically, so an unexpected output
  *   property fails instead of hiding behind a one-sided traversal;
- * - a native compares its intrinsic brand rather than a realm-local constructor
+ * - A native compares its intrinsic brand rather than a realm-local constructor
  *   identity, so a `Uint16Array` never satisfies a `Uint8Array`;
- * - `ArrayBuffer`, `SharedArrayBuffer`, and `DataView` compare visible bytes,
- *   not only a byte length;
- * - functions compare by reference identity.
+ * - `ArrayBuffer`, `SharedArrayBuffer`, and `DataView` compare visible bytes, not
+ *   only a byte length;
+ * - Functions compare by reference identity.
  *
  * The one deliberate looseness is inherited from the operations themselves: a
  * `null`, `undefined`, empty array, or empty `Map` on either side satisfies a
@@ -37,11 +37,11 @@ export interface IStrictEqualContext {
   /**
    * Collects the `Blob` pairs whose bytes must be compared asynchronously.
    *
-   * `Blob.arrayBuffer()` is asynchronous, so a synchronous oracle can only reach
-   * a blob's metadata. Supplying this accumulator lets an asynchronous caller
-   * finish the comparison through {@link strict_blobs_equal_to}; a synchronous
-   * walk that meets a `Blob` without one throws instead of quietly skipping the
-   * content.
+   * `Blob.arrayBuffer()` is asynchronous, so a synchronous oracle can only
+   * reach a blob's metadata. Supplying this accumulator lets an asynchronous
+   * caller finish the comparison through {@link strict_blobs_equal_to}; a
+   * synchronous walk that meets a `Blob` without one throws instead of quietly
+   * skipping the content.
    */
   blobs?: Array<[Blob, Blob, string]> | undefined;
 }
@@ -52,9 +52,7 @@ export const strict_equal_to = (
   ctx: IStrictEqualContext,
 ): boolean => recursive_equal_to(x, y, "$input", ctx);
 
-/**
- * Compares the byte content of every `Blob` pair the walk collected.
- */
+/** Compares the byte content of every `Blob` pair the walk collected. */
 export const strict_blobs_equal_to = async (
   ctx: IStrictEqualContext,
 ): Promise<boolean> => {

--- a/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
+++ b/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
@@ -322,12 +322,12 @@ const fixtureAmbientV2: string = [
  * 3. Add a required `flag` property to `CustomLabel` inside `lib.custom.d.ts` and
  *    rebuild with the cache kept; assert the previous input now fails at
  *    `$input.ambient.flag` and a fully updated input succeeds.
- * 4. Re-point `barrel.ts` at `alt.ts`, whose `Nested` adds a required `extra`,
- *    and rebuild with the cache kept; assert the previous input now fails at
+ * 4. Re-point `barrel.ts` at `alt.ts`, whose `Nested` adds a required `extra`, and
+ *    rebuild with the cache kept; assert the previous input now fails at
  *    `$input.nested.extra`.
  * 5. Retype `Cell` from `string` to `number` in `cell.ts` and rebuild with the
- *    cache kept; assert the previous string-valued dynamic entry now fails and a
- *    numeric one succeeds.
+ *    cache kept; assert the previous string-valued dynamic entry now fails and
+ *    a numeric one succeeds.
  */
 export const test_webpack_filesystem_cache_invalidation =
   async (): Promise<void> => {

--- a/tests/test-typia-schema/src/features/json.application/test_json_application_v3_0_dialect.ts
+++ b/tests/test-typia-schema/src/features/json.application/test_json_application_v3_0_dialect.ts
@@ -4,10 +4,11 @@ import typia from "typia";
 /**
  * Verifies typia.json.application emits the OpenAPI 3.0 dialect under "3.0".
  *
- * `json.application` is the third entry point sharing the collection writer that
- * relabeled a 3.1 document as "3.0". Its function parameter and return schemas
- * are filled from that same collection, so an application document is exactly as
- * mislabeled as a bare schema — and no test knew the dialect here either.
+ * `json.application` is the third entry point sharing the collection writer
+ * that relabeled a 3.1 document as "3.0". Its function parameter and return
+ * schemas are filled from that same collection, so an application document is
+ * exactly as mislabeled as a bare schema — and no test knew the dialect here
+ * either.
  *
  * 1. Declare a controller whose method takes a tuple and a literal union and
  *    returns a nullable type.
@@ -40,7 +41,11 @@ export const test_json_application_v3_0_dialect = (): void => {
 
   const serialized: string = JSON.stringify(app);
   for (const keyword of ["const", "prefixItems", '"type":"null"'])
-    TestValidator.equals(`no ${keyword} under 3.0`, serialized.includes(keyword), false);
+    TestValidator.equals(
+      `no ${keyword} under 3.0`,
+      serialized.includes(keyword),
+      false,
+    );
 };
 
 const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));

--- a/tests/test-typia-schema/src/features/json.isStringify/test_json_is_stringify_non_callable_to_json.ts
+++ b/tests/test-typia-schema/src/features/json.isStringify/test_json_is_stringify_non_callable_to_json.ts
@@ -14,12 +14,12 @@ interface IJsonable {
  * Serializing a `toJSON`-bearing type means calling `toJSON`, and the emitted
  * union arm that does so carries its own `typeof input.toJSON === "function"`
  * test. When that arm was the only one, the surrounding code dropped the test
- * along with the choice — there is nothing to choose between — and left the call
- * unguarded. A value whose `toJSON` is a non-function then threw
+ * along with the choice — there is nothing to choose between — and left the
+ * call unguarded. A value whose `toJSON` is a non-function then threw
  * `input.value.toJSON is not a function` from inside the serializer, so
  * `isStringify` and `validateStringify`, whose whole purpose is to answer for
- * untrusted input without a `try`/`catch`, threw on exactly the input they exist
- * to handle.
+ * untrusted input without a `try`/`catch`, threw on exactly the input they
+ * exist to handle.
  *
  * `JSON.stringify` ignores a non-callable `toJSON` and serializes the object
  * itself, which is what the guard now falls back to.
@@ -32,11 +32,11 @@ interface IJsonable {
  * 1. Take a value whose nested `toJSON` is a number rather than a function.
  * 2. Require `stringify` to answer, and its answer to be JSON. The answer
  *    describes the declared shape, so the function member is omitted and the
- *    result is `{}` rather than native `JSON.stringify`'s `{"toJSON":1}` — typia
- *    does not emit a member the type does not declare.
+ *    result is `{}` rather than native `JSON.stringify`'s `{"toJSON":1}` —
+ *    typia does not emit a member the type does not declare.
  * 3. Require `isStringify` and `validateStringify` to answer rather than throw.
- * 4. Keep the positive twin passing: a real `toJSON` still serializes through
- *    its return value.
+ * 4. Keep the positive twin passing: a real `toJSON` still serializes through its
+ *    return value.
  */
 export const test_json_is_stringify_non_callable_to_json = (): void => {
   const invalid: IJsonable = { keep: 1, value: { toJSON: 1 } } as never;

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_function_member_spelling_parity.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_function_member_spelling_parity.ts
@@ -27,14 +27,14 @@ interface AliasHolder {
  * spellings survived as a `$ref` to an empty component — two schemas for one
  * type, and neither describing what the serializer produces.
  *
- * 1. Declare one call signature two ways: an interface and a function type
- *    alias. The named-type-literal spelling of the same signature belongs to
+ * 1. Declare one call signature two ways: an interface and a function type alias.
+ *    The named-type-literal spelling of the same signature belongs to
  *    samchon/typia#2238, which is what stops it being expanded structurally in
  *    the first place, so it is pinned there rather than here.
  * 2. Generate the schema for a holder of each and require the documents to be
  *    equal.
- * 3. Require the member itself to be absent, so the parity cannot be satisfied
- *    by all three describing it wrongly in the same way.
+ * 3. Require the member itself to be absent, so the parity cannot be satisfied by
+ *    all three describing it wrongly in the same way.
  * 4. Require the neighboring data member to survive, so omission is confined to
  *    the function.
  */
@@ -42,9 +42,10 @@ export const test_json_schema_function_member_spelling_parity = (): void => {
   const shape = (
     unit: ReturnType<typeof typia.json.schema<InterfaceHolder>>,
   ): unknown => {
-    const components = JSON.parse(
-      JSON.stringify(unit.components),
-    ) as Record<string, Record<string, any>>;
+    const components = JSON.parse(JSON.stringify(unit.components)) as Record<
+      string,
+      Record<string, any>
+    >;
     const schemas = components.schemas ?? {};
     // Keyed by the holder's own name, which necessarily differs between the two
     // spellings, so compare the shapes rather than the map: the property set,

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_oneof_declaration_syntax.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_oneof_declaration_syntax.ts
@@ -11,9 +11,9 @@ import typia from "typia";
  * declared it. The generator files an `interface` member under metadata
  * `Objects` and a `type` alias of an object literal under `Aliases`, and the
  * eligibility gate used to accept only the former, so one alias member silently
- * dropped the discriminator for the whole union while `oneOf` kept the very same
- * `$ref` targets. Negative shapes are pinned beside the positives so resolving
- * aliases cannot start over-emitting.
+ * dropped the discriminator for the whole union while `oneOf` kept the very
+ * same `$ref` targets. Negative shapes are pinned beside the positives so
+ * resolving aliases cannot start over-emitting.
  *
  * 1. Declare one tagged union three ways: all `interface`, all `type` alias, and
  *    mixed.
@@ -66,7 +66,9 @@ export const test_json_schema_oneof_declaration_syntax = (): void => {
     TestValidator.predicate(`${label} union is oneOf`, () => value !== null);
 
   // every declaration syntax must carry the same discriminator
-  const expected = (prefix: string): OpenApi.IJsonSchema.IOneOf.IDiscriminator => ({
+  const expected = (
+    prefix: string,
+  ): OpenApi.IJsonSchema.IOneOf.IDiscriminator => ({
     propertyName: "type",
     mapping: {
       circle: `#/components/schemas/${prefix}Circle`,

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_name_cascade.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_name_cascade.ts
@@ -28,13 +28,13 @@ interface IArguments {
  * therefore never join its disambiguating suffix with a dot: the escaped base
  * of `RecursiveObject<"A/B">` is exactly the legal name of the unrelated
  * `RecursiveObjectA_x2F_B` interface, so a dotted suffix would present that
- * interface as a parent and leak its description into the escaped schema an
- * LLM reads.
+ * interface as a parent and leak its description into the escaped schema an LLM
+ * reads.
  *
  * 1. Declare an interface owning the escaped base name of a forbidden type.
  * 2. Generate the schema so both land in `components.schemas`.
- * 3. Assert the escaped name exposes no allocated component as a parent, and
- *    that its escaped description never mentions the unrelated interface.
+ * 3. Assert the escaped name exposes no allocated component as a parent, and that
+ *    its escaped description never mentions the unrelated interface.
  */
 export const test_json_schema_openapi_component_name_cascade = (): void => {
   const collection = typia.json.schema<IArguments, "3.1">();
@@ -79,10 +79,8 @@ export const test_json_schema_openapi_component_name_cascade = (): void => {
     "the escaped schema does not inherit the unrelated description",
     () => (escaped.value?.description ?? "").includes("UNRELATED") === false,
   );
-  TestValidator.predicate(
-    "the escaped schema keeps its own description",
-    () =>
-      (escaped.value?.description ?? "").includes("GENERIC RECURSIVE OBJECT"),
+  TestValidator.predicate("the escaped schema keeps its own description", () =>
+    (escaped.value?.description ?? "").includes("GENERIC RECURSIVE OBJECT"),
   );
 };
 

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_name_generic_argument.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_openapi_component_name_generic_argument.ts
@@ -51,11 +51,11 @@ interface IArguments {
  * `IPage<IShoppingSale.ISummary>` idiom, so it needs no contrived naming.
  *
  * 1. Reference a generic instantiated with a qualified argument, an unrelated
- *    interface named exactly after the flattened prefix, and a genuinely
- *    merged interface-plus-namespace pair.
- * 2. Assert every reference escapes, that the flattened key claims no
- *    allocated component as a parent, and that its escaped description never
- *    mentions the unrelated interface.
+ *    interface named exactly after the flattened prefix, and a genuinely merged
+ *    interface-plus-namespace pair.
+ * 2. Assert every reference escapes, that the flattened key claims no allocated
+ *    component as a parent, and that its escaped description never mentions the
+ *    unrelated interface.
  * 3. Assert the real namespace member still inherits its real parent's
  *    description, so the cascade itself is intact.
  */
@@ -70,9 +70,11 @@ export const test_json_schema_openapi_component_name_generic_argument =
 
     const key = (accessor: string): string =>
       (
-        (root.properties?.[accessor] as
-          | OpenApi.IJsonSchema.IReference
-          | undefined)?.$ref ?? ""
+        (
+          root.properties?.[accessor] as
+            | OpenApi.IJsonSchema.IReference
+            | undefined
+        )?.$ref ?? ""
       )
         .split("/")
         .at(-1)!;
@@ -105,12 +107,10 @@ export const test_json_schema_openapi_component_name_generic_argument =
     // Resolution is asserted first: "inherits no unrelated description" is a
     // negative, and a reference that stopped escaping at all would satisfy it
     // without meaning anything.
-    TestValidator.predicate(
-      "every reference escapes",
-      () =>
-        ["flattened", "unrelated", "parent", "member"].every(
-          (accessor) => describe(accessor) !== FAILED,
-        ),
+    TestValidator.predicate("every reference escapes", () =>
+      ["flattened", "unrelated", "parent", "member"].every(
+        (accessor) => describe(accessor) !== FAILED,
+      ),
     );
     TestValidator.predicate(
       "the flattened generic inherits no unrelated description",

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_v3_0_dialect.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_v3_0_dialect.ts
@@ -40,7 +40,11 @@ export const test_json_schema_v3_0_dialect = (): void => {
 
   const serialized: string = JSON.stringify(unit);
   for (const keyword of ["const", "prefixItems", '"type":"null"'])
-    TestValidator.equals(`no ${keyword} under 3.0`, serialized.includes(keyword), false);
+    TestValidator.equals(
+      `no ${keyword} under 3.0`,
+      serialized.includes(keyword),
+      false,
+    );
 };
 
 const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));

--- a/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_dialect.ts
+++ b/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_dialect.ts
@@ -53,7 +53,11 @@ export const test_json_schemas_v3_0_dialect = (): void => {
   // The negative twin: no 3.1-only keyword may appear anywhere in the document.
   const serialized: string = JSON.stringify(collection);
   for (const keyword of ["const", "prefixItems", '"type":"null"'])
-    TestValidator.equals(`no ${keyword} under 3.0`, serialized.includes(keyword), false);
+    TestValidator.equals(
+      `no ${keyword} under 3.0`,
+      serialized.includes(keyword),
+      false,
+    );
 };
 
 const clean = <T>(value: T): T => JSON.parse(JSON.stringify(value));

--- a/tests/test-typia-schema/src/features/json.stringify/test_json_stringify_contextual_undefined.ts
+++ b/tests/test-typia-schema/src/features/json.stringify/test_json_stringify_contextual_undefined.ts
@@ -63,7 +63,11 @@ export const test_json_stringify_contextual_undefined = (): void => {
     oracle(`${label} / stringify`, raw(input), input);
 
     const isText: string | null = guarded(input);
-    TestValidator.equals(`${label} / isStringify accepts`, isText !== null, true);
+    TestValidator.equals(
+      `${label} / isStringify accepts`,
+      isText !== null,
+      true,
+    );
     if (isText !== null) oracle(`${label} / isStringify`, isText, input);
 
     oracle(`${label} / assertStringify`, asserted(input), input);

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_component_name_collision.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_component_name_collision.ts
@@ -19,10 +19,10 @@ interface IArguments {
  * through a different replacer than the OpenAPI generator, so it is a genuinely
  * independent surface for the same root cause rather than a second view of one
  * document. The allocator used to mint `<Base>.o<N>` without checking that id
- * against the ids already handed out, which collapsed the real
- * `namespace Foo { interface o1 }` member and a second `Foo` onto one `$defs`
- * key. The model was then handed one type's shape under two parameters, and
- * typia's own runtime validator rejected what the model produced for the other.
+ * against the ids already handed out, which collapsed the real `namespace Foo {
+ * interface o1 }` member and a second `Foo` onto one `$defs` key. The model was
+ * then handed one type's shape under two parameters, and typia's own runtime
+ * validator rejected what the model produced for the other.
  *
  * 1. Generate LLM parameters referencing three colliding types.
  * 2. Assert each parameter carries a distinct local reference.

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_invert_default_round_trip.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_invert_default_round_trip.ts
@@ -49,7 +49,11 @@ export const test_llm_schema_invert_default_round_trip = (): void => {
     schema: string,
     $defs: {},
   }) as OpenApi.IJsonSchema.IString;
-  TestValidator.equals("string default restored", stringInverted.default, "body");
+  TestValidator.equals(
+    "string default restored",
+    stringInverted.default,
+    "body",
+  );
   TestValidator.equals(
     "string minLength restored",
     stringInverted.minLength,

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_parity_converter_strict.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_parity_converter_strict.ts
@@ -6,12 +6,13 @@ import typia, { tags } from "typia";
 /**
  * Verifies the native strict LLM schema agrees with `@typia/utils`' converter.
  *
- * Under `strict`, constraint keywords are shifted out of the schema and into the
- * description as `@tag value` lines. Two owners implement that shift — the Go
- * emitter `typia.llm.*` calls, and `OpenApiConstraintShifter` in `@typia/utils`
- * — and they once disagreed on `default`, which the numeric path deleted instead
- * of shifting. The oracle below was already correct when that shipped; only the
- * fixture was blind, because it omitted the single tag they disagreed on.
+ * Under `strict`, constraint keywords are shifted out of the schema and into
+ * the description as `@tag value` lines. Two owners implement that shift — the
+ * Go emitter `typia.llm.*` calls, and `OpenApiConstraintShifter` in
+ * `@typia/utils` — and they once disagreed on `default`, which the numeric path
+ * deleted instead of shifting. The oracle below was already correct when that
+ * shipped; only the fixture was blind, because it omitted the single tag they
+ * disagreed on.
  *
  * The fixture therefore exercises every tag both shift functions handle rather
  * than a sample: a correct comparison over an incomplete input proves nothing
@@ -25,7 +26,10 @@ export const test_llm_schema_parity_converter_strict = (): void => {
   interface IStrictChild {
     // The complete string shift set: minLength, maxLength, format, pattern,
     // contentMediaType, default.
-    code: string & tags.MinLength<2> & tags.MaxLength<8> & tags.Pattern<"^[a-z]+$">;
+    code: string &
+      tags.MinLength<2> &
+      tags.MaxLength<8> &
+      tags.Pattern<"^[a-z]+$">;
     media: string & tags.ContentMediaType<"text/plain"> & tags.Default<"body">;
     id: string & tags.Format<"uuid">;
     // The complete numeric shift set: minimum, maximum, exclusiveMinimum,

--- a/tests/test-typia-schema/src/features/notations/test_notation_underscore_boundary.ts
+++ b/tests/test-typia-schema/src/features/notations/test_notation_underscore_boundary.ts
@@ -2,7 +2,8 @@ import { TestValidator } from "@nestia/e2e";
 import typia from "typia";
 
 /**
- * Verifies notation runtime output equals the `*Case<T>` type on underscore keys.
+ * Verifies notation runtime output equals the `*Case<T>` type on underscore
+ * keys.
  *
  * Issue #2190: on a key mixing an underscore with a case boundary the
  * `snake`/`kebab` conversion lowercased each underscore-delimited segment
@@ -32,7 +33,8 @@ export const test_notation_underscore_boundary = (): void => {
   };
 
   // ---- static keys: soundness against the declared *Case<T> type ----
-  const snaked: typia.SnakeCase<Battery> = typia.notations.snake<Battery>(value);
+  const snaked: typia.SnakeCase<Battery> =
+    typia.notations.snake<Battery>(value);
   TestValidator.equals("snake foo_bar_baz", snaked.foo_bar_baz, 1);
   TestValidator.equals("snake open_ai_key", snaked.open_ai_key, 2);
   TestValidator.equals("snake http_foo_bar", snaked.http_foo_bar, 3);

--- a/tests/test-typia-schema/src/features/protobuf.decode/ProtobufVarintCorpus.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/ProtobufVarintCorpus.ts
@@ -21,8 +21,8 @@ import { TestGlobal } from "../../TestGlobal";
  * lenient, while `protowire` rejects. typia follows `protowire`.
  *
  * A fault class, not a message, is what the corpus records. The mapping from a
- * class to the exact text typia raises lives in {@link message} — one table,
- * in one place, rather than a string repeated across the regressions.
+ * class to the exact text typia raises lives in {@link message} — one table, in
+ * one place, rather than a string repeated across the regressions.
  */
 export namespace ProtobufVarintCorpus {
   /** The wire fault classes the corpus distinguishes. */

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_absent_scalar_defaults.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_absent_scalar_defaults.ts
@@ -6,22 +6,24 @@ import typia from "typia";
  *
  * In proto3 a singular scalar equal to its default is not written on the wire,
  * so a conformant peer encodes an all-defaults message as the empty payload and
- * an absent scalar must decode to its type default: `number -> 0`,
- * `boolean -> false`, `bigint -> 0n`, `string -> ""`. typia seeded an absent
- * required `number`/`boolean`/`bigint` with `undefined` instead, so `decode`
- * returned `undefined` and every validating decoder threw `invalid type` on a
- * valid peer message. The typia encoder writes every required non-nullable
- * field unconditionally even at the default, so this never surfaced in a
- * typia-only round-trip; the oracle here is a hand-built absent-field payload,
- * not typia's own encode output.
+ * an absent scalar must decode to its type default: `number -> 0`, `boolean ->
+ * false`, `bigint -> 0n`, `string -> ""`. typia seeded an absent required
+ * `number`/`boolean`/`bigint` with `undefined` instead, so `decode` returned
+ * `undefined` and every validating decoder threw `invalid type` on a valid peer
+ * message. The typia encoder writes every required non-nullable field
+ * unconditionally even at the default, so this never surfaced in a typia-only
+ * round-trip; the oracle here is a hand-built absent-field payload, not typia's
+ * own encode output.
  *
  * 1. Decode the empty payload for a message of required `number`, `boolean`,
  *    `bigint`, and `string` through every direct and factory decoder, asserting
- *    each field takes its typed default and every validating decoder accepts it.
+ *    each field takes its typed default and every validating decoder accepts
+ *    it.
  * 2. Assert an absent optional scalar stays `undefined` and an absent nullable
- *    scalar stays `null`, so the new seed touches only the required scalar case.
- * 3. Assert a constrained scalar at the default is judged by its constraint on
- *    the seeded `0`, the precise diagnostic, not an `invalid type` on `undefined`.
+ *    scalar stays `null`, so the new seed touches only the required scalar
+ *    case.
+ * 3. Assert a constrained scalar at the default is judged by its constraint on the
+ *    seeded `0`, the precise diagnostic, not an `invalid type` on `undefined`.
  */
 export const test_protobuf_decode_absent_scalar_defaults = (): void => {
   // an all-defaults proto3 message: a conformant peer omits every field equal
@@ -49,7 +51,10 @@ export const test_protobuf_decode_absent_scalar_defaults = (): void => {
     [
       "validateDecode",
       (input) =>
-        unwrap("validateDecode", typia.protobuf.validateDecode<IScalars>(input)),
+        unwrap(
+          "validateDecode",
+          typia.protobuf.validateDecode<IScalars>(input),
+        ),
     ],
     [
       "createValidateDecode",

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_varint_bounds.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_decode_varint_bounds.ts
@@ -18,11 +18,11 @@ import { ProtobufVarintCorpus } from "./ProtobufVarintCorpus";
  * `google.golang.org/protobuf`. Nothing here is transcribed, so a decoder that
  * disagreed with the reference Go parser could not also agree with this file.
  *
- * 1. Cross all eight direct and factory wrappers with every malformed corpus
- *    row placed as a 32-bit, 64-bit, boolean, packed, map, and nested value.
- * 2. Reject the same rows as top-level and group tags, as bytes, string,
- *    packed, map, nested, unknown-field, and group-contained length prefixes,
- *    and as the value of an unknown varint field the decoder only skips.
+ * 1. Cross all eight direct and factory wrappers with every malformed corpus row
+ *    placed as a 32-bit, 64-bit, boolean, packed, map, and nested value.
+ * 2. Reject the same rows as top-level and group tags, as bytes, string, packed,
+ *    map, nested, unknown-field, and group-contained length prefixes, and as
+ *    the value of an unknown varint field the decoder only skips.
  * 3. Preserve every accepted row's decoded value, trailing fields, and encoder
  *    round trips.
  */

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_invalid_utf8.ts
@@ -52,10 +52,9 @@ const assertOverflow = (label: string, task: () => unknown): void => {
   } catch (error) {
     if (error instanceof Error && error.message === OVERFLOW_ERROR) return;
     if (error instanceof Error && error.message === INVALID_UTF8_ERROR)
-      throw new Error(
-        `${label} was relabeled as an encoding fault.`,
-        { cause: error },
-      );
+      throw new Error(`${label} was relabeled as an encoding fault.`, {
+        cause: error,
+      });
     throw new Error(`${label} raised an unstable error.`, { cause: error });
   }
   throw new Error(`${label} was accepted as a Protobuf string.`);
@@ -96,9 +95,15 @@ const ENCODER = new TextEncoder();
  * length. That isolates the boundary contract from the encoding contract.
  */
 const TRUNCATED_FRAMES = [
-  ["declared length past the buffer", Uint8Array.of(0x08, ...ENCODER.encode("abc"))],
+  [
+    "declared length past the buffer",
+    Uint8Array.of(0x08, ...ENCODER.encode("abc")),
+  ],
   ["declared length with no payload", Uint8Array.of(0x04)],
-  ["declared length one byte short", Uint8Array.of(0x05, ...ENCODER.encode("text"))],
+  [
+    "declared length one byte short",
+    Uint8Array.of(0x05, ...ENCODER.encode("text")),
+  ],
 ] as const;
 
 const VALID_TEXTS = [

--- a/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_varint_bounds.ts
+++ b/tests/test-typia-schema/src/features/protobuf.decode/test_protobuf_reader_varint_bounds.ts
@@ -4,8 +4,8 @@ import { _ProtobufReader } from "typia/lib/internal/_ProtobufReader";
 import { ProtobufVarintCorpus } from "./ProtobufVarintCorpus";
 
 /**
- * Verifies every runtime Protobuf varint reader matches the reference Go
- * parser over the shared corpus.
+ * Verifies every runtime Protobuf varint reader matches the reference Go parser
+ * over the shared corpus.
  *
  * A ten-byte varint has room for only one payload bit in its final byte. The
  * scalar readers, length readers, and unknown-field skipper must reject both a
@@ -15,8 +15,8 @@ import { ProtobufVarintCorpus } from "./ProtobufVarintCorpus";
  * Rejecting is only half of it. The corpus also carries the canonical maximum
  * that terminates at each width from one byte through ten, so every early
  * return in `varint32` and `varint64` keeps a positive control. The nine-byte
- * row matters most: it is the legal encoding of `9223372036854775807`, the
- * very value the issue's malformed ten-byte witness used to fabricate.
+ * row matters most: it is the legal encoding of `9223372036854775807`, the very
+ * value the issue's malformed ten-byte witness used to fabricate.
  *
  * Every byte string and every verdict below comes from
  * `packages/typia/test/protobuf_varint_corpus.json`, which the Go test
@@ -24,12 +24,12 @@ import { ProtobufVarintCorpus } from "./ProtobufVarintCorpus";
  * `google.golang.org/protobuf`. Nothing here is transcribed, so this regression
  * cannot quietly disagree with the oracle that justifies it.
  *
- * 1. Cross every public integer and boolean reader, and the unknown-field
- *    skipper, with every corpus row.
+ * 1. Cross every public integer and boolean reader, and the unknown-field skipper,
+ *    with every corpus row.
  * 2. Read the rejected rows again as byte, string, fork, unknown-field, and
  *    group-contained lengths and as a group's field tag.
- * 3. Preserve the decoded value of every accepted row, exact pointer
- *    advancement, and the trailing byte behind it.
+ * 3. Preserve the decoded value of every accepted row, exact pointer advancement,
+ *    and the trailing byte behind it.
  */
 export const test_protobuf_reader_varint_bounds = (): void => {
   const entries: ProtobufVarintCorpus.IEntry[] = ProtobufVarintCorpus.entries();
@@ -114,10 +114,12 @@ export const test_protobuf_reader_varint_bounds = (): void => {
   // one varint would continue into an eleventh byte, the other terminates and
   // carries a value bit above 63. The loops above assert each row's own text,
   // and this pins the distinction the corpus draws between them.
-  const overlong: ProtobufVarintCorpus.IEntry =
-    ProtobufVarintCorpus.find("ten continuation bytes");
-  const overflow: ProtobufVarintCorpus.IEntry =
-    ProtobufVarintCorpus.find("excess tenth payload");
+  const overlong: ProtobufVarintCorpus.IEntry = ProtobufVarintCorpus.find(
+    "ten continuation bytes",
+  );
+  const overflow: ProtobufVarintCorpus.IEntry = ProtobufVarintCorpus.find(
+    "excess tenth payload",
+  );
   if (
     ProtobufVarintCorpus.bytes(overlong).length !==
     ProtobufVarintCorpus.bytes(overflow).length
@@ -166,10 +168,10 @@ interface IValueReader {
 /**
  * Every public varint consumer, with the projection the wire format demands.
  *
- * A field narrower than the varint keeps the low bits, which is what a
- * Protocol Buffer parser does with a 64-bit varint on a 32-bit field, so each
- * 32-bit expectation is the oracle value reduced rather than an independent
- * guess. `bool` is excluded from the value column and covered separately.
+ * A field narrower than the varint keeps the low bits, which is what a Protocol
+ * Buffer parser does with a 64-bit varint on a 32-bit field, so each 32-bit
+ * expectation is the oracle value reduced rather than an independent guess.
+ * `bool` is excluded from the value column and covered separately.
  */
 const VALUE_READERS: IValueReader[] = [
   {
@@ -216,8 +218,8 @@ const zigzag = (value: bigint): bigint =>
 /**
  * Require the reader to decode an accepted row exactly.
  *
- * A trailing byte follows the varint so that consuming one byte too many or
- * too few is visible as a wrong index rather than as an accidental buffer end.
+ * A trailing byte follows the varint so that consuming one byte too many or too
+ * few is visible as a wrong index rather than as an accidental buffer end.
  */
 const assertAccepted = (
   entry: ProtobufVarintCorpus.IEntry,

--- a/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_duplicate_name_identifier.ts
+++ b/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_duplicate_name_identifier.ts
@@ -15,14 +15,14 @@ interface IArguments {
  *
  * `protobuf.message` splits a metadata name on `.` and nests each segment as a
  * child message, so it reads the same dot the OpenAPI key space does. Two
- * unrelated `Foo` types therefore used to emit the second one *inside* the
+ * unrelated `Foo` types therefore used to emit the second one _inside_ the
  * first, as `message Foo { message o1 { ... } }`. The counter is no longer
  * joined with a dot, which separates them — but a message name is an
  * identifier, so the separator has to survive `ProtobufNameEncoder`, or the
  * emitted schema is text no Protobuf parser accepts.
  *
- * protobuf.js resolves the document the way a consumer would, which is what
- * makes it a fair witness for *name resolution*: a collision or a broken
+ * Protobuf.js resolves the document the way a consumer would, which is what
+ * makes it a fair witness for _name resolution_: a collision or a broken
  * separator shows up as a lookup failure rather than a pattern mismatch. It is
  * not a witness for legality. protobuf.js is lenient — it accepts a proto3
  * document containing `required`, reports its syntax as proto3, and records the
@@ -32,14 +32,15 @@ interface IArguments {
  *
  * 1. Reference two distinct types that share the declared name `Foo`.
  * 2. Parse the emitted document with protobuf.js and resolve every message.
- * 3. Assert the duplicate is a sibling rather than a child, and that each of
- *    the two `Foo` types keeps its own field.
+ * 3. Assert the duplicate is a sibling rather than a child, and that each of the
+ *    two `Foo` types keeps its own field.
  */
 export const test_protobuf_message_duplicate_name_identifier = (): void => {
   const message: string = typia.protobuf.message<IArguments>();
 
   // 1. THE GRAMMAR ACCEPTS THE DOCUMENT
-  const parsed = (): pjs.IParserResult => pjs.parse(message, { keepCase: true });
+  const parsed = (): pjs.IParserResult =>
+    pjs.parse(message, { keepCase: true });
   TestValidator.predicate("protobuf.js parses the emitted document", () => {
     try {
       parsed();
@@ -50,9 +51,9 @@ export const test_protobuf_message_duplicate_name_identifier = (): void => {
   });
 
   const root: pjs.Root = parsed().root;
-  const declared: string[] = [...message.matchAll(/message\s+(\S+)\s*\{/gu)].map(
-    (m) => m[1]!,
-  );
+  const declared: string[] = [
+    ...message.matchAll(/message\s+(\S+)\s*\{/gu),
+  ].map((m) => m[1]!);
   TestValidator.equals(
     "every distinct type declares its own message",
     3,

--- a/tests/test-typia-schema/src/features/random/test_random_string_pattern_format_length.ts
+++ b/tests/test-typia-schema/src/features/random/test_random_string_pattern_format_length.ts
@@ -83,7 +83,10 @@ export const test_random_string_pattern_format_length = (): void => {
   }
   {
     // A short window near the email minimum exercises the shrink path.
-    type T = string & tags.Format<"email"> & tags.MinLength<5> & tags.MaxLength<9>;
+    type T = string &
+      tags.Format<"email"> &
+      tags.MinLength<5> &
+      tags.MaxLength<9>;
     const create = typia.createRandom<T>();
     roundTrip(
       "email & short window",
@@ -104,7 +107,10 @@ export const test_random_string_pattern_format_length = (): void => {
     );
   }
   {
-    type T = string & tags.Format<"url"> & tags.MinLength<40> & tags.MaxLength<60>;
+    type T = string &
+      tags.Format<"url"> &
+      tags.MinLength<40> &
+      tags.MaxLength<60>;
     const create = typia.createRandom<T>();
     roundTrip(
       "url & length window",

--- a/tests/test-typia-schema/src/features/standardSchema/test_standard_schema_escaped_key_paths.ts
+++ b/tests/test-typia-schema/src/features/standardSchema/test_standard_schema_escaped_key_paths.ts
@@ -28,8 +28,8 @@ const KEYS: readonly string[] = [
  * Verifies Standard Schema reports issues for keys that need escaping.
  *
  * The transform folds a sole-literal key into the emitted path as source text,
- * and `~standard.validate()` parses that path back with JSON.parse. Escaping the
- * key for Go rather than for JavaScript left a raw control character in the
+ * and `~standard.validate()` parses that path back with JSON.parse. Escaping
+ * the key for Go rather than for JavaScript left a raw control character in the
  * path, so JSON.parse threw and destroyed the whole result instead of reporting
  * the one property that failed. A quote-only fix leaves that throw live, which
  * is why the control characters are pinned here beside the quote.
@@ -50,14 +50,11 @@ export const test_standard_schema_escaped_key_paths = (): void => {
 
   TestValidator.equals("issue count", KEYS.length, result.issues.length);
   for (const key of KEYS)
-    TestValidator.predicate(
-      `issue path for ${JSON.stringify(key)}`,
-      () =>
-        result.issues!.some(
-          (issue) =>
-            issue.path?.length === 1 &&
-            segmentKey(issue.path[0]) === key,
-        ),
+    TestValidator.predicate(`issue path for ${JSON.stringify(key)}`, () =>
+      result.issues!.some(
+        (issue) =>
+          issue.path?.length === 1 && segmentKey(issue.path[0]) === key,
+      ),
     );
 };
 

--- a/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
@@ -22,10 +22,10 @@ interface ICommentBigint {
 }
 
 /**
- * Verifies that the int64 validators enforce the signed 64-bit range on both the
- * number and bigint paths.
+ * Verifies that the int64 validators enforce the signed 64-bit range on both
+ * the number and bigint paths.
  *
- * int64-max is `2 ** 63 - 1`, which no `number` can represent -- it rounds to
+ * Int64-max is `2 ** 63 - 1`, which no `number` can represent -- it rounds to
  * `2 ** 63` -- so the number path accepts `2 ** 63` as int64-max's only float
  * form. The bigint path represents the bound exactly, so it enforces the true
  * inclusive range and still rejects magnitudes such as `2n ** 200n` that the
@@ -42,7 +42,11 @@ export const test_type_int64_range = (): void => {
     MINIMUM <= value && value <= MAXIMUM;
 
   // The oracle must be able to represent the boundary the validators cannot.
-  TestValidator.equals("2 ** 63 is not an int64", false, oracle(BigInt(2 ** 63)));
+  TestValidator.equals(
+    "2 ** 63 is not an int64",
+    false,
+    oracle(BigInt(2 ** 63)),
+  );
   TestValidator.equals(
     "the largest double below 2 ** 63 is an int64",
     true,
@@ -135,7 +139,11 @@ export const test_type_int64_range = (): void => {
   // On the exact bigint path, typia never certifies a value its own encoder will
   // corrupt: every in-range bigint survives protobuf byte-for-byte.
   for (const value of [MINIMUM, MAXIMUM, 0n, -1n, 1n, 2n ** 62n]) {
-    TestValidator.equals(`round trip ${value} is certified`, true, oracle(value));
+    TestValidator.equals(
+      `round trip ${value} is certified`,
+      true,
+      oracle(value),
+    );
     const decoded: typia.Resolved<ITaggedBigint> = typia.protobuf.decode<
       typia.Resolved<ITaggedBigint>
     >(typia.protobuf.encode<ITaggedBigint>({ value }));

--- a/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
@@ -25,7 +25,7 @@ interface ICommentBigint {
  * Verifies that the uint64 validators enforce the unsigned 64-bit range on both
  * the number and bigint paths.
  *
- * uint64-max is `2 ** 64 - 1`, which no `number` can represent -- it rounds to
+ * Uint64-max is `2 ** 64 - 1`, which no `number` can represent -- it rounds to
  * `2 ** 64` -- so the number path accepts `2 ** 64` as uint64-max's only float
  * form. The bigint path represents the bound exactly, so it enforces the true
  * inclusive range and still rejects magnitudes such as `2n ** 64n` that the
@@ -90,7 +90,11 @@ export const test_type_uint64_range = (): void => {
 
   // A non-integer is never a uint64, whatever its magnitude.
   for (const value of [0.5, 1.5]) {
-    TestValidator.equals(`_isTypeUint64(${value})`, false, _isTypeUint64(value));
+    TestValidator.equals(
+      `_isTypeUint64(${value})`,
+      false,
+      _isTypeUint64(value),
+    );
     TestValidator.equals(
       `number type tag on ${value}`,
       false,
@@ -136,7 +140,11 @@ export const test_type_uint64_range = (): void => {
   // On the exact bigint path, typia never certifies a value its own encoder will
   // corrupt: every in-range bigint survives protobuf byte-for-byte.
   for (const value of [MINIMUM, MAXIMUM, 1n, 2n ** 63n]) {
-    TestValidator.equals(`round trip ${value} is certified`, true, oracle(value));
+    TestValidator.equals(
+      `round trip ${value} is certified`,
+      true,
+      oracle(value),
+    );
     const decoded: typia.Resolved<ITaggedBigint> = typia.protobuf.decode<
       typia.Resolved<ITaggedBigint>
     >(typia.protobuf.encode<ITaggedBigint>({ value }));

--- a/tests/test-utils-automated/src/TestAutomation.ts
+++ b/tests/test-utils-automated/src/TestAutomation.ts
@@ -62,12 +62,13 @@ export namespace TestAutomation {
   /**
    * Structures held out of the OpenAPI validate matrix, and why each is out.
    *
-   * This replaces three source-text scans (`"never"`, `"[key: "`, `'<"uint32">'`)
-   * that the selector ran over each fixture's raw file. Matching source text
-   * means prose decides coverage: a doc comment that merely mentioned one of
-   * those words dropped a structure from the matrix silently, with nothing to
-   * observe (#2136). The set below reproduces those three scans exactly — the
-   * same 148 structures resolve to the same 83 validate and 80 equality cases.
+   * This replaces three source-text scans (`"never"`, `"[key: "`,
+   * `'<"uint32">'`) that the selector ran over each fixture's raw file.
+   * Matching source text means prose decides coverage: a doc comment that
+   * merely mentioned one of those words dropped a structure from the matrix
+   * silently, with nothing to observe (#2136). The set below reproduces those
+   * three scans exactly — the same 148 structures resolve to the same 83
+   * validate and 80 equality cases.
    *
    * The reason belongs here rather than on the fixture because it describes the
    * emitted schema, not the fixture: nothing about `DynamicSimple` makes it
@@ -111,27 +112,28 @@ export namespace TestAutomation {
    * their schema simply states less than the type does, so no validator could
    * reject the fixture's spoiler and the miss is the emitter's:
    *
-   * - `DynamicComposite`, `DynamicTemplate`, `DynamicUnion` — an index
-   *   signature emits `additionalProperties`, a single schema shared by every
-   *   key. The normalized object schema has no `patternProperties`, so distinct
-   *   key patterns and their distinct value types collapse into one union:
+   * - `DynamicComposite`, `DynamicTemplate`, `DynamicUnion` — an index signature
+   *   emits `additionalProperties`, a single schema shared by every key. The
+   *   normalized object schema has no `patternProperties`, so distinct key
+   *   patterns and their distinct value types collapse into one union:
    *   `DynamicTemplate` becomes `additionalProperties: string | number |
-   *   boolean`, which permits the spoiler `prefix_wrong: false` that its
-   *   `` [key: `prefix_${string}`]: string `` member forbids. The
-   *   over-approximation is forced by the target format, not a validator gap.
+   *   boolean`, which permits the spoiler `prefix_wrong: false` that its `[key:
+   *   `prefix_${string}`]: string` member forbids. The over-approximation is
+   *   forced by the target format, not a validator gap.
    * - `TypeTagType` — an integer width tag emits no range: `Type<"uint32">`
    *   becomes `{ type: "integer", minimum: 0 }` and `Type<"int32">` becomes a
    *   bare `{ type: "integer" }`. No upper bound is ever emitted, so the
-   *   spoiler `uint = 4294967296` is inside every constraint the schema states.
+   *   spoiler `uint = 4294967296` is inside every constraint the schema
+   *   states.
    * - `TemplateInterpolationTagged` — a template literal emits a `pattern` for
    *   its structural shape alone, and the interpolated tags never reach it.
-   *   `` percent: `${number & Minimum<0> & Maximum<100>}%` `` emits
+   *   `percent: `${number & Minimum<0> & Maximum<100>}%`` emits
    *   `^([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?%)$`, which `"150%"` matches. The
    *   first miss is that `Maximum<100>`, not a `uint32` tag.
    *
    * The four marked `passes today` are measured to validate cleanly against
    * their own spoilers, and are held out only because admitting them changes
-   * *which* structures the matrix covers — a separate decision from *how* they
+   * _which_ structures the matrix covers — a separate decision from _how_ they
    * are selected, left to #2136's follow-up.
    */
   const HELD_OUT: Record<string, string> = {

--- a/tests/test-utils-automated/src/regressions/test_structure_selection_ignores_prose.ts
+++ b/tests/test-utils-automated/src/regressions/test_structure_selection_ignores_prose.ts
@@ -12,7 +12,8 @@ import { TestGlobal } from "../TestGlobal";
  * `uint32`/`uint64` tag silently left the validate matrix with no signal —
  * coverage loss that no assertion could observe (#2136). `TypeTagRange` carries
  * a doc comment that legitimately reads "must never accept", which the old
- * `content.includes("never")` scan would match, dropping it from both matrices.
+ * `content.includes("never")` scan would match, dropping it from both
+ * matrices.
  *
  * The guard runs first on purpose: it fails if that prose ever disappears, so
  * this case cannot quietly decay into an oracle that proves nothing.

--- a/tests/test-utils/src/features/llm/invert/test_llm_invert_non_enumerable_definition.ts
+++ b/tests/test-utils/src/features/llm/invert/test_llm_invert_non_enumerable_definition.ts
@@ -14,8 +14,8 @@ import { ILlmSchema } from "typia";
  * silently dropping one of the two. Escaping the stray key is not enough: it
  * produces exactly the name the legal definition holds.
  *
- * 1. Give `$defs` an own non-enumerable forbidden key whose escaped form
- *    collides with a second, legal, enumerable key.
+ * 1. Give `$defs` an own non-enumerable forbidden key whose escaped form collides
+ *    with a second, legal, enumerable key.
  * 2. Invert references to both.
  * 3. Assert each resolves to a distinct component carrying its own content.
  */
@@ -27,7 +27,10 @@ export const test_llm_invert_non_enumerable_definition = (): void => {
     configurable: true,
     enumerable: false,
     writable: true,
-    value: { type: "string", description: "forbidden non-enumerable definition" },
+    value: {
+      type: "string",
+      description: "forbidden non-enumerable definition",
+    },
   });
 
   const components: OpenApi.IComponents = { schemas: {} };
@@ -46,9 +49,8 @@ export const test_llm_invert_non_enumerable_definition = (): void => {
   });
 
   const schemas: Record<string, OpenApi.IJsonSchema> = components.schemas ?? {};
-  TestValidator.predicate(
-    "every allocated component key is legal",
-    () => Object.keys(schemas).every((key) => /^[a-zA-Z0-9.\-_]+$/.test(key)),
+  TestValidator.predicate("every allocated component key is legal", () =>
+    Object.keys(schemas).every((key) => /^[a-zA-Z0-9.\-_]+$/.test(key)),
   );
   TestValidator.equals(
     "the legal definition keeps its exact name",
@@ -62,7 +64,10 @@ export const test_llm_invert_non_enumerable_definition = (): void => {
     )
       ? inverted.properties?.[property]
       : undefined;
-    if (schema === undefined || OpenApiTypeChecker.isReference(schema) === false)
+    if (
+      schema === undefined ||
+      OpenApiTypeChecker.isReference(schema) === false
+    )
       return undefined;
     const target: OpenApi.IJsonSchema | undefined =
       schemas[schema.$ref.replace("#/components/schemas/", "")];

--- a/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
+++ b/tests/test-utils/src/features/llm/schema/test_llm_schema_json_pointer_references.ts
@@ -108,8 +108,8 @@ export const test_llm_schema_json_pointer_references = (): void => {
     const componentKey: string | undefined = Object.keys(
       components.schemas!,
     ).find(
-      (name) => (components.schemas![name] as { type?: string }).type ===
-        "number",
+      (name) =>
+        (components.schemas![name] as { type?: string }).type === "number",
     );
     TestValidator.predicate(
       `${label}: inversion allocates a legal component key`,

--- a/tests/test-utils/src/features/naming/test_naming_convention_camel.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_camel.ts
@@ -14,8 +14,8 @@ import { NamingConvention } from "@typia/utils";
  * doubled underscore stays on the snake path.
  *
  * 1. Convert camelCase, PascalCase, and snake_case inputs.
- * 2. Convert underscore-plus-case-boundary, all-caps, and trailing-underscore
- *    keys (#2193), including the `a_b_c` single-char-middle asymmetry.
+ * 2. Convert underscore-plus-case-boundary, all-caps, and trailing-underscore keys
+ *    (#2193), including the `a_b_c` single-char-middle asymmetry.
  * 3. Convert degenerate inputs (empty, underscores only, single word).
  */
 export const test_naming_convention_camel = (): void => {

--- a/tests/test-utils/src/features/naming/test_naming_convention_empty.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_empty.ts
@@ -6,9 +6,9 @@ import { NamingConvention } from "@typia/utils";
  *
  * The helpers are siblings of one contract, so a caller that picks one by name
  * must not discover that a single member throws where the rest return `""`.
- * `localize` was exactly that outlier (#2136). Asserting the whole family in one
- * place makes the shared boundary a property of the namespace rather than of
- * whichever helper happened to be tested, so a future helper cannot quietly
+ * `localize` was exactly that outlier (#2136). Asserting the whole family in
+ * one place makes the shared boundary a property of the namespace rather than
+ * of whichever helper happened to be tested, so a future helper cannot quietly
  * reintroduce a partial member.
  *
  * 1. Collect every helper that maps a string to a string.

--- a/tests/test-utils/src/features/naming/test_naming_convention_localize.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_localize.ts
@@ -6,8 +6,8 @@ import { NamingConvention } from "@typia/utils";
  *
  * `localize` asserted `str[0]!` without ever checking for it, so the empty
  * string raised a `TypeError` while all five sibling helpers returned `""`
- * (#2136). No in-repo caller could reach that branch — every call site guards on
- * `method.startsWith("create")` — but `@typia/utils` is published, and an
+ * (#2136). No in-repo caller could reach that branch — every call site guards
+ * on `method.startsWith("create")` — but `@typia/utils` is published, and an
  * external caller has no such guard. Pins the boundary alongside the ordinary
  * conversions so the total contract cannot regress to a partial one.
  *

--- a/tests/test-utils/src/features/naming/test_naming_convention_notation_parity.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_notation_parity.ts
@@ -11,13 +11,14 @@ import typia from "typia";
  * boundary the snake/kebab copy lowercased each underscore-delimited segment
  * atomically (`fooBar_baz` -> `foobar_baz`) and the pascal copy dropped the
  * inner-character lowercasing of an all-caps run (`MAX_COUNT` -> `MAXCOUNT`),
- * both diverging from the notation contract (#2186, #2190). This asserts the two
- * producers agree over the exact #2190 witness matrix by comparing each
+ * both diverging from the notation contract (#2186, #2190). This asserts the
+ * two producers agree over the exact #2190 witness matrix by comparing each
  * `NamingConvention` output to the live `typia.notations.*` conversion of the
  * same key, so the copy can never silently diverge from the contract again.
  *
  * 1. Convert a witness object of underscore-boundary, all-caps, and plain keys
- *    through each `typia.notations.*` transform and read the produced key list.
+ *    through each `typia.notations.*` transform and read the produced key
+ *    list.
  * 2. Convert every source key through the matching `NamingConvention` helper.
  * 3. Require each helper output to equal the notation-produced key.
  */

--- a/tests/test-utils/src/features/naming/test_naming_convention_pascal.ts
+++ b/tests/test-utils/src/features/naming/test_naming_convention_pascal.ts
@@ -9,14 +9,14 @@ import { NamingConvention } from "@typia/utils";
  * contract. Issue #2186/#2193: the converter capitalized each underscore
  * segment without lowercasing its inner characters, so an all-caps key
  * (`MAX_COUNT`) produced `MAXCOUNT` and an underscore-plus-case-boundary key
- * (`fooBar_baz`) kept its inner boundary as `FooBarBaz`, both diverging from the
- * `PascalCase<T>` results `MaxCount` and `FoobarBaz`. Each segment's first
+ * (`fooBar_baz`) kept its inner boundary as `FooBarBaz`, both diverging from
+ * the `PascalCase<T>` results `MaxCount` and `FoobarBaz`. Each segment's first
  * character is uppercased and its tail lowercased, while a trailing underscore
  * is dropped (`fooBar_` → `Foobar`) — the asymmetry against camelCase.
  *
  * 1. Convert camelCase, PascalCase, and snake_case inputs.
- * 2. Convert underscore-plus-case-boundary, all-caps, and trailing-underscore
- *    keys (#2186/#2193), including the `a_b_c` single-char-segment run.
+ * 2. Convert underscore-plus-case-boundary, all-caps, and trailing-underscore keys
+ *    (#2186/#2193), including the `a_b_c` single-char-segment run.
  * 3. Convert degenerate inputs (empty, underscores only, single word).
  */
 export const test_naming_convention_pascal = (): void => {

--- a/tests/test-utils/src/features/openapi/test_openapi_naming_numeric_constraints.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_naming_numeric_constraints.ts
@@ -7,20 +7,22 @@ import { OpenApiValidator } from "@typia/utils";
  * declares, with its own value.
  *
  * `OpenApiSchemaNamingRule` used to read `exclusiveMinimum`/`exclusiveMaximum`
- * as booleans gating the `minimum`/`maximum` branch, so an exclusive bound alone
- * named itself just `number`, a paired `minimum` leaked its value under the
- * exclusive name, and the falsy-but-declared `exclusiveMinimum: 0` vanished. The
- * declaration (`OpenApi.IJsonSchema.IInteger`/`INumber`) is authoritative: those
- * fields are numbers. A declared integer `format` — carried through an external
- * document by `OpenApiConverter` — is likewise dropped; it must echo as
- * `tags.Type<...>`, agreeing with `OpenApiIntegerValidator.describeType`.
+ * as booleans gating the `minimum`/`maximum` branch, so an exclusive bound
+ * alone named itself just `number`, a paired `minimum` leaked its value under
+ * the exclusive name, and the falsy-but-declared `exclusiveMinimum: 0`
+ * vanished. The declaration (`OpenApi.IJsonSchema.IInteger`/`INumber`) is
+ * authoritative: those fields are numbers. A declared integer `format` —
+ * carried through an external document by `OpenApiConverter` — is likewise
+ * dropped; it must echo as `tags.Type<...>`, agreeing with
+ * `OpenApiIntegerValidator.describeType`.
  *
- * 1. For each schema, validate a wrong-typed value so the report's `expected`
- *    is exactly the top-level type name the naming rule produced.
+ * 1. For each schema, validate a wrong-typed value so the report's `expected` is
+ *    exactly the top-level type name the naming rule produced.
  * 2. Assert that name states every declared constraint with its own value,
- *    including the `exclusiveMinimum: 0` boundary and a declared integer format.
- * 3. Keep the negative regressions: a bare integer/number invents no format,
- *    and a number never echoes a format its validator does not report.
+ *    including the `exclusiveMinimum: 0` boundary and a declared integer
+ *    format.
+ * 3. Keep the negative regressions: a bare integer/number invents no format, and a
+ *    number never echoes a format its validator does not report.
  */
 export const test_openapi_naming_numeric_constraints = (): void => {
   const matrix: Array<{
@@ -57,7 +59,10 @@ export const test_openapi_naming_numeric_constraints = (): void => {
     // INTEGER — declared format echoed as tags.Type<...>
     {
       title: "integer declared format int32",
-      schema: { type: "integer", format: "int32" } as OpenApi.IJsonSchema.IInteger,
+      schema: {
+        type: "integer",
+        format: "int32",
+      } as OpenApi.IJsonSchema.IInteger,
       expected: 'number & tags.Type<"int32">',
     },
     {
@@ -106,7 +111,10 @@ export const test_openapi_naming_numeric_constraints = (): void => {
     // NUMBER — regression: number never echoes a format (its validator does not)
     {
       title: "number ignores format its validator never reports",
-      schema: { type: "number", format: "double" } as OpenApi.IJsonSchema.INumber,
+      schema: {
+        type: "number",
+        format: "double",
+      } as OpenApi.IJsonSchema.INumber,
       expected: "number",
     },
     {
@@ -124,7 +132,9 @@ export const test_openapi_naming_numeric_constraints = (): void => {
       required: true,
     });
     if (result.success)
-      throw new Error(`Expected "${title}" to fail against a non-number value.`);
+      throw new Error(
+        `Expected "${title}" to fail against a non-number value.`,
+      );
     TestValidator.equals(title, expected, result.errors[0]?.expected);
   }
 };

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_format_uri_reference.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_format_uri_reference.ts
@@ -23,9 +23,9 @@ interface ICommentUriReferenceValue {
  * takes `path-noscheme`, whose first segment is `segment-nz-nc` and excludes
  * `:`, while every later segment is `*pchar` and includes it. Sharing one
  * `path-rootless` alternative across both sides therefore accepts
- * `1bad:relative`, which is neither a URI (`1bad` cannot be a scheme, which must
- * begin with ALPHA) nor a relative-ref. The same expression is copied into the
- * typia runtime helper, the native code generator, and the @typia/utils
+ * `1bad:relative`, which is neither a URI (`1bad` cannot be a scheme, which
+ * must begin with ALPHA) nor a relative-ref. The same expression is copied into
+ * the typia runtime helper, the native code generator, and the @typia/utils
  * validator, so the matrix runs through every owner rather than trusting one of
  * them — they agree with each other even when all three are wrong, so every
  * expectation here comes from RFC 3986 rather than from current output. It also

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_integer_bound_message.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_integer_bound_message.ts
@@ -12,12 +12,12 @@ import { OpenApiValidator } from "@typia/utils";
  * the schema: OpenAPI spells it as `format`, and `OpenApiConverter` passes an
  * external document's `format` straight through to this validator.
  *
- * 1. Violate each of the five bounds on a schema declaring no `format`, and
- *    assert no width is invented.
- * 2. Violate the same five on a schema declaring `format: "int32"`, and assert
- *    the declared width is still reported.
- * 3. Assert a differing declared width is echoed rather than flattened to
- *    `int32`, and that the verdict itself never changes.
+ * 1. Violate each of the five bounds on a schema declaring no `format`, and assert
+ *    no width is invented.
+ * 2. Violate the same five on a schema declaring `format: "int32"`, and assert the
+ *    declared width is still reported.
+ * 3. Assert a differing declared width is echoed rather than flattened to `int32`,
+ *    and that the verdict itself never changes.
  * 4. Assert a `format` that is not a string names no width at all.
  */
 export const test_openapi_validator_integer_bound_message = (): void => {

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_object_undefined_property.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_object_undefined_property.ts
@@ -28,8 +28,8 @@ interface IUndefined {
  *    and that a defined extra key still is.
  * 2. Confirm an `additionalProperties` schema does not constrain a key with no
  *    JSON form, under either `equals` value.
- * 3. Round-trip a type whose members erase from the emitted schema and require
- *    the emitter's own schema to accept the emitter's own value.
+ * 3. Round-trip a type whose members erase from the emitted schema and require the
+ *    emitter's own schema to accept the emitter's own value.
  */
 export const test_openapi_validator_object_undefined_property = (): void => {
   const schema: OpenApi.IJsonSchema.IObject = {

--- a/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
@@ -8,8 +8,8 @@ import { Calculator } from "../structures/Calculator";
 /**
  * Verifies Vercel tool feedback fences typia's annotated JSON exactly once.
  *
- * `LlmJson.stringify` already wraps its output in a ```` ```json ```` fence, so
- * a caller that adds a second one hands the model ```` ```json\n```json ````.
+ * `LlmJson.stringify` already wraps its output in a ````json` fence, so a
+ * caller that adds a second one hands the model ````json\n```json`.
  * `VercelToolsRegistrar` formats that same result on two separate paths — once
  * for invalid arguments and once for an invalid output — and a fence added back
  * to either one is invisible to an `includes("```json")` check, which passes

--- a/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_output_schema.ts
@@ -20,8 +20,8 @@ import { Calculator } from "../structures/Calculator";
  *    schema-conforming failure branch with actionable paths.
  *
  * The markdown fencing of that feedback is asserted by
- * `test_vercel_tool_error_single_json_fence`, which counts the fence on both the
- * arguments and output paths.
+ * `test_vercel_tool_error_single_json_fence`, which counts the fence on both
+ * the arguments and output paths.
  */
 export const test_vercel_tool_output_schema = async (): Promise<void> => {
   const controller: ILlmController<Calculator> =


### PR DESCRIPTION
Post-Campaign Cleanup for the issue campaign that closed #2082, #2256, #2252, #2253, #2200, #2238, #2267, #2268, #2270, #2271, and #2272.

The campaign suspends `pnpm format` on implementation branches so a reformat never lands mixed with a fix. This is the single change that owns the formatter result.

**72 files, entirely prettier output** — JSDoc comment reflow and line-width driven re-wrapping. No code semantics change. Most of it predates the campaign; the cleanup step absorbs it regardless of origin.

**Excluded deliberately:** running the formatter on this Windows checkout also rewrote line endings in 280 further files with no content change. `git status` reports them as modified while `git diff --numstat` shows 0/0, so only files whose content actually differs are staged. Committing the rest would have put 280 files of environment noise into the repository's history under a cleanup label.