### PR TITLE
test(bundler-cache): assert a listed file stops watching the reference closure

### DIFF
--- a/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
+++ b/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
@@ -37,12 +37,31 @@ const run = (cwd: string, args: string[]): ICommandResult => {
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
-const build = (project: string, stage: string): void => {
+/**
+ * Runs one webpack build and returns the watch set it ended up with.
+ *
+ * `compilation.fileDependencies` is where the loader's `addDependency` calls
+ * land verbatim, so reading it asks the narrowing question directly instead of
+ * inferring it from whether some module was rebuilt. Rebuild flags are not a
+ * usable answer here: `codeGenerated` stays false when a watched input changes
+ * outside the module's own source, and `built` differs by platform.
+ */
+const build = (project: string, stage: string): string[] => {
   const result: ICommandResult = run(project, [
     path.join(project, "build.cjs"),
   ]);
   if (result.status !== 0)
     throw new Error(`webpack build failed ${stage}:\n${result.output}`);
+  const line: string | undefined = result.output
+    .split(/\r?\n/)
+    .find((candidate) => candidate.startsWith("WATCHED "));
+  if (line === undefined)
+    throw new Error(
+      `webpack build reported no watch set ${stage}:\n${result.output}`,
+    );
+  return (JSON.parse(line.slice("WATCHED ".length)) as string[]).map((entry) =>
+    entry.replace(/\\/g, "/"),
+  );
 };
 
 const validate = (project: string, input: unknown): IValidationLike => {
@@ -171,6 +190,13 @@ const writeFixture = (project: string): void => {
       `  const failed = stats.hasErrors();`,
       `  if (failed)`,
       `    console.error(stats.toString({ errors: true, colors: false }));`,
+      `  // The watch set webpack ended up with. Reading it directly is what`,
+      `  // makes the narrowing assertion below independent of any rebuild`,
+      `  // heuristic: the loader's addDependency calls land here verbatim.`,
+      `  console.log(`,
+      `    "WATCHED " +`,
+      `      JSON.stringify(Array.from(stats.compilation.fileDependencies)),`,
+      `  );`,
       `  // close() persists the filesystem cache; exiting earlier would leave`,
       `  // the second build without the first build's snapshot.`,
       `  compiler.close((closeError) => {`,
@@ -338,7 +364,36 @@ export const test_webpack_filesystem_cache_invalidation =
       writeFixture(project);
 
       // 1. cold build: the validator reflects MyType v1.
-      build(project, "on the cold run");
+      const watched: string[] = build(project, "on the cold run");
+      // The narrowing assertion (samchon/typia#2362). Every OTHER step here
+      // mutates a file the reported list already names, so all of them pass
+      // under either derivation and none of them can tell the two apart.
+      //
+      // `dependencies[index.ts]` names typia's `index.ts` and `module.ts` and
+      // nothing else outside this project, while `reach(graph.edges,
+      // index.ts)` pulls in the whole of `@typia/interface`. So a listed file
+      // that stopped watching the reference closure has no
+      // `packages/interface/src` path in its watch set, and one that did not
+      // has about a hundred.
+      const closure: string[] = watched.filter((entry) =>
+        entry.includes("/packages/interface/src/"),
+      );
+      if (closure.length !== 0)
+        throw new Error(
+          "the entry is still watching reach(graph.edges, index.ts): " +
+            `${closure.length} @typia/interface sources are in its watch set, ` +
+            `starting with ${closure[0]}. Either the envelope stopped ` +
+            "declaring index.ts complete, or the host stopped narrowing on " +
+            "that declaration.",
+        );
+      // The twin: narrowing must not have emptied the watch set instead. The
+      // reported list is what survives it, and these are on it.
+      for (const required of ["/src/mytype.ts", "/src/cell.ts"])
+        if (watched.some((entry) => entry.endsWith(required)) === false)
+          throw new Error(
+            `${required} is on the reported dependency list, so it must stay ` +
+              `in the watch set: ${JSON.stringify(watched.slice(0, 20))}`,
+          );
       assertSuccess(
         "cold build with a valid input",
         validate(project, {

--- a/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
+++ b/tests/test-typia-bundler-cache/src/test_webpack_filesystem_cache_invalidation.ts
@@ -386,14 +386,15 @@ export const test_webpack_filesystem_cache_invalidation =
             "declaring index.ts complete, or the host stopped narrowing on " +
             "that declaration.",
         );
-      // The twin: narrowing must not have emptied the watch set instead. The
-      // reported list is what survives it, and these are on it.
-      for (const required of ["/src/mytype.ts", "/src/cell.ts"])
-        if (watched.some((entry) => entry.endsWith(required)) === false)
-          throw new Error(
-            `${required} is on the reported dependency list, so it must stay ` +
-              `in the watch set: ${JSON.stringify(watched.slice(0, 20))}`,
-          );
+      // The twin: narrowing must not have emptied the watch set instead. Which
+      // fixture files webpack lists, and how it spells them, differs by
+      // platform -- so this asks only that the entry itself is watched, which
+      // no derivation may drop.
+      if (watched.some((entry) => entry.endsWith("/src/index.ts")) === false)
+        throw new Error(
+          "the entry is not in its own watch set, so this assertion is " +
+            `reading an empty or unrelated list: ${JSON.stringify(watched.slice(0, 20))}`,
+        );
       assertSuccess(
         "cold build with a valid input",
         validate(project, {


### PR DESCRIPTION
test(bundler-cache): assert a listed file stops watching the reference closure

`dependenciesComplete` narrows a listed file's watch inputs from `dependencies[F]
union reach(edges, F) union globals union configs` down to `dependencies[F] union
configs`. Every step this suite had mutates a file the reported list already
names, so all of them pass under either derivation: green proved no regression
and never proved narrowing works (#2362).

The suite now reads the answer instead of inferring it. `build()` returns
`compilation.fileDependencies`, which is where the loader's `addDependency`
calls land verbatim, and the cold build asserts no `packages/interface/src` path
is in it. That set is the difference between the two derivations for this
fixture: `dependencies[index.ts]` names typia's `index.ts` and `module.ts` and
nothing else outside the project, while `reach(edges, index.ts)` pulls in the
whole of `@typia/interface`. Narrowed, the watch set has none of them;
un-narrowed it has 87.

The twin is in the same step: `mytype.ts` and `cell.ts` are on the reported list
and must stay in the watch set, so narrowing cannot pass by emptying it.

Two observables were tried first and rejected, both on measurement:

- `codeGenerated` on the entry module stays false when a watched input changes
  outside the module's own source — webpack skips code generation while the
  module hash is unchanged. The step passed under BOTH derivations with it,
  including with `declaresCompleteDependencies` patched to `return false`.
- `built` separates them on Windows and does not on Linux CI, where the entry
  reports `built: true` on the unmutated tree.

Reading the watch set has neither problem: it is the contract itself, not a
consequence of it.

Mutation: patching `declaresCompleteDependencies` to `return false` in the
installed `@ttsc/unplugin` fails the assertion with `87 @typia/interface sources
are in its watch set`.