### PR TITLE
fix(native): terminate type-name composition on a self-recursive type graph

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestRecursiveConditionalAliasNameTransform pins the transform over a type
+// whose resolved graph names itself (issue #2331).
+//
+// `Primitive<T>` instantiated at the self-recursive union `type Node = Date |
+// Node[]` resolves to `string & Format<"date-time"> | X[]`, where the array's
+// sole type argument is that very union. The name builders walked union member
+// -> array reference -> type argument and arrived back at the type whose name
+// was still being composed, so they recursed until the plugin process died of a
+// Go stack overflow: no diagnostic, no emit, and ttsc itself taken down with it.
+// `Primitive` is only one witness -- any self-recursive conditional alias
+// produces the same graph -- so the fixture pins the bare `Rec<T>` form too.
+//
+// The names the fix produces have to stay usable, not merely terminate: the
+// cycle's placeholder is the type's own symbol with its arguments unexpanded, so
+// a JSON schema component keeps a short key instead of being named after a
+// several-hundred-character structural dump of the elided rendering.
+//
+//  1. Transform is / assert / json.schema over `Primitive<Node>`, the bare
+//     recursive conditional alias, and the recursive-JsonValue object, beside
+//     controls (named recursive union, self-recursive array alias, recursive
+//     interface) that already transformed and must keep their names.
+//  2. Require the emit to carry a recursive array validator rather than an
+//     inlined expansion.
+//  3. Execute the emitted validators over positive, negative, nested and
+//     boundary values, and require the recursive schema to self-reference
+//     through a bounded component name.
+func TestRecursiveConditionalAliasNameTransform(t *testing.T) {
+  project := recursiveConditionalAliasNameProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("recursive conditional alias transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  if strings.Contains(out, "_ia0") == false {
+    t.Fatalf("expected a recursive array validator in the emit, got:\n%s", out)
+  }
+  recursiveConditionalAliasNameRunRuntimeCases(t, project, out)
+}
+
+func recursiveConditionalAliasNameProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "recursive-conditional-alias-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() {
+    _ = os.RemoveAll(dir)
+  })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(recursiveConditionalAliasNameTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(recursiveConditionalAliasNameSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}
+
+func recursiveConditionalAliasNameRunRuntimeCases(t *testing.T, project string, js string) {
+  t.Helper()
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  runtimeDir := filepath.Join(project, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "is-format-date-time-stub.cjs"), []byte(recursiveConditionalAliasNameFormatStub), 0o644); err != nil {
+    t.Fatalf("write format stub: %v", err)
+  }
+  js = strings.ReplaceAll(js, `require("typia/lib/internal/_isFormatDateTime")`, `require("./is-format-date-time-stub.cjs")`)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, js)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(recursiveConditionalAliasNameRuntimeRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("recursive conditional alias runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const recursiveConditionalAliasNameTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
+    "types": ["*"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`
+
+// The shipped helper validates the RFC 3339 date-time shape; the runtime cases
+// only need it to separate a date-time string from a plain one, and a stable
+// predicate keeps a failure reproducible.
+const recursiveConditionalAliasNameFormatStub = `module.exports._isFormatDateTime = (value) =>
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/.test(value);
+`
+
+const recursiveConditionalAliasNameSource = `import typia, { Primitive, tags } from "typia";
+
+// 1. the reported case: Primitive over a self-recursive union carrying Date.
+//    Primitive rewrites the Date arm to a date-time string and keeps the array
+//    arm pointing back at the whole union.
+type Node = Date | Node[];
+export const isPrimitiveNode = typia.createIs<Primitive<Node>>();
+export const assertPrimitiveNode = typia.createAssert<Primitive<Node>>();
+export const schemaPrimitiveNode = typia.json.schema<Primitive<Node>>();
+
+// 2. the same graph without Primitive: any self-recursive conditional alias
+//    instantiates to a union whose array member's type argument is that union
+type Rec<T> = T extends Date
+  ? string
+  : T extends (infer U)[]
+    ? Rec<U>[]
+    : never;
+export const isRec = typia.createIs<Rec<Node>>();
+
+// 3. the second report: the recursion sits behind an object property
+interface JsonObject {
+  [key: string]: JsonValue;
+}
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+interface Output {
+  at: Date;
+  payload: JsonValue;
+}
+export const isOutput = typia.createIs<Primitive<Output>>();
+
+// controls: recursions that already named themselves through an alias or a
+// declaration must keep transforming and must not take the cycle placeholder
+type Named = (string & tags.Format<"date-time">) | Named[];
+export const isNamed = typia.createIs<Named>();
+
+type SelfArray = SelfArray[];
+export const isSelfArray = typia.createIs<SelfArray>();
+
+interface ICategory {
+  name: string;
+  children: ICategory[];
+}
+export const isCategory = typia.createIs<ICategory>();
+export const schemaCategory = typia.json.schema<ICategory>();
+`
+
+const recursiveConditionalAliasNameRuntimeRunner = `const mod = require("./main.cjs");
+
+let failures = 0;
+const expect = (label, actual, expected) => {
+  if (actual !== expected) {
+    console.log("FAIL " + label + ": expected " + expected + ", got " + actual);
+    failures++;
+  }
+};
+
+const DATE = "2020-01-01T00:00:00.000Z";
+
+// --- 1. Primitive<Node>: date-time string or (recursively) an array of those ---
+expect("primitive top date-time", mod.isPrimitiveNode(DATE), true);
+expect("primitive top plain string", mod.isPrimitiveNode("nope"), false);
+expect("primitive top number", mod.isPrimitiveNode(1), false);
+expect("primitive top null", mod.isPrimitiveNode(null), false);
+expect("primitive top Date instance", mod.isPrimitiveNode(new Date(0)), false);
+expect("primitive empty array", mod.isPrimitiveNode([]), true);
+expect("primitive flat array", mod.isPrimitiveNode([DATE, DATE]), true);
+expect("primitive flat array bad member", mod.isPrimitiveNode([DATE, "nope"]), false);
+expect("primitive nested array", mod.isPrimitiveNode([[[DATE]], []]), true);
+expect("primitive nested bad leaf", mod.isPrimitiveNode([[[1]]]), false);
+
+// the emitted recursive validator must not be fooled by a self-referencing value
+const cyclic = [];
+cyclic.push(cyclic);
+expect("primitive cyclic value terminates", mod.isPrimitiveNode(cyclic), true);
+
+// --- 1b. assert reports the arm, and passes what is valid ---
+expect("assert passes", JSON.stringify(mod.assertPrimitiveNode([DATE])), JSON.stringify([DATE]));
+let assertPath = "";
+let assertExpected = "";
+try {
+  mod.assertPrimitiveNode(["nope"]);
+  failures++;
+  console.log("FAIL assert should have thrown");
+} catch (exp) {
+  assertPath = String(exp.path);
+  assertExpected = String(exp.expected);
+}
+expect("assert names the path", assertPath, "$input[0]");
+// The expected string is the same name the fix has to keep readable: the arm
+// itself, not a structural dump of the cycle it sits in.
+expect("assert names the arm", assertExpected.includes('Format<"date-time">'), true);
+expect("assert expectation is bounded", assertExpected.length <= 64, true);
+
+// --- 2. the bare recursive conditional alias: string or (recursively) arrays ---
+expect("rec top string", mod.isRec("anything"), true);
+expect("rec top number", mod.isRec(1), false);
+expect("rec nested array", mod.isRec([["a"], []]), true);
+expect("rec nested bad leaf", mod.isRec([[1]]), false);
+
+// --- 3. the recursion behind an object property ---
+expect("output valid", mod.isOutput({ at: DATE, payload: { a: [1, "b", null, { c: true }] } }), true);
+expect("output bad date", mod.isOutput({ at: "nope", payload: 1 }), false);
+expect("output missing key", mod.isOutput({ payload: 1 }), false);
+expect("output bad payload", mod.isOutput({ at: DATE, payload: undefined }), false);
+
+// --- controls: the recursions that already worked ---
+expect("named recursive union", mod.isNamed([[DATE]]), true);
+expect("named recursive union bad leaf", mod.isNamed([["nope"]]), false);
+expect("self array alias", mod.isSelfArray([[], [[]]]), true);
+expect("self array alias bad leaf", mod.isSelfArray([1]), false);
+expect("category valid", mod.isCategory({ name: "a", children: [{ name: "b", children: [] }] }), true);
+expect("category bad child", mod.isCategory({ name: "a", children: [{ name: 1, children: [] }] }), false);
+
+// --- the schema names the cycle without dumping its structural expansion ---
+const unit = mod.schemaPrimitiveNode;
+const keys = Object.keys(unit.components.schemas || {});
+expect("schema has one component", keys.length, 1);
+const key = keys[0];
+// The pre-fix walk could only have produced a name built from the checker's
+// elided rendering, which runs to several hundred characters; the placeholder
+// keeps it in the same range as an ordinary named component.
+expect("component name is bounded", key !== undefined && key.length <= 64, true);
+expect("component is an array", unit.components.schemas[key].type, "array");
+const items = unit.components.schemas[key].items;
+const refs = (items.oneOf || []).filter((elem) => elem.$ref !== undefined);
+expect("array items reference the component itself", refs.length === 1 && refs[0].$ref === "#/components/schemas/" + key, true);
+expect("array items keep the date-time arm", (items.oneOf || []).some((elem) => elem.format === "date-time"), true);
+
+// control: a named recursion still uses its declared name
+expect("category component name", Object.keys(mod.schemaCategory.components.schemas || {})[0], "ICategory");
+
+if (failures > 0) {
+  throw new Error(failures + " assertion(s) failed");
+}
+console.log("all recursive-conditional-alias cases passed");
+`

--- a/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
@@ -202,6 +202,16 @@ expect("primitive flat array", mod.isPrimitiveNode([DATE, DATE]), true);
 expect("primitive flat array bad member", mod.isPrimitiveNode([DATE, "nope"]), false);
 expect("primitive nested array", mod.isPrimitiveNode([[[DATE]], []]), true);
 expect("primitive nested bad leaf", mod.isPrimitiveNode([[[1]]]), false);
+expect("primitive nested Date instance", mod.isPrimitiveNode([[new Date(0)]]), false);
+
+// depth boundary: the emitted validator recurses through one function, so a
+// deep value must not need a deeper emit
+let deep = [DATE];
+for (let i = 0; i < 64; ++i) deep = [deep];
+expect("primitive deeply nested", mod.isPrimitiveNode(deep), true);
+let deepBad = [1];
+for (let i = 0; i < 64; ++i) deepBad = [deepBad];
+expect("primitive deeply nested bad leaf", mod.isPrimitiveNode(deepBad), false);
 
 // the emitted recursive validator must not be fooled by a self-referencing value
 const cyclic = [];
@@ -251,15 +261,17 @@ const unit = mod.schemaPrimitiveNode;
 const keys = Object.keys(unit.components.schemas || {});
 expect("schema has one component", keys.length, 1);
 const key = keys[0];
-// The pre-fix walk could only have produced a name built from the checker's
-// elided rendering, which runs to several hundred characters; the placeholder
-// keeps it in the same range as an ordinary named component.
-expect("component name is bounded", key !== undefined && key.length <= 64, true);
-expect("component is an array", unit.components.schemas[key].type, "array");
-const items = unit.components.schemas[key].items;
-const refs = (items.oneOf || []).filter((elem) => elem.$ref !== undefined);
-expect("array items reference the component itself", refs.length === 1 && refs[0].$ref === "#/components/schemas/" + key, true);
-expect("array items keep the date-time arm", (items.oneOf || []).some((elem) => elem.format === "date-time"), true);
+if (key !== undefined) {
+  // The pre-fix walk could only have produced a name built from the checker's
+  // elided rendering, which runs to several hundred characters; the placeholder
+  // keeps it in the same range as an ordinary named component.
+  expect("component name is bounded", key.length <= 64, true);
+  expect("component is an array", unit.components.schemas[key].type, "array");
+  const items = unit.components.schemas[key].items;
+  const refs = (items.oneOf || []).filter((elem) => elem.$ref !== undefined);
+  expect("array items reference the component itself", refs.length === 1 && refs[0].$ref === "#/components/schemas/" + key, true);
+  expect("array items keep the date-time arm", (items.oneOf || []).some((elem) => elem.format === "date-time"), true);
+}
 
 // control: a named recursion still uses its declared name
 expect("category component name", Object.keys(mod.schemaCategory.components.schemas || {})[0], "ICategory");

--- a/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
@@ -50,6 +50,25 @@ func TestRecursiveConditionalAliasNameTransform(t *testing.T) {
   if strings.Contains(out, "_ia0") == false {
     t.Fatalf("expected a recursive array validator in the emit, got:\n%s", out)
   }
+
+  // The cycle guard is a map, and the name it settles on becomes a helper
+  // identifier and a schema component key. Map iteration order must not reach
+  // either, so the same source has to emit the same bytes.
+  repeat, repeatErr, repeatCode := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if repeatCode != 0 {
+    t.Fatalf("recursive conditional alias repeat transform failed: code=%d stderr=\n%s", repeatCode, repeatErr)
+  }
+  if repeat != out {
+    t.Fatalf("repeat transform emitted different bytes:\nfirst:\n%s\nsecond:\n%s", out, repeat)
+  }
+
   recursiveConditionalAliasNameRunRuntimeCases(t, project, out)
 }
 

--- a/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
@@ -12,11 +12,11 @@ import (
 // whose resolved graph names itself (issue #2331).
 //
 // `Primitive<T>` instantiated at the self-recursive union `type Node = Date |
-// Node[]` resolves to `string & Format<"date-time"> | X[]`, where the array's
-// sole type argument is that very union. The name builders walked union member
-// -> array reference -> type argument and arrived back at the type whose name
-// was still being composed, so they recursed until the plugin process died of a
-// Go stack overflow: no diagnostic, no emit, and ttsc itself taken down with it.
+// Node[]` resolves to a union `X = string & Format<"date-time"> | X[]`, whose
+// array member's sole type argument is `X` itself. The name builders walked
+// union member -> array reference -> type argument and arrived back at the type
+// whose name was still being composed, so they recursed until the plugin process
+// died of a Go stack overflow: no diagnostic, no emit, and ttsc taken with it.
 // `Primitive` is only one witness -- any self-recursive conditional alias
 // produces the same graph -- so the fixture pins the bare `Rec<T>` form too.
 //
@@ -36,14 +36,18 @@ import (
 //     through a bounded component name.
 func TestRecursiveConditionalAliasNameTransform(t *testing.T) {
   project := recursiveConditionalAliasNameProject(t)
-  out, errText, code := ttscTypiaTestCapture(func() int {
-    return runTransform([]string{
-      "--cwd", project,
-      "--tsconfig", "tsconfig.json",
-      "--file", "src/main.ts",
-      "--output", "js",
+  transform := func() (string, string, int) {
+    return ttscTypiaTestCapture(func() int {
+      return runTransform([]string{
+        "--cwd", project,
+        "--tsconfig", "tsconfig.json",
+        "--file", "src/main.ts",
+        "--output", "js",
+      })
     })
-  })
+  }
+
+  out, errText, code := transform()
   if code != 0 {
     t.Fatalf("recursive conditional alias transform failed: code=%d stderr=\n%s", code, errText)
   }
@@ -54,14 +58,7 @@ func TestRecursiveConditionalAliasNameTransform(t *testing.T) {
   // The cycle guard is a map, and the name it settles on becomes a helper
   // identifier and a schema component key. Map iteration order must not reach
   // either, so the same source has to emit the same bytes.
-  repeat, repeatErr, repeatCode := ttscTypiaTestCapture(func() int {
-    return runTransform([]string{
-      "--cwd", project,
-      "--tsconfig", "tsconfig.json",
-      "--file", "src/main.ts",
-      "--output", "js",
-    })
-  })
+  repeat, repeatErr, repeatCode := transform()
   if repeatCode != 0 {
     t.Fatalf("recursive conditional alias repeat transform failed: code=%d stderr=\n%s", repeatCode, repeatErr)
   }

--- a/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/recursive_conditional_alias_name_transform_test.go
@@ -183,6 +183,7 @@ export const isOutput = typia.createIs<Primitive<Output>>();
 // declaration must keep transforming and must not take the cycle placeholder
 type Named = (string & tags.Format<"date-time">) | Named[];
 export const isNamed = typia.createIs<Named>();
+export const schemaNamed = typia.json.schema<Named>();
 
 type SelfArray = SelfArray[];
 export const isSelfArray = typia.createIs<SelfArray>();
@@ -289,8 +290,15 @@ if (key !== undefined) {
   expect("array items keep the date-time arm", (items.oneOf || []).some((elem) => elem.format === "date-time"), true);
 }
 
-// control: a named recursion still uses its declared name
+// controls: a recursion reached through a declaration names every component it
+// emits from that declaration, so the placeholder never applies to one
 expect("category component name", Object.keys(mod.schemaCategory.components.schemas || {})[0], "ICategory");
+const namedKeys = Object.keys(mod.schemaNamed.components.schemas || {});
+expect(
+  "named recursion names every component from its declaration",
+  namedKeys.length !== 0 && namedKeys.every((elem) => elem.includes("Named")),
+  true,
+);
 
 if (failures > 0) {
   throw new Error(failures + " assertion(s) failed");

--- a/packages/typia/native/core/factories/TypeFactory.go
+++ b/packages/typia/native/core/factories/TypeFactory.go
@@ -77,12 +77,35 @@ func (typeFactoryNamespace) GetReturnTypeOfClassMethod(props TypeFactory_GetRetu
 }
 
 func (typeFactoryNamespace) GetFullName(props TypeFactory_GetFullNameProps) string {
+  return typeFactory_get_full_name(props, nil)
+}
+
+// typeFactory_get_full_name carries the set of types whose name is still being
+// composed on the current path. A recursive type graph revisits the very same
+// *Type while its own name is unfinished -- `Rec<Node>` resolving to
+// `string | Rec<Node>[]` walks union member -> array reference -> type argument
+// -> the same union -- so an unguarded walk never terminates and overflows the
+// plugin's stack instead of naming the type (#2331). A type reached a second
+// time on one path is therefore named by its own symbol with its arguments left
+// unexpanded -- the recursion's placeholder, `Array<string | Array>` for the
+// example above -- and a symbol-less one by the checker's own rendering, which
+// already collapses the cycle into an elided form.
+func typeFactory_get_full_name(
+  props TypeFactory_GetFullNameProps,
+  visiting map[*shimchecker.Type]bool,
+) string {
   if props.Checker == nil || props.Type == nil {
     return ""
   }
   symbol := props.Symbol
   if symbol == nil {
     symbol = props.Type.Symbol()
+  }
+  if visiting[props.Type] {
+    if symbol != nil {
+      return typeFactory_get_name(symbol)
+    }
+    return props.Checker.TypeToString(props.Type)
   }
   if symbol == nil {
     if props.Type.IsUnion() || props.Type.IsIntersection() {
@@ -92,12 +115,14 @@ func (typeFactoryNamespace) GetFullName(props TypeFactory_GetFullNameProps) stri
       }
       children := props.Type.Types()
       names := make([]string, 0, len(children))
+      visiting = typeFactory_mark_visiting(visiting, props.Type)
       for _, child := range children {
-        names = append(names, TypeFactory.GetFullName(TypeFactory_GetFullNameProps{
+        names = append(names, typeFactory_get_full_name(TypeFactory_GetFullNameProps{
           Checker: props.Checker,
           Type:    child,
-        }))
+        }, visiting))
       }
+      delete(visiting, props.Type)
       return strings.Join(names, joiner)
     }
     return props.Checker.TypeToString(props.Type)
@@ -107,20 +132,33 @@ func (typeFactoryNamespace) GetFullName(props TypeFactory_GetFullNameProps) stri
   if len(generic) == 0 {
     return name
   }
+  visiting = typeFactory_mark_visiting(visiting, props.Type)
+  defer delete(visiting, props.Type)
   if name == "Promise" {
-    return TypeFactory.GetFullName(TypeFactory_GetFullNameProps{
+    return typeFactory_get_full_name(TypeFactory_GetFullNameProps{
       Checker: props.Checker,
       Type:    generic[0],
-    })
+    }, visiting)
   }
   names := make([]string, 0, len(generic))
   for _, child := range generic {
-    names = append(names, TypeFactory.GetFullName(TypeFactory_GetFullNameProps{
+    names = append(names, typeFactory_get_full_name(TypeFactory_GetFullNameProps{
       Checker: props.Checker,
       Type:    child,
-    }))
+    }, visiting))
   }
   return name + "<" + strings.Join(names, ", ") + ">"
+}
+
+func typeFactory_mark_visiting(
+  visiting map[*shimchecker.Type]bool,
+  typ *shimchecker.Type,
+) map[*shimchecker.Type]bool {
+  if visiting == nil {
+    visiting = map[*shimchecker.Type]bool{}
+  }
+  visiting[typ] = true
+  return visiting
 }
 
 func typeFactory_explore_name(node *shimast.Node, name string) string {

--- a/packages/typia/native/core/factories/TypeFactory.go
+++ b/packages/typia/native/core/factories/TypeFactory.go
@@ -77,35 +77,12 @@ func (typeFactoryNamespace) GetReturnTypeOfClassMethod(props TypeFactory_GetRetu
 }
 
 func (typeFactoryNamespace) GetFullName(props TypeFactory_GetFullNameProps) string {
-  return typeFactory_get_full_name(props, nil)
-}
-
-// typeFactory_get_full_name carries the set of types whose name is still being
-// composed on the current path. A recursive type graph revisits the very same
-// *Type while its own name is unfinished -- `Rec<Node>` resolving to
-// `string | Rec<Node>[]` walks union member -> array reference -> type argument
-// -> the same union -- so an unguarded walk never terminates and overflows the
-// plugin's stack instead of naming the type (#2331). A type reached a second
-// time on one path is therefore named by its own symbol with its arguments left
-// unexpanded -- the recursion's placeholder, `Array<string | Array>` for the
-// example above -- and a symbol-less one by the checker's own rendering, which
-// already collapses the cycle into an elided form.
-func typeFactory_get_full_name(
-  props TypeFactory_GetFullNameProps,
-  visiting map[*shimchecker.Type]bool,
-) string {
   if props.Checker == nil || props.Type == nil {
     return ""
   }
   symbol := props.Symbol
   if symbol == nil {
     symbol = props.Type.Symbol()
-  }
-  if visiting[props.Type] {
-    if symbol != nil {
-      return typeFactory_get_name(symbol)
-    }
-    return props.Checker.TypeToString(props.Type)
   }
   if symbol == nil {
     if props.Type.IsUnion() || props.Type.IsIntersection() {
@@ -115,14 +92,12 @@ func typeFactory_get_full_name(
       }
       children := props.Type.Types()
       names := make([]string, 0, len(children))
-      visiting = typeFactory_mark_visiting(visiting, props.Type)
       for _, child := range children {
-        names = append(names, typeFactory_get_full_name(TypeFactory_GetFullNameProps{
+        names = append(names, TypeFactory.GetFullName(TypeFactory_GetFullNameProps{
           Checker: props.Checker,
           Type:    child,
-        }, visiting))
+        }))
       }
-      delete(visiting, props.Type)
       return strings.Join(names, joiner)
     }
     return props.Checker.TypeToString(props.Type)
@@ -132,33 +107,20 @@ func typeFactory_get_full_name(
   if len(generic) == 0 {
     return name
   }
-  visiting = typeFactory_mark_visiting(visiting, props.Type)
-  defer delete(visiting, props.Type)
   if name == "Promise" {
-    return typeFactory_get_full_name(TypeFactory_GetFullNameProps{
+    return TypeFactory.GetFullName(TypeFactory_GetFullNameProps{
       Checker: props.Checker,
       Type:    generic[0],
-    }, visiting)
+    })
   }
   names := make([]string, 0, len(generic))
   for _, child := range generic {
-    names = append(names, typeFactory_get_full_name(TypeFactory_GetFullNameProps{
+    names = append(names, TypeFactory.GetFullName(TypeFactory_GetFullNameProps{
       Checker: props.Checker,
       Type:    child,
-    }, visiting))
+    }))
   }
   return name + "<" + strings.Join(names, ", ") + ">"
-}
-
-func typeFactory_mark_visiting(
-  visiting map[*shimchecker.Type]bool,
-  typ *shimchecker.Type,
-) map[*shimchecker.Type]bool {
-  if visiting == nil {
-    visiting = map[*shimchecker.Type]bool{}
-  }
-  visiting[typ] = true
-  return visiting
 }
 
 func typeFactory_explore_name(node *shimast.Node, name string) string {

--- a/packages/typia/native/core/schemas/metadata/MetadataCollection.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataCollection.go
@@ -810,7 +810,35 @@ var metadataCollection_replacers = []metadataCollection_replacer{
 }
 
 func metadataCollection_getFullName(checker *nativechecker.Checker, typ *nativechecker.Type) string {
+  return metadataCollection_getFullNameOf(checker, typ, nil)
+}
+
+// metadataCollection_getFullNameOf carries the types whose name is still being
+// composed on the current path. A recursive type graph reaches the same *Type
+// again before its name is finished: `type Rec<T> = T extends Date ? string : T
+// extends (infer U)[] ? Rec<U>[] : never` instantiated at `Date | Node[]`
+// resolves to the union `string | Rec<Node>[]`, whose array member is a
+// reference whose sole type argument is that very union. Walking union member ->
+// array reference -> type argument returns to the union, so the unguarded walk
+// never terminates and overflows the plugin's stack instead of naming the type
+// (#2331). A type reached a second time on one path is therefore named by its
+// own symbol with its arguments left unexpanded -- the recursion's placeholder,
+// `Array<string | Array>` for the example above -- and a symbol-less one by the
+// anonymous marker the collection already allocates unique names from. Expanding
+// the checker's elided rendering there instead would name every such component
+// after a several-hundred-character structural dump.
+func metadataCollection_getFullNameOf(
+  checker *nativechecker.Checker,
+  typ *nativechecker.Type,
+  visiting map[*nativechecker.Type]bool,
+) string {
   if checker == nil || typ == nil {
+    return "__type"
+  }
+  if visiting[typ] {
+    if symbol := metadataCollection_nameSymbol(typ); symbol != nil {
+      return metadataCollection_getName(symbol)
+    }
     return "__type"
   }
   rendered := metadataCollection_sanitizeName(checker.TypeToString(typ))
@@ -834,9 +862,11 @@ func metadataCollection_getFullName(checker *nativechecker.Checker, typ *nativec
       }
       children := typ.Types()
       names := make([]string, 0, len(children))
+      visiting = metadataCollection_markVisiting(visiting, typ)
       for _, child := range children {
-        names = append(names, metadataCollection_getFullName(checker, child))
+        names = append(names, metadataCollection_getFullNameOf(checker, child, visiting))
       }
+      delete(visiting, typ)
       return strings.Join(names, joiner)
     }
     if rendered != "" {
@@ -864,14 +894,36 @@ func metadataCollection_getFullName(checker *nativechecker.Checker, typ *nativec
     }
     return name
   }
+  visiting = metadataCollection_markVisiting(visiting, typ)
+  defer delete(visiting, typ)
   if name == "Promise" {
-    return metadataCollection_getFullName(checker, generic[0])
+    return metadataCollection_getFullNameOf(checker, generic[0], visiting)
   }
   names := make([]string, 0, len(generic))
   for _, child := range generic {
-    names = append(names, metadataCollection_getFullName(checker, child))
+    names = append(names, metadataCollection_getFullNameOf(checker, child, visiting))
   }
   return name + "<" + strings.Join(names, ", ") + ">"
+}
+
+// metadataCollection_nameSymbol picks the same symbol the main body does: the
+// alias symbol first, then the type's own.
+func metadataCollection_nameSymbol(typ *nativechecker.Type) *nativeast.Symbol {
+  if symbol := nativechecker.Type_getTypeNameSymbol(typ); symbol != nil {
+    return symbol
+  }
+  return typ.Symbol()
+}
+
+func metadataCollection_markVisiting(
+  visiting map[*nativechecker.Type]bool,
+  typ *nativechecker.Type,
+) map[*nativechecker.Type]bool {
+  if visiting == nil {
+    visiting = map[*nativechecker.Type]bool{}
+  }
+  visiting[typ] = true
+  return visiting
 }
 
 func metadataCollection_getName(symbol *nativeast.Symbol) string {

--- a/packages/typia/native/core/schemas/metadata/MetadataCollection.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataCollection.go
@@ -835,14 +835,6 @@ func metadataCollection_getFullNameOf(
   if checker == nil || typ == nil {
     return "__type"
   }
-  if visiting[typ] {
-    if symbol := metadataCollection_nameSymbol(typ); symbol != nil {
-      return metadataCollection_getName(symbol)
-    }
-    return "__type"
-  }
-  rendered := metadataCollection_sanitizeName(checker.TypeToString(typ))
-
   // Mirror TypeFactory.getFullName: prefer the alias symbol, then the type's
   // own symbol. getTypeNameSymbol already returns t.alias.symbol first (the
   // alias symbol), so a non-nil result that differs from typ.Symbol() means the
@@ -854,6 +846,13 @@ func metadataCollection_getFullNameOf(
   if symbol == nil {
     symbol = rawSymbol
   }
+  if visiting[typ] {
+    if symbol != nil {
+      return metadataCollection_getName(symbol)
+    }
+    return "__type"
+  }
+  rendered := metadataCollection_sanitizeName(checker.TypeToString(typ))
   if symbol == nil {
     if typ.IsUnion() || typ.IsIntersection() {
       joiner := " | "
@@ -904,15 +903,6 @@ func metadataCollection_getFullNameOf(
     names = append(names, metadataCollection_getFullNameOf(checker, child, visiting))
   }
   return name + "<" + strings.Join(names, ", ") + ">"
-}
-
-// metadataCollection_nameSymbol picks the same symbol the main body does: the
-// alias symbol first, then the type's own.
-func metadataCollection_nameSymbol(typ *nativechecker.Type) *nativeast.Symbol {
-  if symbol := nativechecker.Type_getTypeNameSymbol(typ); symbol != nil {
-    return symbol
-  }
-  return typ.Symbol()
 }
 
 func metadataCollection_markVisiting(

--- a/tests/test-typia-schema/src/features/validate/test_validate_recursive_conditional_alias.ts
+++ b/tests/test-typia-schema/src/features/validate/test_validate_recursive_conditional_alias.ts
@@ -17,7 +17,8 @@ import typia, { Primitive, tags } from "typia";
  * 1. Validate values against the recursive `Primitive<Node>` union.
  * 2. Read the emitted JSON schema and require the array component to reference
  *    itself under a bounded name.
- * 3. Compare against a named recursive union, which must keep its declared name.
+ * 3. Compare against a named recursive union, which must keep validating and must
+ *    still name its component from the declaration.
  */
 export const test_validate_recursive_conditional_alias = (): void => {
   type Node = Date | Node[];
@@ -98,5 +99,16 @@ export const test_validate_recursive_conditional_alias = (): void => {
     "named recursion rejects",
     typia.is<Named>([["nope"]]),
     false,
+  );
+
+  // Every component this recursion emits is reached through the declaration, so
+  // each name must be built from it -- the cycle placeholder never applies.
+  const namedKeys: string[] = Object.keys(
+    typia.json.schema<Named>().components.schemas ?? {},
+  );
+  TestValidator.predicate(
+    "named recursion names every component from the declaration",
+    () =>
+      namedKeys.length !== 0 && namedKeys.every((key) => key.includes("Named")),
   );
 };

--- a/tests/test-typia-schema/src/features/validate/test_validate_recursive_conditional_alias.ts
+++ b/tests/test-typia-schema/src/features/validate/test_validate_recursive_conditional_alias.ts
@@ -109,6 +109,7 @@ export const test_validate_recursive_conditional_alias = (): void => {
   TestValidator.predicate(
     "named recursion names every component from the declaration",
     () =>
-      namedKeys.length !== 0 && namedKeys.every((key) => key.includes("Named")),
+      namedKeys.length !== 0 &&
+      namedKeys.every((elem) => elem.includes("Named")),
   );
 };

--- a/tests/test-typia-schema/src/features/validate/test_validate_recursive_conditional_alias.ts
+++ b/tests/test-typia-schema/src/features/validate/test_validate_recursive_conditional_alias.ts
@@ -1,0 +1,102 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia, { Primitive, tags } from "typia";
+
+/**
+ * Verifies a self-recursive conditional alias validates and names itself.
+ *
+ * `Primitive<T>` over `type Node = Date | Node[]` resolves to a union whose
+ * array member's sole type argument is that very union, so the transformer's
+ * name builders walked back into a type whose name was still being composed and
+ * recursed until the plugin died of a stack overflow (#2331). The fix names
+ * such a revisited type after its own symbol, so this pins both halves: the
+ * type has to transform at all, and the name it settles on has to stay usable
+ * as a schema component key rather than a structural dump of the elided
+ * rendering.
+ *
+ * 1. Validate values against the recursive `Primitive<Node>` union.
+ * 2. Read the emitted JSON schema and require the array component to reference
+ *    itself under a bounded name.
+ * 3. Compare against a named recursive union, which must keep its declared name.
+ */
+export const test_validate_recursive_conditional_alias = (): void => {
+  type Node = Date | Node[];
+  type Primitified = Primitive<Node>;
+
+  const DATE = "2020-01-01T00:00:00.000Z";
+  const accepted: unknown[] = [DATE, [], [DATE], [[[DATE]], []]];
+  const rejected: unknown[] = ["nope", 1, null, [DATE, "nope"], [[[1]]]];
+  for (const value of accepted)
+    TestValidator.equals(
+      `accepts ${JSON.stringify(value)}`,
+      typia.is<Primitified>(value),
+      true,
+    );
+  for (const value of rejected)
+    TestValidator.equals(
+      `rejects ${JSON.stringify(value)}`,
+      typia.is<Primitified>(value),
+      false,
+    );
+
+  const result = typia.validate<Primitified>([DATE, "nope"]);
+  TestValidator.equals("validate reports failure", result.success, false);
+  if (result.success === false) {
+    const error = result.errors[0]!;
+    TestValidator.equals("validate names the path", error.path, "$input[1]");
+    TestValidator.predicate(
+      "validate keeps the expectation readable",
+      () => error.expected.length <= 64,
+    );
+  }
+
+  const unit = typia.json.schema<Primitified>();
+  const keys: string[] = Object.keys(unit.components.schemas ?? {});
+  TestValidator.equals("one component emitted", keys.length, 1);
+
+  const key: string = keys[0]!;
+  TestValidator.predicate(
+    "component name stays bounded",
+    () => key.length <= 64,
+  );
+
+  const component = unit.components.schemas![key]!;
+  TestValidator.predicate("component is an array", () =>
+    OpenApiTypeChecker.isArray(component),
+  );
+  if (OpenApiTypeChecker.isArray(component)) {
+    const items = component.items;
+    TestValidator.predicate("array items form a union", () =>
+      OpenApiTypeChecker.isOneOf(items),
+    );
+    if (OpenApiTypeChecker.isOneOf(items)) {
+      TestValidator.predicate("array references itself", () =>
+        items.oneOf.some(
+          (elem) =>
+            OpenApiTypeChecker.isReference(elem) &&
+            elem.$ref === `#/components/schemas/${key}`,
+        ),
+      );
+      TestValidator.predicate("array keeps the date-time arm", () =>
+        items.oneOf.some(
+          (elem) =>
+            OpenApiTypeChecker.isString(elem) && elem.format === "date-time",
+        ),
+      );
+    }
+  }
+
+  // Control: a recursion that already named itself through a declaration must
+  // keep that declared name instead of taking the cycle placeholder.
+  type Named = (string & tags.Format<"date-time">) | Named[];
+  TestValidator.equals(
+    "named recursion validates",
+    typia.is<Named>([[DATE]]),
+    true,
+  );
+  TestValidator.equals(
+    "named recursion rejects",
+    typia.is<Named>([["nope"]]),
+    false,
+  );
+};


### PR DESCRIPTION
## Problem

```ts
import typia, { Primitive } from "typia";

type Node = Date | Node[];
typia.createIs<Primitive<Node>>();
```

killed the plugin process:

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
```

No diagnostic, no emit, and `ttsc` taken down with it. Reported in #2331 by @kakasoo, with a second witness where the recursion sits behind an object property (`{ at: Date; payload: JsonValue }`).

## Cause

`Primitive` is a witness, not the cause. Any self-recursive conditional alias instantiates to a union whose array member is a reference whose sole type argument is that very union:

```
Array<X>  ──generic argument──▶  X = string | Array<X>  ──union member──▶  Array<X>
```

`metadataCollection_getFullName` walks exactly that path — union members and generic arguments — with no visited set, so it never terminates. An instrumented plugin measured it: `Iterate_metadata` entered **3 times, maximum depth 2**, while the name builder entered **2,013,074 times** before the stack gave out, revisiting the *same three type pointers* in a loop.

`checker.TypeToString` returned normally on every one of those calls — it elides past a depth bound — so this is typia's recursion, not a compiler defect. A control that declaration-emits the same `Primitive<Node>` with no typia call transforms fine.

## Fix

The walk carries the types whose name is still being composed on the current path and names a revisited one after its own symbol with its arguments unexpanded — the recursion's placeholder, `Array<string | Array>`. The set is per path, not per analysis: every mark is removed on the way out, so a diamond that legitimately reaches one type twice still expands both times.

Naming a revisited type after the checker's elided rendering also terminates, and was the first version, but it named the JSON schema component with a 400-character structural dump. The shipped rule gives `ArrayArraystringFormatdate-time`, and the schema still self-references correctly.

## Scope

`TypeFactory.GetFullName` has the same recursion shape and was guarded in the first commit, then removed in `d0dc679` because Self-Review could not reach it: every caller passes the printed type-argument text as the name, and the one `Name: nil` path hands it a type it returns from without recursing. `metadata_type_full_name` descends only into union and intersection members, which TypeScript flattens, so no cycle can form there. Reasoning for both is on the review thread.

## Verification

- **Regression:** `TestRecursiveConditionalAliasNameTransform` transforms `is` / `assert` / `json.schema` over `Primitive<Node>`, the bare `Rec<T>` alias, and the recursive-`JsonValue` object, beside controls for a named recursive union, `type A = A[]`, and a recursive interface. It executes the emitted validators over positive, negative, nested, 64-deep, self-referencing-value and boundary inputs, requires the schema to self-reference under a bounded name, and requires two transforms of the same source to emit identical bytes.
- **Public surface:** `test_validate_recursive_conditional_alias` runs the same type through the real package — `is`, `validate`, and `json.schema`.
- **Mutation:** reverting only the product file while retaining both tests reproduces `fatal error: stack overflow`. The regression is sensitive to the fix.
- **Consequence surface:** `is`, `assert`, `validate`, `json.stringify`, `json.isParse`, `json.schema`, `random`, `plain.clone`, `plain.classify`, `compare.equals`, `reflect.name`, `reflect.schema` all transform over the recursive type. `json.application` and `notations.camel` still reject it, correctly and by their own contracts.
- **Commands:** `pnpm test:go:native` (targeted), `pnpm --filter ./tests/test-typia-schema start`, root `pnpm test`, and this pull request's CI.

## Deferred

`metadata_type_symbol_name` in `MetadataHelper.go` has no caller but itself — the Map/Set guards use the non-recursive `metadata_type_symbol_base_name`. Noted during review, unrelated to this issue, not touched.

## Not changed

No exported symbol, CLI flag, plugin descriptor shape, or documented behavior. No package version, per the campaign freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
