### PR TITLE
fix(json): spell an exclusive bound the way the 3.0 dialect defines it

### DIFF
--- a/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader.go
+++ b/packages/typia/native/core/programmers/iterate/openapi_v3_downgrader.go
@@ -454,7 +454,40 @@ func openApiV3Downgrader_omit_examples(schema JsonSchema) JsonSchema {
     }
     output[key] = value
   }
-  return output
+  return openApiV3Downgrader_exclusive_bounds(output)
+}
+
+// openApiV3Downgrader_exclusive_bounds rewrites an exclusive numeric bound into
+// the form the 3.0 dialect defines.
+//
+// 3.0's Schema Object descends from JSON Schema draft-04, where
+// `exclusiveMinimum` and `exclusiveMaximum` are booleans qualifying `minimum`
+// and `maximum`; the numeric spelling belongs to 3.1. Carrying the number
+// through left a document that declares itself 3.0 with a 3.1 keyword, and a
+// 3.0 reader taking the value as the boolean its dialect declares finds no
+// `minimum` beside it and drops the bound entirely (#2300).
+//
+// The upgrader already performs the inverse — a boolean `exclusiveMinimum: true`
+// becomes the numeric bound and the redundant `minimum` is dropped — so this
+// makes the pair a round trip.
+func openApiV3Downgrader_exclusive_bounds(schema JsonSchema) JsonSchema {
+  for _, pair := range [][2]string{
+    {"exclusiveMinimum", "minimum"},
+    {"exclusiveMaximum", "maximum"},
+  } {
+    value, ok := schema[pair[0]]
+    if ok == false {
+      continue
+    }
+    if _, boolean := value.(bool); boolean {
+      continue
+    }
+    if openApiV3Downgrader_is_nil(value) == false {
+      schema[pair[1]] = value
+      schema[pair[0]] = true
+    }
+  }
+  return schema
 }
 
 // openApiV3Downgrader_shallow_clone copies a schema's own keys, leaving nested

--- a/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
+++ b/packages/utils/src/converters/internal/OpenApiV3Downgrader.ts
@@ -420,7 +420,34 @@ export namespace OpenApiV3Downgrader {
     schema: Schema,
   ): Omit<Schema, "examples"> => {
     const { examples: _examples, ...rest } = schema;
-    return rest;
+    return exclusiveBounds(rest);
+  };
+
+  /**
+   * Rewrites an exclusive numeric bound into the form the 3.0 dialect defines.
+   *
+   * 3.0's Schema Object descends from JSON Schema draft-04, where
+   * `exclusiveMinimum` and `exclusiveMaximum` are booleans qualifying `minimum`
+   * and `maximum`; the numeric spelling belongs to 3.1. Carrying the number
+   * through left a document that declares itself 3.0 with a 3.1 keyword, and a
+   * 3.0 reader taking the value as the boolean its dialect declares finds no
+   * `minimum` beside it and drops the bound entirely (#2300).
+   *
+   * {@link OpenApiV3Upgrader} already performs the inverse, so this makes the
+   * pair a round trip.
+   */
+  const exclusiveBounds = <Schema extends object>(schema: Schema): Schema => {
+    const target = schema as Record<string, unknown>;
+    for (const [exclusive, inclusive] of [
+      ["exclusiveMinimum", "minimum"],
+      ["exclusiveMaximum", "maximum"],
+    ] as const) {
+      const value: unknown = target[exclusive];
+      if (typeof value !== "number") continue;
+      target[inclusive] = value;
+      target[exclusive] = true;
+    }
+    return schema;
   };
 
   const isNullable =

--- a/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_exclusive_bounds.ts
+++ b/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_exclusive_bounds.ts
@@ -1,0 +1,143 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { tags } from "typia";
+
+interface IBounds {
+  /** Exclusive on both ends. */
+  ratio: number & tags.ExclusiveMinimum<0> & tags.ExclusiveMaximum<1>;
+  /** Exclusive below, inclusive above. */
+  mixed: number & tags.ExclusiveMinimum<0> & tags.Maximum<10>;
+  /** Inclusive on both ends — the negative twin. */
+  plain: number & tags.Minimum<0> & tags.Maximum<10>;
+  /** A bound of zero, the value a boolean coercion reads as false. */
+  zero: number & tags.ExclusiveMinimum<0>;
+  /** Inside an array. */
+  list: Array<number & tags.ExclusiveMaximum<5>>;
+  /** Inside a union member. */
+  either: (number & tags.ExclusiveMinimum<1>) | string;
+}
+
+/**
+ * Verifies a document emitted for OpenAPI 3.0 spells an exclusive bound the way
+ * that dialect defines it.
+ *
+ * The 3.0 Schema Object descends from JSON Schema draft-04, where
+ * `exclusiveMinimum` and `exclusiveMaximum` are booleans qualifying `minimum`
+ * and `maximum`; the numeric spelling belongs to 3.1. The downgrader carried
+ * the number through, so a document labelled 3.0 held a 3.1 keyword with no
+ * `minimum` beside it — and a 3.0 reader taking the value as the boolean its
+ * dialect declares drops the bound entirely (#2300).
+ *
+ * The oracle here is the 3.0 dialect, not the other downgrader. `@typia/utils`
+ * and the Go port are pinned against each other by
+ * `test_json_schemas_v3_0_parity_converter`, and both read this rule the same
+ * wrong way, so that oracle agreed with itself.
+ *
+ * 1. Emit the same type for "3.1" and for "3.0".
+ * 2. Require the 3.1 document to keep the numeric form, and the 3.0 document to
+ *    carry a boolean beside the inclusive keyword it qualifies.
+ * 3. Require no numeric `exclusive*` to survive anywhere in the 3.0 document, at
+ *    any depth.
+ */
+export const test_json_schemas_v3_0_exclusive_bounds = (): void => {
+  const v31 = typia.json.schemas<[IBounds], "3.1">();
+  const v30 = typia.json.schemas<[IBounds], "3.0">();
+  const props31: any = (v31.components as any).schemas.IBounds.properties;
+  const props30: any = (v30.components as any).schemas.IBounds.properties;
+
+  // 3.1 keeps the numeric form it always had.
+  TestValidator.equals(
+    "3.1 keeps a numeric exclusiveMinimum",
+    props31.ratio.exclusiveMinimum,
+    0,
+  );
+  TestValidator.equals(
+    "3.1 keeps a numeric exclusiveMaximum",
+    props31.ratio.exclusiveMaximum,
+    1,
+  );
+
+  // 3.0 spells the same bound as a boolean beside the inclusive keyword.
+  TestValidator.equals(
+    "3.0 exclusive bounds become boolean flags",
+    {
+      minimum: props30.ratio.minimum,
+      exclusiveMinimum: props30.ratio.exclusiveMinimum,
+      maximum: props30.ratio.maximum,
+      exclusiveMaximum: props30.ratio.exclusiveMaximum,
+    },
+    { minimum: 0, exclusiveMinimum: true, maximum: 1, exclusiveMaximum: true },
+  );
+  TestValidator.equals(
+    "3.0 keeps an inclusive bound beside an exclusive one",
+    {
+      minimum: props30.mixed.minimum,
+      exclusiveMinimum: props30.mixed.exclusiveMinimum,
+      maximum: props30.mixed.maximum,
+      exclusiveMaximum: props30.mixed.exclusiveMaximum,
+    },
+    {
+      minimum: 0,
+      exclusiveMinimum: true,
+      maximum: 10,
+      exclusiveMaximum: undefined,
+    },
+  );
+
+  // NEGATIVE TWIN: an inclusive-only leaf gains no flag in either dialect.
+  TestValidator.equals(
+    "an inclusive bound stays inclusive",
+    {
+      minimum: props30.plain.minimum,
+      exclusiveMinimum: props30.plain.exclusiveMinimum,
+      maximum: props30.plain.maximum,
+      exclusiveMaximum: props30.plain.exclusiveMaximum,
+    },
+    {
+      minimum: 0,
+      exclusiveMinimum: undefined,
+      maximum: 10,
+      exclusiveMaximum: undefined,
+    },
+  );
+
+  // BOUNDARY: a bound of zero is the case a boolean coercion reads as false.
+  TestValidator.equals(
+    "a zero bound survives as a flag",
+    {
+      minimum: props30.zero.minimum,
+      exclusiveMinimum: props30.zero.exclusiveMinimum,
+    },
+    { minimum: 0, exclusiveMinimum: true },
+  );
+
+  // The rule holds at depth, not only on a top-level property.
+  TestValidator.equals(
+    "an array element carries the 3.0 form",
+    {
+      maximum: props30.list.items.maximum,
+      exclusiveMaximum: props30.list.items.exclusiveMaximum,
+    },
+    { maximum: 5, exclusiveMaximum: true },
+  );
+
+  // STRUCTURAL: nothing numeric may survive anywhere in the 3.0 document.
+  const offenders: string[] = [];
+  const walk = (node: any, path: string): void => {
+    if (node === null || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      node.forEach((item, index) => walk(item, `${path}[${index}]`));
+      return;
+    }
+    for (const key of ["exclusiveMinimum", "exclusiveMaximum"] as const)
+      if (node[key] !== undefined && typeof node[key] !== "boolean")
+        offenders.push(`${path}.${key} = ${JSON.stringify(node[key])}`);
+    for (const [key, value] of Object.entries(node))
+      walk(value, `${path}.${key}`);
+  };
+  walk(v30, "$");
+  TestValidator.equals(
+    `no numeric exclusive bound survives (${offenders[0] ?? "none"})`,
+    offenders.length,
+    0,
+  );
+};

--- a/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_exclusive_bounds.ts
+++ b/tests/test-typia-schema/src/features/json.schemas/test_json_schemas_v3_0_exclusive_bounds.ts
@@ -23,7 +23,7 @@ interface IBounds {
  * The 3.0 Schema Object descends from JSON Schema draft-04, where
  * `exclusiveMinimum` and `exclusiveMaximum` are booleans qualifying `minimum`
  * and `maximum`; the numeric spelling belongs to 3.1. The downgrader carried
- * the number through, so a document labelled 3.0 held a 3.1 keyword with no
+ * the number through, so a document labeled 3.0 held a 3.1 keyword with no
  * `minimum` beside it — and a 3.0 reader taking the value as the boolean its
  * dialect declares drops the bound entirely (#2300).
  *


### PR DESCRIPTION
## Intent

Cycle 5 of the solo issue campaign, frozen at `27ade5897e` (round 5 discovery).

| Issue | Scope |
| --- | --- |
| #2300 | a document emitted for `"3.0"` carried the 3.1 numeric `exclusiveMinimum`/`exclusiveMaximum`, so a 3.0 reader loses the bound entirely |

## What changed

Both downgraders — the Go port in
`core/programmers/iterate/openapi_v3_downgrader.go` and `@typia/utils`'
`OpenApiV3Downgrader` — now rewrite a numeric exclusive bound into the boolean
flag beside the inclusive keyword it qualifies. They had to move together, and
`test_json_schemas_v3_0_parity_converter` is the witness that they did.

## Why the existing oracle could not see it

`openapi_v3_downgrader.go` describes itself as a deliberately literal port, and
the parity test pins the two implementations against each other on every emitted
construct. Both read this rule the same wrong way, so that oracle agreed with
itself. The upgrader, meanwhile, already converted the boolean form to the
numeric one — so `3.0 → emended → 3.0` was not a round trip, which is the
asymmetry that settles which side was wrong.

## Verification

- `test_json_schemas_v3_0_exclusive_bounds` (new) takes its expectations from the
  3.0 dialect, not from the other implementation: the boolean form at the top
  level, inside an array element, and for a zero bound — the value a boolean
  coercion reads as false; an inclusive-only leaf as the negative twin; the 3.1
  document keeping the numeric form as the control; and a structural assertion
  that no numeric `exclusive*` survives anywhere in the 3.0 output.
- `pnpm --filter ./tests/test-typia-schema start` and
  `pnpm --filter ./tests/test-utils start` both pass, including the parity test.
- Root `pnpm build` and `pnpm test` gate this head, on ttsc 0.19.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mc91ztDB5qujoSxLvfEgBQ
