### PR TITLE
chore(deps): make the ttsc catalog a single anchored declaration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     # experiments/* are not pnpm workspace members, so their manifests are
-    # invisible to the root scan; list them so the ttsc family cannot drift
-    # there again (grouping spans directories, keeping one PR per family bump).
+    # invisible to the root scan; list them so ttsc cannot drift there again.
     directories:
       - "/"
       - "/experiments/mcp"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,18 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    # The @ttsc/* companions (playground, unplugin, wasm) are deliberately
+    # absent. pnpm-workspace.yaml binds the whole family to the &ttsc anchor,
+    # so their catalog entries are YAML aliases carrying no version to rewrite;
+    # asking Dependabot to bump them made it give up on the workspace file and
+    # write the version into the lockfile alone. Allowing ttsc by itself leaves
+    # the anchor line as the single edit, and the aliases follow it.
     allow:
       - dependency-name: "typescript"
       - dependency-name: "ttsc"
-      - dependency-name: "@ttsc/*"
-    # ttsc and the @ttsc/* companions (playground, unplugin, wasm) release in
-    # lockstep; bumping them separately leaves the catalog on mixed versions.
+    # ttsc is declared in the root catalog and in both experiments manifests;
+    # group it so one release opens one pull request across all three.
     groups:
       ttsc:
         patterns:
           - "ttsc"
-          - "@ttsc/*"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "bumpp": "^10.4.1",
     "prettier": "^3.8.1",
-    "prettier-plugin-jsdoc": "^1.8.0",
-    "ttsc": "catalog:typescript"
+    "prettier-plugin-jsdoc": "^1.8.0"
   }
 }

--- a/packages/typia/native/go.mod
+++ b/packages/typia/native/go.mod
@@ -5,7 +5,7 @@ go 1.26
 // Build-time floor: the driver reference-graph SDK
 // (driver.NewTransformGraph / driver.TransformGraph / driver.TransformOutputKey)
 // this plugin consumes exists only in ttsc >= 0.19.2. That floor is enforced
-// through typia's package.json peerDependencies (ttsc / @ttsc/unplugin), not
+// through typia's package.json peerDependencies (ttsc), not
 // here: ttsc builds this plugin from source on the user's machine and its
 // buildSourcePlugin generates `replace github.com/samchon/ttsc/packages/ttsc
 // v0.0.0 => <installed ttsc root>`, so the require below must stay v0.0.0 or the

--- a/packages/typia/native/go.mod
+++ b/packages/typia/native/go.mod
@@ -5,10 +5,10 @@ go 1.26
 // Build-time floor: the driver reference-graph SDK
 // (driver.NewTransformGraph / driver.TransformGraph / driver.TransformOutputKey)
 // this plugin consumes exists only in ttsc >= 0.19.2. That floor is enforced
-// through typia's package.json peerDependencies (ttsc), not
-// here: ttsc builds this plugin from source on the user's machine and its
-// buildSourcePlugin generates `replace github.com/samchon/ttsc/packages/ttsc
-// v0.0.0 => <installed ttsc root>`, so the require below must stay v0.0.0 or the
+// through typia's package.json `ttsc` peerDependency, not here: ttsc builds
+// this plugin from source on the user's machine and its buildSourcePlugin
+// generates `replace github.com/samchon/ttsc/packages/ttsc v0.0.0 =>
+// <installed ttsc root>`, so the require below must stay v0.0.0 or the
 // generated replace no longer matches and the plugin build fails to resolve.
 require (
 	github.com/microsoft/typescript-go/shim/ast v0.0.0

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -43,13 +43,9 @@
     "tinyglobby": "^0.2.12"
   },
   "peerDependencies": {
-    "@ttsc/unplugin": ">=0.19.2",
     "ttsc": ">=0.19.2"
   },
   "peerDependenciesMeta": {
-    "@ttsc/unplugin": {
-      "optional": true
-    },
     "ttsc": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,9 +70,6 @@ importers:
       prettier-plugin-jsdoc:
         specifier: ^1.8.0
         version: 1.8.0(prettier@3.8.3)
-      ttsc:
-        specifier: catalog:typescript
-        version: 0.19.2
 
   benchmark:
     dependencies:
@@ -311,9 +308,6 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
-      '@ttsc/unplugin':
-        specifier: '>=0.19.2'
-        version: 0.19.2(ttsc@0.19.2)
       '@typia/interface':
         specifier: workspace:^
         version: link:../interface

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,19 +13,15 @@ overrides:
   zod@4: 4.1.12
 catalogs:
   typescript:
-    # typia's native transform consults ttsc's reference-graph SDK (ttsc >=
-    # 0.19.2), and @ttsc/unplugin reads the resulting `graph` envelope, so both
-    # move to 0.19.2 together (@ttsc/unplugin 0.19.2 peers on ttsc 0.19.2).
-    ttsc: ^0.19.2
-    '@ttsc/unplugin': ^0.19.2
-    # @ttsc/wasm / @ttsc/playground drive only the website's in-browser
-    # playground, which links ttsc's wasm host Go API — unrelated to the graph
-    # SDK. website.yml clones the ttsc sibling at the installed @ttsc/wasm
-    # version to build that host, so these two pin the Go host API the
-    # playground compiles against: they move only together with
-    # website/compiler/cmd/playground, which implements host.Plugin.
-    '@ttsc/playground': ^0.19.2
-    '@ttsc/wasm': ^0.19.2
+    # The ttsc family releases in lockstep, so the whole family takes its
+    # version from the &ttsc anchor: set it on ttsc alone. @ttsc/unplugin peers
+    # on its exact matching ttsc, and website.yml clones the ttsc sibling at
+    # the installed @ttsc/wasm version to build the browser-playground host
+    # that website/compiler/cmd/playground implements.
+    ttsc: &ttsc ^0.19.2
+    '@ttsc/unplugin': *ttsc
+    '@ttsc/playground': *ttsc
+    '@ttsc/wasm': *ttsc
     ts-node: ^10.9.2
     typescript: ^7.0.2
   rolldown:

--- a/website/src/content/docs/setup/index.mdx
+++ b/website/src/content/docs/setup/index.mdx
@@ -14,7 +14,7 @@ typia is a compile-time transformer, so your build has to run through the TypeSc
 
 > [!IMPORTANT]
 >
-> typia's native transform requires [`ttsc`](https://github.com/samchon/ttsc) **0.19.2 or newer**. ttsc builds typia's plugin from source against your installed ttsc, and the plugin consults ttsc's host-owned reference-graph SDK (added in ttsc 0.19.2) so bundler caches and watch mode invalidate generated validators soundly. On an older ttsc the plugin build fails to compile. This floor is declared through typia's optional `peerDependencies`, so an older `ttsc` (or `@ttsc/unplugin`) already in your project surfaces an npm version-mismatch warning; type-only consumers that install neither are unaffected.
+> typia's native transform requires [`ttsc`](https://github.com/samchon/ttsc) **0.19.2 or newer**. On an older ttsc the transform fails to build.
 
 ## Install
 
@@ -54,8 +54,6 @@ Keep the TypeScript project strict:
   }
 }
 ```
-
-`ttsc` discovers the typia transform from the `ttsc` field in `typia/package.json`, so the default setup does not require a typia entry in `compilerOptions.plugins`.
 
 ## Build
 


### PR DESCRIPTION
## Intent

Every ttsc bump Dependabot has opened since the pnpm catalog landed was closed unmerged. This makes the ttsc version a single anchored declaration and removes the two things that made Dependabot produce an unmergeable diff.

## Why the Dependabot PRs failed

Two distinct failures, both reproducible in the closed PRs:

**Anchor present (#2065).** Dependabot touched `pnpm-lock.yaml` only, never `pnpm-workspace.yaml`. It could not rewrite a version behind a YAML alias, so it wrote the new version into the one literal foothold it had — the root importer's `ttsc` specifier — and left the catalog at the old version.

**Anchor absent (#2019, #2065, #2282).** Dependabot updated both files correctly except for the root importer, where it rewrote `specifier: catalog:typescript` into a literal range while the root `package.json` kept the catalog reference. Nested workspace importers were fine.

Either way CI died at the first step:

```
ERR_PNPM_OUTDATED_LOCKFILE
specifiers in the lockfile ({... "ttsc":"^0.19.3"})
don't match specs in package.json ({... "ttsc":"catalog:typescript"})
```

## Scope

**`@ttsc/unplugin` peer dependency removed from `packages/typia`.** typia has no reference to it anywhere in `src/` — the bundler plugin reads typia's transform output, not the reverse. The entry was also redundant: `@ttsc/unplugin@X` peers on `ttsc: "X"` exactly, so typia's `ttsc >= 0.19.2` already excludes every unplugin release below that floor. The `ttsc` optional peer stays; `packages/typia/native` consumes `driver.LoadProgram`, `driver.NewTransformGraph`, `driver.TransformOutputKey`, and `prog.EmitWithPluginTransformers`, which exist only in ttsc 0.19.2+. The `native/go.mod` comment naming both peers is updated.

**Root `package.json` ttsc entry removed.** It was the only root-level catalog reference, and therefore the foothold Dependabot corrupted. Nothing at the root ran ttsc: no script in `package.json`, no `scripts/` reference, no workflow invocation — the workflows name `node_modules/.cache/ttsc`, which is the plugin cache path, not the binary.

**ttsc catalog family bound to one `&ttsc` anchor.** The version is declared once on `ttsc`; `@ttsc/unplugin`, `@ttsc/playground`, and `@ttsc/wasm` alias it. This restores the arrangement from `b9d256c16`, which #2140 unwound to hold `@ttsc/wasm` back during the playground host API migration — a split #2143 has since made unnecessary. The two comment blocks justifying the split are replaced by one describing the lockstep.

**Dependabot allow list narrowed to `typescript` and `ttsc`.** The `@ttsc/*` catalog entries are now aliases with no version to rewrite, so asking Dependabot to bump them is what made it abandon the workspace file. Bumping the anchor line alone carries the family, and every `@ttsc/*` consumer resolves through the catalog: `config/`, `tests/test-typia-bundler-cache/`, and `website/`. Neither `experiments/mcp` nor `experiments/smoke` declares any `@ttsc/*`, so no manifest loses coverage. The group is kept because `ttsc` is also declared literally in both experiments manifests and one release should still open one pull request.

**Setup guide digressions cut.** The ttsc floor note explained the reference-graph SDK, bundler cache invalidation, peer declaration mechanics, the npm warning surface, and the type-only consumer exception; a reader installing typia acts on one fact. The note describing how ttsc discovers the transform from typia's own `package.json` was internal detail whose actionable half already opens Transform Options.

## Verification

Local build and test runs were prohibited for this change, so CI is the verification surface. What was checked locally:

- `pnpm install` regenerated the lockfile; its only content changes are the two removed importer entries.
- `pnpm-workspace.yaml` parsed with `yaml`: all four family entries resolve to `^0.19.2`, identical to the pre-anchor literals, so the lockfile needs no version change.
- `pnpm format` produced changes in four files unrelated to this work — `packages/typia/src/executable/FileSystemIdentity.ts`, `tests/test-typia-generate/scripts/identity/inode-precision.ts`, and the two `test_*_tool_error_single_json_fence.ts` suites. They are JSDoc rewraps left by earlier commits that did not run the formatter. They are reverted and excluded from this branch rather than folded in silently, and they still need a separate formatting pass on master.

## Deferred

Whether Dependabot preserves `&ttsc` when it rewrites the anchor line is unverified — it cannot be exercised locally. If it drops the anchor, the three `*ttsc` aliases become undefined and `pnpm-workspace.yaml` fails to parse, which surfaces loudly in that PR's install step rather than silently. The next daily run settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
