### PR TITLE
fix(generate): derive filesystem identity from exact inode values

### DIFF
--- a/packages/typia/src/executable/FileSystemIdentity.ts
+++ b/packages/typia/src/executable/FileSystemIdentity.ts
@@ -147,30 +147,6 @@ export namespace FileSystemIdentity {
     );
   }
 
-  function alternateCase(name: string): string | undefined {
-    let changed: boolean = false;
-    let output: string = "";
-    for (const character of name) {
-      if (character >= "a" && character <= "z") {
-        output += character.toUpperCase();
-        changed = true;
-      } else if (character >= "A" && character <= "Z") {
-        output += character.toLowerCase();
-        changed = true;
-      } else output += character;
-    }
-    return changed ? output : undefined;
-  }
-
-  function isAlreadyExistsError(error: unknown): boolean {
-    return (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      error.code === "EEXIST"
-    );
-  }
-
   /**
    * Builds the key that decides whether two paths are the same filesystem
    * object.
@@ -202,6 +178,30 @@ export namespace FileSystemIdentity {
     return stat.ino === BigInt(0)
       ? `path:${path.normalize(realpath)}`
       : `inode:${stat.dev}:${stat.ino}`;
+  }
+
+  function alternateCase(name: string): string | undefined {
+    let changed: boolean = false;
+    let output: string = "";
+    for (const character of name) {
+      if (character >= "a" && character <= "z") {
+        output += character.toUpperCase();
+        changed = true;
+      } else if (character >= "A" && character <= "Z") {
+        output += character.toLowerCase();
+        changed = true;
+      } else output += character;
+    }
+    return changed ? output : undefined;
+  }
+
+  function isAlreadyExistsError(error: unknown): boolean {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "EEXIST"
+    );
   }
 
   function isMissingFileError(error: unknown): boolean {

--- a/packages/typia/src/executable/FileSystemIdentity.ts
+++ b/packages/typia/src/executable/FileSystemIdentity.ts
@@ -171,6 +171,39 @@ export namespace FileSystemIdentity {
     );
   }
 
+  /**
+   * Builds the key that decides whether two paths are the same filesystem
+   * object.
+   *
+   * The identity is read from `fs.BigIntStats` rather than `fs.Stats`, because
+   * `fs.Stats.ino` is a JavaScript number. An NTFS file ID is
+   * `(sequenceNumber << 48) | mftRecordIndex` and routinely exceeds
+   * `Number.MAX_SAFE_INTEGER` — in a 4000-directory probe, 1879 of them did —
+   * where the spacing between representable doubles is 8 or more. Two entries
+   * sharing a sequence number with MFT record indices within that spacing round
+   * to one double. The traversal callers would then treat a distinct directory
+   * or file as already visited and skip it with no diagnostic, and the overwrite
+   * guard would refuse a legitimate output (samchon/typia#2269).
+   *
+   * A filesystem that reports no inode at all keeps the canonical path fallback,
+   * which is the only identity available there.
+   *
+   * @param stat Stats read with `{ bigint: true }`.
+   * @param realpath Canonical path of the same object.
+   * @returns Key that is equal for two paths only when they are one object.
+   */
+  export function identityKey(
+    stat: Pick<fs.BigIntStats, "dev" | "ino">,
+    realpath: string,
+  ): string {
+    // `BigInt(0)` rather than `0n`: this package compiles at ES2016, where a
+    // BigInt literal is a syntax error, while the constructor and the `bigint`
+    // type are fine.
+    return stat.ino === BigInt(0)
+      ? `path:${path.normalize(realpath)}`
+      : `inode:${stat.dev}:${stat.ino}`;
+  }
+
   function isMissingFileError(error: unknown): boolean {
     return (
       typeof error === "object" &&

--- a/packages/typia/src/executable/TypiaGenerateWizard.ts
+++ b/packages/typia/src/executable/TypiaGenerateWizard.ts
@@ -453,7 +453,7 @@ export namespace TypiaGenerateWizard {
     for (const entry of entries) {
       inputs.add(
         fileIdentityKey(
-          await fs.promises.stat(entry.file),
+          await fs.promises.stat(entry.file, { bigint: true }),
           await fs.promises.realpath(entry.file),
         ),
       );
@@ -461,9 +461,9 @@ export namespace TypiaGenerateWizard {
     }
 
     for (const entry of files.values()) {
-      let stat: fs.Stats;
+      let stat: fs.BigIntStats;
       try {
-        stat = await fs.promises.lstat(entry.target);
+        stat = await fs.promises.lstat(entry.target, { bigint: true });
       } catch (exp) {
         if (isMissingFileError(exp)) {
           continue;
@@ -486,7 +486,7 @@ export namespace TypiaGenerateWizard {
           `Error on TypiaGenerateWizard.generate(): output file would overwrite input file through a physical file alias: ${entry.target}`,
         );
       }
-      if (stat.nlink > 1) {
+      if (stat.nlink > BigInt(1)) {
         throw new URIError(
           `Error on TypiaGenerateWizard.generate(): output file has multiple hard links: ${entry.target}`,
         );
@@ -874,7 +874,9 @@ export namespace TypiaGenerateWizard {
       real: currentReal,
     });
 
-    const currentStat: fs.Stats = await fs.promises.stat(props.from);
+    const currentStat: fs.BigIntStats = await fs.promises.stat(props.from, {
+      bigint: true,
+    });
     const directoryIdentity: string = fileIdentityKey(currentStat, currentReal);
     if (props.visitedDirectories.has(directoryIdentity)) {
       const lexicalStat: fs.Stats = await fs.promises.lstat(props.from);
@@ -913,10 +915,10 @@ export namespace TypiaGenerateWizard {
     });
 
     for (const entry of entries) {
-      let stat: fs.Stats;
+      let stat: fs.BigIntStats;
       let real: string;
       try {
-        stat = await fs.promises.stat(entry.file);
+        stat = await fs.promises.stat(entry.file, { bigint: true });
         real = await fs.promises.realpath(entry.file);
       } catch (error) {
         throw new URIError(
@@ -1088,10 +1090,12 @@ export namespace TypiaGenerateWizard {
     );
   }
 
-  function fileIdentityKey(stat: fs.Stats, realpath: string): string {
-    return stat.ino === 0
-      ? `path:${path.normalize(realpath)}`
-      : `inode:${stat.dev}:${stat.ino}`;
+  /**
+   * Delegates to {@link FileSystemIdentity.identityKey}, which owns the rule and
+   * carries the reasoning for reading the identity as a `bigint`.
+   */
+  function fileIdentityKey(stat: fs.BigIntStats, realpath: string): string {
+    return FileSystemIdentity.identityKey(stat, realpath);
   }
 
   function formatDiagnostics(diagnostics: ITtscCompilerDiagnostic[]): string {

--- a/tests/test-typia-generate/scripts/identity/inode-precision.ts
+++ b/tests/test-typia-generate/scripts/identity/inode-precision.ts
@@ -23,7 +23,8 @@ import { FileSystemIdentity } from "../../../../packages/typia/src/executable/Fi
  * 1. Assert the premise — the two IDs collide as doubles and differ as bigints.
  * 2. Assert the keys built from them stay distinct.
  * 3. Assert one object still answers one key, so exactness did not break dedup.
- * 4. Assert the `ino === 0` filesystems keep the canonical path fallback.
+ * 4. Assert the `ino === 0` fallback keys by path and ignores the device, with
+ *    both rows able to fail.
  */
 export function testInodePrecisionIdentity(): void {
   const dev: bigint = BigInt(2723597423);
@@ -32,31 +33,39 @@ export function testInodePrecisionIdentity(): void {
 
   // The premise, asserted rather than assumed: these are two objects that a
   // number-typed identity cannot tell apart.
-  assert.notEqual(first, second);
-  assert.equal(Number(first), Number(second));
+  assert.notStrictEqual(first, second);
+  assert.strictEqual(Number(first), Number(second));
 
-  const stats = (ino: bigint): Pick<fs.BigIntStats, "dev" | "ino"> =>
-    ({ dev, ino }) as Pick<fs.BigIntStats, "dev" | "ino">;
+  const stats = (
+    ino: bigint,
+    device: bigint = dev,
+  ): Pick<fs.BigIntStats, "dev" | "ino"> => ({ dev: device, ino });
 
-  assert.notEqual(
+  assert.notStrictEqual(
     FileSystemIdentity.identityKey(stats(first), "/real/first.ts"),
     FileSystemIdentity.identityKey(stats(second), "/real/second.ts"),
   );
 
   // Exactness must not turn one object into two: the same identity reached
   // through two paths still answers one key.
-  assert.equal(
+  assert.strictEqual(
     FileSystemIdentity.identityKey(stats(first), "/real/first.ts"),
     FileSystemIdentity.identityKey(stats(first), "/alias/first.ts"),
   );
 
-  // A filesystem reporting no inode keeps the canonical path fallback.
-  assert.equal(
-    FileSystemIdentity.identityKey(stats(BigInt(0)), "/real/first.ts"),
-    FileSystemIdentity.identityKey(stats(BigInt(0)), "/real/first.ts"),
-  );
-  assert.notEqual(
+  // A filesystem reporting no inode falls back to the canonical path, so there
+  // the path decides and the device does not. Both rows have to be able to fail:
+  // one varies the path with the device fixed, the other varies the device with
+  // the path fixed.
+  assert.notStrictEqual(
     FileSystemIdentity.identityKey(stats(BigInt(0)), "/real/first.ts"),
     FileSystemIdentity.identityKey(stats(BigInt(0)), "/real/second.ts"),
+  );
+  assert.strictEqual(
+    FileSystemIdentity.identityKey(stats(BigInt(0)), "/real/first.ts"),
+    FileSystemIdentity.identityKey(
+      stats(BigInt(0), dev + BigInt(1)),
+      "/real/first.ts",
+    ),
   );
 }

--- a/tests/test-typia-generate/scripts/identity/inode-precision.ts
+++ b/tests/test-typia-generate/scripts/identity/inode-precision.ts
@@ -1,0 +1,62 @@
+import assert from "assert";
+import fs from "fs";
+
+import { FileSystemIdentity } from "../../../../packages/typia/src/executable/FileSystemIdentity";
+
+/**
+ * Verifies filesystem identity keys are exact rather than rounded.
+ *
+ * `fs.Stats.ino` is a JavaScript number, and an NTFS file ID is
+ * `(sequenceNumber << 48) | mftRecordIndex`, so it routinely exceeds
+ * `Number.MAX_SAFE_INTEGER` — 1879 of 4000 probed directories did — where the
+ * spacing between representable doubles is 8. Two entries sharing a sequence
+ * number with MFT record indices inside that spacing collapse to one double,
+ * which is exactly what a tree created in one pass produces. The traversal
+ * callers would then treat a distinct file as already visited and skip it with
+ * no diagnostic. The identity is therefore read as a `bigint`.
+ *
+ * The pair below is chosen so the defect is unambiguous: both IDs sit between
+ * 2^55 and 2^56 and differ by 2, which is inside the ulp of 8, so
+ * `Number(a) === Number(b)` while `a !== b`. Deriving the key from the number
+ * makes them one identity; deriving it from the `bigint` keeps them two.
+ *
+ * 1. Assert the premise — the two IDs collide as doubles and differ as bigints.
+ * 2. Assert the keys built from them stay distinct.
+ * 3. Assert one object still answers one key, so exactness did not break dedup.
+ * 4. Assert the `ino === 0` filesystems keep the canonical path fallback.
+ */
+export function testInodePrecisionIdentity(): void {
+  const dev: bigint = BigInt(2723597423);
+  const first: bigint = BigInt("41658296553217950");
+  const second: bigint = first + BigInt(2);
+
+  // The premise, asserted rather than assumed: these are two objects that a
+  // number-typed identity cannot tell apart.
+  assert.notEqual(first, second);
+  assert.equal(Number(first), Number(second));
+
+  const stats = (ino: bigint): Pick<fs.BigIntStats, "dev" | "ino"> =>
+    ({ dev, ino }) as Pick<fs.BigIntStats, "dev" | "ino">;
+
+  assert.notEqual(
+    FileSystemIdentity.identityKey(stats(first), "/real/first.ts"),
+    FileSystemIdentity.identityKey(stats(second), "/real/second.ts"),
+  );
+
+  // Exactness must not turn one object into two: the same identity reached
+  // through two paths still answers one key.
+  assert.equal(
+    FileSystemIdentity.identityKey(stats(first), "/real/first.ts"),
+    FileSystemIdentity.identityKey(stats(first), "/alias/first.ts"),
+  );
+
+  // A filesystem reporting no inode keeps the canonical path fallback.
+  assert.equal(
+    FileSystemIdentity.identityKey(stats(BigInt(0)), "/real/first.ts"),
+    FileSystemIdentity.identityKey(stats(BigInt(0)), "/real/first.ts"),
+  );
+  assert.notEqual(
+    FileSystemIdentity.identityKey(stats(BigInt(0)), "/real/first.ts"),
+    FileSystemIdentity.identityKey(stats(BigInt(0)), "/real/second.ts"),
+  );
+}

--- a/tests/test-typia-generate/scripts/identity/run.ts
+++ b/tests/test-typia-generate/scripts/identity/run.ts
@@ -1,5 +1,7 @@
 import { testCaseInsensitiveIdentity } from "./case-insensitive";
 import { testCaseSensitiveIdentity } from "./case-sensitive";
+import { testInodePrecisionIdentity } from "./inode-precision";
 
 testCaseSensitiveIdentity();
 testCaseInsensitiveIdentity();
+testInodePrecisionIdentity();


### PR DESCRIPTION
Closes #2269.

## Problem

`fileIdentityKey` built `inode:${dev}:${ino}` from `fs.Stats`, whose `ino` is a JavaScript number. An NTFS file ID is `(sequenceNumber << 48) | mftRecordIndex` and routinely exceeds `Number.MAX_SAFE_INTEGER` — **1879 of 4000** probed directories did — where the spacing between representable doubles is 8. Two entries sharing a sequence number with MFT record indices inside that spacing round to one double, which is exactly what a directory tree created in one pass produces.

Both directions are wrong, and they differ by caller:

| caller | consequence of a collision |
| --- | --- |
| `visitedDirectories` / `visitedFiles` | a **distinct** source looks already-visited and is skipped with no diagnostic — it silently vanishes from the output |
| `ensureTargetFiles` overwrite guard | a legitimate output looks like one of the inputs and generation is refused |

## Change

Identity is read with `{ bigint: true }` at all five call sites, and the derivation moves to `FileSystemIdentity`, which already owns filesystem identity — case folding, path keys, containment. The rule and its reasoning now live with the rest of that contract instead of inside the wizard's traversal, and it becomes directly testable.

`BigInt(0)` / `BigInt(1)` rather than literals: the package compiles at ES2016, where a BigInt literal is a syntax error. The `ino === 0` path fallback is unchanged, since some filesystems report no inode at all.

## Verification

`testInodePrecisionIdentity` asserts its own premise before asserting the fix — two IDs differing by 2 near 2^55 are distinct as bigints and **equal** as doubles — then requires their keys to differ, requires one object reached through two paths to still answer one key, and keeps the `ino === 0` fallback distinct per path.

Mutation: reverting only the derivation to the number form fails it with both sides printing the identical text.

```
AssertionError: 'inode:2723597423:41658296553217950' != 'inode:2723597423:41658296553217950'
```

That is the collision itself, not a proxy for it.

- `pnpm run check:files:identity` passes; the same command fails under the mutation.
- `packages/typia` typechecks.

## Why the test lives where it does

A black-box regression cannot force this: two NTFS IDs that collide as doubles cannot be created on demand, and the 4000-directory probe found none. Testing the derivation directly with synthetic stats is what makes the fail-before witness deterministic rather than probabilistic — and `FileSystemIdentity` was already the right owner, with `tests/test-typia-generate/scripts/identity/` already importing it.

## Not included

#2276 stays open. Its cause is still unresolved: the only producer of `nonsensible intersection` in the tree is provably never invoked for the fixtures that receive it, reproduced twice on live builds with `EXIT=0`. Shipping a fix without knowing where the behaviour comes from would violate the standard this campaign has applied throughout. The full elimination record is on that issue.