### PR TITLE
fix(random): draw a short idn-hostname the widened validator accepts

### DIFF
--- a/packages/typia/src/internal/_randomFormatHostname.ts
+++ b/packages/typia/src/internal/_randomFormatHostname.ts
@@ -29,8 +29,8 @@ const pickLength = (props: _ILengthProps): number => {
 
 /**
  * Builds dot-joined hostname labels totaling exactly `length` characters, each
- * label within 63 chars. Shared with the idn-hostname generator, which reserves
- * a fixed `.<tld>` suffix and realizes the rest as these leading labels.
+ * label within 63 chars. Shared with the idn-hostname generator, which realizes
+ * its length the same way since #2317 gave the two formats one structure.
  */
 export const _randomHostnameLabels = (length: number): string => {
   const parts: string[] = [];

--- a/packages/typia/src/internal/_randomFormatIdnHostname.ts
+++ b/packages/typia/src/internal/_randomFormatIdnHostname.ts
@@ -6,20 +6,19 @@ import { _ILengthProps } from "./_randomStringLength";
 export const _randomFormatIdnHostname = (props?: _ILengthProps): string => {
   if (props?.minLength === undefined && props?.maxLength === undefined)
     return `${random(10)}.${random(3)}`;
-  // `_isFormatIdnHostname` requires at least one label, a dot, and a >=2-char
-  // TLD (`(…\.)+[a-z¡-￿]{2,}`), none of which the non-idn hostname generator
-  // guarantees on its length path (it can emit a single dotless label). Reserve
-  // a fixed `.<2-char TLD>` and realize the rest as dot-joined leading labels.
-  const length: number = pickLength(props);
-  return `${_randomHostnameLabels(length - 3)}.${random(2)}`;
+  // idn-hostname shares hostname's structure (a single label of 1..63 chars is
+  // valid, no dot or trailing label required), so the requested length is
+  // realized the same way: split it across dot-joined labels. #2317 dropped the
+  // mandatory dot and two-character trailing label this generator used to
+  // reserve, which is why it now realizes a length below four.
+  return _randomHostnameLabels(pickLength(props));
 };
 
 const MAX_TOTAL = 253;
-const MIN_TOTAL = 4; // the shortest idn hostname, `x.yy`: label(1) + `.` + tld(2)
 
 const pickLength = (props: _ILengthProps): number => {
-  let low: number = props.minLength === undefined ? MIN_TOTAL : props.minLength;
-  if (low < MIN_TOTAL) low = MIN_TOTAL;
+  let low: number = props.minLength === undefined ? 1 : props.minLength;
+  if (low < 1) low = 1;
   const high: number =
     props.maxLength === undefined
       ? Math.min(MAX_TOTAL, low + 14)

--- a/tests/test-typia-schema/src/features/random/test_random_string_pattern_format_length.ts
+++ b/tests/test-typia-schema/src/features/random/test_random_string_pattern_format_length.ts
@@ -144,8 +144,36 @@ export const test_random_string_pattern_format_length = (): void => {
     );
   }
 
-  // IDN formats (issue #2215): the length path must yield a dot plus a
-  // >=2-character TLD so the stricter idn checker accepts every draw.
+  // IDN formats (issue #2215): the length path must yield a value the stricter
+  // idn checker accepts at every draw. idn-hostname shares hostname's structure
+  // since #2317, so a single label of one or more characters is valid — the
+  // short cases below pin that the generator realizes them instead of throwing
+  // (issue #2319).
+  {
+    // A single label at lengths 1..3, valid since #2317, which the generator
+    // used to refuse because it reserved a `.<2-char TLD>` suffix.
+    type T = string & tags.Format<"idn-hostname"> & tags.MaxLength<3>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-hostname & short single label",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
+  {
+    type T = string &
+      tags.Format<"idn-hostname"> &
+      tags.MinLength<1> &
+      tags.MaxLength<1>;
+    const create = typia.createRandom<T>();
+    roundTrip(
+      "idn-hostname single character",
+      (v) => typia.is<T>(v),
+      () => typia.random<T>(),
+      () => create(),
+    );
+  }
   {
     type T = string & tags.Format<"idn-hostname"> & tags.MinLength<40>;
     const create = typia.createRandom<T>();
@@ -181,7 +209,7 @@ export const test_random_string_pattern_format_length = (): void => {
     );
   }
   {
-    // A short window near the idn-hostname minimum (`x.yy`) forces the short path.
+    // A short window forces the short path; a single label fills it.
     type T = string &
       tags.Format<"idn-hostname"> &
       tags.MinLength<4> &
@@ -336,13 +364,15 @@ export const test_random_string_pattern_format_length = (): void => {
   assertThrows("fixed-length format & conflicting maxLength", () =>
     typia.random<string & tags.Format<"uuid"> & tags.MaxLength<10>>(),
   );
-  // Below the idn minimums (`x@x.yy` = 6, `x.yy` = 4) there is no matching value
-  // to emit, so the draw must throw rather than yield a `is`-rejected string.
+  // Below the idn-email minimum (`x@x.yy` = 6) there is no matching value to
+  // emit, so the draw must throw rather than yield a `is`-rejected string.
   assertThrows("idn-email & impossible maxLength", () =>
     typia.random<string & tags.Format<"idn-email"> & tags.MaxLength<5>>(),
   );
+  // idn-hostname now accepts a single label of any length, so the only
+  // unsatisfiable window is the empty one: `MaxLength<0>` admits no value.
   assertThrows("idn-hostname & impossible maxLength", () =>
-    typia.random<string & tags.Format<"idn-hostname"> & tags.MaxLength<3>>(),
+    typia.random<string & tags.Format<"idn-hostname"> & tags.MaxLength<0>>(),
   );
 };
 


### PR DESCRIPTION
Cycle 3 of `campaign-2026-07-22`. Owns #2319 — the follow-on to #2317 where `_randomFormatIdnHostname` kept the pre-widening grammar and threw for the single-label short hosts the validator now accepts.

## What changed
- `_randomFormatIdnHostname` drops the stale `MIN_TOTAL = 4` and the reserved `.<2-char TLD>` suffix; it now realizes its length exactly as `_randomFormatHostname` does (floor 1, `_randomHostnameLabels(pickLength)`), so a single label of 1..63 chars is produced. Its header comment described the pre-#2317 grammar; it now describes the current one.
- `test_random_string_pattern_format_length`: the `MaxLength<3>` `assertThrows` becomes a positive `roundTrip` (lengths 1..3), joined by an exact single-character case; the unsatisfiable slot moves to `MaxLength<0>`.
- `_randomHostnameLabels`'s shared-helper doc no longer claims the idn generator reserves a `.<tld>` suffix (a comment-rot follow-on the commit reader caught).

## Verification
| Command | Result |
| --- | --- |
| root `pnpm test` | TEST=0 (12 workspaces + both Go trees) |
| `test-typia-schema` random suites | Success; short 1..3, exact 1, 10..40, multi-label, unconstrained all draw `is`-accepted values; `MaxLength<0>` throws |
| mutation | reverting the generator to master fails the short-single-label `roundTrip` (`unable to generate…`) |

Base `f6415ce`. Close-line carried by the commit. CI pending.