### PR TITLE
fix(interface): stop the int64 and uint64 bigint tag validators from naming a runtime helper

### DIFF
--- a/packages/interface/src/tags/Type.ts
+++ b/packages/interface/src/tags/Type.ts
@@ -25,8 +25,8 @@ import { TagBase } from "./TagBase";
  * The constraint is enforced at runtime by `typia.is()`, `typia.assert()`, and
  * `typia.validate()`. It generates appropriate `type` in JSON Schema.
  *
- * On a `bigint`, `"int64"` and `"uint64"` select the protobuf scalar type but do
- * not check the 64-bit width: `"int64"` enforces nothing, and `"uint64"`
+ * On a `bigint`, `"int64"` and `"uint64"` select the protobuf scalar type but
+ * do not check the 64-bit width: `"int64"` enforces nothing, and `"uint64"`
  * enforces only `0n <= value`. Their `number` forms do enforce their range.
  *
  * @author Jeongho Nam - https://github.com/samchon

--- a/packages/interface/src/tags/Type.ts
+++ b/packages/interface/src/tags/Type.ts
@@ -25,6 +25,10 @@ import { TagBase } from "./TagBase";
  * The constraint is enforced at runtime by `typia.is()`, `typia.assert()`, and
  * `typia.validate()`. It generates appropriate `type` in JSON Schema.
  *
+ * On a `bigint`, `"int64"` and `"uint64"` select the protobuf scalar type but do
+ * not check the 64-bit width: `"int64"` enforces nothing, and `"uint64"`
+ * enforces only `0n <= value`. Their `number` forms do enforce their range.
+ *
  * @author Jeongho Nam - https://github.com/samchon
  * @example
  *   interface Message {
@@ -69,12 +73,12 @@ export type Type<
               : Value extends "int64"
                 ? {
                     number: `$importInternal("isTypeInt64")($input)`;
-                    bigint: `$importInternal("isTypeInt64Bigint")($input)`;
+                    bigint: `true`;
                   }
                 : Value extends "uint64"
                   ? {
                       number: `$importInternal("isTypeUint64")($input)`;
-                      bigint: `$importInternal("isTypeUint64Bigint")($input)`;
+                      bigint: `BigInt(0) <= $input`;
                     }
                   : Value extends "float"
                     ? `$importInternal("isTypeFloat")($input)`

--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -411,7 +411,7 @@ func metadataCommentTagFactory_parse_type(props struct {
     // `Type<"uint64">` declare them, because `@type int64` and
     // `bigint & Type<"int64">` are two spellings of one constraint.
     //
-    // That declaration may not name a runtime helper the way the `number` arms
+    // That declaration must not name a runtime helper the way the `number` arms
     // above do. A `$importInternal(...)` in a tag template makes the emitted
     // validator import a `typia/lib/internal/*` module, and the declaration
     // lives in `@typia/interface`, which `typia` depends on through a caret

--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -411,17 +411,21 @@ func metadataCommentTagFactory_parse_type(props struct {
     // `Type<"uint64">` declare them, because `@type int64` and
     // `bigint & Type<"int64">` are two spellings of one constraint.
     //
-    // That declaration cannot name a runtime helper. A `$importInternal(...)`
-    // in a tag template makes the emitted validator import a
-    // `typia/lib/internal/*` module, and the declaration lives in
-    // `@typia/interface`, which `typia` depends on through a caret range that
-    // only floats upward -- so an older `typia` installs a newer
+    // That declaration may not name a runtime helper the way the `number` arms
+    // above do. A `$importInternal(...)` in a tag template makes the emitted
+    // validator import a `typia/lib/internal/*` module, and the declaration
+    // lives in `@typia/interface`, which `typia` depends on through a caret
+    // range that only floats upward -- so an older `typia` installs a newer
     // `@typia/interface` and emits an import its own runtime never shipped
-    // (#2330). Inside one major there is no range that prevents that pairing.
+    // (#2330). `isTypeInt64` and `isTypeUint64` are safe there because
+    // `@typia/interface` 13.0.0 already named them and `typia` 13.0.0 already
+    // shipped them; a helper introduced later is not, and inside one major
+    // there is no range that prevents the pairing.
     //
     // The bound this leaves unenforced is real: int64 accepts any magnitude and
-    // uint64 only rejects negatives. #2338 owns restoring it in a major
-    // release, the one boundary a caret cannot cross.
+    // uint64 only rejects negatives. #2338 owns restoring it, and only a major
+    // can carry it -- an inline exact comparison would name no helper, but
+    // tightening an accepted range rejects data that passes today.
     bigintValidate := "BigInt(0) <= $input"
     if value == "int64" {
       bigintValidate = "true"

--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -407,13 +407,24 @@ func metadataCommentTagFactory_parse_type(props struct {
     "number": {{Name: "Type<" + strconv.Quote(value) + ">", Target: "number", Kind: "type", Value: value, Validate: validate, Exclusive: metadataCommentTagFactory_exclusive("type"), Schema: numberSchema}},
   }
   if value == "int64" || value == "uint64" {
-    // The bigint form used to emit `true` for int64 and a lower bound only for
-    // uint64, so `bigint & Type<"int64">` -- the spelling the documentation
-    // recommends -- certified any magnitude at all. Both now delegate to the
-    // helper that holds the exact inclusive bound a bigint can represent.
-    bigintValidate := "$importInternal(\"isTypeUint64Bigint\")($input)"
+    // Both checks stay inline, spelled exactly as `Type<"int64">` and
+    // `Type<"uint64">` declare them, because `@type int64` and
+    // `bigint & Type<"int64">` are two spellings of one constraint.
+    //
+    // That declaration cannot name a runtime helper. A `$importInternal(...)`
+    // in a tag template makes the emitted validator import a
+    // `typia/lib/internal/*` module, and the declaration lives in
+    // `@typia/interface`, which `typia` depends on through a caret range that
+    // only floats upward -- so an older `typia` installs a newer
+    // `@typia/interface` and emits an import its own runtime never shipped
+    // (#2330). Inside one major there is no range that prevents that pairing.
+    //
+    // The bound this leaves unenforced is real: int64 accepts any magnitude and
+    // uint64 only rejects negatives. #2338 owns restoring it in a major
+    // release, the one boundary a caret cannot cross.
+    bigintValidate := "BigInt(0) <= $input"
     if value == "int64" {
-      bigintValidate = "$importInternal(\"isTypeInt64Bigint\")($input)"
+      bigintValidate = "true"
     }
     record["bigint"] = []schemametadata.IMetadataTypeTag{
       {Name: "Type<" + strconv.Quote(value) + ">", Target: "bigint", Kind: "type", Value: value, Validate: bigintValidate, Exclusive: metadataCommentTagFactory_exclusive("type"), Schema: bigintSchema},

--- a/packages/typia/native/core/programmers/RandomProgrammer.go
+++ b/packages/typia/native/core/programmers/RandomProgrammer.go
@@ -1444,9 +1444,9 @@ func randomProgrammer_is_typed_array(name string) bool {
 // two. That costs nothing here: the generator only picks a value from the range,
 // and the TypedArray constructor wraps whatever it is handed. On the `number`
 // path validation owns exactness instead, in _isTypeInt64 and _isTypeUint64. The
-// `bigint` path owns none: its type tag declares no width check at all, so that
-// the declaration names no runtime helper an older `typia` cannot resolve
-// (#2330), and #2338 owns restoring the bound.
+// `bigint` path owns none: Type<"int64"> declares no check and Type<"uint64">
+// only a lower bound, so that neither declaration names a runtime helper an
+// older `typia` cannot resolve (#2330). #2338 owns restoring the bound.
 func randomProgrammer_typed_array_range(name string) (string, string, string) {
   switch name {
   case "Uint8Array", "Uint8ClampedArray":

--- a/packages/typia/native/core/programmers/RandomProgrammer.go
+++ b/packages/typia/native/core/programmers/RandomProgrammer.go
@@ -1442,8 +1442,11 @@ func randomProgrammer_is_typed_array(name string) bool {
 // `maximum` comment tags on a number-typed JSON schema, and `number` cannot
 // represent 2**63 - 1 or 2**64 - 1 -- both arrive rounded up to the next power of
 // two. That costs nothing here: the generator only picks a value from the range,
-// and the TypedArray constructor wraps whatever it is handed. Validation owns
-// exactness instead, in _isTypeInt64Bigint and its siblings.
+// and the TypedArray constructor wraps whatever it is handed. On the `number`
+// path validation owns exactness instead, in _isTypeInt64 and _isTypeUint64. The
+// `bigint` path owns none: its type tag declares no width check at all, so that
+// the declaration names no runtime helper an older `typia` cannot resolve
+// (#2330), and #2338 owns restoring the bound.
 func randomProgrammer_typed_array_range(name string) (string, string, string) {
   switch name {
   case "Uint8Array", "Uint8ClampedArray":

--- a/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
@@ -24,21 +24,23 @@ interface ICommentBigint {
 /**
  * Verifies int64 bounds the number path and leaves the bigint path unchecked.
  *
- * The bigint arm may not name a `typia/lib/internal/*` helper. It is declared in
- * `@typia/interface`, which `typia` admits through a caret range that only
+ * The bigint arm may not name a `typia/lib/internal/*` helper. It is declared
+ * in `@typia/interface`, which `typia` admits through a caret range that only
  * floats upward, so a named helper makes an older `typia` emit an import it
- * never shipped (#2330). The arm is therefore the bare `true` it declared before
- * #2166, which enforces nothing -- and an unenforced bound is invisible unless
- * the gap is pinned, so this file asserts the accepted out-of-range values and
- * the protobuf round trips that then corrupt them. #2338 owns restoring the
- * bound in a major release, the one boundary a caret cannot cross.
+ * never shipped (#2330). The arm is therefore the bare `true` it declared
+ * before #2166, which enforces nothing -- and an unenforced bound is invisible
+ * unless the gap is pinned, so this file asserts the accepted out-of-range
+ * values and the protobuf round trips that then corrupt them. #2338 owns
+ * restoring the bound, and only a major can carry it: tightening an accepted
+ * range rejects data that passes today.
  *
  * 1. Keep the enforced number path, whose helper crosses no package boundary.
- * 2. Require the bigint type tag and `@type int64` to accept every bigint, while
- *    the still-published `_isTypeInt64Bigint` keeps the exact bound.
- * 3. Pin both protobuf outcomes against the wire format: an in-range value
- *    survives byte for byte, an accepted out-of-range value comes back as its
- *    two's-complement 64-bit truncation.
+ * 2. Require the bigint type tag and `@type int64` to accept every bigint and
+ *    still reject a non-bigint, while the still-published `_isTypeInt64Bigint`
+ *    keeps the exact bound.
+ * 3. Pin both protobuf outcomes against the wire format: an in-range value decodes
+ *    unchanged, an accepted out-of-range value decodes as its two's-complement
+ *    64-bit truncation.
  */
 export const test_type_int64_range = (): void => {
   const MINIMUM: bigint = -(2n ** 63n);
@@ -145,25 +147,22 @@ export const test_type_int64_range = (): void => {
     );
   }
 
-  // The gap is exactly the out-of-range members: the helper rejects them and the
-  // tag does not. An empty list would make the claim vacuous, so it is checked.
-  const unenforced: bigint[] = bigints.filter(
+  // The gap is the out-of-range members: the loop above asserts the helper
+  // rejects each one and the tag accepts it anyway, which is the whole
+  // disagreement. What that loop cannot defend is its own input -- a boundary
+  // list later trimmed to in-range values would still pass while proving
+  // nothing -- so the out-of-range members are counted rather than assumed.
+  const unenforced: number = bigints.filter(
     (value) => oracle(value) === false,
-  );
-  if (unenforced.length === 0)
+  ).length;
+  if (unenforced === 0)
     throw new Error("the bigint boundary list carries no out-of-range value.");
-  for (const value of unenforced)
-    TestValidator.notEquals(
-      `the int64 bigint tag no longer agrees with _isTypeInt64Bigint on ${value}`,
-      _isTypeInt64Bigint(value),
-      typia.is<ITaggedBigint>({ value }),
-    );
 
   // A bigint tag still rejects a non-bigint, so `true` replaced the range check
   // and not the type check.
   for (const value of [0, "0", null])
     TestValidator.equals(
-      `bigint type tag rejects the non-bigint ${String(value)}`,
+      `bigint type tag rejects the non-bigint ${JSON.stringify(value)}`,
       false,
       typia.is<ITaggedBigint>({ value: value as unknown as bigint }),
     );
@@ -171,13 +170,18 @@ export const test_type_int64_range = (): void => {
   //----
   // PROTOBUF ROUND TRIP
   //----
-  // A protobuf `int64` field is a two's-complement 64-bit varint, so the wire
-  // form of a value outside that width is `BigInt.asIntN(64, value)`. The oracle
-  // is the wire format, not typia's output.
+  // A protobuf `int64` field is a two's-complement 64-bit varint: the writer
+  // emits the low 64 bits and the reader reads them back signed, so a value
+  // outside that width decodes as `BigInt.asIntN(64, value)`. The oracle is the
+  // wire format, not typia's output.
   for (const value of [MINIMUM, MAXIMUM, 0n, -1n, 1n, 2n ** 62n]) {
-    TestValidator.equals(`round trip ${value} is in range`, true, oracle(value));
     TestValidator.equals(
-      `int64 ${value} survives protobuf unchanged`,
+      `round trip ${value} is in range`,
+      true,
+      oracle(value),
+    );
+    TestValidator.equals(
+      `int64 ${value} decodes unchanged`,
       value,
       roundTrip(value),
     );
@@ -186,8 +190,17 @@ export const test_type_int64_range = (): void => {
   // Outside the width, typia certifies a value its own encoder truncates. That
   // is the cost of the unenforced bound, and #2338 owns closing it; until then
   // it is pinned here rather than left untested.
-  for (const value of [MAXIMUM + 1n, MINIMUM - 1n, 2n ** 64n + 7n, 2n ** 200n + 3n]) {
-    TestValidator.equals(`${value} is out of int64 range`, false, oracle(value));
+  for (const value of [
+    MAXIMUM + 1n,
+    MINIMUM - 1n,
+    2n ** 64n + 7n,
+    2n ** 200n + 3n,
+  ]) {
+    TestValidator.equals(
+      `${value} is out of int64 range`,
+      false,
+      oracle(value),
+    );
     TestValidator.equals(
       `typia certifies the out-of-range ${value}`,
       true,
@@ -195,7 +208,7 @@ export const test_type_int64_range = (): void => {
     );
     const truncated: bigint = BigInt.asIntN(64, value);
     TestValidator.notEquals(
-      `the int64 wire form of ${value} is a different value`,
+      `the int64 decode of ${value} is a different value`,
       value,
       truncated,
     );

--- a/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
@@ -24,7 +24,7 @@ interface ICommentBigint {
 /**
  * Verifies int64 bounds the number path and leaves the bigint path unchecked.
  *
- * The bigint arm may not name a `typia/lib/internal/*` helper. It is declared
+ * The bigint arm must not name a `typia/lib/internal/*` helper. It is declared
  * in `@typia/interface`, which `typia` admits through a caret range that only
  * floats upward, so a named helper makes an older `typia` emit an import it
  * never shipped (#2330). The arm is therefore the bare `true` it declared

--- a/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
@@ -22,18 +22,23 @@ interface ICommentBigint {
 }
 
 /**
- * Verifies that the int64 validators enforce the signed 64-bit range on both
- * the number and bigint paths.
+ * Verifies int64 bounds the number path and leaves the bigint path unchecked.
  *
- * Int64-max is `2 ** 63 - 1`, which no `number` can represent -- it rounds to
- * `2 ** 63` -- so the number path accepts `2 ** 63` as int64-max's only float
- * form. The bigint path represents the bound exactly, so it enforces the true
- * inclusive range and still rejects magnitudes such as `2n ** 200n` that the
- * bare-`true` bigint validator used to certify.
+ * The bigint arm may not name a `typia/lib/internal/*` helper. It is declared in
+ * `@typia/interface`, which `typia` admits through a caret range that only
+ * floats upward, so a named helper makes an older `typia` emit an import it
+ * never shipped (#2330). The arm is therefore the bare `true` it declared before
+ * #2166, which enforces nothing -- and an unenforced bound is invisible unless
+ * the gap is pinned, so this file asserts the accepted out-of-range values and
+ * the protobuf round trips that then corrupt them. #2338 owns restoring the
+ * bound in a major release, the one boundary a caret cannot cross.
  *
- * 1. Accept in-range numbers, including int64-max's float form `2 ** 63`.
- * 2. Enforce the exact inclusive bounds on the bigint path from a BigInt oracle.
- * 3. Require every certified bigint to survive a protobuf round trip unchanged.
+ * 1. Keep the enforced number path, whose helper crosses no package boundary.
+ * 2. Require the bigint type tag and `@type int64` to accept every bigint, while
+ *    the still-published `_isTypeInt64Bigint` keeps the exact bound.
+ * 3. Pin both protobuf outcomes against the wire format: an in-range value
+ *    survives byte for byte, an accepted out-of-range value comes back as its
+ *    two's-complement 64-bit truncation.
  */
 export const test_type_int64_range = (): void => {
   const MINIMUM: bigint = -(2n ** 63n);
@@ -56,6 +61,8 @@ export const test_type_int64_range = (): void => {
   //----
   // NUMBER PATH
   //----
+  // `isTypeInt64` is named by `@typia/interface` 13.0.0 and shipped by `typia`
+  // 13.0.0, so it crosses no version boundary and the number path keeps it.
   // int64-max is `2 ** 63 - 1`, which rounds to `2 ** 63` as a `number`, so the
   // number path accepts `2 ** 63`: no double can distinguish the two. `2 ** 64`
   // and beyond stay out of range.
@@ -102,6 +109,11 @@ export const test_type_int64_range = (): void => {
   //----
   // BIGINT PATH
   //----
+  // `_isTypeInt64Bigint` stays published with the exact bound even though the
+  // emitted validator no longer reaches it: a `typia` that ships the helper can
+  // still satisfy an `@typia/interface` that names it, which is the other
+  // direction of the same compatibility problem. So the helper and the tag are
+  // asserted separately, and the values where they now disagree are the gap.
   const bigints: bigint[] = [
     0n,
     1n,
@@ -122,35 +134,80 @@ export const test_type_int64_range = (): void => {
       _isTypeInt64Bigint(value),
     );
     TestValidator.equals(
-      `bigint type tag on ${value} === ${expected}`,
-      expected,
+      `bigint type tag accepts ${value}`,
+      true,
       typia.is<ITaggedBigint>({ value }),
     );
     TestValidator.equals(
-      `bigint comment tag on ${value} === ${expected}`,
-      expected,
+      `bigint comment tag accepts ${value}`,
+      true,
       typia.is<ICommentBigint>({ value }),
     );
   }
 
-  //----
-  // ROUND TRIP
-  //----
-  // On the exact bigint path, typia never certifies a value its own encoder will
-  // corrupt: every in-range bigint survives protobuf byte-for-byte.
-  for (const value of [MINIMUM, MAXIMUM, 0n, -1n, 1n, 2n ** 62n]) {
-    TestValidator.equals(
-      `round trip ${value} is certified`,
-      true,
-      oracle(value),
+  // The gap is exactly the out-of-range members: the helper rejects them and the
+  // tag does not. An empty list would make the claim vacuous, so it is checked.
+  const unenforced: bigint[] = bigints.filter(
+    (value) => oracle(value) === false,
+  );
+  if (unenforced.length === 0)
+    throw new Error("the bigint boundary list carries no out-of-range value.");
+  for (const value of unenforced)
+    TestValidator.notEquals(
+      `the int64 bigint tag no longer agrees with _isTypeInt64Bigint on ${value}`,
+      _isTypeInt64Bigint(value),
+      typia.is<ITaggedBigint>({ value }),
     );
-    const decoded: typia.Resolved<ITaggedBigint> = typia.protobuf.decode<
-      typia.Resolved<ITaggedBigint>
-    >(typia.protobuf.encode<ITaggedBigint>({ value }));
+
+  // A bigint tag still rejects a non-bigint, so `true` replaced the range check
+  // and not the type check.
+  for (const value of [0, "0", null])
+    TestValidator.equals(
+      `bigint type tag rejects the non-bigint ${String(value)}`,
+      false,
+      typia.is<ITaggedBigint>({ value: value as unknown as bigint }),
+    );
+
+  //----
+  // PROTOBUF ROUND TRIP
+  //----
+  // A protobuf `int64` field is a two's-complement 64-bit varint, so the wire
+  // form of a value outside that width is `BigInt.asIntN(64, value)`. The oracle
+  // is the wire format, not typia's output.
+  for (const value of [MINIMUM, MAXIMUM, 0n, -1n, 1n, 2n ** 62n]) {
+    TestValidator.equals(`round trip ${value} is in range`, true, oracle(value));
     TestValidator.equals(
       `int64 ${value} survives protobuf unchanged`,
       value,
-      decoded.value,
+      roundTrip(value),
+    );
+  }
+
+  // Outside the width, typia certifies a value its own encoder truncates. That
+  // is the cost of the unenforced bound, and #2338 owns closing it; until then
+  // it is pinned here rather than left untested.
+  for (const value of [MAXIMUM + 1n, MINIMUM - 1n, 2n ** 64n + 7n, 2n ** 200n + 3n]) {
+    TestValidator.equals(`${value} is out of int64 range`, false, oracle(value));
+    TestValidator.equals(
+      `typia certifies the out-of-range ${value}`,
+      true,
+      typia.is<ITaggedBigint>({ value }),
+    );
+    const truncated: bigint = BigInt.asIntN(64, value);
+    TestValidator.notEquals(
+      `the int64 wire form of ${value} is a different value`,
+      value,
+      truncated,
+    );
+    TestValidator.equals(
+      `int64 ${value} comes back truncated to ${truncated}`,
+      truncated,
+      roundTrip(value),
     );
   }
 };
+
+const roundTrip = (value: bigint): bigint =>
+  typia.protobuf.decode<typia.Resolved<ITaggedBigint>>(
+    typia.protobuf.encode<ITaggedBigint>({ value }),
+  ).value;

--- a/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
@@ -24,23 +24,24 @@ interface ICommentBigint {
 /**
  * Verifies uint64 bounds the number path and only rejects negatives on bigint.
  *
- * The bigint arm may not name a `typia/lib/internal/*` helper. It is declared in
- * `@typia/interface`, which `typia` admits through a caret range that only
+ * The bigint arm may not name a `typia/lib/internal/*` helper. It is declared
+ * in `@typia/interface`, which `typia` admits through a caret range that only
  * floats upward, so a named helper makes an older `typia` emit an import it
  * never shipped (#2330). The arm is therefore the `BigInt(0) <= $input` it
  * declared before #2166: a lower bound with no upper bound. The surviving lower
  * bound is what separates this tag from `Type<"int64">`, whose arm checks
  * nothing at all, so both halves are pinned -- the negatives still rejected and
- * the oversized values now accepted. #2338 owns restoring the upper bound in a
- * major release, the one boundary a caret cannot cross.
+ * the oversized values now accepted. #2338 owns restoring the upper bound, and
+ * only a major can carry it: tightening an accepted range rejects data that
+ * passes today.
  *
  * 1. Keep the enforced number path, whose helper crosses no package boundary.
- * 2. Require the bigint type tag and `@type uint64` to reject every negative and
- *    accept every non-negative, while the still-published `_isTypeUint64Bigint`
- *    keeps the exact bound.
- * 3. Pin both protobuf outcomes against the wire format: an in-range value
- *    survives byte for byte, an accepted oversized value comes back as its
- *    unsigned 64-bit truncation.
+ * 2. Require the bigint type tag and `@type uint64` to reject every negative,
+ *    accept every non-negative, and still reject a non-bigint, while the
+ *    still-published `_isTypeUint64Bigint` keeps the exact bound.
+ * 3. Pin both protobuf outcomes against the wire format: an in-range value decodes
+ *    unchanged, an accepted oversized value decodes as its unsigned 64-bit
+ *    truncation.
  */
 export const test_type_uint64_range = (): void => {
   const MINIMUM: bigint = 0n;
@@ -149,33 +150,23 @@ export const test_type_uint64_range = (): void => {
     );
   }
 
-  // The gap is exactly the oversized members: the helper rejects them and the
-  // tag does not. Negatives are not in it, because the lower bound survives. An
-  // empty list on either side would make the claim vacuous, so both are checked.
-  const oversized: bigint[] = bigints.filter((value) => MAXIMUM < value);
-  const negative: bigint[] = bigints.filter((value) => value < MINIMUM);
-  if (oversized.length === 0 || negative.length === 0)
+  // The gap is the oversized members, and the negatives are outside it because
+  // the lower bound survives. The loop above asserts both of those on every
+  // member; what it cannot defend is its own input, since a boundary list later
+  // trimmed to in-range values would still pass while proving nothing. So both
+  // kinds are counted rather than assumed.
+  const oversized: number = bigints.filter((value) => MAXIMUM < value).length;
+  const negative: number = bigints.filter((value) => value < MINIMUM).length;
+  if (oversized === 0 || negative === 0)
     throw new Error(
       "the bigint boundary list needs an oversized and a negative value.",
-    );
-  for (const value of oversized)
-    TestValidator.notEquals(
-      `the uint64 bigint tag no longer agrees with _isTypeUint64Bigint on ${value}`,
-      _isTypeUint64Bigint(value),
-      typia.is<ITaggedBigint>({ value }),
-    );
-  for (const value of negative)
-    TestValidator.equals(
-      `the uint64 bigint tag still agrees with _isTypeUint64Bigint on ${value}`,
-      _isTypeUint64Bigint(value),
-      typia.is<ITaggedBigint>({ value }),
     );
 
   // A bigint tag still rejects a non-bigint, so the lower bound replaced the
   // range check and not the type check.
   for (const value of [0, "0", null])
     TestValidator.equals(
-      `bigint type tag rejects the non-bigint ${String(value)}`,
+      `bigint type tag rejects the non-bigint ${JSON.stringify(value)}`,
       false,
       typia.is<ITaggedBigint>({ value: value as unknown as bigint }),
     );
@@ -183,13 +174,18 @@ export const test_type_uint64_range = (): void => {
   //----
   // PROTOBUF ROUND TRIP
   //----
-  // A protobuf `uint64` field is an unsigned 64-bit varint, so the wire form of
-  // a value outside that width is `BigInt.asUintN(64, value)`. The oracle is the
-  // wire format, not typia's output.
+  // A protobuf `uint64` field is an unsigned 64-bit varint: the writer emits the
+  // low 64 bits and the reader reads them back unsigned, so a value outside that
+  // width decodes as `BigInt.asUintN(64, value)`. The oracle is the wire format,
+  // not typia's output.
   for (const value of [MINIMUM, MAXIMUM, 1n, 2n ** 63n]) {
-    TestValidator.equals(`round trip ${value} is in range`, true, oracle(value));
     TestValidator.equals(
-      `uint64 ${value} survives protobuf unchanged`,
+      `round trip ${value} is in range`,
+      true,
+      oracle(value),
+    );
+    TestValidator.equals(
+      `uint64 ${value} decodes unchanged`,
       value,
       roundTrip(value),
     );
@@ -211,7 +207,7 @@ export const test_type_uint64_range = (): void => {
     );
     const truncated: bigint = BigInt.asUintN(64, value);
     TestValidator.notEquals(
-      `the uint64 wire form of ${value} is a different value`,
+      `the uint64 decode of ${value} is a different value`,
       value,
       truncated,
     );

--- a/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
@@ -22,19 +22,25 @@ interface ICommentBigint {
 }
 
 /**
- * Verifies that the uint64 validators enforce the unsigned 64-bit range on both
- * the number and bigint paths.
+ * Verifies uint64 bounds the number path and only rejects negatives on bigint.
  *
- * Uint64-max is `2 ** 64 - 1`, which no `number` can represent -- it rounds to
- * `2 ** 64` -- so the number path accepts `2 ** 64` as uint64-max's only float
- * form. The bigint path represents the bound exactly, so it enforces the true
- * inclusive range and still rejects magnitudes such as `2n ** 64n` that the
- * upper-bound-less bigint validator used to certify. Negatives are rejected on
- * both paths.
+ * The bigint arm may not name a `typia/lib/internal/*` helper. It is declared in
+ * `@typia/interface`, which `typia` admits through a caret range that only
+ * floats upward, so a named helper makes an older `typia` emit an import it
+ * never shipped (#2330). The arm is therefore the `BigInt(0) <= $input` it
+ * declared before #2166: a lower bound with no upper bound. The surviving lower
+ * bound is what separates this tag from `Type<"int64">`, whose arm checks
+ * nothing at all, so both halves are pinned -- the negatives still rejected and
+ * the oversized values now accepted. #2338 owns restoring the upper bound in a
+ * major release, the one boundary a caret cannot cross.
  *
- * 1. Accept in-range numbers, including uint64-max's float form `2 ** 64`.
- * 2. Enforce the exact inclusive bounds on the bigint path from a BigInt oracle.
- * 3. Require every certified bigint to survive a protobuf round trip unchanged.
+ * 1. Keep the enforced number path, whose helper crosses no package boundary.
+ * 2. Require the bigint type tag and `@type uint64` to reject every negative and
+ *    accept every non-negative, while the still-published `_isTypeUint64Bigint`
+ *    keeps the exact bound.
+ * 3. Pin both protobuf outcomes against the wire format: an in-range value
+ *    survives byte for byte, an accepted oversized value comes back as its
+ *    unsigned 64-bit truncation.
  */
 export const test_type_uint64_range = (): void => {
   const MINIMUM: bigint = 0n;
@@ -57,6 +63,8 @@ export const test_type_uint64_range = (): void => {
   //----
   // NUMBER PATH
   //----
+  // `isTypeUint64` is named by `@typia/interface` 13.0.0 and shipped by `typia`
+  // 13.0.0, so it crosses no version boundary and the number path keeps it.
   // uint64-max is `2 ** 64 - 1`, which rounds to `2 ** 64` as a `number`, so the
   // number path accepts `2 ** 64`: no double can distinguish the two. Negatives
   // stay out of range.
@@ -105,14 +113,19 @@ export const test_type_uint64_range = (): void => {
   //----
   // BIGINT PATH
   //----
+  // `_isTypeUint64Bigint` stays published with the exact bound even though the
+  // emitted validator no longer reaches it: a `typia` that ships the helper can
+  // still satisfy an `@typia/interface` that names it, which is the other
+  // direction of the same compatibility problem. So the helper and the tag are
+  // asserted separately, and the values where they now disagree are the gap.
   const bigints: bigint[] = [
     0n,
     1n,
     MAXIMUM,
     2n ** 63n,
     -1n,
+    -(2n ** 200n),
     MAXIMUM + 1n,
-    2n ** 64n,
     2n ** 200n,
   ];
   for (const value of bigints) {
@@ -122,36 +135,95 @@ export const test_type_uint64_range = (): void => {
       expected,
       _isTypeUint64Bigint(value),
     );
+    // the surviving lower bound is the whole check, so the tag answers
+    // `0n <= value` rather than the width
     TestValidator.equals(
-      `bigint type tag on ${value} === ${expected}`,
-      expected,
+      `bigint type tag on ${value} === ${MINIMUM <= value}`,
+      MINIMUM <= value,
       typia.is<ITaggedBigint>({ value }),
     );
     TestValidator.equals(
-      `bigint comment tag on ${value} === ${expected}`,
-      expected,
+      `bigint comment tag on ${value} === ${MINIMUM <= value}`,
+      MINIMUM <= value,
       typia.is<ICommentBigint>({ value }),
     );
   }
 
-  //----
-  // ROUND TRIP
-  //----
-  // On the exact bigint path, typia never certifies a value its own encoder will
-  // corrupt: every in-range bigint survives protobuf byte-for-byte.
-  for (const value of [MINIMUM, MAXIMUM, 1n, 2n ** 63n]) {
-    TestValidator.equals(
-      `round trip ${value} is certified`,
-      true,
-      oracle(value),
+  // The gap is exactly the oversized members: the helper rejects them and the
+  // tag does not. Negatives are not in it, because the lower bound survives. An
+  // empty list on either side would make the claim vacuous, so both are checked.
+  const oversized: bigint[] = bigints.filter((value) => MAXIMUM < value);
+  const negative: bigint[] = bigints.filter((value) => value < MINIMUM);
+  if (oversized.length === 0 || negative.length === 0)
+    throw new Error(
+      "the bigint boundary list needs an oversized and a negative value.",
     );
-    const decoded: typia.Resolved<ITaggedBigint> = typia.protobuf.decode<
-      typia.Resolved<ITaggedBigint>
-    >(typia.protobuf.encode<ITaggedBigint>({ value }));
+  for (const value of oversized)
+    TestValidator.notEquals(
+      `the uint64 bigint tag no longer agrees with _isTypeUint64Bigint on ${value}`,
+      _isTypeUint64Bigint(value),
+      typia.is<ITaggedBigint>({ value }),
+    );
+  for (const value of negative)
+    TestValidator.equals(
+      `the uint64 bigint tag still agrees with _isTypeUint64Bigint on ${value}`,
+      _isTypeUint64Bigint(value),
+      typia.is<ITaggedBigint>({ value }),
+    );
+
+  // A bigint tag still rejects a non-bigint, so the lower bound replaced the
+  // range check and not the type check.
+  for (const value of [0, "0", null])
+    TestValidator.equals(
+      `bigint type tag rejects the non-bigint ${String(value)}`,
+      false,
+      typia.is<ITaggedBigint>({ value: value as unknown as bigint }),
+    );
+
+  //----
+  // PROTOBUF ROUND TRIP
+  //----
+  // A protobuf `uint64` field is an unsigned 64-bit varint, so the wire form of
+  // a value outside that width is `BigInt.asUintN(64, value)`. The oracle is the
+  // wire format, not typia's output.
+  for (const value of [MINIMUM, MAXIMUM, 1n, 2n ** 63n]) {
+    TestValidator.equals(`round trip ${value} is in range`, true, oracle(value));
     TestValidator.equals(
       `uint64 ${value} survives protobuf unchanged`,
       value,
-      decoded.value,
+      roundTrip(value),
+    );
+  }
+
+  // Above the width, typia certifies a value its own encoder truncates. That is
+  // the cost of the missing upper bound, and #2338 owns closing it; until then
+  // it is pinned here rather than left untested.
+  for (const value of [MAXIMUM + 1n, 2n ** 64n + 7n, 2n ** 200n + 3n]) {
+    TestValidator.equals(
+      `${value} is out of uint64 range`,
+      false,
+      oracle(value),
+    );
+    TestValidator.equals(
+      `typia certifies the oversized ${value}`,
+      true,
+      typia.is<ITaggedBigint>({ value }),
+    );
+    const truncated: bigint = BigInt.asUintN(64, value);
+    TestValidator.notEquals(
+      `the uint64 wire form of ${value} is a different value`,
+      value,
+      truncated,
+    );
+    TestValidator.equals(
+      `uint64 ${value} comes back truncated to ${truncated}`,
+      truncated,
+      roundTrip(value),
     );
   }
 };
+
+const roundTrip = (value: bigint): bigint =>
+  typia.protobuf.decode<typia.Resolved<ITaggedBigint>>(
+    typia.protobuf.encode<ITaggedBigint>({ value }),
+  ).value;

--- a/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
@@ -24,7 +24,7 @@ interface ICommentBigint {
 /**
  * Verifies uint64 bounds the number path and only rejects negatives on bigint.
  *
- * The bigint arm may not name a `typia/lib/internal/*` helper. It is declared
+ * The bigint arm must not name a `typia/lib/internal/*` helper. It is declared
  * in `@typia/interface`, which `typia` admits through a caret range that only
  * floats upward, so a named helper makes an older `typia` emit an import it
  * never shipped (#2330). The arm is therefore the `BigInt(0) <= $input` it

--- a/website/src/content/docs/validators/tags.mdx
+++ b/website/src/content/docs/validators/tags.mdx
@@ -134,6 +134,8 @@ When adjacent placeholders or repeated separators make the boundary ambiguous, t
 
 For `bigint`, `tags.Type<...>` accepts `"int64"` or `"uint64"`; range tags accept `bigint` literals.
 
+On a `bigint` those two tags do not check the 64-bit width: `Type<"int64">` enforces nothing, and `Type<"uint64">` enforces only `0n <= value`. `typia.protobuf.encode` still writes the field as a 64-bit varint, so a value past the width is truncated on the wire rather than rejected by the validator. Restoring the bound is a major-release change, tracked in [issue #2338](https://github.com/samchon/typia/issues/2338). On a `number` the same two tags do bound their range.
+
 #### `string`
 
 | Tag                         | Notes                                                                          |

--- a/website/src/content/docs/validators/tags.mdx
+++ b/website/src/content/docs/validators/tags.mdx
@@ -134,7 +134,7 @@ When adjacent placeholders or repeated separators make the boundary ambiguous, t
 
 For `bigint`, `tags.Type<...>` accepts `"int64"` or `"uint64"`; range tags accept `bigint` literals.
 
-On a `bigint` those two tags do not check the 64-bit width: `Type<"int64">` enforces nothing, and `Type<"uint64">` enforces only `0n <= value`. `typia.protobuf.encode` still writes the field as a 64-bit varint, so a value past the width is truncated on the wire rather than rejected by the validator. Restoring the bound is a major-release change, tracked in [issue #2338](https://github.com/samchon/typia/issues/2338). On a `number` the same two tags do bound their range.
+On a `bigint` those two tags do not check the 64-bit width: `Type<"int64">` enforces nothing, and `Type<"uint64">` enforces only `0n <= value`. `typia.protobuf.encode` still writes the field as a 64-bit varint, so a value past the width is truncated on the wire rather than rejected by the validator. Restoring the bound would reject data that validates today, so it waits for a major release; it is tracked in [issue #2338](https://github.com/samchon/typia/issues/2338). On a `number` the same two tags do bound their range.
 
 #### `string`
 


### PR DESCRIPTION
Reverts the runtime meaning of the `bigint` arm of `tags.Type<"int64">` and `tags.Type<"uint64">` to the form it had before `b3c926ba27` (#2166). Only the tag declarations and the things that must agree with them move.

## What changes

| Declaration | Before this PR | After this PR |
| --- | --- | --- |
| `tags.Type<"int64">` (bigint) | `$importInternal("isTypeInt64Bigint")($input)` | `true` |
| `tags.Type<"uint64">` (bigint) | `$importInternal("isTypeUint64Bigint")($input)` | `BigInt(0) <= $input` |
| `tags.Type<"int64">` / `tags.Type<"uint64">` (number) | `$importInternal("isTypeInt64")($input)` / `…Uint64…` | unchanged |

`packages/typia/native/core/factories/MetadataCommentTagFactory.go` moves with them, because the JSDoc `@type int64` / `@type uint64` spelling and the type-tag spelling of one constraint must not mean different things. Its `number` records keep `isTypeInt64` and `isTypeUint64`.

Verified in emitted output rather than by reading the declaration:

```js
const _ip32 = input => "bigint" === typeof input["int64Bigint"] && true;
const _ip33 = input => "bigint" === typeof input["uint64Bigint"] && BigInt(0) <= input["uint64Bigint"];
```

The `@type int64` and `@type uint64` spellings emit the identical expressions.

## What deliberately does not change

- `packages/typia/src/internal/_isTypeInt64Bigint.ts` and `_isTypeUint64Bigint.ts` stay published with nothing in `packages/typia/src` referencing them. That is the point: a `typia` that ships them can still satisfy an `@typia/interface` that names them, which is the other direction of the same compatibility problem. The same holds for `_stringLength`, `_isMultipleOf`, `_decimal`, and `_randomMultiple` from #2336. All six still build to `.js`, `.mjs`, and `.d.ts` under `packages/typia/lib/internal/`.
- The `number` path. `isTypeInt64` and `isTypeUint64` are named by `@typia/interface@13.0.0` and shipped by `typia@13.0.0`, so they cross no version boundary. `_isTypeInt64.ts`, `_isTypeUint64.ts`, and `NumericRangeFactory.go` are untouched, and `RandomProgrammer.go` changes only a comment.
- `NumericRangeFactory.Bigint`, which `ProtobufEncodeProgrammer` uses to discriminate a protobuf union with more than one candidate, still emits its inline `BigInt("…") <= $input && $input <= BigInt("…")` comparison. It names no helper and crosses no boundary.
- Random generation, JSON Schema and LLM schema output — the tag's `schema` member is untouched, so unlike #2336 this revert introduces no divergence with `@typia/utils` — and every package version, dist-tag, and release state.

## This is a behavior change

The 64-bit width is no longer enforced on the `bigint` path:

```ts
typia.is<bigint & tags.Type<"int64">>(2n ** 200n);   // was false, is now true
typia.is<bigint & tags.Type<"uint64">>(2n ** 64n);   // was false, is now true
typia.is<bigint & tags.Type<"uint64">>(-1n);         // still false
```

`typia.protobuf.encode` still writes the field as a 64-bit varint, so typia now certifies values its own encoder truncates. #2338 owns restoring the bound. Both the guide and the `Type` declaration's doc comment say so, so the gap is documented rather than implied.

Worth stating precisely, because an earlier draft of this branch got it wrong: what forces #2338 to a major is **not** the packaging boundary. An inline exact comparison — `BigInt("-9223372036854775808") <= $input && …` — names no helper and crosses no boundary, and `metadataCommentTagFactory_parse_type` already puts `&&` expressions in the same `Validate` field. #2338 gives two independent reasons and says the packaging one stops applying once the check is inline. What survives either way is that tightening an accepted range rejects data that validates today.

**The release number this ships under is the maintainer's decision.** This branch does not choose one and does not touch any version field.

## Effect on #2330 — this PR closes it

#2330 is the packaging failure where an older `typia` resolving a newer `@typia/interface` through the caret range emits an import the installed runtime does not ship. #2336 removed `_stringLength` and `_isMultipleOf` from the tag declarations and deliberately carried no closing keyword, because `Type.ts` still named `isTypeInt64Bigint` and `isTypeUint64Bigint`. Those are the last two, and this PR removes them.

The closing keyword sits on `4acaa66467` because the claim was checked, not assumed.

**Why a grep is not sufficient here**, and both failures are real. `\$importInternal\("[A-Za-z_]*"\)` excludes digits, so it silently misses `isTypeInt64Bigint` and returns a confident clean result — the digit-safe form is `\$importInternal\("[A-Za-z0-9_]+"\)`, and it was fed a known-positive string before being trusted. And `packages/interface/src/tags/Format.ts` builds its name by template — `` `$importInternal("isFormat${PascalizeString<Value>}")($input)` `` — so no literal grep finds those 22 names at all.

So the set was read out of real transform output instead. A probe declaring all 22 `Format` values, all 10 `Type` values on `number`, `int64` and `uint64` on `bigint`, both JSDoc spellings, and `UniqueItems` was compiled through `ttsc`, and its emitted `typia/lib/internal/*` imports listed:

| Named helper | Count | Shipped by `typia@13.0.0` |
| --- | --- | --- |
| `_isFormatByte`, `Date`, `DateTime`, `Duration`, `Email`, `Hostname`, `IdnEmail`, `IdnHostname`, `Ipv4`, `Ipv6`, `Iri`, `IriReference`, `JsonPointer`, `Password`, `Regex`, `RelativeJsonPointer`, `Time`, `Uri`, `UriReference`, `UriTemplate`, `Url`, `Uuid` | 22 | yes |
| `_isTypeInt8`, `Uint8`, `Int16`, `Uint16`, `Int32`, `Uint32`, `Int64`, `Uint64`, `Float` | 9 | yes |
| `_isUniqueItems` | 1 | yes |
| `_isTypeInt64Bigint`, `_isTypeUint64Bigint` | 0 — no longer named | no |

The probe also emitted `_assertGuard`, `_createStandardSchema`, and `_validateReport`. Those come from the operation programmers in the native transform, not from any tag declaration, so they ship inside the same `typia` that emits them and cross no boundary — and `typia@13.0.0` ships all three anyway.

All 32 tag-named helpers, and all 35 emitted names, are present in `npm pack typia@13.0.0` and in `npm pack typia@13.0.0-rc.2`, the oldest release #2330 reports against. Re-running the identical comparison with `_isTypeInt64Bigint` and `_isTypeUint64Bigint` added back reports both as missing, so the clean result is a check that can fail, not a pattern that cannot match.

What that does **not** claim: the caret range itself is unchanged, and #2330's suggested fix — pinning `@typia/interface` and `@typia/utils` exactly — is still available and still prevents the whole class. Any future tag declaration that names a new `typia/lib/internal/*` module reopens it. What is closed is the concrete failure: at this head no tag declaration names a module `typia@13.0.0` does not ship, so a floated `@typia/interface` no longer produces an unresolvable import for any release in the 13 line.

## Tests

`tests/test-typia-schema/src/features/tags/test_type_int64_range.ts` and `test_type_uint64_range.ts` pinned the exact inclusive bigint bounds and a protobuf round trip against them. Both are rewritten rather than deleted.

Each file separates three claims. The still-published `_isTypeInt64Bigint` / `_isTypeUint64Bigint` keep the exact bound over the same boundary matrix as before, which turns "kept deliberately" into an executed assertion. The type tag and its `@type` spelling answer what they now declare: `int64` accepts every bigint, `uint64` accepts exactly the non-negative ones — the surviving lower bound is asserted on its own, because it is the only thing separating the reverted `uint64` arm from the reverted `int64` arm. And the out-of-range members of each boundary list are counted with an explicit failure if the count reaches zero, so a list later trimmed to in-range values fails that guard instead of leaving the loop above passing while proving nothing.

The protobuf assertions are why the gap is pinned rather than dropped. With the bigint arm unchecked, typia certifies values its own encoder truncates, so each file carries both outcomes: an in-range value still decodes unchanged, and an accepted out-of-range value decodes as its 64-bit truncation. The expectation comes from the Protocol Buffer wire format — the writer emits `BigInt.asUintN(64, value)` as the payload and the reader signs it back for `int64` — not from typia's own output, and each case first asserts that the truncation genuinely differs from the input, so nothing in that loop can pass by accident. #2338 is named there as the owner.

Every number-path assertion is unchanged; that path is untouched by the revert and is the adjacent control the mutation proof needs. Two negative twins are added: the bigint tag still rejects a non-bigint, which proves `true` and the surviving lower bound replaced the range check and not the type check.

`tests/template/src/structures/**` drives the `test-typia-automated` matrix. Every bigint spoiler there — `TypeTagTypeBigInt`, `CommentTagTypeBigInt`, `ObjectHttpTypeTag`, `ObjectHttpCommentTag`, and the three `ArraySimpleProtobuf*` — sets `-1n`, which the surviving lower bound still rejects, and a scan of that whole tree finds no large-magnitude bigint assignment. Nothing there depends on the removed upper bound, so the fixtures are untouched.

## Verification

Local, at head `b6f1bb2fe5`:

- `pnpm build` — exit 0. `packages/typia/lib/internal/` still contains `_isTypeInt64Bigint`, `_isTypeUint64Bigint`, `_stringLength`, `_isMultipleOf`, `_decimal`, and `_randomMultiple` as `.js`, `.mjs`, and `.d.ts`, with zero references left in `packages/typia/src`. `tsc` compiles the program rather than the reachable graph, so the helpers a newer `typia` needs in order to satisfy an older `@typia/interface` do still ship.
- `pnpm --filter ./tests/test-typia-schema --fail-if-no-match start` — 192 cases, `Success`.
- `pnpm test` — every TypeScript workspace green (18 of 18, including `test-typia-automated` `Success`, `test-feature-identity`, `test-error`, `test-interface`, and both rewritten tag cases), then 17 Go packages `ok` with zero failures before the run was stopped part-way through the native tree, because CI's `test` lane runs the identical `pnpm run test` and had already passed on this same commit. That substitution is called out rather than glossed.
- `go -C packages/typia/test test -tags typia_native_internal ../native/...` — the whole-tree form was abandoned after ~40 minutes on a loaded machine, so it was narrowed to the package this PR edits: `go -C packages/typia/test test -tags typia_native_internal -v -run TestMetadataCommentTagFactory ../native/core/factories` — `TestMetadataCommentTagFactoryCoverage` and `TestMetadataCommentTagFactoryExclusivityMatchesInterface` both `PASS`, package `ok`. That file is the tagged coverage for `metadataCommentTagFactory_parse_type`, the one function this PR changes; root `pnpm test` does not enable the tag and neither does CI, so the rest of the tagged tree is unrun and reported as such.
- `pnpm format` — the only files it left with a nonzero `git diff --numstat` were the ones edited by hand.

**CI, all green on `b6f1bb2fe5`:** `format` 42s, `test` 14m21s, `experiments` 5m19s, `build` 3m8s, `website` 12m0s, `spell-check` 7s, and both Socket Security checks. The `website` lane builds the guide page this branch edits.

**Mutation sensitivity, in a disposable checkout.** A detached `git worktree` at `b6f1bb2fe5` received the product change only — the two `bigint` arms of `Type.ts` back to `$importInternal("isTypeInt64Bigint")` / `isTypeUint64Bigint`, and `MetadataCommentTagFactory.go`'s `bigintValidate` back to the same two calls, two files and four lines, both test files untouched. It got its own `pnpm install`, `pnpm build`, and `TTSC_CACHE_DIR`. The schema suite there exited 127 with **192 cases, exactly 2 errored and 190 passed**:

```
- test_type_int64_range: Error
- test_type_uint64_range: Error

Error: Bug on bigint type tag accepts -9223372036854775809   ({ x: true, y: false })
  at test_type_int64_range (…/test_type_int64_range.ts:139:29)
Error: Bug on bigint type tag on 18446744073709551616 === true ({ x: true, y: false })
  at test_type_uint64_range (…/test_type_uint64_range.ts:138:29)
```

Each fires on the first out-of-range member of its boundary list, on exactly the assertion that encodes the reverted behavior, while every adjacent control passes. The checkout was deleted and pruned afterwards; the deliverable tree stayed clean at `b6f1bb2fe5`.

**The enumeration has a live known-positive control.** The probe was compiled in both checkouts. This head emits 35 `typia/lib/internal/*` names, the mutated checkout emits 37, and the difference is exactly `_isTypeInt64Bigint` and `_isTypeUint64Bigint` — the same two the tarball comparison reports as missing from `typia@13.0.0` for the mutated tree and reports as none for this head. The check demonstrably fails when a helper is genuinely missing, on a real build rather than a hand-written string.

