### PR TITLE
fix: seal the random format-length class and the protobuf diagnostic code

### DIFF
--- a/.agents/skills/project/SKILL.md
+++ b/.agents/skills/project/SKILL.md
@@ -37,6 +37,7 @@ The `packages/typia/src/transform.ts` file is a plugin descriptor, not a transfo
   - `test-typia-automated`, `test-utils-automated`: generator-driven matrix suites over their configured typia operations and `@typia/template` structures; their generated `src/features/` trees are rebuilt by the suite.
   - `test-interface`: compile-time tests for the exported `@typia/interface` types.
   - `test-typia-cli`, `test-typia-generate`: CLI and project-layout integration suites, including the `typia generate` command.
+  - `test-typia-bundler-cache`: webpack persistent filesystem-cache invalidation through `@ttsc/unplugin`; the only suite that exercises a bundler's cache.
   - `test-typia-exact-optional`: focused `exactOptionalPropertyTypes` behavior.
   - `test-feature-identity`: repository check that every suite's tracked `src/features` file exports exactly one `test_*` function named after the file, that one suite never exports a name twice, and that every `tests/*` workspace declares the package name `@typia/<directory>`.
   - `test-error`: transform-rejection verification; the build must fail and every fixture must be named by a typia diagnostic.

--- a/packages/typia/native/cmd/ttsc-typia/protobuf_diagnostic_code_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/protobuf_diagnostic_code_transform_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "regexp"
+  "sort"
+  "strings"
+  "testing"
+)
+
+// TestProtobufDiagnosticCodeTransform verifies that a rejected protobuf call
+// site is named by its own API in the diagnostic code (#2285).
+//
+// `ProtobufFactory.Metadata` used to compose the code as `"typia.protobuf." +
+// props.Method`, while the encode and decode programmers pass the whole call
+// accessor (`ModuloMethodText`, the same text `TypeGuardError.method` carries).
+// Sixteen of the seventeen entry points therefore reported
+// `TS(typia.protobuf.typia.protobuf.encode)`; only `protobuf.message` was
+// correct, because its programmer passed a bare literal. The code is the only
+// machine-readable identity a typia rejection has, so a code that names no API
+// is a silent loss for anyone searching it.
+//
+// The oracle is the fixture source, not another copy of the expected string: a
+// diagnostic code is correct only when the accessor it names is literally the
+// accessor written at a call site in that file. A concatenation defect cannot
+// satisfy that, and neither can a misspelling.
+//
+//  1. Write one fixture that calls every protobuf entry point with `bigint`,
+//     which none of them supports.
+//  2. Transform it and collect every diagnostic code the transform reported.
+//  3. Require each code to be an accessor present in the fixture, and require
+//     every entry point to have been named.
+func TestProtobufDiagnosticCodeTransform(t *testing.T) {
+  methods := []string{
+    "message",
+    "encode",
+    "decode",
+    "assertEncode",
+    "assertDecode",
+    "isEncode",
+    "isDecode",
+    "validateEncode",
+    "validateDecode",
+    "createEncode",
+    "createDecode",
+    "createAssertEncode",
+    "createAssertDecode",
+    "createIsEncode",
+    "createIsDecode",
+    "createValidateEncode",
+    "createValidateDecode",
+  }
+  project, source := protobufDiagnosticCodeProject(t, methods)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+    })
+  })
+  if code == 0 {
+    t.Fatalf("protobuf fixture transformed successfully, want failure:\nstdout=%s\nstderr=%s", out, errText)
+  }
+
+  codes := map[string]bool{}
+  for _, match := range protobufDiagnosticCodePattern.FindAllStringSubmatch(out, -1) {
+    codes[match[1]] = true
+  }
+  if len(codes) == 0 {
+    t.Fatalf("no typia diagnostic code was reported:\nstdout=%s\nstderr=%s", out, errText)
+  }
+
+  unnamed := []string{}
+  for reported := range codes {
+    if !strings.Contains(source, reported+"<") {
+      unnamed = append(unnamed, reported)
+    }
+  }
+  sort.Strings(unnamed)
+  if len(unnamed) != 0 {
+    t.Fatalf(
+      "diagnostic code(s) name no call site in the fixture: %s",
+      strings.Join(unnamed, ", "),
+    )
+  }
+
+  missing := []string{}
+  for _, method := range methods {
+    if !codes["typia.protobuf."+method] {
+      missing = append(missing, method)
+    }
+  }
+  if len(missing) != 0 {
+    t.Fatalf(
+      "no diagnostic named these entry points: %s\nstdout=%s",
+      strings.Join(missing, ", "),
+      out,
+    )
+  }
+}
+
+// The command reports diagnostics as JSON, and `code` is the field ttsc renders
+// as `error TS(<code>)`; reading it here keeps the assertion on the value the
+// transform produced rather than on one renderer's formatting.
+var protobufDiagnosticCodePattern = regexp.MustCompile(`"code":"([^"]+)"`)
+
+func protobufDiagnosticCodeProject(t *testing.T, methods []string) (string, string) {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "protobuf-code-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(protobufDiagnosticCodeTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  lines := []string{`import typia from "typia";`, ""}
+  for _, method := range methods {
+    lines = append(lines, protobufDiagnosticCodeCall(method))
+  }
+  source := strings.Join(lines, "\n") + "\n"
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir, source
+}
+
+// protobufDiagnosticCodeCall writes the call form each entry point takes: the
+// factories take no value argument, the encoders take the message, and the
+// decoders take the buffer.
+func protobufDiagnosticCodeCall(method string) string {
+  call := "typia.protobuf." + method + "<bigint>"
+  switch {
+  case method == "message" || strings.HasPrefix(method, "create"):
+    return call + "();"
+  case strings.HasSuffix(method, "Decode"):
+    return call + "(new Uint8Array());"
+  default:
+    return call + "(1n as any);"
+  }
+}
+
+const protobufDiagnosticCodeTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`

--- a/packages/typia/native/core/factories/ProtobufFactory.go
+++ b/packages/typia/native/core/factories/ProtobufFactory.go
@@ -17,6 +17,11 @@ type protobufFactoryNamespace struct{}
 var ProtobufFactory = protobufFactoryNamespace{}
 
 type ProtobufFactory_IProps struct {
+  // Method is the fully qualified typia API the call site invoked, exactly as
+  // it must appear in the diagnostic code (`typia.protobuf.encode`). It is the
+  // sole source of that code: composing the code here from a shorter spelling
+  // let the encode and decode programmers, which already pass the whole call
+  // accessor, report `typia.protobuf.typia.protobuf.encode`.
   Method     string
   Checker    *shimchecker.Checker
   Components *schemametadata.MetadataCollection
@@ -40,7 +45,7 @@ func (protobufFactoryNamespace) Metadata(props ProtobufFactory_IProps) *schemame
       Code   string
       Errors []nativecontext.TransformerError_MetadataFactory_IError
     }{
-      Code:   "typia.protobuf." + props.Method,
+      Code:   props.Method,
       Errors: protobufFactory_errors(result.Errors),
     }))
   }

--- a/packages/typia/native/core/programmers/protobuf/ProtobufMessageProgrammer.go
+++ b/packages/typia/native/core/programmers/protobuf/ProtobufMessageProgrammer.go
@@ -35,7 +35,7 @@ func (protobufMessageProgrammerNamespace) Write(props ProtobufMessageProgrammer_
   f := nativecontext.EmitFactoryOf(protobufMessageProgrammer_factory, props.Context.Emit)
   collection := schemametadata.NewMetadataCollection()
   nativefactories.ProtobufFactory.Metadata(nativefactories.ProtobufFactory_IProps{
-    Method:     "message",
+    Method:     "typia.protobuf.message",
     Checker:    props.Context.Checker,
     Components: collection,
     Type:       props.Type,

--- a/packages/typia/native/transform/features/protobuf/ProtobufMessageTransformer.go
+++ b/packages/typia/native/transform/features/protobuf/ProtobufMessageTransformer.go
@@ -20,7 +20,7 @@ func (protobufMessageTransformerNamespace) Transform(props nativetransform.ITran
   typ := props.Context.Checker.GetTypeFromTypeNode(props.Expression.TypeArguments.Nodes[0])
   if typ != nil && typ.IsTypeParameter() {
     panic(nativetransform.NewTransformerError(nativetransform.TransformerError_IProps{
-      Code:    "tyipa.protobuf.message",
+      Code:    "typia.protobuf.message",
       Message: "non-specified generic argument.",
     }))
   }

--- a/packages/typia/src/executable/FileSystemIdentity.ts
+++ b/packages/typia/src/executable/FileSystemIdentity.ts
@@ -152,17 +152,17 @@ export namespace FileSystemIdentity {
    * object.
    *
    * The identity is read from `fs.BigIntStats` rather than `fs.Stats`, because
-   * `fs.Stats.ino` is a JavaScript number. An NTFS file ID is
-   * `(sequenceNumber << 48) | mftRecordIndex` and routinely exceeds
-   * `Number.MAX_SAFE_INTEGER` — in a 4000-directory probe, 1879 of them did —
-   * where the spacing between representable doubles is 8 or more. Two entries
-   * sharing a sequence number with MFT record indices within that spacing round
-   * to one double. The traversal callers would then treat a distinct directory
-   * or file as already visited and skip it with no diagnostic, and the overwrite
-   * guard would refuse a legitimate output (samchon/typia#2269).
+   * `fs.Stats.ino` is a JavaScript number. An NTFS file ID is `(sequenceNumber
+   * << 48) | mftRecordIndex` and routinely exceeds `Number.MAX_SAFE_INTEGER` —
+   * in a 4000-directory probe, 1879 of them did — where the spacing between
+   * representable doubles is 8 or more. Two entries sharing a sequence number
+   * with MFT record indices within that spacing round to one double. The
+   * traversal callers would then treat a distinct directory or file as already
+   * visited and skip it with no diagnostic, and the overwrite guard would
+   * refuse a legitimate output (samchon/typia#2269).
    *
-   * A filesystem that reports no inode at all keeps the canonical path fallback,
-   * which is the only identity available there.
+   * A filesystem that reports no inode at all keeps the canonical path
+   * fallback, which is the only identity available there.
    *
    * @param stat Stats read with `{ bigint: true }`.
    * @param realpath Canonical path of the same object.

--- a/packages/typia/src/internal/_randomFormatByte.ts
+++ b/packages/typia/src/internal/_randomFormatByte.ts
@@ -1,6 +1,33 @@
-import { _ILengthProps, _randomFormatLength } from "./_randomStringLength";
+import { _randomString } from "./_randomString";
+import {
+  _ILengthProps,
+  _RANDOM_LENGTH_ERROR,
+  _randomLengthPick,
+  _randomLengthWindow,
+} from "./_randomStringLength";
 
-export const _randomFormatByte = (props?: _ILengthProps): string =>
-  _randomFormatLength(props, () => FIXED);
+export const _randomFormatByte = (props?: _ILengthProps): string => {
+  if (props?.minLength === undefined && props?.maxLength === undefined)
+    return FIXED;
+  // Base64 encodes three bytes as four characters, so a valid length is always
+  // a multiple of four; the window is raised to the first multiple it contains
+  // and the draw steps by four from there. Every character `_randomString`
+  // emits is in the base64 alphabet, so the result needs no padding.
+  const window = _randomLengthWindow(props, { minimum: 0, spread: 16 });
+  const low: number = Math.ceil(window.low / 4) * 4;
+  if (low > window.high) throw new Error(_RANDOM_LENGTH_ERROR);
+  const length: number =
+    low +
+    4 *
+      _randomLengthPick({
+        low: 0,
+        high: Math.floor((window.high - low) / 4),
+      });
+  return _randomString({
+    type: "string",
+    minLength: length,
+    maxLength: length,
+  });
+};
 
 const FIXED = "vt7ekz4lIoNTTS9sDQYdWKharxIFAR54+z/umIxSgUM=";

--- a/packages/typia/src/internal/_randomFormatDate.ts
+++ b/packages/typia/src/internal/_randomFormatDate.ts
@@ -1,23 +1,7 @@
-import { _randomInteger } from "./_randomInteger";
-import { _randomFormatLength } from "./_randomStringLength";
+import { _ILengthProps, _randomFormatLength } from "./_randomStringLength";
+import { __IEpochProps, __randomEpoch } from "./private/__randomEpoch";
 
-export const _randomFormatDate = (props?: {
-  minimum?: number;
-  maximum?: number;
-  minLength?: number;
-  maxLength?: number;
-}) =>
+export const _randomFormatDate = (props?: __IEpochProps & _ILengthProps) =>
   _randomFormatLength(props, () =>
-    new Date(
-      _randomInteger({
-        type: "integer",
-        minimum: props?.minimum ?? 0,
-        maximum:
-          (props?.maximum ?? props?.minimum === undefined)
-            ? Date.now()
-            : props.minimum + 365 * 24 * 60 * 60 * 1_000,
-      }),
-    )
-      .toISOString()
-      .substring(0, 10),
+    new Date(__randomEpoch(props)).toISOString().substring(0, 10),
   );

--- a/packages/typia/src/internal/_randomFormatDatetime.ts
+++ b/packages/typia/src/internal/_randomFormatDatetime.ts
@@ -1,21 +1,35 @@
-import { _randomInteger } from "./_randomInteger";
-import { _randomFormatLength } from "./_randomStringLength";
+import {
+  _ILengthProps,
+  _RANDOM_LENGTH_ERROR,
+  _randomLengthPick,
+  _randomLengthWindow,
+} from "./_randomStringLength";
+import { __randomDigits } from "./private/__randomComposition";
+import { __IEpochProps, __randomEpoch } from "./private/__randomEpoch";
 
-export const _randomFormatDatetime = (props?: {
-  minimum?: number;
-  maximum?: number;
-  minLength?: number;
-  maxLength?: number;
-}) =>
-  _randomFormatLength(props, () =>
-    new Date(
-      _randomInteger({
-        type: "integer",
-        minimum: props?.minimum ?? 0,
-        maximum:
-          (props?.maximum ?? props?.minimum === undefined)
-            ? Date.now()
-            : props.minimum + 365 * 24 * 60 * 60 * 1_000,
-      }),
-    ).toISOString(),
-  );
+export const _randomFormatDatetime = (
+  props?: __IEpochProps & _ILengthProps,
+) => {
+  const instant = (): string => new Date(__randomEpoch(props)).toISOString();
+  if (props?.minLength === undefined && props?.maxLength === undefined)
+    return instant();
+  // `YYYY-MM-DDTHH:MM:SS` plus `Z` is the shortest instant, and a fractional
+  // second grows it one digit at a time. Because that fraction needs both a dot
+  // and at least one digit, 21 is the single length between the two forms that
+  // no instant can have.
+  const window = _randomLengthWindow(props, {
+    minimum: SECONDS + 1,
+    spread: 8,
+  });
+  let length: number = _randomLengthPick(window);
+  if (length === SECONDS + 2)
+    length = window.high >= SECONDS + 3 ? SECONDS + 3 : SECONDS + 1;
+  if (length < window.low || length > window.high)
+    throw new Error(_RANDOM_LENGTH_ERROR);
+  const base: string = instant().substring(0, SECONDS);
+  return length === SECONDS + 1
+    ? `${base}Z`
+    : `${base}.${__randomDigits(length - SECONDS - 2)}Z`;
+};
+
+const SECONDS = "0000-00-00T00:00:00".length;

--- a/packages/typia/src/internal/_randomFormatDuration.ts
+++ b/packages/typia/src/internal/_randomFormatDuration.ts
@@ -1,8 +1,13 @@
 import { _randomInteger } from "./_randomInteger";
-import { _ILengthProps, _randomFormatLength } from "./_randomStringLength";
+import {
+  _ILengthProps,
+  _randomLengthPick,
+  _randomLengthWindow,
+} from "./_randomStringLength";
+import { __randomNumeric } from "./private/__randomComposition";
 
-export const _randomFormatDuration = (props?: _ILengthProps): string =>
-  _randomFormatLength(props, () => {
+export const _randomFormatDuration = (props?: _ILengthProps): string => {
+  if (props?.minLength === undefined && props?.maxLength === undefined) {
     const period: string = durate([
       ["Y", random(0, 100)],
       ["M", random(0, 12)],
@@ -15,7 +20,17 @@ export const _randomFormatDuration = (props?: _ILengthProps): string =>
     ]);
     if (period.length + time.length === 0) return "PT0S";
     return `P${period}${time.length ? "T" : ""}${time}`;
-  });
+  }
+  // A single designator carries an unbounded digit count, so `P<n>Y` expresses
+  // every length from three upward and `P1Y` is the shortest duration there is.
+  const length: number = _randomLengthPick(
+    _randomLengthWindow(props, { minimum: MINIMUM, spread: 6 }),
+  );
+  return `P${__randomNumeric(length - MINIMUM + 1)}Y`;
+};
+
+const MINIMUM = "P1Y".length;
+
 const durate = (elements: [string, number][]) =>
   elements
     .filter(([_unit, value]) => value !== 0)

--- a/packages/typia/src/internal/_randomFormatIpv4.ts
+++ b/packages/typia/src/internal/_randomFormatIpv4.ts
@@ -1,8 +1,37 @@
 import { _randomInteger } from "./_randomInteger";
-import { _ILengthProps, _randomFormatLength } from "./_randomStringLength";
+import {
+  _ILengthProps,
+  _randomLengthPick,
+  _randomLengthWindow,
+} from "./_randomStringLength";
+import { __randomComposition } from "./private/__randomComposition";
 
-export const _randomFormatIpv4 = (props?: _ILengthProps): string =>
-  _randomFormatLength(props, () => new Array(4).fill(0).map(random).join("."));
+export const _randomFormatIpv4 = (props?: _ILengthProps): string => {
+  if (props?.minLength === undefined && props?.maxLength === undefined)
+    return new Array(4).fill(0).map(random).join(".");
+  // Three dots plus four octets of one to three digits: `0.0.0.0` is the
+  // shortest address and `255.255.255.255` the longest, and every length
+  // between them is reached by choosing how many digits each octet spends.
+  const length: number = _randomLengthPick(
+    _randomLengthWindow(props, {
+      minimum: 4 * DIGITS_MIN + DOTS,
+      maximum: 4 * DIGITS_MAX + DOTS,
+      spread: 8,
+    }),
+  );
+  return __randomComposition({
+    total: length - DOTS,
+    count: 4,
+    minimum: DIGITS_MIN,
+    maximum: DIGITS_MAX,
+  })
+    .map(octet)
+    .join(".");
+};
+
+const DOTS = 3;
+const DIGITS_MIN = 1;
+const DIGITS_MAX = 3;
 
 const random = () =>
   _randomInteger({
@@ -10,3 +39,14 @@ const random = () =>
     minimum: 0,
     maximum: 255,
   });
+
+// An octet is bounded by 255, so a three-digit one starts at 100 and stops
+// there rather than at 999.
+const octet = (digits: number): string =>
+  String(
+    _randomInteger({
+      type: "integer",
+      minimum: digits === 1 ? 0 : Math.pow(10, digits - 1),
+      maximum: digits === 3 ? 255 : Math.pow(10, digits) - 1,
+    }),
+  );

--- a/packages/typia/src/internal/_randomFormatIpv6.ts
+++ b/packages/typia/src/internal/_randomFormatIpv6.ts
@@ -1,8 +1,61 @@
+import { _randomFormatIpv4 } from "./_randomFormatIpv4";
 import { _randomInteger } from "./_randomInteger";
-import { _ILengthProps, _randomFormatLength } from "./_randomStringLength";
+import {
+  _ILengthProps,
+  _randomLengthPick,
+  _randomLengthWindow,
+} from "./_randomStringLength";
+import { __randomComposition } from "./private/__randomComposition";
 
-export const _randomFormatIpv6 = (props?: _ILengthProps): string =>
-  _randomFormatLength(props, () => new Array(8).fill(0).map(random).join(":"));
+export const _randomFormatIpv6 = (props?: _ILengthProps): string => {
+  if (props?.minLength === undefined && props?.maxLength === undefined)
+    return new Array(GROUPS).fill(0).map(random).join(":");
+  const length: number = _randomLengthPick(
+    _randomLengthWindow(props, {
+      minimum: SHORTEST,
+      maximum: LONGEST,
+      spread: 12,
+    }),
+  );
+  // `::` alone is the all-zero address, and the three forms below cover every
+  // length between it and the padded IPv4-suffixed address: a compressed prefix
+  // for the short ones, eight groups of one to four hexadecimal digits for the
+  // middle, and six groups plus a dotted-quad tail for the long ones.
+  if (length === SHORTEST) return "::";
+  if (length < GROUPS * DIGITS_MIN + COLONS) {
+    // `::` plus `count` groups spends one colon between each pair.
+    const count: number = Math.ceil((length - 1) / (DIGITS_MAX + 1));
+    return `::${compose(length - 1 - count, count)}`;
+  }
+  if (length <= GROUPS * DIGITS_MAX + COLONS)
+    return compose(length - COLONS, GROUPS);
+  // The dotted-quad tail is drawn at its longest so the six leading groups keep
+  // a composable number of digits.
+  const tail: string = _randomFormatIpv4({
+    minLength: IPV4_MAX,
+    maxLength: IPV4_MAX,
+  });
+  return `${compose(length - IPV4_MAX - EMBEDDED, EMBEDDED)}:${tail}`;
+};
+
+const GROUPS = 8;
+const COLONS = GROUPS - 1;
+const DIGITS_MIN = 1;
+const DIGITS_MAX = 4;
+const EMBEDDED = 6; // groups preceding a dotted-quad tail
+const IPV4_MAX = "255.255.255.255".length;
+const SHORTEST = "::".length;
+const LONGEST = EMBEDDED * DIGITS_MAX + EMBEDDED + IPV4_MAX;
+
+const compose = (digits: number, count: number): string =>
+  __randomComposition({
+    total: digits,
+    count,
+    minimum: DIGITS_MIN,
+    maximum: DIGITS_MAX,
+  })
+    .map(group)
+    .join(":");
 
 const random = () =>
   _randomInteger({
@@ -10,3 +63,14 @@ const random = () =>
     minimum: 0,
     maximum: 65_535,
   }).toString(16);
+
+const group = (digits: number): string => {
+  let text: string = "";
+  for (let i: number = 0; i < digits; ++i)
+    text += _randomInteger({
+      type: "integer",
+      minimum: 0,
+      maximum: 15,
+    }).toString(16);
+  return text;
+};

--- a/packages/typia/src/internal/_randomFormatJsonPointer.ts
+++ b/packages/typia/src/internal/_randomFormatJsonPointer.ts
@@ -1,13 +1,33 @@
 import { _randomString } from "./_randomString";
-import { _ILengthProps, _randomSegmentLength } from "./_randomStringLength";
+import {
+  _ILengthProps,
+  _randomLengthPick,
+  _randomLengthWindow,
+  _randomSegmentLength,
+} from "./_randomStringLength";
 
 export const _randomFormatJsonPointer = (props?: _ILengthProps): string => {
   if (props?.minLength === undefined && props?.maxLength === undefined)
-    return `/components/schemas/${random()}`;
+    return `${PREFIX}${random()}`;
   // The `/components/schemas/` prefix (20 chars) is fixed; the reference token
   // after it grows or shrinks to hit the requested length.
-  return `/components/schemas/${_randomSegmentLength(props, 20, 10, 0)}`;
+  if (props.maxLength === undefined || props.maxLength >= PREFIX.length)
+    return `${PREFIX}${_randomSegmentLength(props, PREFIX.length, 10, 0)}`;
+  // Below that prefix a pointer still exists: the empty pointer addresses the
+  // whole document, and one `/`-prefixed token addresses a member of it.
+  const length: number = _randomLengthPick(
+    _randomLengthWindow(props, { minimum: 0, spread: 6 }),
+  );
+  return length === 0
+    ? ""
+    : `/${_randomString({
+        type: "string",
+        minLength: length - 1,
+        maxLength: length - 1,
+      })}`;
 };
+
+const PREFIX = "/components/schemas/";
 
 const random = () =>
   _randomString({ type: "string", minLength: 10, maxLength: 10 });

--- a/packages/typia/src/internal/_randomFormatRegex.ts
+++ b/packages/typia/src/internal/_randomFormatRegex.ts
@@ -1,7 +1,25 @@
-import { _ILengthProps, _randomFormatLength } from "./_randomStringLength";
+import { _randomString } from "./_randomString";
+import {
+  _ILengthProps,
+  _randomLengthPick,
+  _randomLengthWindow,
+} from "./_randomStringLength";
 
-export const _randomFormatRegex = (props?: _ILengthProps): string =>
-  _randomFormatLength(props, () => FIXED);
+export const _randomFormatRegex = (props?: _ILengthProps): string => {
+  if (props?.minLength === undefined && props?.maxLength === undefined)
+    return FIXED;
+  // Every character `_randomString` emits is a literal in regular expression
+  // syntax, so a source of any length — including the empty source `new
+  // RegExp("")` accepts — compiles.
+  const length: number = _randomLengthPick(
+    _randomLengthWindow(props, { minimum: 0, spread: 16 }),
+  );
+  return _randomString({
+    type: "string",
+    minLength: length,
+    maxLength: length,
+  });
+};
 
 const FIXED =
   "/^(?:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.){3}(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)$/";

--- a/packages/typia/src/internal/_randomFormatRelativeJsonPointer.ts
+++ b/packages/typia/src/internal/_randomFormatRelativeJsonPointer.ts
@@ -1,15 +1,28 @@
 import { _randomInteger } from "./_randomInteger";
-import { _ILengthProps, _randomFormatLength } from "./_randomStringLength";
+import { _randomString } from "./_randomString";
+import {
+  _ILengthProps,
+  _randomLengthPick,
+  _randomLengthWindow,
+} from "./_randomStringLength";
+import { __randomNumeric } from "./private/__randomComposition";
 
 export const _randomFormatRelativeJsonPointer = (
   props?: _ILengthProps,
-): string =>
-  _randomFormatLength(
-    props,
-    () =>
-      `${_randomInteger({
-        type: "integer",
-        minimum: 0,
-        maximum: 10,
-      })}#`,
+): string => {
+  if (props?.minLength === undefined && props?.maxLength === undefined)
+    return `${_randomInteger({ type: "integer", minimum: 0, maximum: 10 })}#`;
+  // The leading non-negative integer stands alone as a pointer, so a single
+  // digit is the shortest form; `#` names the key and a `/`-prefixed token names
+  // a member, which absorbs any remaining length.
+  const length: number = _randomLengthPick(
+    _randomLengthWindow(props, { minimum: 1, spread: 6 }),
   );
+  if (length === 1) return __randomNumeric(1);
+  if (length === 2) return `${__randomNumeric(1)}#`;
+  return `${__randomNumeric(1)}/${_randomString({
+    type: "string",
+    minLength: length - 2,
+    maxLength: length - 2,
+  })}`;
+};

--- a/packages/typia/src/internal/_randomFormatTime.ts
+++ b/packages/typia/src/internal/_randomFormatTime.ts
@@ -1,17 +1,50 @@
 import { _randomInteger } from "./_randomInteger";
-import { _ILengthProps, _randomFormatLength } from "./_randomStringLength";
+import {
+  _ILengthProps,
+  _RANDOM_LENGTH_ERROR,
+  _randomLengthPick,
+  _randomLengthWindow,
+} from "./_randomStringLength";
+import { __randomDigits } from "./private/__randomComposition";
 
-export const _randomFormatTime = (props?: _ILengthProps): string =>
-  _randomFormatLength(props, () =>
+export const _randomFormatTime = (props?: _ILengthProps): string => {
+  const clock = (): string =>
     new Date(
-      _randomInteger({
-        type: "integer",
-        minimum: 0,
-        maximum: DAY,
-      }),
-    )
-      .toISOString()
-      .substring(11),
-  );
+      _randomInteger({ type: "integer", minimum: 0, maximum: DAY }),
+    ).toISOString();
+  if (props?.minLength === undefined && props?.maxLength === undefined)
+    return clock().substring(11);
+  // `HH:MM:SS` carries a mandatory offset — one character as `Z`, six as
+  // `+HH:MM` — and an optional fraction of one to nine digits between them.
+  // Together they express 9 and every length from 11 through 24; 10 is the one
+  // gap, because a fraction needs both a dot and a digit.
+  const window = _randomLengthWindow(props, {
+    minimum: CLOCK + 1,
+    maximum: CLOCK + 1 + FRACTION_MAX + OFFSET,
+    spread: 6,
+  });
+  let length: number = _randomLengthPick(window);
+  if (length === CLOCK + 2)
+    length = window.high >= CLOCK + 3 ? CLOCK + 3 : CLOCK + 1;
+  if (length < window.low || length > window.high)
+    throw new Error(_RANDOM_LENGTH_ERROR);
+  const base: string = clock().substring(11, 11 + CLOCK);
+  if (length === CLOCK + 1) return `${base}Z`;
+  // Nine fraction digits cap the `Z` form at 19 characters, so anything longer
+  // spends the extra five on a numeric offset instead.
+  return length <= CLOCK + 2 + FRACTION_MAX
+    ? `${base}.${__randomDigits(length - CLOCK - 2)}Z`
+    : `${base}.${__randomDigits(length - CLOCK - 1 - OFFSET)}${offset()}`;
+};
 
 const DAY = 86_400_000;
+const CLOCK = "00:00:00".length;
+const OFFSET = "+00:00".length;
+const FRACTION_MAX = 9;
+
+const offset = (): string =>
+  `${_randomInteger({ type: "integer", minimum: 0, maximum: 1 }) === 0 ? "+" : "-"}${pad(
+    _randomInteger({ type: "integer", minimum: 0, maximum: 23 }),
+  )}:${pad(_randomInteger({ type: "integer", minimum: 0, maximum: 59 }))}`;
+
+const pad = (value: number): string => String(value).padStart(2, "0");

--- a/packages/typia/src/internal/_randomStringLength.ts
+++ b/packages/typia/src/internal/_randomStringLength.ts
@@ -1,4 +1,8 @@
+import { _randomInteger } from "./_randomInteger";
 import { _randomString } from "./_randomString";
+
+export const _RANDOM_LENGTH_ERROR =
+  "unable to generate a random string satisfying both the format and the length constraints.";
 
 /**
  * Length bounds forwarded to a string format or pattern generator.
@@ -36,21 +40,63 @@ export const _randomSegmentLength = (
   // characters so the generated length varies, mirroring `_randomString`.
   const high: number =
     props?.maxLength === undefined ? low + fallback : props.maxLength - fixed;
-  if (high < low || high < minimum)
-    throw new Error(
-      "unable to generate a random string satisfying both the format and the length constraints.",
-    );
+  if (high < low || high < minimum) throw new Error(_RANDOM_LENGTH_ERROR);
   return _randomString({ type: "string", minLength: low, maxLength: high });
 };
 
 /**
- * Wraps a fixed- or narrow-length format generator (uuid, ipv4, date, ...) with
- * the requested length window.
+ * Intersects the requested length window with the lengths a format's grammar
+ * can express, and draws one of them.
  *
- * These formats cannot grow an arbitrary segment, so the generator is retried a
- * bounded number of times and the first draw inside the window is returned. A
- * window that excludes every length the format can produce is unsatisfiable and
- * throws instead of silently yielding an out-of-range value.
+ * `minimum` and `maximum` are the shortest and longest values the format admits
+ * — omit `maximum` when the grammar is open above — and `spread` is how far
+ * past the floor an unbounded request may reach, so an open side still varies
+ * the way `_randomString` does. The caller draws from the returned window and
+ * applies whatever step its grammar has (base64 lengths are multiples of four,
+ * a fractional second needs at least one digit).
+ *
+ * Throws only when the window and the grammar do not overlap at all. That is
+ * the distinction the retry driver below cannot make: it redraws one shape, so
+ * it gives up on every length that shape never emits even when the format
+ * itself accepts one (issue #2284).
+ */
+export const _randomLengthWindow = (
+  props: _ILengthProps | undefined,
+  format: { minimum: number; maximum?: number; spread?: number },
+): { low: number; high: number } => {
+  const ceiling: number = format.maximum ?? Number.MAX_SAFE_INTEGER;
+  const low: number = Math.max(
+    props?.minLength ?? format.minimum,
+    format.minimum,
+  );
+  const high: number = Math.min(
+    props?.maxLength ?? low + (format.spread ?? 0),
+    ceiling,
+  );
+  if (low > high) throw new Error(_RANDOM_LENGTH_ERROR);
+  return { low, high };
+};
+
+/** Draws a length inside a window produced by {@link _randomLengthWindow}. */
+export const _randomLengthPick = (window: {
+  low: number;
+  high: number;
+}): number =>
+  _randomInteger({
+    type: "integer",
+    minimum: window.low,
+    maximum: window.high,
+  });
+
+/**
+ * Wraps a fixed-length format generator (uuid, date) with the requested length
+ * window.
+ *
+ * Use it only where the grammar admits exactly one length, so a window that
+ * excludes it is genuinely unsatisfiable. A format that can express more than
+ * one length must build its value at a length drawn from
+ * {@link _randomLengthWindow} instead; redrawing one shape cannot reach a length
+ * that shape never emits.
  */
 export const _randomFormatLength = (
   props: _ILengthProps | undefined,
@@ -66,7 +112,5 @@ export const _randomFormatLength = (
     )
       return value;
   }
-  throw new Error(
-    "unable to generate a random string satisfying both the format and the length constraints.",
-  );
+  throw new Error(_RANDOM_LENGTH_ERROR);
 };

--- a/packages/typia/src/internal/private/__randomComposition.ts
+++ b/packages/typia/src/internal/private/__randomComposition.ts
@@ -1,0 +1,50 @@
+import { _randomInteger } from "../_randomInteger";
+
+/**
+ * Splits `total` into `count` parts, each inside `[minimum, maximum]`.
+ *
+ * Used where a format's length is the sum of its segments — an IPv4 octet spans
+ * one to three digits, an IPv6 group one to four — so a requested total length
+ * is realized by choosing how many characters each segment contributes instead
+ * of redrawing whole addresses and hoping one lands in the window (issue
+ * #2284).
+ *
+ * The caller guarantees `count * minimum <= total <= count * maximum`; each
+ * part is drawn from the range that still leaves the remaining parts
+ * satisfiable.
+ */
+export const __randomComposition = (props: {
+  total: number;
+  count: number;
+  minimum: number;
+  maximum: number;
+}): number[] => {
+  const parts: number[] = [];
+  let remaining: number = props.total;
+  for (let i: number = 0; i < props.count; ++i) {
+    const rest: number = props.count - i - 1;
+    const value: number = _randomInteger({
+      type: "integer",
+      minimum: Math.max(props.minimum, remaining - rest * props.maximum),
+      maximum: Math.min(props.maximum, remaining - rest * props.minimum),
+    });
+    parts.push(value);
+    remaining -= value;
+  }
+  return parts;
+};
+
+/** Draws `length` decimal digits, leading zeros included. */
+export const __randomDigits = (length: number): string => {
+  let text: string = "";
+  for (let i: number = 0; i < length; ++i)
+    text += String(_randomInteger({ type: "integer", minimum: 0, maximum: 9 }));
+  return text;
+};
+
+/** Draws a decimal number of exactly `length` digits without a leading zero. */
+export const __randomNumeric = (length: number): string =>
+  length <= 1
+    ? String(_randomInteger({ type: "integer", minimum: 0, maximum: 9 }))
+    : String(_randomInteger({ type: "integer", minimum: 1, maximum: 9 })) +
+      __randomDigits(length - 1);

--- a/packages/typia/src/internal/private/__randomEpoch.ts
+++ b/packages/typia/src/internal/private/__randomEpoch.ts
@@ -1,0 +1,34 @@
+import { _randomInteger } from "../_randomInteger";
+
+export interface __IEpochProps {
+  minimum?: number;
+  maximum?: number;
+}
+
+/**
+ * Draws an epoch millisecond inside the requested bounds.
+ *
+ * Shared by the `date` and `date-time` generators, which had the same bound
+ * expression written twice: `props?.maximum ?? props?.minimum === undefined`
+ * parses as `props?.maximum ?? (props?.minimum === undefined)` because `??`
+ * binds looser than `===`, so any supplied `maximum` made the condition truthy
+ * and was replaced by `Date.now()`, while `maximum: 0` fell through to
+ * `undefined + one year` and produced `NaN` (issue #2287). Keeping the
+ * resolution in one place is what stops the two copies from drifting again.
+ *
+ * With no bound at all the window ends at the present instant; with only a
+ * lower bound it spans one year from there.
+ */
+export const __randomEpoch = (props?: __IEpochProps): number => {
+  const minimum: number = props?.minimum ?? 0;
+  const maximum: number =
+    props?.maximum ??
+    (props?.minimum === undefined ? Date.now() : props.minimum + YEAR);
+  return _randomInteger({
+    type: "integer",
+    minimum,
+    maximum,
+  });
+};
+
+const YEAR = 365 * 24 * 60 * 60 * 1_000;

--- a/tests/test-error/index.js
+++ b/tests/test-error/index.js
@@ -16,6 +16,12 @@ const path = require("path");
  *    build before the transform runs and would leave this suite with nothing to
  *    observe.
  * 3. Require every fixture to be named by at least one typia diagnostic.
+ * 4. Require every diagnostic code to name an accessor the fixture actually
+ *    writes. The code is the only machine-readable identity a rejection carries,
+ *    and accepting anything that merely starts with `TS(typia.` let
+ *    `TS(typia.protobuf.typia.protobuf.encode)` pass for sixteen entry points
+ *    (#2285). The fixture source is the oracle: a code composed by
+ *    concatenation, or misspelled, names no call site in it.
  */
 const SRC = path.join(__dirname, "src");
 const ANSI = /\x1b\[[0-9;]*m/g;
@@ -66,22 +72,25 @@ const build = () => {
  */
 const parse = (output) => {
   const typia = new Map();
+  const codes = new Map();
   const compiler = [];
   for (const line of output.split(/\r?\n/)) {
     const match = line.match(/^(\S.*\.ts):\d+:\d+ - error ([^\s:]+):/);
     if (match === null) continue;
     const file = normalize(match[1]);
-    if (match[2].startsWith("TS(typia."))
+    if (match[2].startsWith("TS(typia.")) {
       typia.set(file, (typia.get(file) ?? 0) + 1);
-    else compiler.push(line.trim());
+      if (codes.has(file) === false) codes.set(file, new Set());
+      codes.get(file).add(match[2].slice("TS(".length, -1));
+    } else compiler.push(line.trim());
   }
-  return { typia, compiler };
+  return { typia, codes, compiler };
 };
 
 const main = () => {
   const list = fixtures();
   const { code, output } = build();
-  const { typia, compiler } = parse(output);
+  const { typia, codes, compiler } = parse(output);
 
   const fail = (reasons) => {
     for (const reason of reasons) console.error(reason);
@@ -127,9 +136,27 @@ const main = () => {
           ]),
     ]);
 
+  // EVERY DIAGNOSTIC CODE MUST NAME AN ACCESSOR ITS FIXTURE WRITES
+  const unnamed = [];
+  for (const [file, reported] of codes) {
+    const source = fs.readFileSync(path.join(SRC, file), "utf8");
+    for (const name of reported)
+      if (source.includes(name) === false) unnamed.push(`src/${file}: ${name}`);
+  }
+  if (unnamed.length !== 0)
+    fail([
+      `${unnamed.length} diagnostic code(s) name no call site in their fixture.`,
+      "A typia rejection must be identified by the API that was invoked, so the",
+      "code has to be an accessor the fixture writes.",
+      "",
+      ...unnamed.sort(),
+      "",
+    ]);
+
   const total = [...typia.values()].reduce((x, y) => x + y, 0);
   console.log(
-    `Every fixture rejected: ${list.length} files, ${total} typia diagnostics.`,
+    `Every fixture rejected: ${list.length} files, ${total} typia diagnostics, ` +
+      `${[...codes.values()].reduce((x, y) => x + y.size, 0)} distinct codes named.`,
   );
 };
 main();

--- a/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
+++ b/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
@@ -11,12 +11,12 @@ import { Calculator } from "../structures/Calculator";
  * Verifies a LangChain argument failure fences typia's feedback exactly once.
  *
  * `LlmJson.stringify` owns the markdown fence around its annotated JSON, so a
- * caller that wraps the return value in a second ````json` fence hands the
- * model ````json\n```json` — broken markdown, in the one payload whose whole
- * purpose is to be read back and corrected. Counting the fence is what pins
- * this, because asserting the feedback merely `includes("```json")` passes with
- * one fence or two; asserting the body is `LlmJson.stringify`'s output verbatim
- * additionally pins that the registrar wraps it in nothing at all.
+ * caller that wraps the return value in a second `json` fence hands the model
+ * `json\n`json` — broken markdown, in the one payload whose whole purpose is to
+ * be read back and corrected. Counting the fence is what pins this, because
+ * asserting the feedback merely `includes("`json")`passes with one fence or
+ * two; asserting the body is`LlmJson.stringify`'s output verbatim additionally
+ * pins that the registrar wraps it in nothing at all.
  *
  * 1. Build a class controller and convert it to LangChain tools.
  * 2. Invoke `add` with a non-numeric operand to force typia's feedback.

--- a/tests/test-typia-generate/scripts/identity/inode-precision.ts
+++ b/tests/test-typia-generate/scripts/identity/inode-precision.ts
@@ -16,9 +16,9 @@ import { FileSystemIdentity } from "../../../../packages/typia/src/executable/Fi
  * no diagnostic. The identity is therefore read as a `bigint`.
  *
  * The pair below is chosen so the defect is unambiguous: both IDs sit between
- * 2^55 and 2^56 and differ by 2, which is inside the ulp of 8, so
- * `Number(a) === Number(b)` while `a !== b`. Deriving the key from the number
- * makes them one identity; deriving it from the `bigint` keeps them two.
+ * 2^55 and 2^56 and differ by 2, which is inside the ulp of 8, so `Number(a)
+ * === Number(b)` while `a !== b`. Deriving the key from the number makes them
+ * one identity; deriving it from the `bigint` keeps them two.
  *
  * 1. Assert the premise — the two IDs collide as doubles and differ as bigints.
  * 2. Assert the keys built from them stay distinct.

--- a/tests/test-typia-schema/src/features/random/test_random_format_date_epoch_bounds.ts
+++ b/tests/test-typia-schema/src/features/random/test_random_format_date_epoch_bounds.ts
@@ -1,0 +1,54 @@
+import { TestValidator } from "@nestia/e2e";
+import { _randomFormatDate } from "typia/lib/internal/_randomFormatDate";
+import { _randomFormatDatetime } from "typia/lib/internal/_randomFormatDatetime";
+
+/**
+ * Verifies the date and date-time generators honor an explicit `maximum` epoch.
+ *
+ * Both helpers declared `minimum` and `maximum` props and resolved the upper
+ * bound with `props?.maximum ?? props?.minimum === undefined`, which parses as
+ * `props?.maximum ?? (props?.minimum === undefined)` because `??` binds looser
+ * than `===`. Any supplied `maximum` therefore made the condition truthy and
+ * was replaced by `Date.now()`, while `maximum: 0` fell through to `undefined +
+ * one year` and produced `NaN` (#2287). The transform forwards only length
+ * bounds today, so these props are exercised here directly.
+ *
+ * 1. Draw many dates and instants inside a closed one-month window.
+ * 2. Require every draw to land inside it.
+ * 3. Require `maximum: 0` to mean the epoch itself rather than `NaN`, and the
+ *    unbounded call to keep its present-day upper bound.
+ */
+export const test_random_format_date_epoch_bounds = (): void => {
+  const minimum: number = Date.UTC(2000, 0, 1);
+  const maximum: number = Date.UTC(2000, 0, 31);
+  const outside: string[] = [];
+  for (let i: number = 0; i < 200; ++i) {
+    const date: string = _randomFormatDate({ minimum, maximum });
+    if (date < "2000-01-01" || date > "2000-01-31") outside.push(date);
+    const instant: string = _randomFormatDatetime({ minimum, maximum });
+    const time: number = new Date(instant).getTime();
+    if (Number.isNaN(time) || time < minimum || time > maximum)
+      outside.push(instant);
+  }
+  TestValidator.equals(
+    `closed epoch window (${outside.length ? outside[0] : "none"})`,
+    outside.length,
+    0,
+  );
+
+  // BOUNDARY: zero is a bound, not a missing value.
+  TestValidator.equals(
+    "maximum zero pins the epoch",
+    _randomFormatDate({ maximum: 0 }),
+    "1970-01-01",
+  );
+
+  // CONTROL: an unbounded draw still stops at the present instant.
+  const now: number = Date.now();
+  const unbounded: number = new Date(_randomFormatDatetime()).getTime();
+  TestValidator.equals(
+    `unbounded draw stays in the past (${unbounded})`,
+    unbounded <= now + 1_000 && unbounded >= 0,
+    true,
+  );
+};

--- a/tests/test-typia-schema/src/features/random/test_random_format_length_grammar.ts
+++ b/tests/test-typia-schema/src/features/random/test_random_format_length_grammar.ts
@@ -1,0 +1,214 @@
+import { TestValidator } from "@nestia/e2e";
+import { _isFormatByte } from "typia/lib/internal/_isFormatByte";
+import { _isFormatDate } from "typia/lib/internal/_isFormatDate";
+import { _isFormatDateTime } from "typia/lib/internal/_isFormatDateTime";
+import { _isFormatDuration } from "typia/lib/internal/_isFormatDuration";
+import { _isFormatIpv4 } from "typia/lib/internal/_isFormatIpv4";
+import { _isFormatIpv6 } from "typia/lib/internal/_isFormatIpv6";
+import { _isFormatJsonPointer } from "typia/lib/internal/_isFormatJsonPointer";
+import { _isFormatRegex } from "typia/lib/internal/_isFormatRegex";
+import { _isFormatRelativeJsonPointer } from "typia/lib/internal/_isFormatRelativeJsonPointer";
+import { _isFormatTime } from "typia/lib/internal/_isFormatTime";
+import { _isFormatUuid } from "typia/lib/internal/_isFormatUuid";
+import { _randomFormatByte } from "typia/lib/internal/_randomFormatByte";
+import { _randomFormatDate } from "typia/lib/internal/_randomFormatDate";
+import { _randomFormatDatetime } from "typia/lib/internal/_randomFormatDatetime";
+import { _randomFormatDuration } from "typia/lib/internal/_randomFormatDuration";
+import { _randomFormatIpv4 } from "typia/lib/internal/_randomFormatIpv4";
+import { _randomFormatIpv6 } from "typia/lib/internal/_randomFormatIpv6";
+import { _randomFormatJsonPointer } from "typia/lib/internal/_randomFormatJsonPointer";
+import { _randomFormatRegex } from "typia/lib/internal/_randomFormatRegex";
+import { _randomFormatRelativeJsonPointer } from "typia/lib/internal/_randomFormatRelativeJsonPointer";
+import { _randomFormatTime } from "typia/lib/internal/_randomFormatTime";
+import { _randomFormatUuid } from "typia/lib/internal/_randomFormatUuid";
+
+interface IEntry {
+  name: string;
+  random: (props?: { minLength?: number; maxLength?: number }) => string;
+  is: (value: string) => boolean;
+  /**
+   * Lengths the format's grammar expresses, read off its validator rather than
+   * off the generator: base64 spends four characters per three bytes; a dotted
+   * quad runs from `0.0.0.0` to `255.255.255.255`; an IPv6 address runs from
+   * the compressed `::` to a padded dotted-quad tail; an instant is either
+   * seconds-precise or carries a dot plus at least one digit, which is why 21
+   * is missing; a clock adds `Z` or a six-character offset to those, capped at
+   * nine fraction digits; a duration is `P` plus one designator.
+   */
+  realizable: (length: number) => boolean;
+}
+
+const ENTRIES: IEntry[] = [
+  {
+    name: "byte",
+    random: _randomFormatByte,
+    is: _isFormatByte,
+    realizable: (n) => n % 4 === 0,
+  },
+  {
+    name: "regex",
+    random: _randomFormatRegex,
+    is: _isFormatRegex,
+    realizable: () => true,
+  },
+  {
+    name: "ipv4",
+    random: _randomFormatIpv4,
+    is: _isFormatIpv4,
+    realizable: (n) => n >= 7 && n <= 15,
+  },
+  {
+    name: "ipv6",
+    random: _randomFormatIpv6,
+    is: _isFormatIpv6,
+    realizable: (n) => n >= 2 && n <= 45,
+  },
+  {
+    name: "date-time",
+    random: _randomFormatDatetime,
+    is: _isFormatDateTime,
+    realizable: (n) => n === 20 || n >= 22,
+  },
+  {
+    name: "time",
+    random: _randomFormatTime,
+    is: _isFormatTime,
+    realizable: (n) => n === 9 || (n >= 11 && n <= 24),
+  },
+  {
+    name: "duration",
+    random: _randomFormatDuration,
+    is: _isFormatDuration,
+    realizable: (n) => n >= 3,
+  },
+  {
+    name: "relative-json-pointer",
+    random: _randomFormatRelativeJsonPointer,
+    is: _isFormatRelativeJsonPointer,
+    realizable: (n) => n >= 1,
+  },
+  {
+    name: "json-pointer",
+    random: _randomFormatJsonPointer,
+    is: _isFormatJsonPointer,
+    realizable: () => true,
+  },
+  {
+    name: "date",
+    random: _randomFormatDate,
+    is: _isFormatDate,
+    realizable: (n) => n === 10,
+  },
+  {
+    name: "uuid",
+    random: _randomFormatUuid,
+    is: _isFormatUuid,
+    realizable: (n) => n === 36,
+  },
+];
+
+const MAX_LENGTH = 48;
+const DRAWS = 8;
+
+/**
+ * Verifies every string-format generator covers the exact set of lengths its
+ * own validator accepts.
+ *
+ * `typia.random<T>()` can only be written against a literal type, so the
+ * per-format sibling test pins the end-to-end path at chosen lengths while this
+ * one walks the whole window matrix through the helpers the transform emits.
+ * The two directions are what make the class impossible to half-fix: a
+ * generator that widens its output would satisfy "never throws", and one that
+ * keeps a fixed shape would satisfy "throws when asked for something odd"
+ * (#2284).
+ *
+ * 1. For every format and every length up to 48, draw with `minLength ===
+ *    maxLength`.
+ * 2. Require a realizable length to yield a value of exactly that length that the
+ *    format's own validator accepts.
+ * 3. Require an unrealizable length to throw instead of yielding an invalid value,
+ *    and require one-sided windows to respect their single bound.
+ */
+export const test_random_format_length_grammar = (): void => {
+  const failures: string[] = [];
+  for (const entry of ENTRIES) {
+    for (let length = 0; length <= MAX_LENGTH; ++length)
+      exact(entry, length, failures);
+    for (const props of [
+      undefined,
+      { minLength: 0 },
+      { maxLength: MAX_LENGTH },
+      { minLength: 12 },
+      { minLength: 12, maxLength: 40 },
+    ])
+      window(entry, props, failures);
+  }
+  TestValidator.equals(
+    `format length grammar (${failures.length ? failures[0] : "none"})`,
+    failures.length,
+    0,
+  );
+};
+
+const exact = (entry: IEntry, length: number, failures: string[]): void => {
+  const expected: boolean = entry.realizable(length);
+  for (let i: number = 0; i < DRAWS; ++i) {
+    let value: string | null = null;
+    let thrown: boolean = false;
+    try {
+      value = entry.random({ minLength: length, maxLength: length });
+    } catch {
+      thrown = true;
+    }
+    if (expected === false) {
+      if (thrown === false)
+        failures.push(
+          `${entry.name}@${length}: expected a throw, got ${JSON.stringify(value)}`,
+        );
+      return;
+    }
+    if (thrown) {
+      failures.push(`${entry.name}@${length}: threw at a realizable length`);
+      return;
+    }
+    if (value!.length !== length) {
+      failures.push(
+        `${entry.name}@${length}: produced length ${value!.length}`,
+      );
+      return;
+    }
+    if (entry.is(value!) === false) {
+      failures.push(
+        `${entry.name}@${length}: produced ${JSON.stringify(value)} its own validator rejects`,
+      );
+      return;
+    }
+  }
+};
+
+const window = (
+  entry: IEntry,
+  props: { minLength?: number; maxLength?: number } | undefined,
+  failures: string[],
+): void => {
+  for (let i: number = 0; i < DRAWS; ++i) {
+    let value: string;
+    try {
+      value = entry.random(props);
+    } catch {
+      // A one-sided window can still exclude every length the format has, as
+      // `uuid` does for anything but 36.
+      return;
+    }
+    const low: number = props?.minLength ?? 0;
+    const high: number = props?.maxLength ?? Number.MAX_SAFE_INTEGER;
+    if (value.length < low || value.length > high)
+      failures.push(
+        `${entry.name} ${JSON.stringify(props)}: length ${value.length} outside the window`,
+      );
+    else if (entry.is(value) === false)
+      failures.push(
+        `${entry.name} ${JSON.stringify(props)}: produced ${JSON.stringify(value)} its own validator rejects`,
+      );
+  }
+};

--- a/tests/test-typia-schema/src/features/random/test_random_format_length_window.ts
+++ b/tests/test-typia-schema/src/features/random/test_random_format_length_window.ts
@@ -1,0 +1,344 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies typia.random draws every format at a length its own validator
+ * accepts, and refuses only genuinely unsatisfiable windows.
+ *
+ * #2192 converted part of the format set to length-aware builders and left nine
+ * formats on the retry driver, which redraws one fixed shape and gives up.
+ * Those nine then threw for lengths their own grammar expresses:
+ * `Format<"byte">` and `Format<"regex">` return a single constant, so every
+ * window excluding 44 and 86 failed, and `ipv4` / `ipv6` / `date-time` / `time`
+ * / `duration` / `json-pointer` / `relative-json-pointer` failed for any window
+ * their natural shape misses (#2284). Each positive case below pins an exact
+ * length, so a generator that merely widens its output cannot pass.
+ *
+ * 1. Draw each format at an exact length and require `is` of the same type.
+ * 2. Repeat with one-sided and wide windows, plus the already-correct controls.
+ * 3. Require a window with no realizable length to keep throwing.
+ */
+export const test_random_format_length_window = (): void => {
+  // POSITIVE: an exact length every format's grammar expresses.
+  {
+    // Base64 encodes three bytes as four characters, so 24 is valid and 25 is
+    // not.
+    type T = string &
+      tags.Format<"byte"> &
+      tags.MinLength<24> &
+      tags.MaxLength<24>;
+    roundTrip(
+      "byte exact length",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"regex"> &
+      tags.MinLength<24> &
+      tags.MaxLength<24>;
+    roundTrip(
+      "regex exact length",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // `0.0.0.0` — every octet single-digit.
+    type T = string &
+      tags.Format<"ipv4"> &
+      tags.MinLength<7> &
+      tags.MaxLength<7>;
+    roundTrip(
+      "ipv4 shortest",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // `255.255.255.255` — every octet three digits.
+    type T = string &
+      tags.Format<"ipv4"> &
+      tags.MinLength<15> &
+      tags.MaxLength<15>;
+    roundTrip(
+      "ipv4 longest",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // `::` — the compressed all-zero address.
+    type T = string &
+      tags.Format<"ipv6"> &
+      tags.MinLength<2> &
+      tags.MaxLength<2>;
+    roundTrip(
+      "ipv6 compressed",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // `0:0:0:0:0:0:0:0` — the shortest uncompressed address.
+    type T = string &
+      tags.Format<"ipv6"> &
+      tags.MinLength<15> &
+      tags.MaxLength<15>;
+    roundTrip(
+      "ipv6 full form",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // A dotted-quad tail is the only form this long.
+    type T = string &
+      tags.Format<"ipv6"> &
+      tags.MinLength<45> &
+      tags.MaxLength<45>;
+    roundTrip(
+      "ipv6 embedded ipv4",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // `2020-01-01T00:00:00Z` — seconds precision, no fraction.
+    type T = string &
+      tags.Format<"date-time"> &
+      tags.MinLength<20> &
+      tags.MaxLength<20>;
+    roundTrip(
+      "date-time without fraction",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"date-time"> &
+      tags.MinLength<26> &
+      tags.MaxLength<26>;
+    roundTrip(
+      "date-time with fraction",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // `00:00:00Z` — the shortest full time.
+    type T = string &
+      tags.Format<"time"> &
+      tags.MinLength<9> &
+      tags.MaxLength<9>;
+    roundTrip(
+      "time shortest",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // Nine fraction digits cap the `Z` form, so this length needs an offset.
+    type T = string &
+      tags.Format<"time"> &
+      tags.MinLength<24> &
+      tags.MaxLength<24>;
+    roundTrip(
+      "time longest with offset",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // `P1Y` — one designator is the shortest duration.
+    type T = string &
+      tags.Format<"duration"> &
+      tags.MinLength<3> &
+      tags.MaxLength<3>;
+    roundTrip(
+      "duration shortest",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"json-pointer"> &
+      tags.MinLength<6> &
+      tags.MaxLength<6>;
+    roundTrip(
+      "json-pointer below the reference prefix",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    // The empty pointer addresses the whole document.
+    type T = string & tags.Format<"json-pointer"> & tags.MaxLength<0>;
+    roundTrip(
+      "json-pointer empty",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"relative-json-pointer"> &
+      tags.MinLength<1> &
+      tags.MaxLength<1>;
+    roundTrip(
+      "relative-json-pointer shortest",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"relative-json-pointer"> &
+      tags.MinLength<8> &
+      tags.MaxLength<8>;
+    roundTrip(
+      "relative-json-pointer with a member token",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+
+  // ONE-SIDED AND WIDE WINDOWS.
+  {
+    type T = string &
+      tags.Format<"byte"> &
+      tags.MinLength<24> &
+      tags.MaxLength<40>;
+    roundTrip(
+      "byte window",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string & tags.Format<"ipv6"> & tags.MinLength<20>;
+    roundTrip(
+      "ipv6 lower bound only",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string & tags.Format<"duration"> & tags.MaxLength<12>;
+    roundTrip(
+      "duration upper bound only",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+
+  // CONTROLS: the unconstrained draws and the already-correct formats.
+  {
+    type T = string & tags.Format<"byte">;
+    roundTrip(
+      "byte unconstrained",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string & tags.Format<"ipv6">;
+    roundTrip(
+      "ipv6 unconstrained",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"uuid"> &
+      tags.MinLength<36> &
+      tags.MaxLength<36>;
+    roundTrip(
+      "uuid exact length",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"date"> &
+      tags.MinLength<10> &
+      tags.MaxLength<10>;
+    roundTrip(
+      "date exact length",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+    );
+  }
+
+  // NEGATIVE: no length inside the window is realizable.
+  assertThrows("byte between two multiples of four", () =>
+    typia.random<
+      string & tags.Format<"byte"> & tags.MinLength<25> & tags.MaxLength<27>
+    >(),
+  );
+  assertThrows("ipv4 shorter than the shortest address", () =>
+    typia.random<string & tags.Format<"ipv4"> & tags.MaxLength<6>>(),
+  );
+  assertThrows("ipv4 longer than the longest address", () =>
+    typia.random<string & tags.Format<"ipv4"> & tags.MinLength<16>>(),
+  );
+  assertThrows("ipv6 longer than an embedded dotted quad", () =>
+    typia.random<string & tags.Format<"ipv6"> & tags.MinLength<46>>(),
+  );
+  assertThrows("date-time between the two instant forms", () =>
+    typia.random<
+      string &
+        tags.Format<"date-time"> &
+        tags.MinLength<21> &
+        tags.MaxLength<21>
+    >(),
+  );
+  assertThrows("time between the two clock forms", () =>
+    typia.random<
+      string & tags.Format<"time"> & tags.MinLength<10> & tags.MaxLength<10>
+    >(),
+  );
+  assertThrows("time longer than a full offset clock", () =>
+    typia.random<string & tags.Format<"time"> & tags.MinLength<25>>(),
+  );
+  assertThrows("duration shorter than one designator", () =>
+    typia.random<string & tags.Format<"duration"> & tags.MaxLength<2>>(),
+  );
+  assertThrows("uuid at any other length", () =>
+    typia.random<string & tags.Format<"uuid"> & tags.MaxLength<35>>(),
+  );
+};
+
+const COUNT = 200;
+
+const roundTrip = (
+  title: string,
+  is: (input: unknown) => boolean,
+  draw: () => string,
+): void => {
+  let failures: number = 0;
+  let first: string | null = null;
+  for (let i = 0; i < COUNT; ++i) {
+    const value: string = draw();
+    if (is(value) === false) {
+      ++failures;
+      if (first === null) first = value;
+    }
+  }
+  TestValidator.equals(`${title} (first invalid: ${first})`, failures, 0);
+};
+
+const assertThrows = (title: string, closure: () => unknown): void => {
+  let thrown: boolean = false;
+  try {
+    closure();
+  } catch {
+    thrown = true;
+  }
+  TestValidator.equals(title, thrown, true);
+};

--- a/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
@@ -8,12 +8,12 @@ import { Calculator } from "../structures/Calculator";
 /**
  * Verifies Vercel tool feedback fences typia's annotated JSON exactly once.
  *
- * `LlmJson.stringify` already wraps its output in a ````json` fence, so a
- * caller that adds a second one hands the model ````json\n```json`.
- * `VercelToolsRegistrar` formats that same result on two separate paths — once
- * for invalid arguments and once for an invalid output — and a fence added back
- * to either one is invisible to an `includes("```json")` check, which passes
- * with one fence or two. Counting the fence on both paths is what pins it.
+ * `LlmJson.stringify` already wraps its output in a `json` fence, so a caller
+ * that adds a second one hands the model `json\n`json`. `VercelToolsRegistrar`
+ * formats that same result on two separate paths — once for invalid arguments
+ * and once for an invalid output — and a fence added back to either one is
+ * invisible to an `includes("`json")` check, which passes with one fence or
+ * two. Counting the fence on both paths is what pins it.
  *
  * 1. Build a controller whose method both takes and returns a typed value.
  * 2. Force an argument failure and count the fences in its feedback.

--- a/website/src/content/docs/json/schema.mdx
+++ b/website/src/content/docs/json/schema.mdx
@@ -212,16 +212,16 @@ typia.json.schemas<[Something]>();
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash
-main.ts:12:1 - error TS(typia.json.schemas): unsupported type detected
+main.ts:12:1 - error TS(typia.json.schemas): typia transform error: unsupported type detected
 
 - Something.bigint: bigint
-  - JSON does not support bigint type.
+  - JSON schema does not support bigint type.
 
 - Something.array: bigint
-  - JSON does not support bigint type.
+  - JSON schema does not support bigint type.
 
-- Nested.uint64: (bigint & Type<"uint64">)
-  - JSON does not support bigint type.
+- Nested.uint64: (bigint & Typeuint64)
+  - JSON schema does not support bigint type.
 ```
   </Tabs.Tab>
 </Tabs>

--- a/website/src/content/docs/llm/application.mdx
+++ b/website/src/content/docs/llm/application.mdx
@@ -142,16 +142,16 @@ const app: ILlmApplication = typia.llm.application<BbsArticleController>();
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal"
-examples/src/llm/application.violation.ts:15:30 - error TS(typia.llm.application): unsupported type detected
+examples/src/llm/application.violation.ts:15:30 - error TS(typia.llm.application): typia transform error: unsupported type detected
 
 - BbsArticleController.create: unknown
-  - LLM application's function ("create")'s return type must not be union type with undefined.
+  - LLM application's function ("create") return type cannot be optional (union with undefined).
 
 - BbsArticleController.add: unknown
-  - LLM application's function ("add")'s return type must be an object type.
+  - LLM application's function ("add") return type must be a single object type.
 
 - BbsArticleController.erase: unknown
-  - LLM application's function ("erase")'s parameter must be an object type.
+  - LLM application's function ("erase") parameter must be a single object type.
 ```
   </Tabs.Tab>
 </Tabs>

--- a/website/src/content/docs/llm/parameters.mdx
+++ b/website/src/content/docs/llm/parameters.mdx
@@ -237,41 +237,33 @@ LLMs use keyworded arguments. typia enforces this at compile time:
 - No dynamic keys (`Record<string, V>`)
 - `T` may not be nullable or optional
 
+`T` is also constrained by the signature itself (`Parameters extends Record<string, any>`), so a primitive such as `typia.llm.parameters<string>()` is rejected by TypeScript with `TS2344` before the transform runs, and no typia diagnostic appears for it.
+
 <Tabs items={["Source That Won't Compile", "Compiler Errors"]}>
   <Tabs.Tab>
 ```typescript filename="src/examples/llm.parameters.violation.ts" showLineNumbers
 import typia from "typia";
 
-typia.llm.parameters<string>();
 typia.llm.parameters<Record<string, boolean>>();
 typia.llm.parameters<Array<number>>();
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal"
-src/examples/llm.parameters.violation.ts:3:1 - error TS(typia.llm.parameters): unsupported type detected
-
-- string
-  - LLM parameters must be an object type.
-
-3 typia.llm.parameters<string>();
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-src/examples/llm.parameters.violation.ts:4:1 - error TS(typia.llm.parameters): unsupported type detected
+src/examples/llm.parameters.violation.ts:3:1 - error TS(typia.llm.parameters): typia transform error: unsupported type detected
 
 - Recordstringboolean
-  - LLM parameters must be an object type.
   - LLM parameters must not have dynamic keys.
 
-4 typia.llm.parameters<Record<string, boolean>>();
+3 typia.llm.parameters<Record<string, boolean>>();
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-src/examples/llm.parameters.violation.ts:5:1 - error TS(typia.llm.parameters): unsupported type detected
+src/examples/llm.parameters.violation.ts:4:1 - error TS(typia.llm.parameters): typia transform error: unsupported type detected
 
 - Arraynumber
   - LLM parameters must be an object type.
 
-5 typia.llm.parameters<Array<number>>();
+4 typia.llm.parameters<Array<number>>();
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
   </Tabs.Tab>

--- a/website/src/content/docs/llm/schema.mdx
+++ b/website/src/content/docs/llm/schema.mdx
@@ -154,7 +154,7 @@ typia.llm.schema<[number, string]>({});
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash
-src/examples/llm.schema.bigint-and-tuple.ts:3:1 - error TS(typia.llm.schema): unsupported type detected
+src/examples/llm.schema.bigint-and-tuple.ts:3:1 - error TS(typia.llm.schema): typia transform error: unsupported type detected
 
 - bigint
   - LLM schema does not support bigint type.
@@ -162,9 +162,10 @@ src/examples/llm.schema.bigint-and-tuple.ts:3:1 - error TS(typia.llm.schema): un
 3 typia.llm.schema<bigint>({});
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-src/examples/llm.schema.bigint-and-tuple.ts:4:1 - error TS(typia.llm.schema): failed to convert JSON schema to LLM schema.
+src/examples/llm.schema.bigint-and-tuple.ts:4:1 - error TS(typia.llm.schema): typia transform error: unsupported type detected
 
-  - $input.schema: LLM does not allow tuple type.
+- numberstring
+  - LLM schema does not support tuple type.
 
 4 typia.llm.schema<[number, string]>({});
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -172,38 +173,64 @@ src/examples/llm.schema.bigint-and-tuple.ts:4:1 - error TS(typia.llm.schema): fa
   </Tabs.Tab>
 </Tabs>
 
-### No dynamic object keys
+### Dynamic object keys
 
-`Record<string, T>` is not allowed. Convert it to an array of `{ key, value }` pairs:
+`Record<string, T>` compiles, and the emitted definition carries the value type as `additionalProperties`:
+
+<Tabs items={["TypeScript Source", "Emitted Schema"]}>
+  <Tabs.Tab>
+```typescript filename="src/examples/llm.schema.additionalProperties.ts" showLineNumbers
+import typia, { ILlmSchema } from "typia";
+
+const $defs: Record<string, ILlmSchema> = {};
+const schema = typia.llm.schema<Record<string, number>>($defs);
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json
+{
+  "schema": { "$ref": "#/$defs/Recordstringnumber" },
+  "$defs": {
+    "Recordstringnumber": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": { "type": "number" }
+    }
+  }
+}
+```
+  </Tabs.Tab>
+</Tabs>
+
+How far that travels depends on the provider, since a model that ignores `additionalProperties` sees an object with no properties at all. When you want the keys to reach the model, convert the record to an array of `{ key, value }` pairs:
 
 ```typescript
-// not allowed
-typia.llm.schema<Record<string, number>>({});
-
-// recommended
 typia.llm.schema<Array<{ key: string; value: number }>>({});
 ```
 
+Under `strict: true` the record is rejected instead, because the OpenAI structured-output subset the strict schema targets has no `additionalProperties` form to carry it:
+
 <Tabs items={["Source That Won't Compile", "Compiler Errors"]}>
   <Tabs.Tab>
-```typescript filename="src/examples/llm.schema.additionalProperties.ts" showLineNumbers
+```typescript filename="src/examples/llm.schema.additionalProperties.strict.ts" showLineNumbers
 import typia from "typia";
 
-typia.llm.schema<Record<string, number>>({});
+typia.llm.schema<Record<string, number>, { strict: true }>({});
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash
-src/examples/llm.schema.additionalProperties.ts:3:1 - error TS(typia.llm.schema): unsupported type detected
+src/examples/llm.schema.additionalProperties.strict.ts:3:1 - error TS(typia.llm.schema): typia transform error: unsupported type detected
 
 - Recordstringnumber
-  - LLM schema does not support dynamic property in object.
+  - Strict mode does not allow dynamic property in object.
 
 - Recordstringnumber: Recordstringnumber
-  - LLM schema does not support dynamic property in object.
+  - Strict mode does not allow dynamic property in object.
 
-3 typia.llm.schema<Record<string, number>>({});
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+3 typia.llm.schema<Record<string, number>, { strict: true }>({});
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
   </Tabs.Tab>
 </Tabs>

--- a/website/src/content/docs/llm/structuredOutput.mdx
+++ b/website/src/content/docs/llm/structuredOutput.mdx
@@ -219,41 +219,33 @@ Same as [`parameters`](/docs/llm/parameters) and [`schema`](/docs/llm/schema):
 - No dynamic keys (`Record<string, V>`)
 - `T` may not be nullable or optional
 
+A primitive `T` is rejected by TypeScript itself (`TS2344`) before the transform runs, because the signature constrains it to `Record<string, any>`.
+
 <Tabs items={["Source That Won't Compile", "Compiler Errors"]}>
   <Tabs.Tab>
 ```typescript filename="src/examples/llm.structuredOutput.violation.ts" showLineNumbers
 import typia from "typia";
 
-typia.llm.structuredOutput<string>();
 typia.llm.structuredOutput<Record<string, boolean>>();
 typia.llm.structuredOutput<Array<number>>();
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash filename="Terminal"
-src/examples/llm.structuredOutput.violation.ts:3:1 - error TS(typia.llm.structuredOutput): unsupported type detected
-
-- string
-  - LLM parameters must be an object type.
-
-3 typia.llm.structuredOutput<string>();
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-src/examples/llm.structuredOutput.violation.ts:4:1 - error TS(typia.llm.structuredOutput): unsupported type detected
+src/examples/llm.structuredOutput.violation.ts:3:1 - error TS(typia.llm.structuredOutput): typia transform error: unsupported type detected
 
 - Recordstringboolean
-  - LLM parameters must be an object type.
   - LLM parameters must not have dynamic keys.
 
-4 typia.llm.structuredOutput<Record<string, boolean>>();
+3 typia.llm.structuredOutput<Record<string, boolean>>();
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-src/examples/llm.structuredOutput.violation.ts:5:1 - error TS(typia.llm.structuredOutput): unsupported type detected
+src/examples/llm.structuredOutput.violation.ts:4:1 - error TS(typia.llm.structuredOutput): typia transform error: unsupported type detected
 
 - Arraynumber
   - LLM parameters must be an object type.
 
-5 typia.llm.structuredOutput<Array<number>>();
+4 typia.llm.structuredOutput<Array<number>>();
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
   </Tabs.Tab>

--- a/website/src/content/docs/protobuf/message.mdx
+++ b/website/src/content/docs/protobuf/message.mdx
@@ -153,27 +153,30 @@ typia.protobuf.createEncode<Cat | Dog>();
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash
-main.ts:6:1 - error TS(typia.protobuf.message): unsupported type detected
+main.ts:6:1 - error TS(typia.protobuf.message): typia transform error: unsupported type detected
 
 - bigint
   - target type must be a sole and static object type
 
-main.ts:7:1 - error TS(typia.protobuf.createDecode): unsupported type detected
+main.ts:7:1 - error TS(typia.protobuf.createDecode): typia transform error: unsupported type detected
 
 - Record<string, number>
   - target type must be a sole and static object type
 
-main.ts:8:1 - error TS(typia.protobuf.createDecode): unsupported type detected
+main.ts:8:1 - error TS(typia.protobuf.createDecode): typia transform error: unsupported type detected
 
 - Map<(number & Type<"float">), Dog>
   - target type must be a sole and static object type
 
-main.ts:9:1 - error TS(typia.protobuf.createEncode): unsupported type detected
-
-- Array<boolean>
+- (number & Type<"float">)
   - target type must be a sole and static object type
 
-main.ts:10:1 - error TS(typia.protobuf.createEncode): unsupported type detected
+main.ts:9:1 - error TS(typia.protobuf.createEncode): typia transform error: unsupported type detected
+
+- Array<false | true>
+  - target type must be a sole and static object type
+
+main.ts:10:1 - error TS(typia.protobuf.createEncode): typia transform error: unsupported type detected
 
 - (Cat | Dog)
   - target type must be a sole and static object type
@@ -209,29 +212,32 @@ typia.protobuf.message<IPointer<Map<number | string, Dog>>>();
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash
-main.ts:7:1 - error TS(typia.protobuf.message): unsupported type detected
+main.ts:7:1 - error TS(typia.protobuf.message): typia transform error: unsupported type detected
 
-- IPointer<Array<Array<number>>>[key]: Array<Array<number>>
+- IPointer<Array<Array<number>>>.value: Array<Array<number>>
   - does not support over two dimensional array type
 
-main.ts:8:1 - error TS(typia.protobuf.createEncode): unsupported type detected
+main.ts:8:1 - error TS(typia.protobuf.createEncode): typia transform error: unsupported type detected
 
-- IPointer<Record<string, Array<string>>>[key]: Record<string, Array<string>>
+- IPointer<Record<string, string[]>>.value: Record<string, string[]>
   - does not support dynamic object with array value type
 
-main.ts:9:1 - error TS(typia.protobuf.createDecode): unsupported type detected
+- Record<string, string[]>: Record<string, string[]>
+  - does not support dynamic object with array value type
 
-- IPointer<Map<string, Cat | Dog>>[key]: Map<string, (Cat | Dog)>
+main.ts:9:1 - error TS(typia.protobuf.createDecode): typia transform error: unsupported type detected
+
+- IPointer<Map<string, Cat | Dog>>.value: Map<string, (Cat | Dog)>
   - does not support union type in map value type
 
-main.ts:10:1 - error TS(typia.protobuf.message): unsupported type detected
+main.ts:10:1 - error TS(typia.protobuf.message): typia transform error: unsupported type detected
 
-- IPointer<Map<Cat, string>>[key]: Map<Cat, string>
+- IPointer<Map<Cat, string>>.value: Map<Cat, string>
   - does not support non-atomic key typed map
 
-main.ts:11:1 - error TS(typia.protobuf.message): unsupported type detected
+main.ts:11:1 - error TS(typia.protobuf.message): typia transform error: unsupported type detected
 
-- IPointer<Map<string | number, Dog>>[key]: Map<(number | string), Dog>
+- IPointer<Map<string | number, Dog>>.value: Map<(number | string), Dog>
   - does not support union key typed map
   - does not support non-atomic key typed map
 ````
@@ -270,7 +276,7 @@ typia.protobuf.message<Something>();
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash
-main.ts:13:1 - error TS(typia.protobuf.message): unsupported type detected
+main.ts:13:1 - error TS(typia.protobuf.message): typia transform error: unsupported type detected
 
 - Something.any: any
   - does not support any type
@@ -283,8 +289,8 @@ main.ts:13:1 - error TS(typia.protobuf.message): unsupported type detected
 
 - Something.dict: (Set<string> | WeakMap | WeakSet)
   - does not support Set type
-  - does not support WeakSet type. Use Array type instead.
   - does not support WeakMap type. Use Map type instead.
+  - does not support WeakSet type. Use Array type instead.
 
 - Something.date: Date
   - does not support Date type. Use string type instead.


### PR DESCRIPTION
## Intent

One unified cycle pull request for the solo issue campaign frozen at
`88fafb36f2`. It owns the complete accepted cycle; nothing is deferred to a
second pull request.

| Issue | Scope |
| --- | --- |
| #2285 | protobuf transform diagnostics report `TS(typia.protobuf.typia.protobuf.encode)`; `tests/test-error` only checks the `TS(typia.` prefix |
| #2287 | `_randomFormatDate` / `_randomFormatDatetime` discard their declared `maximum` prop through `??` / `===` precedence |
| #2284 | `typia.random<string & Format<F> & MinLength/MaxLength>` throws for nine formats although the requested length is one their own validator accepts |
| #2286 | documented "Compiler Errors" tabs no longer match what typia emits, and one documented restriction no longer exists |
| #2288 | `project` skill Layout omits `tests/test-typia-bundler-cache` |

## Order

`#2285 → #2286` (the documentation records the corrected diagnostic code) and
`#2287 → #2284` (both touch the date/datetime generators). `#2288` is
independent.

## Verification

Pending. This body is the claim written before any code exists; per-commit
progress is recorded as comments, and each commit closes the issues it earns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mc91ztDB5qujoSxLvfEgBQ
