### PR TITLE
fix: widen idn-hostname to a superset of hostname, and close two CI gate gaps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,10 @@ jobs:
       # `benchmark/` is a compiled workspace of ~780 sources that no lane
       # compiled, so a transform, interface, or utils change could break every
       # benchmark program and stay green until someone next ran a benchmark
-      # (issue #2316). `pnpm run build` above warms the plugin cache, so this is
-      # just the compile. `--fail-if-no-match` because a `--filter` selecting
-      # nothing exits 0, which would report success without compiling anything.
+      # (issue #2316). It is the only workspace here that applies the typia
+      # transform, so this step is what builds the Go plugin -- the restore
+      # above lets it reuse a prior run's cache instead of a cold build.
+      # `--fail-if-no-match` because a `--filter` selecting nothing exits 0,
+      # which would report success without compiling anything.
       - name: Build Benchmark
         run: pnpm --filter ./benchmark --fail-if-no-match run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,14 @@
 name: build
-on: 
+on:
   pull_request:
     paths:
       - '.github/workflows/build.yml'
+      - 'benchmark/**'
       - 'config/**'
       - 'packages/**'
       # `packages/{langchain,mcp}`'s build shells out to
       # `scripts/create-conditional-declarations.cjs`, so `pnpm run build`
-      # exercises it. `scripts/format-go.cjs` is reached only by
-      # `pnpm run format`, which no lane runs, so this trigger covers one of the
-      # two files rather than the directory.
+      # exercises it. `scripts/format-go.cjs` is run by `format.yml`.
       - 'scripts/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -26,9 +25,31 @@ jobs:
         with:
           go-version: 1.26.x
       - uses: pnpm/action-setup@v4
-      
+
       - name: Install Dependencies
         run: pnpm install
 
+      # ttsc compiles the typia Go plugin on first use into
+      # node_modules/.cache/ttsc, keyed by content (plugin source + ttsc/tsgo
+      # versions). Restoring a stale cache is safe: a changed source misses the
+      # binary key but still reuses the incremental go-build objects. Restored
+      # after `pnpm install` so an install-time node_modules rebuild cannot
+      # discard it.
+      - name: Restore ttsc Plugin Cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/ttsc
+          key: ttsc-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/typia/native/**') }}
+          restore-keys: ttsc-cache-${{ runner.os }}-
+
       - name: Build Packages
         run: pnpm run build
+
+      # `benchmark/` is a compiled workspace of ~780 sources that no lane
+      # compiled, so a transform, interface, or utils change could break every
+      # benchmark program and stay green until someone next ran a benchmark
+      # (issue #2316). `pnpm run build` above warms the plugin cache, so this is
+      # just the compile. `--fail-if-no-match` because a `--filter` selecting
+      # nothing exits 0, which would report success without compiling anything.
+      - name: Build Benchmark
+        run: pnpm --filter ./benchmark --fail-if-no-match run build

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,6 +5,9 @@ on:
       - '.github/workflows/format.yml'
       - '**/*.ts'
       - '**/*.go'
+      # `format:go` is `node scripts/format-go.cjs`, so a change to the
+      # formatter script itself must re-run the gate.
+      - 'scripts/**'
       - 'prettier.config.js'
       - '**/prettier.config.js'
       - '.prettierignore'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,40 @@
+name: format
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/format.yml'
+      - '**/*.ts'
+      - '**/*.go'
+      - 'prettier.config.js'
+      - '**/prettier.config.js'
+      - '.prettierignore'
+      - '**/.prettierignore'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+jobs:
+  Ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.26.x
+      - uses: pnpm/action-setup@v4
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      # `pnpm format` is the command every commit is required to run
+      # (.agents/skills/development/SKILL.md), yet no other lane ran it, so a
+      # tree the formatter would rewrite could merge unnoticed -- and the
+      # rewrite is not always harmless: prettier-plugin-jsdoc deletes the space
+      # beside a doc-comment code span that itself contains a backtick, gluing
+      # prose together (issue #2315). This lane makes the tree and the formatter
+      # agree: format writes, and any resulting change fails the diff.
+      - name: Formatting is idempotent
+        run: |
+          pnpm run format
+          git diff --exit-code

--- a/packages/typia/native/core/factories/FormatCheatSheet.go
+++ b/packages/typia/native/core/factories/FormatCheatSheet.go
@@ -45,7 +45,7 @@ var FormatCheatSheet = map[string]string{
   "email":                 "/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test($input)",
   "hostname":              "/^(?=.{1,253}\\.?$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[-0-9a-z]{0,61}[0-9a-z])?)*\\.?$/i.test($input)",
   "idn-email":             "/^(([^<>()[\\]\\.,;:\\s@\\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\\"]+)*)|(\\\".+\\\"))@(([^<>()[\\]\\.,;:\\s@\\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\\"]{2,})$/i.test($input)",
-  "idn-hostname":          "/^([a-z0-9\\u00a1-\\uffff0-9]+(-[a-z0-9\\u00a1-\\uffff0-9]+)*\\.)+[a-z\\u00a1-\\uffff]{2,}$/i.test($input)",
+  "idn-hostname":          "/^(?=.{1,253}\\.?$)[a-z0-9\\u00a1-\\uffff](?:[a-z0-9\\u00a1-\\uffff-]{0,61}[a-z0-9\\u00a1-\\uffff])?(?:\\.[a-z0-9\\u00a1-\\uffff](?:[a-z0-9\\u00a1-\\uffff-]{0,61}[a-z0-9\\u00a1-\\uffff])?)*\\.?$/i.test($input)",
   "iri":                   `(() => !/[\u0000-\u0020\u007f-\u009f\ud800-\udfff"<>\\^\x60{|}]/u.test($input) && !/%(?![0-9A-Fa-f]{2})/u.test($input) && /^[A-Za-z][A-Za-z0-9+.-]*:/u.test($input))()`,
   "iri-reference":         `(() => { if (/[\u0000-\u0020\u007f-\u009f\ud800-\udfff"<>\\^\x60{|}]/u.test($input) || /%(?![0-9A-Fa-f]{2})/u.test($input)) return false; const colon = $input.indexOf(":"); const boundary = $input.search(/[/?#]/u); return colon === -1 || (boundary !== -1 && boundary < colon) || /^[A-Za-z][A-Za-z0-9+.-]*:/u.test($input); })()`,
   "ipv4":                  "/^(?:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.){3}(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)$/.test($input)",

--- a/packages/typia/src/internal/_isFormatIdnHostname.ts
+++ b/packages/typia/src/internal/_isFormatIdnHostname.ts
@@ -1,4 +1,8 @@
 export const _isFormatIdnHostname = (str: string): boolean => PATTERN.test(str);
 
+// The ASCII `hostname` structure with the label character class extended by the
+// non-ASCII range: every valid host name is a valid IDN host name, so this must
+// accept a single label, a one-to-63-character label in any position, and a
+// name up to 253 characters, exactly as `_isFormatHostname` does (issue #2317).
 const PATTERN =
-  /^([a-z0-9\u00a1-\uffff0-9]+(-[a-z0-9\u00a1-\uffff0-9]+)*\.)+[a-z\u00a1-\uffff]{2,}$/i;
+  /^(?=.{1,253}\.?$)[a-z0-9\u00a1-\uffff](?:[a-z0-9\u00a1-\uffff-]{0,61}[a-z0-9\u00a1-\uffff])?(?:\.[a-z0-9\u00a1-\uffff](?:[a-z0-9\u00a1-\uffff-]{0,61}[a-z0-9\u00a1-\uffff])?)*\.?$/i;

--- a/packages/utils/src/validators/functional/_isFormatIdnHostname.ts
+++ b/packages/utils/src/validators/functional/_isFormatIdnHostname.ts
@@ -1,4 +1,8 @@
 export const _isFormatIdnHostname = (str: string): boolean => PATTERN.test(str);
 
+// The ASCII `hostname` structure with the label character class extended by the
+// non-ASCII range: every valid host name is a valid IDN host name, so this must
+// accept a single label, a one-to-63-character label in any position, and a
+// name up to 253 characters, exactly as `_isFormatHostname` does (issue #2317).
 const PATTERN =
-  /^([a-z0-9\u00a1-\uffff0-9]+(-[a-z0-9\u00a1-\uffff0-9]+)*\.)+[a-z\u00a1-\uffff]{2,}$/i;
+  /^(?=.{1,253}\.?$)[a-z0-9\u00a1-\uffff](?:[a-z0-9\u00a1-\uffff-]{0,61}[a-z0-9\u00a1-\uffff])?(?:\.[a-z0-9\u00a1-\uffff](?:[a-z0-9\u00a1-\uffff-]{0,61}[a-z0-9\u00a1-\uffff])?)*\.?$/i;

--- a/tests/template/src/structures/TypeTagFormat.ts
+++ b/tests/template/src/structures/TypeTagFormat.ts
@@ -101,7 +101,11 @@ export namespace TypeTagFormat {
       return ["$input.idnEmail"];
     },
     (input) => {
-      input.idnHostname = "깃허브";
+      // A leading hyphen is not a legal label start. `"깃허브"` was the spoiler
+      // here until #2317 made single-label hosts valid — which is what
+      // idn-hostname is for — so the invalid case had to move to one that stays
+      // invalid.
+      input.idnHostname = "-깃허브";
       return ["$input.idnHostname"];
     },
     (input) => {

--- a/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
+++ b/tests/test-langchain/src/features/test_langchain_tool_error_single_json_fence.ts
@@ -11,16 +11,17 @@ import { Calculator } from "../structures/Calculator";
  * Verifies a LangChain argument failure fences typia's feedback exactly once.
  *
  * `LlmJson.stringify` owns the markdown fence around its annotated JSON, so a
- * caller that wraps the return value in a second `json` fence hands the model
- * `json\n`json` — broken markdown, in the one payload whose whole purpose is to
- * be read back and corrected. Counting the fence is what pins this, because
- * asserting the feedback merely `includes("`json")`passes with one fence or
- * two; asserting the body is`LlmJson.stringify`'s output verbatim additionally
- * pins that the registrar wraps it in nothing at all.
+ * caller that adds a second fence hands the model two opening JSON fences with
+ * nothing between them — broken markdown, in the one payload whose whole
+ * purpose is to be read back and corrected. Counting the fence is what pins
+ * this: an assertion that the feedback merely contains an opening JSON fence
+ * passes with one fence or two, and asserting the body equals
+ * `LlmJson.stringify`'s output verbatim additionally pins that the registrar
+ * wraps it in nothing at all.
  *
  * 1. Build a class controller and convert it to LangChain tools.
  * 2. Invoke `add` with a non-numeric operand to force typia's feedback.
- * 3. Assert the message opens exactly one ````json` fence.
+ * 3. Assert the message opens exactly one JSON fence.
  * 4. Assert the message is the registrar's title followed by `LlmJson.stringify`
  *    verbatim.
  */

--- a/tests/test-utils/src/features/openapi/test_openapi_validator_format_parity.ts
+++ b/tests/test-utils/src/features/openapi/test_openapi_validator_format_parity.ts
@@ -4,6 +4,8 @@ import typia, { tags } from "typia";
 import { _isFormatByte } from "typia/lib/internal/_isFormatByte";
 import { _isFormatDate } from "typia/lib/internal/_isFormatDate";
 import { _isFormatDateTime } from "typia/lib/internal/_isFormatDateTime";
+import { _isFormatHostname } from "typia/lib/internal/_isFormatHostname";
+import { _isFormatIdnHostname } from "typia/lib/internal/_isFormatIdnHostname";
 import { _isFormatIpv6 } from "typia/lib/internal/_isFormatIpv6";
 import { _isFormatIri } from "typia/lib/internal/_isFormatIri";
 import { _isFormatIriReference } from "typia/lib/internal/_isFormatIriReference";
@@ -35,6 +37,14 @@ interface ICommentDateTime {
 }
 interface ICommentTime {
   /** @format time */
+  value: string;
+}
+interface ICommentHostname {
+  /** @format hostname */
+  value: string;
+}
+interface ICommentIdnHostname {
+  /** @format idn-hostname */
   value: string;
 }
 
@@ -110,6 +120,20 @@ export const test_openapi_validator_format_parity = (): void => {
         value: string & tags.Format<"time">;
       }>(),
       comment: typia.createIs<ICommentTime>(),
+    },
+    hostname: {
+      direct: _isFormatHostname,
+      tagged: typia.createIs<{
+        value: string & tags.Format<"hostname">;
+      }>(),
+      comment: typia.createIs<ICommentHostname>(),
+    },
+    "idn-hostname": {
+      direct: _isFormatIdnHostname,
+      tagged: typia.createIs<{
+        value: string & tags.Format<"idn-hostname">;
+      }>(),
+      comment: typia.createIs<ICommentIdnHostname>(),
     },
   } satisfies Record<string, IChecker>;
   const matrices: Record<keyof typeof checks, IMatrix> = {
@@ -250,6 +274,37 @@ export const test_openapi_validator_format_parity = (): void => {
         "1:59:59Z",
       ],
     },
+    // Every valid ASCII host name is a valid IDN host name; the two share one
+    // structure and differ only in the permitted label characters, so the same
+    // ASCII rows appear under both, and the IDN column adds unicode labels.
+    hostname: {
+      valids: [
+        "hostname",
+        "localhost",
+        "a",
+        "a.b",
+        "x.y.z",
+        "example.com",
+        "sub.domain.co.kr",
+        "host.",
+      ],
+      invalids: ["", "-a", "a-", "a..b", ".a", "a.-b", "a_b", "실례"],
+    },
+    "idn-hostname": {
+      valids: [
+        "hostname",
+        "localhost",
+        "a",
+        "a.b",
+        "x.y.z",
+        "example.com",
+        "실례",
+        "실례.테스트",
+        "a.실례",
+        "host.",
+      ],
+      invalids: ["", "-a", "a-", "a..b", ".a", "a.-b", "a_b"],
+    },
   };
 
   for (const [format, matrix] of Object.entries(matrices) as [
@@ -302,6 +357,38 @@ export const test_openapi_validator_format_parity = (): void => {
     "time",
     (typia.json.schema<time>().schema as { format?: string }).format,
   );
+  TestValidator.equals(
+    "hostname schema",
+    "hostname",
+    (typia.json.schema<hostname>().schema as { format?: string }).format,
+  );
+  TestValidator.equals(
+    "idn-hostname schema",
+    "idn-hostname",
+    (typia.json.schema<idnHostname>().schema as { format?: string }).format,
+  );
+
+  // The superset property proved directly: every value the ASCII host-name
+  // validator accepts, the IDN one accepts too. idn-hostname used to require a
+  // dotted name with a two-plus character trailing label, so it rejected the
+  // single-label and single-character-final-label hosts hostname admits (#2317).
+  for (const value of [
+    "hostname",
+    "localhost",
+    "a",
+    "a.b",
+    "x.y.z",
+    "a1.b2",
+    "example.com",
+    "under_score-is.rejected",
+    "-bad",
+    "",
+  ])
+    TestValidator.predicate(
+      `idn-hostname is a superset of hostname for ${JSON.stringify(value)}`,
+      _isFormatHostname(value) === false ||
+        _isFormatIdnHostname(value) === true,
+    );
 };
 
 interface IMatrix {
@@ -316,6 +403,8 @@ type iriReference = string & tags.Format<"iri-reference">;
 type date = string & tags.Format<"date">;
 type dateTime = string & tags.Format<"date-time">;
 type time = string & tags.Format<"time">;
+type hostname = string & tags.Format<"hostname">;
+type idnHostname = string & tags.Format<"idn-hostname">;
 
 const validate = (
   format: string,

--- a/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
+++ b/tests/test-vercel/src/features/test_vercel_tool_error_single_json_fence.ts
@@ -8,12 +8,13 @@ import { Calculator } from "../structures/Calculator";
 /**
  * Verifies Vercel tool feedback fences typia's annotated JSON exactly once.
  *
- * `LlmJson.stringify` already wraps its output in a `json` fence, so a caller
- * that adds a second one hands the model `json\n`json`. `VercelToolsRegistrar`
- * formats that same result on two separate paths — once for invalid arguments
- * and once for an invalid output — and a fence added back to either one is
- * invisible to an `includes("`json")` check, which passes with one fence or
- * two. Counting the fence on both paths is what pins it.
+ * `LlmJson.stringify` already wraps its output in a JSON fence, so a caller
+ * that adds a second one hands the model two opening fences with nothing
+ * between them. `VercelToolsRegistrar` formats that same result on two separate
+ * paths — once for invalid arguments and once for an invalid output — and a
+ * fence added back to either one is invisible to a check that merely looks for
+ * an opening fence, which passes with one fence or two. Counting the fence on
+ * both paths is what pins it.
  *
  * 1. Build a controller whose method both takes and returns a typed value.
  * 2. Force an argument failure and count the fences in its feedback.


### PR DESCRIPTION
Cycle 2 of `campaign-2026-07-22`. Owns the **complete accepted issue set** of the
cycle.

## Cycle issues

| Issue | Subject | Landed by |
| --- | --- | --- |
| #2317 | `Format<"idn-hostname">` rejects valid hosts `hostname` accepts, including the single-label unicode host it exists for | `a61b70c` |
| #2315 | `pnpm format` rewrites committed doc comments into broken prose, and no lane runs it | `8029ea2` |
| #2316 | `benchmark/` is compiled by no workflow, on any event | `ffbf584` |

## What changed

**`idn-hostname`** is now a superset of `hostname`, in all three owners (runtime
helper, `FormatCheatSheet` inline expression, `@typia/utils` copy). It accepts
the single-label hosts and single-character-final-label hosts the ASCII
validator already accepts — including `실례`, the single unicode label the
format exists for — while still rejecting `-a`, `a..b`, over-length labels, and
underscores. The ASCII `hostname` validator is the in-repository oracle, so no
external spec is invoked. `test_openapi_validator_format_parity` gains both
formats across all four reach paths plus a direct superset assertion.

**`pnpm format`** no longer corrupts prose. Two committed doc comments wrapped a
backtick inside a single-backtick markdown span, which `prettier-plugin-jsdoc`
mangles by deleting the adjacent space; both are rewritten to say the same thing
without such a span, and `prettier --check` confirms they are now stable. A new
`format.yml` lane runs `pnpm run format` and fails on any diff, so the tree and
the formatter can no longer disagree unnoticed.

**`benchmark/`** is compiled on every pull request by `build.yml`. It was
compiled by no lane on any event, so a transform, interface, or utils change
could break every benchmark program and stay green. Proven sensitive: the
compile exits 0 intact and exits 2 (`TS2322`) with one benchmark source given a
type error. The lane also gains the ttsc plugin-cache restore its siblings have.

## Verification

| Command | Result |
| --- | --- |
| `pnpm --filter ./tests/test-utils start` | Success (idn-hostname/hostname parity, 4 paths + superset) |
| `pnpm --filter ./tests/test-typia-schema start` | Success |
| `pnpm test:go:native` | pass (native cheat sheet) |
| `pnpm --filter ./tests/test-langchain start` / `test-vercel start` | Success (fence suites, comment-only control) |
| `pnpm --filter ./benchmark --fail-if-no-match run build` | exit 0; exit 2 on a mutated source |
| `pnpm run format` then diff | no real change (CRLF churn only, absent on the runner) |
| root `pnpm test`, build, benchmark, format gate | this pull request's CI + a local integration run |

Base commit `0859d11352`. Each commit carries its own `Close #` line; the body
carries none.
