### PR TITLE
fix(llm): report the schema configuration the call site declared

### DIFF
--- a/packages/interface/src/schema/ILlmApplication.ts
+++ b/packages/interface/src/schema/ILlmApplication.ts
@@ -109,6 +109,16 @@ export namespace ILlmApplication {
     ILlmApplication<Class>,
     "config" | "functions"
   > {
+    /**
+     * Schema configuration the call site declared.
+     *
+     * The transform resolves it from the `Config` generic and emits it here,
+     * because it is the only place that knows it. The runtime finalizer widens
+     * it into {@link ILlmApplication.config} by adding the `validate` hook, so a
+     * consumer reading `application.config.strict` sees what the schemas were
+     * actually built with.
+     */
+    config: ILlmSchema.IConfig;
     functions: Omit<ILlmFunction, "parse" | "coerce">[];
   }
 }

--- a/packages/mcp/src/internal/McpControllerRegistrar.ts
+++ b/packages/mcp/src/internal/McpControllerRegistrar.ts
@@ -43,13 +43,12 @@ export namespace McpControllerRegistrar {
               // description tags instead of keywords, and only that config
               // tells the inverter to read them back.
               //
-              // An HttpLlm application reports the config it was composed with,
-              // so this is exact for it. A typia.llm.controller reports
-              // `strict: false` whatever its Config generic said — a transform
-              // defect, not a reason to guess here: guessing is what erased the
-              // non-strict constraints in the first place. This reads the
-              // declared config and becomes exact for class controllers too the
-              // moment the transform reports it truthfully.
+              // Both application kinds report the config they were built with:
+              // an HttpLlm application the one it was composed with, and a
+              // typia.llm.application or .controller the one its `Config`
+              // generic declared (issue #2293 — until that landed, a strict
+              // class controller reported `strict: false` and every constraint
+              // vanished from this check).
               LlmJson.validate(
                 func.output,
                 true,

--- a/packages/typia/native/core/programmers/llm/LlmApplicationProgrammer.go
+++ b/packages/typia/native/core/programmers/llm/LlmApplicationProgrammer.go
@@ -240,7 +240,15 @@ func (llmApplicationProgrammerNamespace) WriteApplication(props struct {
       functions = append(functions, written)
     }
   }
-  result := map[string]any{"functions": functions}
+  // The call site's schema configuration is resolved here and nowhere else, so
+  // it travels with the emitted application; the runtime finalizer only adds
+  // the validate hook to it. Rebuilding it at runtime reported `strict: false`
+  // for a strict build (issue #2293).
+  strict, _ := props.Config["strict"].(bool)
+  result := map[string]any{
+    "config":    map[string]any{"strict": strict},
+    "functions": functions,
+  }
   if len(metadata.Objects) != 0 {
     if object := metadata.Objects[0].Type; object != nil {
       if description := llmApplicationProgrammer_describe(object.Description, object.JsDocTags); description != nil && len(*description) != 0 {

--- a/packages/typia/src/internal/_llmApplicationFinalize.ts
+++ b/packages/typia/src/internal/_llmApplicationFinalize.ts
@@ -7,7 +7,12 @@ export const _llmApplicationFinalize = <Class extends object = any>(
 ): ILlmApplication<Class> => ({
   ...app,
   config: {
-    ...LlmSchemaConverter.getConfig(),
+    // The schema configuration comes from the emitted application, which is
+    // where the `Config` generic was resolved. Rebuilding it from the
+    // converter's defaults reported `strict: false` for a strict build, and
+    // `@typia/mcp` then inverted a strict output schema without strict, which
+    // drops every constraint it carries as a description tag (issue #2293).
+    ...LlmSchemaConverter.getConfig(app.config),
     validate: config?.validate ?? null,
   },
   functions: app.functions.map((func) => ({

--- a/tests/test-mcp/src/features/test_mcp_tool_output_constraint_enforcement.ts
+++ b/tests/test-mcp/src/features/test_mcp_tool_output_constraint_enforcement.ts
@@ -18,13 +18,12 @@ import typia, { tags } from "typia";
  * application's own config — and every property here is documented, because a
  * description is exactly what used to make the non-strict keywords disappear.
  *
- * The strict controller's `config.strict` is corrected before it is served.
- * `typia.llm.application`/`controller` emit `config: { strict: false }`
- * whatever the `Config` generic says, even while shifting the constraints into
- * the description — the emitted config contradicts the schema beside it,
- * against `ILlmApplication.config`'s own contract. That is a separate transform
- * defect; this case pins the registrar's plumbing against the config the
- * contract promises rather than the one typia currently emits.
+ * The strict controller is served exactly as typia emits it. It used to need
+ * its `config.strict` corrected by hand, because the emitted application
+ * reported `strict: false` whatever the `Config` generic said while shifting
+ * the constraints into the description — the config contradicted the schema
+ * beside it (issue #2293). With the reported config truthful, that correction
+ * would hide the very regression this case exists to catch.
  *
  * 1. Serve the same documented controller twice, once non-strict and once strict.
  * 2. Assert a conforming result is accepted and shipped as structured content.
@@ -38,7 +37,11 @@ export const test_mcp_tool_output_constraint_enforcement =
       ConstraintController,
       { strict: true }
     >("constraint", new ConstraintController());
-    strict.application.config.strict = true;
+    TestValidator.equals(
+      "a strict controller reports the config it was built with",
+      strict.application.config.strict,
+      true,
+    );
 
     const controllers: [string, ILlmController][] = [
       [

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_application_reported_config.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_application_reported_config.ts
@@ -1,0 +1,111 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmApplication } from "@typia/interface";
+import { LlmJson } from "@typia/utils";
+import typia, { tags } from "typia";
+
+interface IApplication {
+  /** Create a member. */
+  create(props: { input: { title: string } }): Promise<{
+    /** How the member scored. */
+    score: number & tags.Minimum<0> & tags.Maximum<100>;
+  }>;
+}
+
+class Service implements IApplication {
+  public async create(_props: { input: { title: string } }): Promise<{
+    score: number & tags.Minimum<0> & tags.Maximum<100>;
+  }> {
+    return { score: 1 };
+  }
+}
+
+/**
+ * Verifies an LLM application reports the schema configuration it was built
+ * with.
+ *
+ * `_llmApplicationFinalize` rebuilt `config` from
+ * `LlmSchemaConverter.getConfig()`, the converter's defaults, so every
+ * application and controller reported `strict: false` however its `Config`
+ * generic read. That is not a cosmetic field: a strict schema carries its
+ * constraints as `@minimum`-style description tags rather than as keywords, and
+ * the inverter only reads them back when told the schema is strict.
+ * `@typia/mcp` validates every tool result with the reported config, so a
+ * strict controller accepted output that violated its own declared range
+ * (#2293).
+ *
+ * The consequence assertion is what makes this test fail before the fix; the
+ * reported flag alone could be satisfied by a constant.
+ *
+ * 1. Read the reported config from an application and a controller, strict and
+ *    default.
+ * 2. Require it to match the declared `Config`, with the `validate` hook
+ *    unaffected.
+ * 3. Invert each output schema with the reported config and require an
+ *    out-of-range value to be rejected in both modes.
+ */
+export const test_llm_application_reported_config = (): void => {
+  const strict: ILlmApplication = typia.llm.application<
+    IApplication,
+    { strict: true }
+  >();
+  const loose: ILlmApplication = typia.llm.application<IApplication>();
+
+  // POSITIVE: the declared configuration is what gets reported.
+  TestValidator.equals(
+    "strict application reports strict",
+    strict.config.strict,
+    true,
+  );
+  TestValidator.equals(
+    "default application reports non-strict",
+    loose.config.strict,
+    false,
+  );
+  TestValidator.equals(
+    "strict controller reports strict",
+    typia.llm.controller<Service, { strict: true }>("service", new Service())
+      .application.config.strict,
+    true,
+  );
+  TestValidator.equals(
+    "default controller reports non-strict",
+    typia.llm.controller<Service, {}>("service", new Service()).application
+      .config.strict,
+    false,
+  );
+
+  // CONTROL: the runtime validate hook keeps its own meaning.
+  TestValidator.equals(
+    "no validate hook is reported as null",
+    loose.config.validate,
+    null,
+  );
+  TestValidator.equals(
+    "a validate hook is reported",
+    typia.llm.application<IApplication>({
+      validate: {
+        create: () => ({ success: true, data: { input: { title: "x" } } }),
+      },
+    }).config.validate !== null,
+    true,
+  );
+
+  // CONSEQUENCE: inverting with the reported config must keep the constraints.
+  for (const [label, app] of [
+    ["strict", strict],
+    ["default", loose],
+  ] as const) {
+    const func = app.functions.find((f) => f.name === "create")!;
+    const validate = LlmJson.validate(func.output!, true, app.config);
+    TestValidator.equals(
+      `${label} output rejects a score above the maximum`,
+      validate({ score: 500 }).success,
+      false,
+    );
+    TestValidator.equals(
+      `${label} output accepts a score inside the range`,
+      validate({ score: 50 }).success,
+      true,
+    );
+  }
+};


### PR DESCRIPTION
## Intent

Cycle 2 of the solo issue campaign, frozen at `3255792cd7`. One issue survived
round 2's verification, and this pull request owns it.

| Issue | Scope |
| --- | --- |
| #2293 | `ILlmApplication.config` always reported `strict: false`, so `@typia/mcp` validated a strict tool's output with every constraint dropped |

## What changed

The transform resolves the `Config` generic and is the only place that knows it,
so it now travels with the emitted application: `WriteApplication` emits
`config: { strict }`, `ILlmApplication.__IPrimitive` carries it, and
`_llmApplicationFinalize` widens it with the `validate` hook instead of
rebuilding it from `LlmSchemaConverter.getConfig()`.

`tests/test-mcp/src/features/test_mcp_tool_output_constraint_enforcement.ts` had
been assigning `strict.application.config.strict = true` by hand, with a comment
naming the defect. That line is gone, so the case now proves the whole path, and
the `McpControllerRegistrar` comment that told readers to expect a wrong value is
corrected.

## Verification

- `test_llm_application_reported_config` (new): the reported config for
  application and controller, strict and default, the `validate` hook controls,
  and the consequence — inverting each output schema with the reported config
  must reject an out-of-range value.
- Mutation: restoring `LlmSchemaConverter.getConfig()` fails both the new case
  (`strict application reports strict`) and the MCP case (`a strict controller
  reports the config it was built with`).
- Local `pnpm build` and `pnpm test` are running; CI gates this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mc91ztDB5qujoSxLvfEgBQ
