### PR TITLE
docs(interface): clarify Type schema contract

### DIFF
--- a/packages/interface/src/tags/Type.ts
+++ b/packages/interface/src/tags/Type.ts
@@ -88,6 +88,15 @@ export type Type<
                     ? `$importInternal("isTypeFloat")($input)`
                     : `true`;
   exclusive: true;
+  // This schema is deliberately coarser than the runtime Type check. It exposes
+  // only the numeric shape and the existing non-negative marker for unsigned
+  // integers, not the full bit-width as minimum/maximum. Random generation
+  // consumes this schema and honors explicit range tags; it does not derive or
+  // intersect this tag's runtime width. A wider declared range can therefore
+  // produce a value that the Type validator rejects, and that is not a random
+  // generator defect. JavaScript number precision also governs the int64 and
+  // uint64 checks as written; do not invent alternate schema bounds to
+  // compensate for it or add width bounds here as an attempted fix.
   schema: Value extends "uint8" | "uint16" | "uint32" | "uint64"
     ? {
         type: "integer";


### PR DESCRIPTION
Intent: record the deliberate boundary between Type runtime validation, its coarse schema contribution, random generation, and JavaScript 64-bit number precision so the dropped #2348/#2351 proposals are not rediscovered. Scope: one internal comment beside Type.schema; no behavior change. Deferred items: none. Local verification: pnpm format; pnpm --filter ./packages/interface build; Prettier check. Skipped: full test suite because this is a comment-only change.