### PR TITLE
fix(native): stop a default-library touch on the identity path from withholding

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/project_dependencies_complete_replaced_library_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/project_dependencies_complete_replaced_library_transform_test.go
@@ -29,6 +29,16 @@ import (
 //  3. Assert both files transformed, so they differ only in what they consulted.
 //  4. Assert `control.ts` is declared complete and `replaced.ts` is not, and
 //     that the replacement file never leaked into the reported dependencies.
+//  5. Assert `nocall.ts` -- no typia call at all, only a CALL on a method the
+//     replaced library declares -- keeps its declaration. Touching a default
+//     library while deciding which declaration a call resolves to cannot change
+//     the emit: typia recognizes its own calls by a `/typia/lib` or `/typia/src`
+//     path, which a compiler-classified default library never has. Withholding
+//     there cost a file its declaration for writing `table.get(...)`, and under
+//     `noembed` -- where every library is on disk -- for calling anything at all
+//     (samchon/typia#2361). `nocall2.ts` is the control that only annotates the
+//     same type, and `replaced.ts` above is the twin that must stay withheld, so
+//     the fix cannot degenerate into never withholding on a library.
 func TestProjectDependenciesCompleteReplacedLibraryTransform(t *testing.T) {
   project := projectDependenciesCompleteReplacedLibraryProject(t)
   out, errText, code := ttscTypiaTestCapture(func() int {
@@ -69,6 +79,17 @@ func TestProjectDependenciesCompleteReplacedLibraryTransform(t *testing.T) {
       t.Fatalf("the reported dependencies must keep excluding compiler-classified default libraries, got %q", entry)
     }
   }
+  for _, key := range []string{"src/nocall.ts", "src/nocall2.ts"} {
+    if !declared[key] {
+      t.Fatalf(
+        "%s holds no typia call, so nothing about the replaced library can "+
+          "change its emitted text; withholding it means the identity channel "+
+          "is still charging a default-library touch: %v",
+        key,
+        envelope.DependenciesComplete,
+      )
+    }
+  }
 }
 
 func projectDependenciesCompleteReplacedLibraryProject(t *testing.T) string {
@@ -90,6 +111,8 @@ func projectDependenciesCompleteReplacedLibraryProject(t *testing.T) string {
     "src/replaced.ts": projectDependenciesCompleteReplacedLibrarySourceReplaced,
     "src/control.ts":  projectDependenciesCompleteReplacedLibrarySourceControl,
     "src/shape.ts":    projectDependenciesCompleteReplacedLibrarySourceShape,
+    "src/nocall.ts":   projectDependenciesCompleteReplacedLibrarySourceNoCall,
+    "src/nocall2.ts":  projectDependenciesCompleteReplacedLibrarySourceNoCall2,
   } {
     path := filepath.Join(dir, filepath.FromSlash(name))
     if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -117,4 +140,14 @@ export const validateShape = (input: unknown) => typia.is<Shape>(input);
 const projectDependenciesCompleteReplacedLibrarySourceShape = `export interface Shape {
   id: string;
 }
+`
+
+// No typia call anywhere, and a CALL on a method the replaced library declares.
+const projectDependenciesCompleteReplacedLibrarySourceNoCall = `const table = new Map<string, number>();
+
+export const lookup = (key: string): number | undefined => table.get(key);
+`
+
+// The control: the same type, annotated but never called on.
+const projectDependenciesCompleteReplacedLibrarySourceNoCall2 = `export const size = (table: Map<string, number>): number => table.size;
 `

--- a/packages/typia/native/cmd/ttsc-typia/transform.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform.go
@@ -228,6 +228,7 @@ func runTransformProject(
   // file its declaration and nothing else.
   schemametadata.MetadataDependency_listen(prog.Checker, schemametadata.MetadataDependency_IListener{
     File:      collector.Touch,
+    Callee:    collector.TouchCallee,
     Unbounded: collector.Unbound,
   })
   defer schemametadata.MetadataDependency_release(prog.Checker)
@@ -449,6 +450,12 @@ type transformDependencyValue struct {
   // withhold marks a file this envelope cannot report but the host-owned bound
   // still carries, so narrowing to the reported list would lose it.
   withhold bool
+  // libraryOnly marks a withhold whose only cause is the compiler classifying
+  // the file as a default library. Such a file can change a consulted type and
+  // so a generated validator, but never which declaration a call resolves to,
+  // which is why the identity channel drops it without withholding
+  // (samchon/typia#2361).
+  libraryOnly bool
 }
 
 func newTransformDependencyCollector(
@@ -499,6 +506,31 @@ func (collector *transformDependencyCollector) Unbound() {
 // completeness declaration: the graph still carries that file, so a narrowed
 // file would stop watching an input the default bound watches.
 func (collector *transformDependencyCollector) Touch(fileName string) {
+  collector.touch(fileName, true)
+}
+
+// TouchCallee records one file reached while deciding WHICH declaration a call
+// resolves to, and does not let a default library withhold the current file.
+//
+// A default library is dropped from the reported list either way -- that
+// contract is samchon/typia#2108's -- but the withholding beside it belongs to
+// the type channel alone. Under `libReplacement` a replaced library can change
+// a generated validator, so a file that consulted one has to give up its
+// declaration. It can never change which declaration a call resolves to:
+// callExpressionTransformer_targetModule recognizes typia's own calls by a path
+// ending in `/typia/lib/<file>.d.ts` or `/typia/src/<file>.ts`, and a file the
+// compiler classifies as a default library satisfies neither wherever it sits
+// on disk. Withholding there cost a file its declaration for calling
+// `table.get(...)`, and under `noembed` -- where every library is a real file --
+// for calling anything at all (samchon/typia#2361).
+//
+// A virtual non-`bundled:///` scheme still withholds on both channels: that drop
+// is about being unwatchable, not about being a library.
+func (collector *transformDependencyCollector) TouchCallee(fileName string) {
+  collector.touch(fileName, false)
+}
+
+func (collector *transformDependencyCollector) touch(fileName string, library bool) {
   if collector.current == "" {
     return
   }
@@ -507,7 +539,7 @@ func (collector *transformDependencyCollector) Touch(fileName string) {
     value = collector.value(fileName)
     collector.values[fileName] = value
   }
-  if value.withhold {
+  if value.withhold && (library || value.libraryOnly == false) {
     collector.Unbound()
   }
   if value.key == "" || value.key == collector.current {
@@ -541,8 +573,11 @@ func (collector *transformDependencyCollector) value(fileName string) transformD
   if strings.HasPrefix(fileName, transformDependencyBundledScheme) {
     return transformDependencyValue{}
   }
-  if strings.Contains(fileName, "://") || collector.isLibraryFile(fileName) {
+  if strings.Contains(fileName, "://") {
     return transformDependencyValue{withhold: true}
+  }
+  if collector.isLibraryFile(fileName) {
+    return transformDependencyValue{withhold: true, libraryOnly: true}
   }
   return transformDependencyValue{key: driver.TransformOutputKey(collector.cwd, fileName)}
 }

--- a/packages/typia/native/core/schemas/metadata/MetadataDependency.go
+++ b/packages/typia/native/core/schemas/metadata/MetadataDependency.go
@@ -28,6 +28,23 @@ var metadataDependency_listeners sync.Map
 type MetadataDependency_IListener struct {
   // File receives each consulted declaration file name.
   File func(fileName string)
+  // Callee receives a declaration file name reached while deciding WHICH
+  // declaration a call resolves to, rather than what a consulted type is built
+  // from.
+  //
+  // The two differ on default libraries alone, and only once the libraries are
+  // real files (`libReplacement`, `noembed`). A replacement really can change a
+  // generated validator, so the type channel withholds the file that consulted
+  // one. It can never change which declaration a call resolves to: typia
+  // recognizes its own calls by a path ending in `/typia/lib/<file>.d.ts` or
+  // `/typia/src/<file>.ts`, and a file the compiler classifies as a default
+  // library satisfies neither, whatever its path on disk. Withholding there
+  // costs a file its declaration for calling `table.get(...)` and, under
+  // `noembed`, for calling anything at all (samchon/typia#2361).
+  //
+  // A host that does not distinguish them may leave this nil; the registry
+  // falls back to File.
+  Callee func(fileName string)
   // Unbounded reports that the analysis consulted something no file list can
   // bound: a declaration whose type this package can only read from an
   // inferred position, or a callee whose identity is decided by an expression
@@ -46,6 +63,9 @@ type MetadataDependency_IListener struct {
 func MetadataDependency_listen(checker *nativechecker.Checker, listener MetadataDependency_IListener) {
   if checker == nil || listener.File == nil {
     return
+  }
+  if listener.Callee == nil {
+    listener.Callee = listener.File
   }
   metadataDependency_listeners.Store(checker, listener)
 }
@@ -275,15 +295,19 @@ func metadataDependency_touchDeclarations(
   if symbol == nil {
     return
   }
+  // Everything this function reaches was reached to decide which declaration a
+  // name selects, so all of it belongs to the identity channel -- the alias hops
+  // as much as the terminus.
+  report := listener.Callee
   if symbol.Flags&nativeast.SymbolFlagsAlias != 0 {
-    metadataDependency_touchPath(checker, listener, symbol)
+    metadataDependency_touchPath(checker, listener, symbol, report)
     if resolved := nativechecker.Checker_getAliasedSymbol(checker, symbol); resolved != nil {
       symbol = resolved
     }
   }
   for _, declaration := range symbol.Declarations {
     if src := nativeast.GetSourceFileOfNode(declaration); src != nil {
-      listener.File(src.FileName())
+      report(src.FileName())
     }
     if nested && metadataDependency_calleeBounded(declaration) == false {
       listener.unbounded()
@@ -808,7 +832,9 @@ func metadataDependency_resolve(
     return nil
   }
   if symbol.Flags&nativeast.SymbolFlagsAlias != 0 {
-    metadataDependency_touchPath(checker, listener, symbol)
+    // The type walk: a hop reached here was reached because a consulted type is
+    // built from what it publishes, so it reports on the consultation channel.
+    metadataDependency_touchPath(checker, listener, symbol, listener.File)
     if resolved := nativechecker.Checker_getAliasedSymbol(checker, symbol); resolved != nil {
       symbol = resolved
     }
@@ -833,6 +859,7 @@ func metadataDependency_touchPath(
   checker *nativechecker.Checker,
   listener MetadataDependency_IListener,
   symbol *nativeast.Symbol,
+  report func(fileName string),
 ) {
   visited := map[*nativeast.Symbol]bool{}
   for symbol != nil && symbol.Flags&nativeast.SymbolFlagsAlias != 0 && visited[symbol] == false {
@@ -843,7 +870,7 @@ func metadataDependency_touchPath(
     }
     // The file that WRITES this hop (the barrel's own `export ... from` line).
     if src := nativeast.GetSourceFileOfNode(declaration); src != nil {
-      listener.File(src.FileName())
+      report(src.FileName())
     }
     specifier := metadataDependency_moduleSpecifier(declaration)
     if specifier == nil {
@@ -864,7 +891,7 @@ func metadataDependency_touchPath(
     }
     for _, moduleDeclaration := range module.Declarations {
       if src := nativeast.GetSourceFileOfNode(moduleDeclaration); src != nil {
-        listener.File(src.FileName())
+        report(src.FileName())
       }
     }
     symbol = metadataDependency_exported(module, declaration)


### PR DESCRIPTION
fix(native): stop a default-library touch on the identity path from withholding

Under `libReplacement` a file lost its completeness declaration merely for
CALLING a method whose declaration lives in an on-disk default library — even
with no typia call anywhere in it, and nothing about that library able to change
its emitted text.

The withholding beside the drop is right for the type channel: a replaced
library really can change a consulted type and so a generated validator, which
is what samchon/typia#2357 established. It is wrong for the identity channel.
`callExpressionTransformer_targetModule` recognizes typia's own calls by a path
ending in `/typia/lib/<file>.d.ts` or `/typia/src/<file>.ts`, and a file the
compiler classifies as a default library satisfies neither wherever it sits on
disk, so a callee-walk touch of one can never change which declaration a call
resolves to.

The collector now has the channel to tell them apart. `MetadataDependency_
IListener` grows a `Callee` reporter, `metadataDependency_touchDeclarations`
and the alias hops it walks report through it, and the host drops a default
library on that channel without raising the admission. A virtual
non-`bundled:///` scheme still withholds on both: that drop is about being
unwatchable, not about being a library. A host that leaves `Callee` nil keeps
the old behavior — the registry falls back to `File`.

The cost this removes is not the one file the reproduction shows. Under
`noembed` every library is a real file, so `console.log(...)`, `arr.map(...)`,
and `JSON.stringify(...)` all touch one and effectively every file in the
project was withheld (stated from the mechanism; this repository cannot build
such a toolchain to measure it).

Mutation rows, both confirmed failing:

| mutation | fails |
| --- | --- |
| route the callee walk back through `File` | the `nocall.ts` declared assertion |
| stop withholding on a library in the type channel too | the `replaced.ts` withheld assertion |

Closes #2361.