### PR TITLE
fix(langchain): check a tool result against the output type it declared

### DIFF
--- a/packages/langchain/src/internal/LangChainToolsRegistrar.ts
+++ b/packages/langchain/src/internal/LangChainToolsRegistrar.ts
@@ -9,6 +9,7 @@ import {
   IHttpLlmFunction,
   ILlmController,
   ILlmFunction,
+  ILlmSchema,
   IValidation,
 } from "@typia/interface";
 import { HttpLlm, LlmJson } from "@typia/utils";
@@ -82,6 +83,7 @@ export namespace LangChainToolsRegistrar {
         createTool({
           name: toolName,
           function: func,
+          config: controller.application.config,
           execute: async (args: unknown) => method.call(execute, args),
         }),
       );
@@ -103,6 +105,7 @@ export namespace LangChainToolsRegistrar {
         createTool({
           name: toolName,
           function: func,
+          config: application.config,
           execute: async (args: unknown) => {
             if (controller.execute !== undefined) {
               const response = await controller.execute({
@@ -128,9 +131,25 @@ export namespace LangChainToolsRegistrar {
   const createTool = (entry: {
     name: string;
     function: ILlmFunction | IHttpLlmFunction;
+    config: ILlmSchema.IConfig;
     execute: (args: unknown) => Promise<unknown>;
-  }): DynamicStructuredTool =>
-    tool(
+  }): DynamicStructuredTool => {
+    // A declared return type is a promise to the model, so a result that breaks
+    // it is reported rather than delivered. `@typia/mcp` and `@typia/vercel`
+    // already refuse one; this tool consulted `output` for its existence alone,
+    // so a method returning nothing was reported while a method returning the
+    // wrong shape was not (#2302).
+    //
+    // The application's own config decides how the schema is read back: a
+    // strict application carries its constraints as description tags instead of
+    // keywords, and only that config tells the inverter to read them.
+    const validateOutput:
+      | ((output: unknown) => IValidation<unknown>)
+      | undefined =
+      entry.function.output === undefined
+        ? undefined
+        : LlmJson.validate(entry.function.output, true, entry.config);
+    return tool(
       async (args: unknown): Promise<unknown> => {
         const valid: IValidation<unknown> = LlmJson.validateArguments(
           entry.function,
@@ -145,12 +164,24 @@ export namespace LangChainToolsRegistrar {
         try {
           const result: unknown = await entry.execute(valid.data);
           if (result === undefined) {
-            return entry.function.output === undefined
+            return validateOutput === undefined
               ? ({ success: true } satisfies ITryResult)
               : ({
                   success: false,
                   error: `Function "${entry.name}" returned undefined despite declaring an output schema`,
                 } satisfies ITryResult);
+          }
+          if (validateOutput !== undefined) {
+            const output: IValidation<unknown> = validateOutput(result);
+            if (output.success === false)
+              return {
+                success: false,
+                error:
+                  `Type errors in "${entry.name}" output:
+
+` + LlmJson.stringify(output),
+              } satisfies ITryResult;
+            return { success: true, data: output.data } satisfies ITryResult;
           }
           return { success: true, data: result } satisfies ITryResult;
         } catch (error) {
@@ -177,6 +208,7 @@ export namespace LangChainToolsRegistrar {
         ) as JSONSchema,
       },
     );
+  };
 
   const getToolName = (
     controllerName: string,

--- a/tests/test-langchain/src/features/test_langchain_tool_output_constraint_enforcement.ts
+++ b/tests/test-langchain/src/features/test_langchain_tool_output_constraint_enforcement.ts
@@ -1,0 +1,136 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toLangChainTools } from "@typia/langchain";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies a tool result is checked against the output type its method
+ * declared.
+ *
+ * The registrar consulted `ILlmFunction.output` for its existence alone: a
+ * method returning nothing was reported, a method returning the wrong shape was
+ * not, so a value violating its own declared range reached the model as a
+ * success while `@typia/mcp` and `@typia/vercel` both refused it (#2302).
+ *
+ * The two schema modes keep constraints in different places — a non-strict
+ * schema as `minimum` and `format` keywords, a strict one as `@minimum 0` tags
+ * in the description — and the inverter reads the tags back only when told the
+ * schema is strict, so the registrar hands it the application's own config.
+ * Every property below is documented, because a description is exactly what
+ * makes the non-strict keywords vanish when that config is wrong.
+ *
+ * 1. Convert the same documented controller twice, once non-strict and once
+ *    strict.
+ * 2. Assert a conforming result is delivered unchanged.
+ * 3. Assert a result violating `Minimum` is reported with its failing path, in
+ *    both modes, and the same for `Format<"email">`.
+ * 4. Assert a method that declares no output keeps its plain success.
+ */
+export const test_langchain_tool_output_constraint_enforcement =
+  async (): Promise<void> => {
+    const strict: ILlmController = typia.llm.controller<
+      ConstraintController,
+      { strict: true }
+    >("constraint", new ConstraintController());
+    TestValidator.equals(
+      "a strict controller reports the config it was built with",
+      strict.application.config.strict,
+      true,
+    );
+
+    const controllers: [string, ILlmController][] = [
+      [
+        "non-strict",
+        typia.llm.controller<ConstraintController>(
+          "constraint",
+          new ConstraintController(),
+        ),
+      ],
+      ["strict", strict],
+    ];
+    for (const [mode, controller] of controllers) {
+      const tools: DynamicStructuredTool[] = toLangChainTools({
+        controllers: [controller],
+      });
+      const read: DynamicStructuredTool = tools.find((t) => t.name === "read")!;
+
+      // POSITIVE: a conforming result passes through untouched.
+      TestValidator.equals(
+        `${mode} conforming output accepted`,
+        await read.invoke({ variant: "valid" }),
+        {
+          success: true,
+          data: { id: "u1", age: 20, email: "member@typia.io" },
+        },
+      );
+
+      // NEGATIVE TWINS: each violation is reported with the path that failed.
+      for (const [variant, path] of [
+        ["minimum", '"path":"$input.age"'],
+        ["format", '"path":"$input.email"'],
+      ] as const) {
+        const result = (await read.invoke({ variant })) as {
+          success?: boolean;
+          error?: string;
+        };
+        TestValidator.predicate(
+          `${mode} ${variant} violation is reported`,
+          result.success === false &&
+            typeof result.error === "string" &&
+            result.error.includes(path),
+        );
+      }
+
+      // CONTROL: a method with no declared output keeps its plain success.
+      const note: DynamicStructuredTool = tools.find((t) => t.name === "note")!;
+      TestValidator.equals(
+        `${mode} undeclared output stays a success`,
+        await note.invoke({ text: "hello" }),
+        { success: true },
+      );
+    }
+  };
+
+class ConstraintController {
+  /** Return a member selected by the test variant. */
+  read(input: ConstraintController.IInput): ConstraintController.IMember {
+    const valid: ConstraintController.IMember = {
+      id: "u1",
+      age: 20,
+      email: "member@typia.io",
+    };
+    switch (input.variant) {
+      case "valid":
+        return valid;
+      case "minimum":
+        return { ...valid, age: -5 };
+      case "format":
+        return { ...valid, email: "not-an-email" };
+    }
+  }
+
+  /** Record a note and return nothing. */
+  note(input: ConstraintController.INote): void {
+    if (input.text.length === 0) throw new Error("empty note");
+  }
+}
+
+namespace ConstraintController {
+  export interface IInput {
+    /** Which member to return. */
+    variant: "valid" | "minimum" | "format";
+  }
+  export interface INote {
+    /** What the note says. */
+    text: string;
+  }
+  export interface IMember {
+    /** How the member is identified. */
+    id: string;
+    /** How old the member is. */
+    age: number & tags.Minimum<0>;
+    /** Where to reach the member. */
+    email: string & tags.Format<"email">;
+  }
+}

--- a/tests/test-vercel/src/features/test_vercel_tool_output_constraint_enforcement.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_output_constraint_enforcement.ts
@@ -15,13 +15,12 @@ import typia, { tags } from "typia";
  * application's own config — and every property here is documented, because a
  * description is exactly what used to make the non-strict keywords disappear.
  *
- * The strict controller's `config.strict` is corrected before it is converted.
- * `typia.llm.application`/`controller` emit `config: { strict: false }`
- * whatever the `Config` generic says, even while shifting the constraints into
- * the description — the emitted config contradicts the schema beside it,
- * against `ILlmApplication.config`'s own contract. That is a separate transform
- * defect; this case pins the registrar's plumbing against the config the
- * contract promises rather than the one typia currently emits.
+ * The strict controller is converted exactly as typia emits it. It used to need
+ * its `config.strict` corrected by hand, because the emitted application
+ * reported `strict: false` whatever the `Config` generic said while shifting
+ * the constraints into the description (issue #2293). With the reported config
+ * truthful, that correction would hide the very regression this case exists to
+ * catch.
  *
  * 1. Convert the same documented controller twice, once non-strict and once
  *    strict.
@@ -35,7 +34,11 @@ export const test_vercel_tool_output_constraint_enforcement =
       ConstraintController,
       { strict: true }
     >("constraint", new ConstraintController());
-    strict.application.config.strict = true;
+    TestValidator.equals(
+      "a strict controller reports the config it was built with",
+      strict.application.config.strict,
+      true,
+    );
 
     const controllers: [string, ILlmController][] = [
       [


### PR DESCRIPTION
## Intent

Cycle 6 of the solo issue campaign.

| Issue | Scope |
| --- | --- |
| #2302 | `@typia/langchain` delivered a tool result violating its declared output type as a success, while `@typia/mcp` and `@typia/vercel` report it |

## What changed

The registrar builds the output validator once per function, from the
application's own config, and reports a violation in the shape it already uses
for argument failures:

```
valid     -> {"success":true,"data":{"score":50}}
violating -> {"success":false,"error":"Type errors in \"read\" output:\n\n```json\n{\n  \"score\": 500 // ❌ [{\"path\":\"$input.score\",\"expected\":\"number & Maximum<100>\"}]\n}\n```"}
```

The config matters: a strict application carries its constraints as description
tags instead of keywords, and only that config tells the inverter to read them
back — which is what #2293 made truthful.

## A stale workaround removed with it

`test_vercel_tool_output_constraint_enforcement` still assigned
`strict.application.config.strict = true` by hand, with a comment naming the
defect #2293 fixed. The MCP twin dropped that line when #2293 landed; the Vercel
one was missed. It is gone, so the case proves the whole path rather than
masking a regression.

## Verification

- `test_langchain_tool_output_constraint_enforcement` (new) mirrors the MCP and
  Vercel cases: the same documented controller served non-strict and strict, a
  conforming result delivered unchanged, `Minimum` and `Format<"email">`
  violations each reported with their failing path, and a method declaring no
  output keeping its plain success as the control.
- Mutation: removing the validation block fails the new case at `non-strict
  minimum violation is reported`.
- `pnpm --filter ./tests/test-langchain start`, `./tests/test-vercel`, and
  `./tests/test-mcp` all pass.
- Root `pnpm build` and `pnpm test` gate this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mc91ztDB5qujoSxLvfEgBQ
