### PR TITLE
fix(deps): pin internal package references to the exact published version

### DIFF
--- a/.agents/skills/development/SKILL.md
+++ b/.agents/skills/development/SKILL.md
@@ -30,7 +30,8 @@ These four are never acceptable; choosing any one means the approach is already 
 - Match existing conventions. Before adding a file, function, or test, open a nearby peer and mirror its naming, location, and code style; don't create parallel structures.
 - Respect package boundaries. The shared native transform lives under `packages/typia/native`; don't fork a second transform into an adapter package or reintroduce a TypeScript-side transformer.
 - Keep package detection installation-safe. Resolve the target package root, as `packages/typia/src/transform.ts` does with `require.resolve("typia/package.json")`; workspace path substrings and hard-coded fixture names fail for npm consumers.
-- Use the workspace catalogs. `pnpm-workspace.yaml` owns `typescript`, `rolldown`, and `utils`; internal package references use `workspace:^`.
+- Use the workspace catalogs. `pnpm-workspace.yaml` owns `typescript`, `rolldown`, and `utils`.
+- Reference one published package from another with `workspace:*`, which pnpm replaces with the exact version at publish. `@typia/interface` states emit contracts in its type declarations — `MinLength` resolves to `` `${Value} <= $importInternal("_stringLength")($input)` `` — so a caret range lets an older `typia` resolve a newer `@typia/interface` and emit imports for runtime helpers it does not ship (#2330). Workspaces outside `packages/` are private and never publish, so their `workspace:^` references are inert.
 - Keep local outputs local. Do not commit `.env` files or the `.tgz` artifacts generated under `experiments/tarballs/`.
 - Preserve the public contract in `.agents/skills/project/SKILL.md`. Renaming or removing `typia.*`, `@typia/interface` types, CLI flags, or the plugin descriptor shape is a deliberate product change, not incidental cleanup.
 - When public behavior changes, update the matching page under `website/src/content/docs/**` in the same change. Follow `.agents/skills/documentation/SKILL.md`.

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -24,8 +24,8 @@
   "homepage": "https://typia.io",
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
-    "@typia/interface": "workspace:^",
-    "@typia/utils": "workspace:^"
+    "@typia/interface": "workspace:*",
+    "@typia/utils": "workspace:*"
   },
   "peerDependencies": {
     "@langchain/core": ">=1.1.30"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@typia/interface": "workspace:^",
-    "@typia/utils": "workspace:^"
+    "@typia/interface": "workspace:*",
+    "@typia/utils": "workspace:*"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.12.0"

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -35,8 +35,8 @@
   "homepage": "https://typia.io",
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
-    "@typia/interface": "workspace:^",
-    "@typia/utils": "workspace:^",
+    "@typia/interface": "workspace:*",
+    "@typia/utils": "workspace:*",
     "commander": "^10.0.0",
     "inquirer": "^8.2.5",
     "randexp": "^0.5.3",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@typia/interface": "workspace:^"
+    "@typia/interface": "workspace:*"
   },
   "devDependencies": {
     "rimraf": "catalog:utils",

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@typia/interface": "workspace:^",
-    "@typia/utils": "workspace:^"
+    "@typia/interface": "workspace:*",
+    "@typia/utils": "workspace:*"
   },
   "peerDependencies": {
     "ai": ">=6.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,10 +250,10 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       '@typia/interface':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../interface
       '@typia/utils':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../utils
     devDependencies:
       '@langchain/core':
@@ -278,10 +278,10 @@ importers:
   packages/mcp:
     dependencies:
       '@typia/interface':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../interface
       '@typia/utils':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../utils
     devDependencies:
       '@modelcontextprotocol/sdk':
@@ -309,10 +309,10 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
       '@typia/interface':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../interface
       '@typia/utils':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../utils
       commander:
         specifier: ^10.0.0
@@ -355,7 +355,7 @@ importers:
   packages/utils:
     dependencies:
       '@typia/interface':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../interface
     devDependencies:
       rimraf:
@@ -377,10 +377,10 @@ importers:
   packages/vercel:
     dependencies:
       '@typia/interface':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../interface
       '@typia/utils':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../utils
     devDependencies:
       '@types/json-schema':


### PR DESCRIPTION
Closes #2330.

## Intent

`typia@13.1.1` breaks on a fresh `npm install`. No lockfile drift, no pnpm, no contaminated worktree — an empty directory is enough:

```
typia            = 13.1.1
@typia/interface = 13.2.0        <- the caret floats it up
typia/lib/internal/_stringLength.js -> absent
```

`@typia/interface` states emit contracts in its type declarations, not only types. `MinLength` resolves to `` `${Value} <= $importInternal("_stringLength")($input)` ``, so the tag names a runtime file that the transform then imports. That reference moved from `$input.length` to `_stringLength` in 13.1.19, and `typia` 13.0.0 through 13.1.1 does not ship `lib/internal/_stringLength`. `_isMultipleOf` moved the same way for `MultipleOf`.

Published manifests carried `"@typia/interface": "^13.2.0"`, which lets the descriptor float above the runtime that has to satisfy it. Every release becomes reachable-broken the moment a later minor adds an `$importInternal` helper. 13.2.0 is intact today only because it is the newest — it is next in line once 13.3.x publishes, for anyone who pins `typia` exactly or with `~`.

## Change

`workspace:*` publishes as the exact version, so `typia@X` can only pair with `@typia/interface@X`.

| | before | after (published) |
| --- | --- | --- |
| `typia` | `^13.2.0` | `13.2.0` |
| `@typia/utils` | `^13.2.0` | `13.2.0` |
| `@typia/langchain` | `^13.2.0` | `13.2.0` |
| `@typia/mcp` | `^13.2.0` | `13.2.0` |
| `@typia/vercel` | `^13.2.0` | `13.2.0` |

The packages release in lockstep through `bumpp -r`, so the caret bought no flexibility that was ever used. This is also how esbuild, next, vue, `@typescript-eslint`, and `ttsc` itself version their internal packages — `ttsc` already pins all seven of its platform packages exactly.

`.agents/skills/development/SKILL.md` mandated `workspace:^` for internal references, so it moves with the code. Without that edit the skill contradicts the manifests and the next contributor reverts them.

## Scope

The five published packages only. Workspaces under `tests/`, `benchmark/`, `website/`, and `examples/` are `private: true`, so the workspace protocol is never replaced there; their `workspace:^` references are inert and stay as they are.

The `pnpm-lock.yaml` diff is restricted to the nine `specifier:` lines. A full `pnpm install` also deduped `@types/whatwg-url`'s `@types/node` from 26.1.2 to 18.19.130 — unrelated registry drift, so it was left out.

## Verification

All local, with pnpm 10.6.4 (the pinned version):

- `pnpm install --frozen-lockfile` exits 0. This is the gate CI runs, since pnpm defaults `frozen-lockfile` to true in CI.
- `pnpm pack` on all five packages emits `13.2.0` for every internal dependency, confirmed by reading `package/package.json` out of each tarball.
- The `workspace:*` -> exact replacement was checked on pnpm 10.6.4 directly, against `workspace:^` and `workspace:~` in the same manifest, before touching this repository.

Root `pnpm format` covers `**/*.ts` and changed Go files. This change touches only `package.json`, `pnpm-lock.yaml`, and `SKILL.md`, none of which it formats, so it was not run.

## Deferred

Already-published `typia@>=13.0.0 <13.1.19` cannot be repaired by this change — a fresh install of those versions still resolves a newer `@typia/interface`. `npm deprecate` over that range is the remaining lever and is not part of this pull request.

`@nestia/core` declares `@typia/interface` and `@typia/utils` directly with carets, which is a second float vector in that repository. Not reachable from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
