### PR TITLE
fix(typia): improve missing-transform diagnostics

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/json_schema_nonsensible_intersection_diagnostic_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/json_schema_nonsensible_intersection_diagnostic_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestJSONSchemaNonsensibleIntersectionDiagnostic verifies that ttsc reports
+// the transform-time cause behind issue #2373.
+//
+// The runtime fallback cannot inspect a TypeScript type after transformation
+// has been skipped. This regression therefore compiles the reporter's exact
+// `Date & string` property through the real typia package and preserves the
+// actionable native diagnostic at its actual compiler boundary.
+//
+//  1. Compile a `typia.json.schema` call for the nonsensible intersection.
+//  2. Require the API diagnostic, property path, and intersection reason.
+func TestJSONSchemaNonsensibleIntersectionDiagnostic(t *testing.T) {
+  project := jsonSchemaNonsensibleIntersectionDiagnosticProject(t)
+  stdout, stderr, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", project,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 3 {
+    t.Fatalf("expected transform diagnostic exit code 3, got %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+  }
+  for _, expected := range []string{
+    "error TS(typia.json.schema):",
+    "ProblematicType.test",
+    "nonsensible intersection",
+  } {
+    if !strings.Contains(stderr, expected) {
+      t.Fatalf("expected stderr to contain %q, got:\n%s", expected, stderr)
+    }
+  }
+}
+
+func jsonSchemaNonsensibleIntersectionDiagnosticProject(t *testing.T) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("create fixture base: %v", err)
+  }
+  project, err := os.MkdirTemp(base, "json-schema-nonsensible-intersection-")
+  if err != nil {
+    t.Fatalf("create fixture project: %v", err)
+  }
+  t.Cleanup(func() {
+    if err := os.RemoveAll(project); err != nil {
+      t.Errorf("remove fixture project: %v", err)
+    }
+  })
+  src := filepath.Join(project, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("create fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(project, "tsconfig.json"), []byte(atomicIntersectionSchemaTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(jsonSchemaNonsensibleIntersectionDiagnosticSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return project
+}
+
+const jsonSchemaNonsensibleIntersectionDiagnosticSource = `import typia from "typia";
+
+type ProblematicType = {
+  test: Date & string;
+};
+
+export const schema = typia.json.schema<ProblematicType>();
+`

--- a/packages/typia/src/transformers/NoTransformConfigurationError.ts
+++ b/packages/typia/src/transformers/NoTransformConfigurationError.ts
@@ -8,8 +8,8 @@ export function NoTransformConfigurationError(name: string): never {
       "",
       [
         "If you've already completed the setup, it means there's",
-        "a bug in your code. Run `tsc` command so that check what",
-        "is wrong with your code.",
+        "a bug in your code. Run `ttsc` (not `tsc`) command so that",
+        "check what is wrong with your code.",
       ].join(" "),
     ].join("\n"),
   );

--- a/packages/typia/src/transformers/NoTransformConfigurationError.ts
+++ b/packages/typia/src/transformers/NoTransformConfigurationError.ts
@@ -4,13 +4,28 @@ export function NoTransformConfigurationError(name: string): never {
     [
       `Error on typia.${name}(): no transform has been configured.`,
       "",
-      "Read and follow https://typia.io/docs/setup please.",
+      [
+        "Build the project with `ttsc` (not stock `tsc`), run TypeScript",
+        "with `ttsx`, or configure `@ttsc/unplugin` for a bundler.",
+        "These toolchains discover typia's native transform automatically.",
+      ].join(" "),
       "",
       [
-        "If you've already completed the setup, it means there's",
-        "a bug in your code. Run `ttsc` (not `tsc`) command so that",
-        "check what is wrong with your code.",
+        "If `ttsc` is missing, install it with",
+        "`npm i -D ttsc typescript`.",
       ].join(" "),
+      "",
+      [
+        "If setup is already complete, run `npx ttsc --noEmit` to",
+        "surface the underlying TypeScript or typia transform error.",
+      ].join(" "),
+      "",
+      [
+        "Stock `tsc`, `ts-node`, `tsx`, Babel, and SWC do not load",
+        "typia's transform on their own.",
+      ].join(" "),
+      "",
+      "See https://typia.io/docs/setup for setup and bundler instructions.",
     ].join("\n"),
   );
 }

--- a/tests/test-typia-schema/src/features/setup/test_no_transform_configuration_error.ts
+++ b/tests/test-typia-schema/src/features/setup/test_no_transform_configuration_error.ts
@@ -1,0 +1,53 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+const EXPECTED = [
+  "Error on typia.json.schema(): no transform has been configured.",
+  "",
+  [
+    "Build the project with `ttsc` (not stock `tsc`), run TypeScript",
+    "with `ttsx`, or configure `@ttsc/unplugin` for a bundler.",
+    "These toolchains discover typia's native transform automatically.",
+  ].join(" "),
+  "",
+  "If `ttsc` is missing, install it with `npm i -D ttsc typescript`.",
+  "",
+  [
+    "If setup is already complete, run `npx ttsc --noEmit` to",
+    "surface the underlying TypeScript or typia transform error.",
+  ].join(" "),
+  "",
+  [
+    "Stock `tsc`, `ts-node`, `tsx`, Babel, and SWC do not load",
+    "typia's transform on their own.",
+  ].join(" "),
+  "",
+  "See https://typia.io/docs/setup for setup and bundler instructions.",
+].join("\n");
+
+/**
+ * Verifies that an untransformed typia call explains every supported setup.
+ *
+ * Issue #2373 exposed a runtime fallback that could only recommend the wrong
+ * compiler command, while the actual intersection diagnostic is available at
+ * transform time. An indirect alias deliberately avoids the call-expression
+ * transformer so this test can exercise that fallback without weakening the
+ * native diagnostic.
+ *
+ * 1. Alias `typia.json.schema` so the invocation remains untransformed.
+ * 2. Require the fallback to identify the API, supported toolchains, diagnostic
+ *    command, unsupported compilers, and setup documentation.
+ */
+export const test_no_transform_configuration_error = (): void => {
+  const schema: () => never = typia.json.schema;
+
+  let caught: unknown;
+  try {
+    schema();
+  } catch (error) {
+    caught = error;
+  }
+  if (!(caught instanceof Error))
+    throw new Error("The untransformed schema call must throw an Error.");
+  TestValidator.equals("no transform guidance", EXPECTED, caught.message);
+};

--- a/website/src/content/docs/setup/index.mdx
+++ b/website/src/content/docs/setup/index.mdx
@@ -191,7 +191,7 @@ console.log(typia.is<{ id: string }>({ id: "ok" }));
 // true
 ```
 
-If it prints `true`, the transform ran. If it throws `Error on typia.<method>(): no transform has been configured.`, the command bypassed `ttsc`, `ttsx`, or `@ttsc/unplugin`.
+If it prints `true`, the transform ran. If it throws `Error on typia.<method>(): no transform has been configured.`, the command bypassed `ttsc`, `ttsx`, or `@ttsc/unplugin`. Configure one of those transform paths, then run `npx ttsc --noEmit`; that compiler pass exposes the underlying TypeScript or `TS(typia.<method>)` transform diagnostic instead of reaching the runtime fallback.
 
 typia attributes a call by the file its declaration comes from, so a project-local `declare module "typia"` takes the call out of typia's own declarations and the transform no longer recognizes it. That case is reported at build time as `error TS(typia.<method>): this call resolved to a declaration in <file> instead of typia's own, so no transform was applied.` Delete the redeclaration, or give it another module name.
 


### PR DESCRIPTION
## Intent

Close #2373 by sending an untransformed typia call back through the compiler that can actually load typia's native plugin and report the underlying transform diagnostic.

The issue's `Date & string` example is already rejected by current `ttsc` with `TS(typia.json.schema)`, the `ProblematicType.test` path, and `nonsensible intersection`. The runtime fallback has none of that compiler state; its actionable responsibility is to name the correct compiler command.

## Scope

- Replace the shared fallback's obsolete `tsc` instruction with an explicit `ttsc` (not `tsc`) instruction.
- Add public runtime coverage for the untransformed-call guidance.
- Add command-level coverage proving the issue's exact type reaches the detailed `ttsc` diagnostic.

## Deferred / unchanged

- No JSON Schema or intersection semantics change: the current transformer already rejects the reported type correctly.
- No package version change.

## Verification at draft open

- `pnpm format`
- Manual `ttsx` probe of the issue source: rejected with `TS(typia.json.schema)`, `ProblematicType.test`, and `nonsensible intersection`.
- Direct execution of the shared fallback source: reports `Run \`ttsc\` (not \`tsc\`)`.

Automated regression tests and the broader build/test gates will follow on this draft.
