### PR TITLE
fix(metadata): answer a callable intersection the way its interface spelling answers

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/callable_type_literal_boundaries_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/callable_type_literal_boundaries_transform_test.go
@@ -527,20 +527,22 @@ func callableTypeLiteralDiagnosticTwins(t *testing.T) []string {
       }
       continue
     }
-    // A member-carrying shape's only function-type spelling is an intersection,
-    // and typia's intersection contract answers those inconsistently: measured
-    // on this same matrix, six such shapes are accepted and agree with the
-    // declaration spellings while six structurally analogous ones are rejected
-    // as nonsensible — `cancel(): void` accepted against `cancel: () => void`
-    // rejected, an optional member accepted against the same member required.
-    // That split is samchon/typia#2276 and belongs to the intersection contract,
-    // not to declaration identity.
+    // Every function-type spelling must report what the declaration spellings
+    // report, including a member-carrying shape's, whose only such spelling is an
+    // intersection of a call signature with the rest.
     //
-    // Nothing is asserted about it here on purpose. An earlier version of this
-    // check expected every such intersection to be rejected, which was written
-    // from source reading and is wrong for half of them; restating it in the
-    // other direction would be equally wrong, and pinning the observed split
-    // would freeze the defect into this regression.
+    // This row is what samchon/typia#2276 closed. Before it, six of the twelve
+    // shapes disagreed here — `cancel(): void` was accepted while
+    // `cancel: () => void` was refused, and an optional member was accepted while
+    // the same member required was not — because a call-signature-only arm was
+    // neither an object nor a phantom brand, so the intersection was called
+    // nonsensible while the interface spelling of the same type, which is one
+    // object carrying a call signature, was accepted.
+    if observed["Alias"] != observed["Interface"] {
+      failures = append(failures, fmt.Sprintf(
+        "%s: alias spelling reported %s but the interface spelling reported %s",
+        shape.Name, observed["Alias"], observed["Interface"]))
+    }
   }
   return failures
 }

--- a/packages/typia/native/cmd/ttsc-typia/callable_type_literal_boundaries_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/callable_type_literal_boundaries_transform_test.go
@@ -532,10 +532,10 @@ func callableTypeLiteralDiagnosticTwins(t *testing.T) []string {
     // intersection of a call signature with the rest.
     //
     // This row is what samchon/typia#2276 closed. Before it, six of the twelve
-    // shapes disagreed here — `cancel(): void` was accepted while
-    // `cancel: () => void` was refused, and an optional member was accepted while
-    // the same member required was not — because a call-signature-only arm was
-    // neither an object nor a phantom brand, so the intersection was called
+    // shapes disagreed here — `{ method(): void }` was accepted while
+    // `{ method: () => void }` was refused, and `{ label?: string }` was accepted
+    // while `{ label: string }` was refused — because a call-signature-only arm
+    // was neither an object nor a phantom brand, so the intersection was called
     // nonsensible while the interface spelling of the same type, which is one
     // object carrying a call signature, was accepted.
     if observed["Alias"] != observed["Interface"] {

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
@@ -161,6 +161,12 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
       // pair, or two constructors. That is a member-free callable, which is what
       // the interface spelling of the same type produces, so this iterator has
       // nothing to merge and hands the type back rather than refusing it.
+      //
+      // Widening this to "signatures were dropped and only brands remain" was
+      // tried and is wrong: `call & Record<never, never>` must reach the
+      // phantom-brand pass below, which drops the brand and leaves the call arm.
+      // Escaping instead makes the emitted validator refuse a function, which
+      // the `directPureCall*EmptyIntersection` anchors catch.
       return escape(false)
     }
   }

--- a/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
+++ b/packages/typia/native/core/factories/internal/metadata/iterate_metadata_intersection.go
@@ -126,6 +126,44 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
   if onlyObjects && len(tagObjects) == 0 {
     return escape(false)
   }
+  // A call-signature-only arm is dropped before the phantom-brand pass, and only
+  // while something else survives. It cannot join that pass: the "every arm was
+  // removable" guard below exists to refuse an intersection of nothing but
+  // brands, and an arm such as `Record<never, never>` is vacuously a phantom
+  // brand, so counting signatures as removable would turn
+  // `call & Record<never, never>` — which the interface spelling accepts — into a
+  // rejection.
+  if len(metadatas) > 1 {
+    kept := make([]*schemametadata.MetadataSchema, 0, len(metadatas))
+    keptIndexes := make([]int, 0, len(indexes))
+    for i, m := range metadatas {
+      if iterate_metadata_intersection_is_call_signature_only(m) {
+        continue
+      }
+      kept = append(kept, m)
+      keptIndexes = append(keptIndexes, indexes[i])
+    }
+    substantial := false
+    for _, m := range kept {
+      if iterate_metadata_intersection_is_removable_brand(m) == false {
+        substantial = true
+        break
+      }
+    }
+    if substantial {
+      // Something that carries real obligations survives, so the signatures are
+      // the part with nothing to describe and the members are what both
+      // spellings must answer for.
+      metadatas = kept
+      indexes = keptIndexes
+    } else if len(kept) == 0 {
+      // Every arm was signatures only — an overload set, a call-and-construct
+      // pair, or two constructors. That is a member-free callable, which is what
+      // the interface spelling of the same type produces, so this iterator has
+      // nothing to merge and hands the type back rather than refusing it.
+      return escape(false)
+    }
+  }
   if len(metadatas) != 1 {
     removable := []int{}
     for i, m := range metadatas {
@@ -297,6 +335,29 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
   return true
 }
 
+// iterate_metadata_intersection_is_call_signature_only reports whether an arm
+// contributes nothing but call or construct signatures, which the intersection
+// can drop the way it drops a phantom brand.
+//
+// `((v: number) => string) & { label: string }` and
+// `interface T { (v: number): string; label: string }` are the same type, and
+// only the first reaches this function — the second is one object carrying a
+// call signature. Without this the first was refused as a nonsensible
+// intersection while the second was accepted, so the answer depended on the
+// spelling (samchon/typia#2276).
+//
+// Dropping the arm loses nothing the interface spelling keeps. #2250 settled
+// that a member-carrying callable stays structural, so neither spelling
+// validates the call signature; the members are what both must describe. An arm
+// that carries any data alongside its signatures is not this case and stays,
+// because dropping it would erase a declared obligation.
+func iterate_metadata_intersection_is_call_signature_only(m *schemametadata.MetadataSchema) bool {
+  return m != nil &&
+    len(m.Functions) != 0 &&
+    m.Nullable == false &&
+    m.Size() == len(m.Functions)
+}
+
 // iterate_metadata_intersection_is_removable_brand reports whether an explored
 // member schema is a phantom "brand" object that an intersection with a
 // non-object member may drop. A value intersected with a non-object survivor is
@@ -314,6 +375,8 @@ func Iterate_metadata_intersection(props IMetadataIteratorProps) bool {
 // a symbol-keyed property is never observable on a JSON value. Any required
 // string-keyed property (literal or not) might be real data, so it keeps the
 // intersection nonsensible rather than silently dropping a declared constraint.
+
+
 func iterate_metadata_intersection_is_removable_brand(m *schemametadata.MetadataSchema) bool {
   if m == nil || m.Size() != 1 || len(m.Objects) != 1 {
     return false


### PR DESCRIPTION
Closes #2276.

## What was wrong

`((v: number) => string) & { label: string }` and `interface T { (v: number): string; label: string }` are the same type, but typia refused the first as a nonsensible intersection and accepted the second. Only the intersection spelling reaches `Iterate_metadata_intersection`; the interface spelling arrives as one object that happens to carry a call signature and never enters the iterator at all.

Inside the iterator a call-signature-only arm was neither an object nor a phantom brand, so after the brand pass two members survived and the single-survivor guard called the intersection nonsensible.

## The fix

Drop a call-signature-only arm before the phantom-brand pass, and only while an arm carrying real obligations survives.

It cannot simply join the brand pass. The `len(removable) == len(metadatas)` guard exists to refuse an intersection of nothing but brands, and an arm such as `Record<never, never>` is *vacuously* a phantom brand — so counting signatures as removable turns `call & Record<never, never>`, which the interface spelling accepts, into a rejection. That regression is what the `directPureCall*EmptyIntersection` anchors caught during development.

When every arm is signatures only — an overload set, a call-and-construct pair, two constructors — the type is a member-free callable, which is exactly what the interface spelling of the same type produces, so the iterator hands it back rather than refusing it.

Dropping the arm loses nothing the interface spelling keeps: #2250 settled that a member-carrying callable stays structural, so neither spelling validates the call signature. An arm carrying any data alongside its signatures is not this case and stays, because dropping it would erase a declared obligation.

## Regression

`TestCallableTypeLiteralBoundariesTransform`'s twelve-shape matrix now asserts alias/interface parity for member-carrying shapes. The previous version deliberately left that unasserted, with a comment saying the observed split should not be frozen into the regression — that split was this defect, so the comment is replaced by the assertion.

Mutation proof: neutralizing the new pass fails exactly the six shapes the issue names and nothing else.

```
Overload:         alias code=3 nonsensible=2  vs interface code=0 nonsensible=0
ConstructOverload: same
CallAndConstruct:  same
MethodProperty:    same
RequiredMember:    same
IndexSignature:    same
```

Local: full `packages/typia/native/...` tree green (14 packages), `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLynHVQdYV8tRPLfc9CnaR