### PR TITLE
fix(native): withhold a caller whose nested callee infers its return type

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/project_dependencies_callee_inference_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_dependencies_callee_inference_transform_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestProjectDependenciesCalleeInferenceTransform verifies a nested call whose
+// identity comes from an inferred return type or a borrowed constant withholds
+// its file, while the same indirection written with a type keeps it.
+//
+// The callee walk reports which files a callee's name resolves through, and for
+// the OUTERMOST callee that is the whole answer: the identity is the resolved
+// declaration, whose file is reported. One call in it stops being the answer,
+// because there the identity is the inner call's return type. `const getNs = ()
+// => ns` and `const FLAG = RAW` both carry it from a file no name on the chain
+// writes, so reporting the names without admitting that declared the caller
+// complete while an edit to the unreported file deleted the generated validator
+// outright (samchon/typia#2360).
+//
+// A function DECLARATION with an inferred return type is the same defect one
+// keyword apart, and it needs its own case: the shared boundedness predicate
+// calls every callable bounded, because the type walk emits one as `typeof x
+// === "function"` and never reads its signature. On this channel the signature
+// is the whole question.
+//
+// The bounded twins are what keep the fix from degenerating into "withhold on
+// every nested call": an indirection with a written return type pins its
+// identity in the file that declares it, and that file must stay declared.
+//
+// The third shape samchon/typia#2360 reports -- an overload selected by a
+// borrowed VALUE -- is NOT pinned here, and the fixture keeps it as the record
+// of that. `const FLAG = RAW` is structurally identical to `const ns = typia`,
+// whose caller must stay declared (samchon/typia#2357), so no boundedness
+// answer separates them; reporting the initializer chain would.
+//
+//  1. Build a project with three unbounded shapes -- a computed argument, a
+//     computed callee, and a function declaration with an inferred return type
+//     -- plus a written-type twin for the `const` and the `function` spellings,
+//     and the borrowed-value overload that stays declared.
+//  2. Run project transform mode and decode the JSON envelope.
+//  3. Assert each file really was rewritten into a validator, so the test is
+//     measuring the shape it intends rather than a call typia never touched.
+//  4. Assert the three unbounded files are absent from `dependenciesComplete`.
+//  5. Assert both annotated twins are present, and that a file whose OUTERMOST
+//     callee resolves to a local `const helper = () => ...` keeps its
+//     declaration -- that name decides nothing, and charging it costs 65 more
+//     files across the test workspaces than the fix needs.
+func TestProjectDependenciesCalleeInferenceTransform(t *testing.T) {
+  project := projectDependenciesCalleeInferenceProject(t)
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--output", "ts",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("project transform failed: code=%d stderr=\n%s", code, errText)
+  }
+  var envelope struct {
+    TypeScript           map[string]string   `json:"typescript"`
+    Dependencies         map[string][]string `json:"dependencies"`
+    DependenciesComplete []string            `json:"dependenciesComplete"`
+  }
+  if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+    t.Fatalf("decode envelope: %v\n%s", err, out)
+  }
+
+  // Guard first: an assertion about dependencies means nothing on a file the
+  // transform never rewrote, and that is exactly how this class hides.
+  for _, file := range []string{
+    "src/main_computed_arg.ts",
+    "src/main_computed_callee.ts",
+    "src/main_overload.ts",
+    "src/main_annotated.ts",
+    "src/main_function.ts",
+    "src/main_function_annotated.ts",
+    "src/main_outermost.ts",
+  } {
+    if text := envelope.TypeScript[file]; !strings.Contains(text, "input is Foo") {
+      t.Fatalf("%s must have been rewritten into a validator, got:\n%s", file, text)
+    }
+  }
+
+  declared := map[string]bool{}
+  for _, key := range envelope.DependenciesComplete {
+    declared[key] = true
+  }
+  for _, file := range []string{
+    "src/main_computed_arg.ts",
+    "src/main_computed_callee.ts",
+    "src/main_function.ts",
+  } {
+    if declared[file] {
+      t.Fatalf(
+        "%s must be withheld: its callee identity comes from an inferred "+
+          "return type or a borrowed constant, and %v does not name the file "+
+          "that decides it",
+        file,
+        envelope.Dependencies[file],
+      )
+    }
+  }
+  for _, file := range []string{
+    "src/main_annotated.ts",
+    "src/main_function_annotated.ts",
+  } {
+    if declared[file] {
+      continue
+    }
+    t.Fatalf(
+      "%s must stay declared: its indirection carries a written return type, "+
+        "so the reported files do pin the identity. Withholding it means the "+
+        "boundedness answer stopped reading the written type: %v",
+      file,
+      envelope.DependenciesComplete,
+    )
+  }
+  if !declared["src/main_outermost.ts"] {
+    t.Fatalf(
+      "src/main_outermost.ts must stay declared: its outermost callee IS the "+
+        "declaration it resolves to, so a local arrow with an inferred return "+
+        "type decides nothing. Withholding it means the nested guard is gone, "+
+        "which costs 65 more files across the test workspaces: %v",
+      envelope.DependenciesComplete,
+    )
+  }
+}
+
+func projectDependenciesCalleeInferenceProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "project-dependencies-callee-inference-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(projectDependenciesEnvelopeTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  for name, body := range map[string]string{
+    "foo.ts":                     projectDependenciesCalleeInferenceSourceFoo,
+    "ns.ts":                      projectDependenciesCalleeInferenceSourceNs,
+    "getns.ts":                   projectDependenciesCalleeInferenceSourceGetNs,
+    "pick.ts":                    projectDependenciesCalleeInferenceSourcePick,
+    "rawflag.ts":                 projectDependenciesCalleeInferenceSourceRawFlag,
+    "flag.ts":                    projectDependenciesCalleeInferenceSourceFlag,
+    "other.ts":                   projectDependenciesCalleeInferenceSourceOther,
+    "sel.ts":                     projectDependenciesCalleeInferenceSourceSel,
+    "main_computed_arg.ts":       projectDependenciesCalleeInferenceSourceComputedArg,
+    "main_computed_callee.ts":    projectDependenciesCalleeInferenceSourceComputedCallee,
+    "main_overload.ts":           projectDependenciesCalleeInferenceSourceOverload,
+    "main_annotated.ts":          projectDependenciesCalleeInferenceSourceAnnotated,
+    "main_function.ts":           projectDependenciesCalleeInferenceSourceFunction,
+    "main_function_annotated.ts": projectDependenciesCalleeInferenceSourceFunctionAnnotated,
+    "main_outermost.ts":          projectDependenciesCalleeInferenceSourceOutermost,
+  } {
+    if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+      t.Fatalf("write %s: %v", name, err)
+    }
+  }
+  return dir
+}
+
+const projectDependenciesCalleeInferenceSourceFoo = `export interface Foo {
+  id: string;
+}
+`
+
+const projectDependenciesCalleeInferenceSourceNs = `import typia from "typia";
+
+export const ns = typia;
+`
+
+// The return type is inferred, so nothing written here says the result is
+// typia's namespace; `ns.ts` decides it and no name on the callee chain reaches
+// that file.
+const projectDependenciesCalleeInferenceSourceGetNs = `import { ns } from "./ns";
+
+export const getNs = () => ns;
+
+export const getNsAnnotated: () => typeof ns = () => ns;
+
+export function getNsFn() {
+  return ns;
+}
+
+export function getNsFnAnnotated(): typeof ns {
+  return ns;
+}
+`
+
+const projectDependenciesCalleeInferenceSourcePick = `export const pick = <T>(value: T): T => value;
+`
+
+const projectDependenciesCalleeInferenceSourceRawFlag = `export const RAW = 1;
+`
+
+// The value is borrowed from another file, so the overload this selects is
+// decided by `rawflag.ts`.
+const projectDependenciesCalleeInferenceSourceFlag = `import { RAW } from "./rawflag";
+
+export const FLAG = RAW;
+`
+
+const projectDependenciesCalleeInferenceSourceOther = `export const other = {
+  is: <T>(_input: unknown): _input is T => false,
+};
+`
+
+const projectDependenciesCalleeInferenceSourceSel = `import typia from "typia";
+
+import { other } from "./other";
+
+export function sel(x: 0): typeof other;
+export function sel(x: 1): typeof typia;
+export function sel(x: number): unknown {
+  return x === 1 ? typia : other;
+}
+`
+
+const projectDependenciesCalleeInferenceSourceComputedArg = `import { Foo } from "./foo";
+import { getNs } from "./getns";
+import { pick } from "./pick";
+
+export const check = (input: unknown) => pick(getNs()).is<Foo>(input);
+`
+
+const projectDependenciesCalleeInferenceSourceComputedCallee = `import { Foo } from "./foo";
+import { getNs } from "./getns";
+
+export const check = (input: unknown) => getNs().is<Foo>(input);
+`
+
+const projectDependenciesCalleeInferenceSourceOverload = `import { Foo } from "./foo";
+import { FLAG } from "./flag";
+import { sel } from "./sel";
+
+export const check = (input: unknown) => sel(FLAG).is<Foo>(input);
+`
+
+// The bounded twin: the indirection's return type is written, so `getns.ts`
+// pins the identity and this file must keep its declaration.
+const projectDependenciesCalleeInferenceSourceAnnotated = `import { Foo } from "./foo";
+import { getNsAnnotated } from "./getns";
+
+export const check = (input: unknown) => getNsAnnotated().is<Foo>(input);
+`
+
+const projectDependenciesCalleeInferenceSourceFunction = `import { Foo } from "./foo";
+import { getNsFn } from "./getns";
+
+export const check = (input: unknown) => getNsFn().is<Foo>(input);
+`
+
+const projectDependenciesCalleeInferenceSourceFunctionAnnotated = `import { Foo } from "./foo";
+import { getNsFnAnnotated } from "./getns";
+
+export const check = (input: unknown) => getNsFnAnnotated().is<Foo>(input);
+`
+
+// The outermost callee's identity IS the declaration it resolves to, so a local
+// arrow with an inferred return type decides nothing here and must not withhold
+// the file. Measured: charging it drops the eight test workspaces from 806
+// declared to 741.
+const projectDependenciesCalleeInferenceSourceOutermost = `import typia from "typia";
+
+import { Foo } from "./foo";
+
+const label = () => "x";
+
+export const check = (input: unknown) => typia.is<Foo>(input) && label() !== "";
+`

--- a/packages/typia/native/core/schemas/metadata/MetadataDependency.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataDependency.go
@@ -148,9 +148,11 @@ func MetadataDependency_touchCallee(checker *nativechecker.Checker, callee *nati
 //     callee chain, while a generic pass-through carries identity through the
 //     argument instead (`pick(ns).is<T>(x)`), so both are reported;
 //     metadataDependency_touchApplied says why the applied walk's answer is
-//     dropped. What this gives up is narrow and stated: an argument that is
-//     itself computed names its own callee and no further, and an overload
-//     selected by an argument's TYPE is carried by no written name at all.
+//     dropped. Reporting the names is not the whole answer there:
+//     metadataDependency_calleeBounded says why a callable reached inside a
+//     nested call must also write its return type. What stays given up is an
+//     overload selected by an argument's TYPE, or by a borrowed VALUE, since no
+//     written name on the chain carries either.
 //   - A function literal is where the walk stops. Written directly in callee
 //     position it is the most bounded declaration there is: the call resolves to
 //     the literal itself, in this very file, and its body is nobody's input.
@@ -198,7 +200,7 @@ func metadataDependency_walkCallee(
     // The whole access resolves to the member the call names; walking on to its
     // qualifier reports whatever selected the object that publishes it, and a
     // module other than the caller may declare that (`helpers.is`).
-    metadataDependency_touchDeclarations(checker, listener, node)
+    metadataDependency_touchDeclarations(checker, listener, node, nested)
   }
   bounded := true
   node.ForEachChild(func(child *nativeast.Node) bool {
@@ -228,10 +230,13 @@ func metadataDependency_walkCallee(
 // literal instead of descending -- so no file is charged with the identifiers
 // inside a callback.
 //
-// What stays unreported is the same boundary the callee chain already states:
-// an argument that is itself computed (`pick(getNs())`) names its own callee and
-// no further, and an overload selected by an argument's TYPE is decided by
-// something no written name carries.
+// What stays unreported is the same boundary the callee chain already states: an
+// argument that is itself computed (`pick(getNs())`) names its own callee and no
+// further. That one no longer over-declares, because the callee it names is a
+// callable whose inferred return type withholds the caller
+// (metadataDependency_calleeBounded); an overload selected by an argument's
+// TYPE, or by a borrowed VALUE, is still decided by something no written name
+// carries.
 func metadataDependency_touchApplied(
   checker *nativechecker.Checker,
   listener MetadataDependency_IListener,
@@ -247,10 +252,21 @@ func metadataDependency_touchApplied(
 // what it names. The caller asks which declaration a name selects, not what
 // that declaration's type is built from; the type graph reports the latter
 // where it is actually consulted.
+//
+// `nested` says the reference sits inside a nested call, and there the question
+// changes. The outermost callee's identity IS the declaration this resolves to,
+// whose file is reported on the line above, so how that declaration was written
+// cannot matter. One call in, the identity is the inner call's RETURN TYPE, and
+// an unbounded declaration -- `const getNs = () => ns`, `const FLAG = RAW` --
+// carries it from a file no written name on this chain reaches. Reporting the
+// names without admitting that declared three shapes complete while an edit to
+// an unreported file deleted the generated validator outright
+// (samchon/typia#2360).
 func metadataDependency_touchDeclarations(
   checker *nativechecker.Checker,
   listener MetadataDependency_IListener,
   reference *nativeast.Node,
+  nested bool,
 ) {
   if checker == nil {
     return
@@ -268,6 +284,9 @@ func metadataDependency_touchDeclarations(
   for _, declaration := range symbol.Declarations {
     if src := nativeast.GetSourceFileOfNode(declaration); src != nil {
       listener.File(src.FileName())
+    }
+    if nested && metadataDependency_calleeBounded(declaration) == false {
+      listener.unbounded()
     }
   }
 }
@@ -415,6 +434,65 @@ func metadataDependency_walkName(
     }
   }
   listener.unbounded()
+}
+
+// metadataDependency_calleeBounded reports whether a declaration reached inside
+// a nested call pins the identity of what that call RETURNS.
+//
+// A nested call's identity is its return type, so the question here is only
+// ever asked of callables -- and of a variable whose initializer is one, which
+// is the same declaration spelled differently. A callable pins the identity
+// when its return type is written; when it is inferred, the identity comes from
+// whatever the body happens to return, which lives in a file no name on the
+// callee chain reaches. `const getNs = () => ns` and `function getNs() { return
+// ns; }` are that shape, and both declared their caller complete while an edit
+// to the unreported `ns.ts` deleted the generated validator outright
+// (samchon/typia#2360).
+//
+// Everything else stays bounded on purpose, and metadataDependency_bounded is
+// deliberately NOT consulted here. It answers a different question -- whether a
+// declaration's TYPE is written where the type walk can read it -- and it calls
+// `const ns = typia` unbounded for want of an annotation. On this channel that
+// declaration is fine: the walk writes the name `ns`, so `ns.ts` is reported
+// and an edit to it invalidates the caller. Withholding on it would take back
+// samchon/typia#2357, whose whole point is that such a caller stays declared.
+//
+// What that leaves open is an overload selected by a borrowed VALUE (`const
+// FLAG = RAW; sel(FLAG).is<T>(x)`): `flag.ts` is reported, `rawflag.ts` is not,
+// and the two are structurally indistinguishable from the pair above.
+// Separating them needs the initializer chain followed and reported, not a
+// boundedness answer.
+func metadataDependency_calleeBounded(declaration *nativeast.Node) bool {
+  if metadataDependency_calleeCallable(declaration) {
+    return declaration.Type() != nil
+  }
+  if declaration.Kind == nativeast.KindVariableDeclaration {
+    if initializer := declaration.Initializer(); initializer != nil &&
+      metadataDependency_calleeCallable(initializer) {
+      return declaration.Type() != nil || initializer.Type() != nil
+    }
+  }
+  return true
+}
+
+// metadataDependency_calleeCallable reports whether a node is a callable whose
+// written return type would pin what a call on it produces.
+//
+// A construct signature is absent on purpose: `new X()` returns `X`, and the
+// class is the declaration the walk already reports.
+func metadataDependency_calleeCallable(node *nativeast.Node) bool {
+  switch node.Kind {
+  case nativeast.KindFunctionDeclaration,
+    nativeast.KindFunctionExpression,
+    nativeast.KindArrowFunction,
+    nativeast.KindMethodDeclaration,
+    nativeast.KindMethodSignature,
+    nativeast.KindCallSignature,
+    nativeast.KindFunctionType,
+    nativeast.KindGetAccessor:
+    return true
+  }
+  return false
 }
 
 // metadataDependency_bounded reports whether a declaration's type is written


### PR DESCRIPTION
fix(native): withhold a caller whose nested callee infers its return type

`dependenciesComplete` declares that a file's `dependencies` entry is its whole
input set. The callee walk reports which files a callee's name resolves through,
which is the whole answer for the OUTERMOST callee — its identity is the
declaration reported on that line. One call in it stops being the answer,
because there the identity is the inner call's return type, and an inferred one
comes from a file no name on the chain reaches.

`getNs().is<Foo>(input)` for `const getNs = () => ns` was declared complete
reporting `foo.ts` and `getns.ts`. Editing only `ns.ts` — never reported —
collapsed the generated validator back to an untransformed call, and a consumer
narrowing on that list keeps serving the stale one (#2360).

Three things the issue's proposal did not have:

- **A function declaration is the same defect one keyword apart.** The shared
  `metadataDependency_bounded` calls every callable bounded, because the type
  walk emits one as `typeof x === "function"` and never reads its signature. On
  this channel the signature is the whole question, so `function getNs() {
  return ns; }` stayed declared with `ns.ts` absent. Measured, then closed.
- **Reusing that predicate regresses #2357.** It calls `const ns = typia`
  unbounded for want of an annotation, so `pick(ns).is<Foo>(x)` — whose deciding
  file `ns.ts` *is* reported — gets withheld, and
  `TestProjectDependenciesCalleeArgumentTransform` fails.
  `metadataDependency_calleeBounded` is therefore its own answer, asked only of
  callables and of variables initialized with one.
- **The cost is 11 files, not 50.** Across the eight test workspaces the
  envelope declares 806 of 831, against 817 before. The proposal's 50 came from
  charging every declaration kind.

The `nested` guard is load-bearing and now pinned: without it a file whose
outermost callee is a local `const label = () => "x"` loses its declaration over
a name that decides nothing, and the eight workspaces drop to 741.

Not fixed, and the fixture records it: an overload selected by a borrowed VALUE
(`const FLAG = RAW; sel(FLAG).is<T>(x)`). `const FLAG = RAW` is structurally
indistinguishable from `const ns = typia`, whose caller must stay declared, so
no boundedness answer separates them — reporting the initializer chain would.

Mutation rows, both confirmed failing:

| mutation | fails |
| --- | --- |
| drop the `nested &&` guard | the outermost-callee assertion |
| drop the boundedness call | the three withholding assertions |

Verified with `pnpm test` and the full Go suite.