### PR TITLE
test: close the two vacuous assertions the scalar tag cycle shipped, and run its merge gates

### DIFF
--- a/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
@@ -200,8 +200,14 @@ export const test_type_int64_range = (): void => {
     // `TestValidator.equals` walks `Object.keys` of its *first* argument and
     // drops any key whose value is `undefined`, so an object built from a throw
     // that carries neither field would compare as `{}` and pass -- exactly the
-    // case this assertion exists to catch. Its array branch compares
-    // positionally instead, so a missing field trips the `typeof` check.
+    // case this assertion exists to catch. The array branch compares
+    // positionally, so a missing field trips the `typeof` check.
+    //
+    // This is also the one call in this file that puts the actual first rather
+    // than the expected. `equals<X, Y extends X>` constrains the second argument
+    // by the first, and the actual is nullable here, so expected-first would not
+    // typecheck. The order carries no safety difference for a fixed-length
+    // tuple, unlike the object shape it replaces.
     let caught: { path?: string; expected?: string } | null = null;
     try {
       typia.protobuf.assertEncode<ITaggedBigint>({ value });

--- a/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_int64_range.ts
@@ -195,6 +195,13 @@ export const test_type_int64_range = (): void => {
     // bare `try`/`catch` would only establish a precondition and leave the catch
     // unfalsifiable; what distinguishes the width check from any other encoder
     // failure is the report the assertion carries.
+    //
+    // The two fields are compared as a tuple, not as an object literal.
+    // `TestValidator.equals` walks `Object.keys` of its *first* argument and
+    // drops any key whose value is `undefined`, so an object built from a throw
+    // that carries neither field would compare as `{}` and pass -- exactly the
+    // case this assertion exists to catch. Its array branch compares
+    // positionally instead, so a missing field trips the `typeof` check.
     let caught: { path?: string; expected?: string } | null = null;
     try {
       typia.protobuf.assertEncode<ITaggedBigint>({ value });
@@ -203,8 +210,8 @@ export const test_type_int64_range = (): void => {
     }
     TestValidator.equals(
       `assertEncode rejects ${value} at the width check`,
-      caught === null ? null : { path: caught.path, expected: caught.expected },
-      { path: "$input.value", expected: 'bigint & Type<"int64">' },
+      [caught?.path ?? null, caught?.expected ?? null],
+      ["$input.value", 'bigint & Type<"int64">'],
     );
   }
 

--- a/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
@@ -196,6 +196,13 @@ export const test_type_uint64_range = (): void => {
     // bare `try`/`catch` would only establish a precondition and leave the catch
     // unfalsifiable; what distinguishes the width check from any other encoder
     // failure is the report the assertion carries.
+    //
+    // The two fields are compared as a tuple, not as an object literal.
+    // `TestValidator.equals` walks `Object.keys` of its *first* argument and
+    // drops any key whose value is `undefined`, so an object built from a throw
+    // that carries neither field would compare as `{}` and pass -- exactly the
+    // case this assertion exists to catch. Its array branch compares
+    // positionally instead, so a missing field trips the `typeof` check.
     let caught: { path?: string; expected?: string } | null = null;
     try {
       typia.protobuf.assertEncode<ITaggedBigint>({ value });
@@ -204,8 +211,8 @@ export const test_type_uint64_range = (): void => {
     }
     TestValidator.equals(
       `assertEncode rejects ${value} at the width check`,
-      caught === null ? null : { path: caught.path, expected: caught.expected },
-      { path: "$input.value", expected: 'bigint & Type<"uint64">' },
+      [caught?.path ?? null, caught?.expected ?? null],
+      ["$input.value", 'bigint & Type<"uint64">'],
     );
   }
 

--- a/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
+++ b/tests/test-typia-schema/src/features/tags/test_type_uint64_range.ts
@@ -201,8 +201,14 @@ export const test_type_uint64_range = (): void => {
     // `TestValidator.equals` walks `Object.keys` of its *first* argument and
     // drops any key whose value is `undefined`, so an object built from a throw
     // that carries neither field would compare as `{}` and pass -- exactly the
-    // case this assertion exists to catch. Its array branch compares
-    // positionally instead, so a missing field trips the `typeof` check.
+    // case this assertion exists to catch. The array branch compares
+    // positionally, so a missing field trips the `typeof` check.
+    //
+    // This is also the one call in this file that puts the actual first rather
+    // than the expected. `equals<X, Y extends X>` constrains the second argument
+    // by the first, and the actual is nullable here, so expected-first would not
+    // typecheck. The order carries no safety difference for a fixed-length
+    // tuple, unlike the object shape it replaces.
     let caught: { path?: string; expected?: string } | null = null;
     try {
       typia.protobuf.assertEncode<ITaggedBigint>({ value });

--- a/tests/test-typia-schema/src/features/validate/test_validate_decimal_multiple_of.ts
+++ b/tests/test-typia-schema/src/features/validate/test_validate_decimal_multiple_of.ts
@@ -78,10 +78,16 @@ export const test_validate_decimal_multiple_of = (): void => {
       typia.is<IJsDocCent>({ value }),
       true,
     );
+    // Both spellings, matching the rejecting side below and the `is` pair
+    // above: the JSDoc name is composed by a different factory, so asserting
+    // one spelling would leave the other free to drift.
     TestValidator.equals(
-      `validate accepts ${value}`,
-      typia.validate<Cent>(value).success,
-      true,
+      `validate accepts ${value} in both spellings`,
+      [
+        typia.validate<Cent>(value).success,
+        typia.validate<IJsDocCent>({ value }).success,
+      ],
+      [true, true],
     );
   }
   for (const value of notMultiples) {


### PR DESCRIPTION
## Intent

The `major-scalar-semantics` cycle for #2335 and #2338 reached `master` through #2344 before its merge gates had run. This pull request runs them, and fixes the two defects the last early-warning pass found in the test code that shipped with it.

Nothing here changes product behaviour. The four tag declarations, the JSDoc factory, and `_randomPattern` are untouched.

## The two defects

**The caught-error assertion in both tag suites passed for exactly the case it was written to catch.** `TestValidator.equals` delegates to `json_equal_to`, whose object branch walks `Object.keys` of its **first** argument and drops every key whose value is `undefined`:

```ts
Object.keys(x)
  .filter((key) => x[key] !== undefined && !exception(key))
  .forEach((key) => iterate(`${accessor}.${key}`)(x[key])(y[key]));
```

The assertion passed the caught error as that first argument, so a throw carrying neither `path` nor `expected` — a protobuf writer `RangeError`, a thrown string, anything not a `TypeGuardError` — compared as `{}` and reported no difference. Measured against the real `json_equal_to`, the object form returns an empty diff for that input and the tuple form returns `["[0]","[1]"]`. The two fields are compared as a tuple now; the array branch iterates positionally, so a missing field trips its `typeof` check.

**`validate` ran only the type-tag spelling on the accepting side.** The commit that added the JSDoc twin to the rejecting side justified it with "every other assertion there runs `Cent` and `IJsDocCent` side by side", which was not true of the accepting loop and which that commit did not make true.

## Gates, all executed

| Gate | Result |
| --- | --- |
| `pnpm test` on integrated `master` (`1d7fdfb63`) | **PASS**, exit 0, 12 suites — the first uncontaminated full run |
| `pnpm build` + `pnpm package:tgz` | **PASS**, six tarballs |
| clean packed consumer | **PASS** — see below |
| mutation proof | **PASS**, both halves — see below |

Two earlier local failures are explained and dismissed with evidence: a `test-typia-generate` ENOENT and one `test_random_recursive_terminates` failure both came from a concurrent branch switch in a shared checkout, not from the change. `master` runs clean.

### Clean packed consumer

A project outside the workspace, `npm install`ing `typia.tgz` + `interface.tgz` + `utils.tgz`, compiling a fixture that uses all four constraints in both spellings. The emitted validator requires exactly:

```
require("typia/lib/internal/_isMultipleOf")
require("typia/lib/internal/_isTypeInt64Bigint")
require("typia/lib/internal/_isTypeUint64Bigint")
require("typia/lib/internal/_stringLength")
```

All four resolve, and all ten behavioural checks pass — both exact 64-bit maxima, `MultipleOf<0.1>` accepting `0.3`, `MinLength<2>` rejecting a single astral character, and the JSDoc spellings agreeing with the type tags.

### Mutation proof

Product source reverted, tests retained:

- reverting the `Type` bigint arms to `true` / `BigInt(0) <= $input` fails both tag suites at `-9223372036854775809` and `18446744073709551616` — one step outside each restored bound — while every number-path assertion still passes;
- reverting `MinLength` / `MaxLength` / `MultipleOf` to the inline forms fails four suites independently: `test_random_astral_pattern_length_window` with the witness `"😀\ude00\ude00"`, `test_random_numeric_multiple_of`, `test_validate_decimal_multiple_of` at `0.03`, and `test_validate_unicode_string_length` at `"😀"` under `MinLength<2>`.

## The release constraint, reproduced instead of reasoned about

`master` carries a breaking change at `13.3.0`. **The release that carries it must be `14.0.0`.** That is not a theoretical worry — pairing the published `typia@13.1.1` with this tree's `@typia/interface@13.3.0` in a clean project:

```
typia@13.1.1 declares @typia/interface ^13.1.1   -- which admits 13.3.0
node_modules/typia/lib/internal/: _stringLength MISSING, _isMultipleOf MISSING,
                                  _isTypeInt64Bigint MISSING, _isTypeUint64Bigint MISSING
emitted: require("typia/lib/internal/_isTypeInt64Bigint")
runtime: Error: Cannot find module '.../typia/lib/internal/_isTypeInt64Bigint.js'
```

The caret range makes that pairing reachable without anyone doing anything unusual. A `13.4.0` release hands that failure to every consumer pinned to an older `13.x`. This is #2330, and only a major boundary closes it.

## Still open, recorded and unpublished

Seven candidates the campaign found outside the two issues' scope, none of them fixed here:

- **no type tag on a dynamic key is enforced** — `[key: string & tags.Format<"uuid">]` accepts `"not-a-uuid"`
- **`typia.random` never intersects a declared range with a `Type<…>` width** — `number & Type<"int32"> & Minimum<-1e12> & Maximum<1e12>` draws a value its own `is` rejects on 499 of 500 tries
- **`test_random_recursive_terminates` asserts a depth bound nothing guarantees** — 0.25 % per draw, tail reaching 17
- **the emitted schema carries no 64-bit `maximum`**, so the runtime check is now stricter than the schema
- **no cross-language guard** pins the JSDoc `Validate` string to its type-tag declaration
- **`int(parsed)` silently overflows** for an out-of-range JSDoc numeric tag (inert today)
- **`TestValidator.equals` is asymmetric in its first argument**, the footgun this pull request fixes two instances of; 72 call sites across the suites pass an object literal first and each would need its own check
