### PR TITLE
fix(typia): emit an empty array for reflect.literals over an empty union

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/reflect_literals_empty_union_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/reflect_literals_empty_union_transform_test.go
@@ -20,9 +20,10 @@ import (
 // vacuously literal-only and `literals<never>(): never[]` has exactly one
 // inhabitant, so both must transform and run.
 //
-//  1. Transform a module whose `reflect.literals` arguments span every spelling
-//     of the empty union a caller reaches -- the keyword, an alias, an
-//     exhaustive `Exclude`, an empty `Extract` -- plus `null`, a fully mixed
+//  1. Transform a module whose `reflect.literals` arguments span every
+//     uninhabited spelling a caller reaches -- the keyword, an alias, an
+//     exhaustive `Exclude`, an empty `Extract`, a TypeScript-collapsed
+//     intersection, and one typia prunes itself -- plus `null`, a fully mixed
 //     literal union, and the plain `boolean` atomic.
 //  2. Execute the emitted CommonJS.
 //  3. Assert `never` yields `[]`, `null` yields `[null]`, and the arguments that
@@ -102,6 +103,13 @@ export const emptyAlias = typia.reflect.literals<Empty>();
 export const emptyExclude = typia.reflect.literals<Exclude<Color, Color>>();
 export const emptyExtract = typia.reflect.literals<Extract<Color, "cyan">>();
 
+// Uninhabited without the keyword: TypeScript collapses one to never itself,
+// while the other stays an intersection whose every distributed member typia
+// prunes away. Both are empty on both sides of the comparison, so the rule the
+// keyword exercises has to cover them too.
+export const emptyCollapsed = typia.reflect.literals<string & number>();
+export const emptyPruned = typia.reflect.literals<(string | number) & { data: number }>();
+
 // A union whose only member is the nullable flag, which carries no bucket.
 export const onlyNull = typia.reflect.literals<null>();
 
@@ -141,6 +149,8 @@ check("never", mod.empty, []);
 check("never alias", mod.emptyAlias, []);
 check("exhaustive Exclude", mod.emptyExclude, []);
 check("empty Extract", mod.emptyExtract, []);
+check("collapsed intersection", mod.emptyCollapsed, []);
+check("pruned intersection", mod.emptyPruned, []);
 check("null", mod.onlyNull, [null]);
 check("mixed", mod.mixed, ["a", 1, true, null]);
 check("booleanAtomic", mod.booleanAtomic, [true, false]);

--- a/packages/typia/native/cmd/ttsc-typia/reflect_literals_empty_union_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/reflect_literals_empty_union_transform_test.go
@@ -20,11 +20,14 @@ import (
 // vacuously literal-only and `literals<never>(): never[]` has exactly one
 // inhabitant, so both must transform and run.
 //
-//  1. Transform a module whose `reflect.literals` arguments span `never`,
-//     `null`, a fully mixed literal union, and the plain `boolean` atomic.
+//  1. Transform a module whose `reflect.literals` arguments span every spelling
+//     of the empty union a caller reaches -- the keyword, an alias, an
+//     exhaustive `Exclude`, an empty `Extract` -- plus `null`, a fully mixed
+//     literal union, and the plain `boolean` atomic.
 //  2. Execute the emitted CommonJS.
 //  3. Assert `never` yields `[]`, `null` yields `[null]`, and the arguments that
-//     already worked keep their exact members and order.
+//     already worked keep their exact members and order, including the sort the
+//     guide documents.
 func TestReflectLiteralsEmptyUnionTransform(t *testing.T) {
   node, err := exec.LookPath("node")
   if err != nil {
@@ -87,8 +90,17 @@ func TestReflectLiteralsEmptyUnionTransform(t *testing.T) {
 
 const reflectLiteralsEmptyUnionSource = `import typia from "typia";
 
-// The empty union: no member on either side of the admission comparison.
+type Color = "red" | "green" | "blue";
+type Empty = never;
+
+// The empty union: no member on either side of the admission comparison. Every
+// spelling a caller reaches it through has to transform, not only the keyword:
+// an alias hides it behind a name, and a conditional or an exhaustive Exclude
+// is how a generic caller produces one without writing "never" at all.
 export const empty = typia.reflect.literals<never>();
+export const emptyAlias = typia.reflect.literals<Empty>();
+export const emptyExclude = typia.reflect.literals<Exclude<Color, Color>>();
+export const emptyExtract = typia.reflect.literals<Extract<Color, "cyan">>();
 
 // A union whose only member is the nullable flag, which carries no bucket.
 export const onlyNull = typia.reflect.literals<null>();
@@ -96,9 +108,13 @@ export const onlyNull = typia.reflect.literals<null>();
 // Controls that already transformed: the flag must join the count without
 // displacing a constant, a boolean atomic, or their order.
 export const mixed = typia.reflect.literals<"a" | 1 | true | null>();
-export const withoutNull = typia.reflect.literals<"a" | "b" | 1 | 2>();
 export const booleanAtomic = typia.reflect.literals<boolean>();
 export const booleanAtomicNull = typia.reflect.literals<boolean | null>();
+
+// Declaration order deliberately disagrees with the emitted order: values of
+// one primitive type are sorted (iterate_metadata_sort), which is the behavior
+// the reflect.literals guide states.
+export const sorted = typia.reflect.literals<"b" | "a" | 10 | 2>();
 `
 
 const reflectLiteralsEmptyUnionRunner = `const mod = require("./main.cjs");
@@ -122,11 +138,14 @@ const check = (label, actual, expected) => {
 };
 
 check("never", mod.empty, []);
+check("never alias", mod.emptyAlias, []);
+check("exhaustive Exclude", mod.emptyExclude, []);
+check("empty Extract", mod.emptyExtract, []);
 check("null", mod.onlyNull, [null]);
 check("mixed", mod.mixed, ["a", 1, true, null]);
-check("withoutNull", mod.withoutNull, ["a", "b", 1, 2]);
 check("booleanAtomic", mod.booleanAtomic, [true, false]);
 check("booleanAtomicNull", mod.booleanAtomicNull, [true, false, null]);
+check("sorted", mod.sorted, ["a", "b", 2, 10]);
 
 console.log("ok");
 `

--- a/packages/typia/native/cmd/ttsc-typia/reflect_literals_empty_union_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/reflect_literals_empty_union_transform_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+  "os"
+  "os/exec"
+  "path/filepath"
+  "testing"
+)
+
+// TestReflectLiteralsEmptyUnionTransform pins issue #2377: the literal set of an
+// empty union is the empty array, not a transform error.
+//
+// The programmer admits a type argument by counting the members it can render,
+// and it renders three kinds -- constant literals, the `boolean` atomic, and
+// `null`. `null` is a `MetadataSchema` flag rather than a bucket, so it was
+// missing from the count, which made two admissible arguments look like "no
+// constant literal type found": `never`, whose union is empty on both sides of
+// the comparison, and `null`, which the public
+// `literals<T extends Atomic.Type | null>()` signature documents. `never` is
+// vacuously literal-only and `literals<never>(): never[]` has exactly one
+// inhabitant, so both must transform and run.
+//
+//  1. Transform a module whose `reflect.literals` arguments span `never`,
+//     `null`, a fully mixed literal union, and the plain `boolean` atomic.
+//  2. Execute the emitted CommonJS.
+//  3. Assert `never` yields `[]`, `null` yields `[null]`, and the arguments that
+//     already worked keep their exact members and order.
+func TestReflectLiteralsEmptyUnionTransform(t *testing.T) {
+  node, err := exec.LookPath("node")
+  if err != nil {
+    t.Skip("node executable not found")
+  }
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "reflect-literals-empty-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(atomicIntersectionSchemaTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(reflectLiteralsEmptyUnionSource), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  ttscTypiaTestTypecheck(t, dir)
+
+  out, errText, code := ttscTypiaTestCapture(func() int {
+    return runTransform([]string{
+      "--cwd", dir,
+      "--tsconfig", "tsconfig.json",
+      "--file", "src/main.ts",
+      "--output", "js",
+    })
+  })
+  if code != 0 {
+    t.Fatalf("reflect.literals empty union transform failed: code=%d stderr=\n%s", code, errText)
+  }
+
+  runtimeDir := filepath.Join(dir, "runtime")
+  if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+    t.Fatalf("mkdir runtime dir: %v", err)
+  }
+  ttscTypiaTestWriteCommonRuntimeStubs(t, runtimeDir)
+  runtimeJS := ttscTypiaTestRewriteCommonJS(t, out)
+  if err := os.WriteFile(filepath.Join(runtimeDir, "main.cjs"), []byte(runtimeJS), 0o644); err != nil {
+    t.Fatalf("write runtime module: %v", err)
+  }
+  runner := filepath.Join(runtimeDir, "run.cjs")
+  if err := os.WriteFile(runner, []byte(reflectLiteralsEmptyUnionRunner), 0o644); err != nil {
+    t.Fatalf("write runtime runner: %v", err)
+  }
+  cmd := exec.Command(node, runner)
+  cmd.Dir = runtimeDir
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("reflect.literals empty union runtime cases failed: %v\n%s", err, output)
+  }
+}
+
+const reflectLiteralsEmptyUnionSource = `import typia from "typia";
+
+// The empty union: no member on either side of the admission comparison.
+export const empty = typia.reflect.literals<never>();
+
+// A union whose only member is the nullable flag, which carries no bucket.
+export const onlyNull = typia.reflect.literals<null>();
+
+// Controls that already transformed: the flag must join the count without
+// displacing a constant, a boolean atomic, or their order.
+export const mixed = typia.reflect.literals<"a" | 1 | true | null>();
+export const withoutNull = typia.reflect.literals<"a" | "b" | 1 | 2>();
+export const booleanAtomic = typia.reflect.literals<boolean>();
+export const booleanAtomicNull = typia.reflect.literals<boolean | null>();
+`
+
+const reflectLiteralsEmptyUnionRunner = `const mod = require("./main.cjs");
+
+const check = (label, actual, expected) => {
+  if (Array.isArray(actual) === false) {
+    throw new Error(label + ": expected an array, got " + JSON.stringify(actual));
+  }
+  if (
+    actual.length !== expected.length ||
+    actual.some((item, index) => item !== expected[index])
+  ) {
+    throw new Error(
+      label +
+        ": expected " +
+        JSON.stringify(expected) +
+        ", got " +
+        JSON.stringify(actual),
+    );
+  }
+};
+
+check("never", mod.empty, []);
+check("null", mod.onlyNull, [null]);
+check("mixed", mod.mixed, ["a", 1, true, null]);
+check("withoutNull", mod.withoutNull, ["a", "b", 1, 2]);
+check("booleanAtomic", mod.booleanAtomic, [true, false]);
+check("booleanAtomicNull", mod.booleanAtomicNull, [true, false, null]);
+
+console.log("ok");
+`

--- a/packages/typia/native/cmd/ttsc-typia/reflect_literals_non_literal_rejection_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/reflect_literals_non_literal_rejection_transform_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestReflectLiteralsNonLiteralRejectionTransform is the negative twin of the
+// empty-union admission fixed for issue #2377.
+//
+// Widening the admission predicate so that the empty union and the bare `null`
+// flag both pass must not widen it any further: every argument that carries a
+// member the emitter cannot render still has to abort the transform. The two
+// diagnostics stay distinguishable as well, because they say different things --
+// `NO` reports that nothing literal was found at all, while `ONLY` reports that
+// something literal was found next to something that is not. Collapsing them
+// would hide which half of a mixed argument is wrong.
+//
+//  1. Transform arguments holding no literal at all (`string`, `any`).
+//  2. Transform arguments mixing a renderable member with a non-literal one,
+//     including `string | null`, the one-axis twin of the newly admitted `null`.
+//  3. Assert each fails, and with the diagnostic its composition calls for.
+func TestReflectLiteralsNonLiteralRejectionTransform(t *testing.T) {
+  cases := []struct {
+    Name     string
+    Argument string
+    Message  string
+  }{
+    {"atomic", "string", "no constant literal type found."},
+    {"any", "any", "no constant literal type found."},
+    {"nullable atomic", "string | null", "only constant literal types are allowed."},
+    {"literal beside atomic", `"a" | number`, "only constant literal types are allowed."},
+    {"literal beside template", "`prefix${number}` | \"a\"", "only constant literal types are allowed."},
+  }
+  for _, tc := range cases {
+    tc := tc
+    t.Run(tc.Name, func(t *testing.T) {
+      project := reflectLiteralsRejectionProject(t, tc.Argument)
+      out, errText, code := ttscTypiaTestCapture(func() int {
+        return runTransform([]string{
+          "--cwd", project,
+          "--tsconfig", "tsconfig.json",
+          "--file", "src/main.ts",
+          "--output", "js",
+        })
+      })
+      if code == 0 {
+        t.Fatalf("reflect.literals<%s> transformed successfully, want rejection:\n%s", tc.Argument, out)
+      }
+      if !strings.Contains(errText, "typia transform error") {
+        t.Fatalf("reflect.literals<%s> diagnostics missing:\nstdout=%s\nstderr=%s", tc.Argument, out, errText)
+      }
+      if !strings.Contains(errText, tc.Message) {
+        t.Fatalf("reflect.literals<%s> reported the wrong reason, want %q:\n%s", tc.Argument, tc.Message, errText)
+      }
+    })
+  }
+}
+
+func reflectLiteralsRejectionProject(t *testing.T, argument string) string {
+  t.Helper()
+  root := ttscTypiaTestRepoRoot(t)
+  base := filepath.Join(root, "packages", "typia", "native", ".tmp-ttsc-typia-tests")
+  if err := os.MkdirAll(base, 0o755); err != nil {
+    t.Fatalf("mkdir temp base: %v", err)
+  }
+  dir, err := os.MkdirTemp(base, "reflect-literals-reject-")
+  if err != nil {
+    t.Fatalf("create temp fixture: %v", err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(dir) })
+  src := filepath.Join(dir, "src")
+  if err := os.MkdirAll(src, 0o755); err != nil {
+    t.Fatalf("mkdir fixture src: %v", err)
+  }
+  if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(atomicIntersectionSchemaTSConfig), 0o644); err != nil {
+    t.Fatalf("write tsconfig: %v", err)
+  }
+  source := "import typia from \"typia\";\n\nexport const values = typia.reflect.literals<" + argument + ">();\n"
+  if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
+    t.Fatalf("write source: %v", err)
+  }
+  return dir
+}

--- a/packages/typia/native/cmd/ttsc-typia/reflect_literals_non_literal_rejection_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/reflect_literals_non_literal_rejection_transform_test.go
@@ -18,9 +18,13 @@ import (
 // something literal was found next to something that is not. Collapsing them
 // would hide which half of a mixed argument is wrong.
 //
-//  1. Transform arguments holding no literal at all (`string`, `any`).
-//  2. Transform arguments mixing a renderable member with a non-literal one,
-//     including `string | null`, the one-axis twin of the newly admitted `null`.
+//  1. Transform arguments holding no literal at all: a bare atomic, `any`, and
+//     a tag-branded atomic, whose brand raises the member count without adding
+//     anything the emitter can render.
+//  2. Transform arguments mixing a renderable member with a non-literal one:
+//     `string | null`, the one-axis twin of the newly admitted `null`, and
+//     `boolean | number`, where the renderable member is an atomic rather than
+//     a constant.
 //  3. Assert each fails, and with the diagnostic its composition calls for.
 func TestReflectLiteralsNonLiteralRejectionTransform(t *testing.T) {
   cases := []struct {
@@ -33,6 +37,8 @@ func TestReflectLiteralsNonLiteralRejectionTransform(t *testing.T) {
     {"nullable atomic", "string | null", "only constant literal types are allowed."},
     {"literal beside atomic", `"a" | number`, "only constant literal types are allowed."},
     {"literal beside template", "`prefix${number}` | \"a\"", "only constant literal types are allowed."},
+    {"renderable atomic beside atomic", "boolean | number", "only constant literal types are allowed."},
+    {"tag branded atomic", `string & tags.Format<"uuid">`, "no constant literal type found."},
   }
   for _, tc := range cases {
     tc := tc
@@ -78,7 +84,7 @@ func reflectLiteralsRejectionProject(t *testing.T, argument string) string {
   if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(atomicIntersectionSchemaTSConfig), 0o644); err != nil {
     t.Fatalf("write tsconfig: %v", err)
   }
-  source := "import typia from \"typia\";\n\nexport const values = typia.reflect.literals<" + argument + ">();\n"
+  source := "import typia, { tags } from \"typia\";\n\nexport const values = typia.reflect.literals<" + argument + ">();\n"
   if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte(source), 0o644); err != nil {
     t.Fatalf("write source: %v", err)
   }

--- a/packages/typia/native/core/programmers/reflect/ReflectLiteralsProgrammer.go
+++ b/packages/typia/native/core/programmers/reflect/ReflectLiteralsProgrammer.go
@@ -29,6 +29,18 @@ func (reflectLiteralsProgrammerNamespace) Write(props ReflectLiteralsProgrammer_
       Escape:   true,
       Constant: true,
       Absorb:   true,
+      // Accept exactly what the emitter below can render: constant literals,
+      // the `boolean` atomic (the `true | false` union), and `null`. The
+      // counts are the whole predicate, so both sides must weigh `null`:
+      // `Nullable` is a flag rather than a bucket, so `MetadataSchema.Size()`
+      // never sees it and `literals<null>()` -- a type argument the public
+      // `T extends Atomic.Type | null` signature documents -- used to be
+      // rejected as carrying no literal at all.
+      //
+      // The empty union is `never`, whose metadata carries no member on either
+      // side. It is vacuously literal-only and `literals<never>(): never[]`
+      // has exactly one inhabitant, so it emits `[]` instead of a diagnostic
+      // (issue #2377).
       Validate: func(next struct {
         Metadata *nativemetadata.MetadataSchema
         Explore  nativefactories.MetadataFactory_IExplore
@@ -43,13 +55,18 @@ func (reflectLiteralsProgrammerNamespace) Write(props ReflectLiteralsProgrammer_
             length++
           }
         }
+        size := next.Metadata.Size()
+        if next.Metadata.Nullable {
+          length++
+          size++
+        }
+        if size == length {
+          return []string{}
+        }
         if length == 0 {
           return []string{string(ReflectLiteralsProgrammer_ErrorMessages_NO)}
         }
-        if next.Metadata.Size() != length {
-          return []string{string(ReflectLiteralsProgrammer_ErrorMessages_ONLY)}
-        }
-        return []string{}
+        return []string{string(ReflectLiteralsProgrammer_ErrorMessages_ONLY)}
       },
     },
     Components: nativemetadata.NewMetadataCollection(),

--- a/packages/typia/native/core/programmers/reflect/ReflectLiteralsProgrammer.go
+++ b/packages/typia/native/core/programmers/reflect/ReflectLiteralsProgrammer.go
@@ -30,17 +30,23 @@ func (reflectLiteralsProgrammerNamespace) Write(props ReflectLiteralsProgrammer_
       Constant: true,
       Absorb:   true,
       // Accept exactly what the emitter below can render: constant literals,
-      // the `boolean` atomic (the `true | false` union), and `null`. The
-      // counts are the whole predicate, so both sides must weigh `null`:
-      // `Nullable` is a flag rather than a bucket, so `MetadataSchema.Size()`
-      // never sees it and `literals<null>()` -- a type argument the public
-      // `T extends Atomic.Type | null` signature documents -- used to be
-      // rejected as carrying no literal at all.
+      // the `boolean` atomic (the `true | false` union), and `null`. `null` is
+      // a `MetadataSchema` flag rather than a bucket, so `Size()` cannot see
+      // it; weighing it on both sides keeps `length` meaning "renderable
+      // members" against `size` meaning "members", which is what lets a
+      // rejected argument carry the diagnostic its composition calls for
+      // instead of collapsing onto `NO`.
       //
-      // The empty union is `never`, whose metadata carries no member on either
-      // side. It is vacuously literal-only and `literals<never>(): never[]`
-      // has exactly one inhabitant, so it emits `[]` instead of a diagnostic
-      // (issue #2377).
+      // Equal counts with no member at all is an uninhabited argument: the
+      // `never` keyword, an alias or `Exclude`/`Extract` that filters
+      // everything away, or an intersection whose every distributed member
+      // prunes to never. Its literal set is empty and
+      // `literals<never>(): never[]` has exactly one inhabitant, so it emits
+      // `[]` rather than a diagnostic (issue #2377). `undefined` and `void`
+      // coalesce to the same empty metadata, but neither satisfies the public
+      // `T extends Atomic.Type | null` bound, and typia refuses to transform
+      // at all without `strictNullChecks` (`transform/transform.go`), so
+      // neither reaches this predicate.
       Validate: func(next struct {
         Metadata *nativemetadata.MetadataSchema
         Explore  nativefactories.MetadataFactory_IExplore

--- a/tests/test-error/src/reflect/error_reflect_literals_mixed.ts
+++ b/tests/test-error/src/reflect/error_reflect_literals_mixed.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+// `null` is a member `reflect.literals` renders, so an argument that mixes it
+// with a non-literal is not "no literal found" but "not only literals" -- and
+// must still be rejected. This is the one-axis negative twin of the bare
+// `null` and `never` arguments that #2377 made compile.
+typia.reflect.literals<string | null>();
+typia.reflect.literals<"a" | number>();

--- a/tests/test-error/src/reflect/error_reflect_literals_mixed.ts
+++ b/tests/test-error/src/reflect/error_reflect_literals_mixed.ts
@@ -1,8 +1,9 @@
 import typia from "typia";
 
 // `null` is a member `reflect.literals` renders, so an argument that mixes it
-// with a non-literal is not "no literal found" but "not only literals" -- and
-// must still be rejected. This is the one-axis negative twin of the bare
-// `null` and `never` arguments that #2377 made compile.
+// with a non-literal must still be rejected -- the one-axis negative twin of
+// the bare `null` and the uninhabited arguments that #2377 made compile. This
+// suite only proves the rejection; the diagnostic each composition earns is
+// asserted by TestReflectLiteralsNonLiteralRejectionTransform.
 typia.reflect.literals<string | null>();
 typia.reflect.literals<"a" | number>();

--- a/tests/test-typia-schema/src/features/reflect.literals/test_reflect_literals_never.ts
+++ b/tests/test-typia-schema/src/features/reflect.literals/test_reflect_literals_never.ts
@@ -1,0 +1,35 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+/**
+ * Verifies typia.reflect.literals reads the empty union as the empty array.
+ *
+ * Pins issue #2377. `never` is the union with no member, so `literals<never>():
+ * never[]` has exactly one inhabitant, `[]`. The admission predicate used to
+ * read "no member" as "no literal member" and refused to compile the call at
+ * all, which made a generic caller — one that computes its type argument with
+ * `Extract` or `Exclude` — break the whole build the moment the filter happened
+ * to select nothing.
+ *
+ * 1. Reflect a bare `never`.
+ * 2. Reflect a `never` produced by an exhaustive `Exclude`, the shape a generic
+ *    caller actually reaches it through.
+ * 3. Assert both are empty arrays, and that a non-empty `Exclude` still keeps its
+ *    surviving members (compared as a set: the emitted order follows the
+ *    metadata sort, not the declaration).
+ */
+export const test_reflect_literals_never = (): void => {
+  TestValidator.equals("bare never", typia.reflect.literals<never>(), []);
+
+  type Color = "red" | "green" | "blue";
+  TestValidator.equals(
+    "exhaustively excluded union",
+    typia.reflect.literals<Exclude<Color, Color>>(),
+    [],
+  );
+  TestValidator.equals(
+    "partially excluded union",
+    [...typia.reflect.literals<Exclude<Color, "red">>()].sort(),
+    ["blue", "green"],
+  );
+};

--- a/tests/test-typia-schema/src/features/reflect.literals/test_reflect_literals_never.ts
+++ b/tests/test-typia-schema/src/features/reflect.literals/test_reflect_literals_never.ts
@@ -15,8 +15,8 @@ import typia from "typia";
  * 2. Reflect a `never` produced by an exhaustive `Exclude`, the shape a generic
  *    caller actually reaches it through.
  * 3. Assert both are empty arrays, and that a non-empty `Exclude` still keeps its
- *    surviving members (compared as a set: the emitted order follows the
- *    metadata sort, not the declaration).
+ *    surviving members, in the sorted order the guide documents rather than the
+ *    declaration order.
  */
 export const test_reflect_literals_never = (): void => {
   TestValidator.equals("bare never", typia.reflect.literals<never>(), []);
@@ -29,7 +29,7 @@ export const test_reflect_literals_never = (): void => {
   );
   TestValidator.equals(
     "partially excluded union",
-    [...typia.reflect.literals<Exclude<Color, "red">>()].sort(),
+    typia.reflect.literals<Exclude<Color, "red">>(),
     ["blue", "green"],
   );
 };

--- a/tests/test-typia-schema/src/features/reflect.literals/test_reflect_literals_nullable.ts
+++ b/tests/test-typia-schema/src/features/reflect.literals/test_reflect_literals_nullable.ts
@@ -11,7 +11,8 @@ import typia from "typia";
  * always rendered the flag. Sibling arguments that pair `null` with a bucket
  * kept working, which is what hid the gap.
  *
- * 1. Reflect a bare `null`.
+ * 1. Reflect a bare `null`, and the same union behind an alias — the spelling a
+ *    caller reaches it through.
  * 2. Reflect `null` paired with a constant, with the `boolean` atomic, and with
  *    both.
  * 3. Assert `null` is present exactly once and always last, after the members that
@@ -19,6 +20,11 @@ import typia from "typia";
  */
 export const test_reflect_literals_nullable = (): void => {
   TestValidator.equals("bare null", typia.reflect.literals<null>(), [null]);
+
+  type Nullable = null;
+  TestValidator.equals("aliased null", typia.reflect.literals<Nullable>(), [
+    null,
+  ]);
   TestValidator.equals(
     "constant with null",
     typia.reflect.literals<"red" | null>(),

--- a/tests/test-typia-schema/src/features/reflect.literals/test_reflect_literals_nullable.ts
+++ b/tests/test-typia-schema/src/features/reflect.literals/test_reflect_literals_nullable.ts
@@ -1,0 +1,37 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+/**
+ * Verifies typia.reflect.literals reports `null` as a member of the union.
+ *
+ * `null` is the one member the signature admits (`literals<T extends
+ * Atomic.Type | null>()`) that metadata carries as a flag instead of a bucket.
+ * The admission predicate counted buckets, so it saw a `null`-only union as
+ * carrying no literal at all and rejected it, even though the emitter has
+ * always rendered the flag. Sibling arguments that pair `null` with a bucket
+ * kept working, which is what hid the gap.
+ *
+ * 1. Reflect a bare `null`.
+ * 2. Reflect `null` paired with a constant, with the `boolean` atomic, and with
+ *    both.
+ * 3. Assert `null` is present exactly once and always last, after the members that
+ *    carry a bucket.
+ */
+export const test_reflect_literals_nullable = (): void => {
+  TestValidator.equals("bare null", typia.reflect.literals<null>(), [null]);
+  TestValidator.equals(
+    "constant with null",
+    typia.reflect.literals<"red" | null>(),
+    ["red", null],
+  );
+  TestValidator.equals(
+    "boolean atomic with null",
+    typia.reflect.literals<boolean | null>(),
+    [true, false, null],
+  );
+  TestValidator.equals(
+    "mixed union with null",
+    typia.reflect.literals<"red" | 1 | true | null>(),
+    ["red", 1, true, null],
+  );
+};

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -813,7 +813,7 @@ Handy for select-box options, discriminated-union test matrices, etc.
 
 `T` may hold only literal types, the `boolean` atomic (which stands for `true | false`), and `null`. An argument that carries anything else — `string`, `number`, a template literal type — is a compile error, so `reflect.literals<"a" | number>()` never compiles into a partial array.
 
-`never` is the union with no member, so `reflect.literals<never>()` emits `[]`. That matters when the argument is computed: `Exclude<Color, Color>` filtering everything away yields an empty array rather than breaking the build.
+`never` is the union with no member, so `reflect.literals<never>()` emits `[]`. That matters when the argument is computed rather than written out: an `Exclude` that filters every member away yields an empty array instead of breaking the build.
 
 <Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -807,7 +807,7 @@ namespace reflect {
 }
 ```
 
-If you have a string-literal union (`"red" | "green" | "blue"`) and you want the runtime array `["red", "green", "blue"]` to iterate over, `reflect.literals` reads the union from the TS type and emits the array.
+If you have a string-literal union (`"red" | "green" | "blue"`) and you want a runtime array to iterate over, `reflect.literals` reads the union from the TS type and emits one. Members of the same primitive type come out sorted rather than in declaration order, so that union emits `["blue", "green", "red"]`.
 
 Handy for select-box options, discriminated-union test matrices, etc.
 

--- a/website/src/content/docs/misc.mdx
+++ b/website/src/content/docs/misc.mdx
@@ -811,6 +811,10 @@ If you have a string-literal union (`"red" | "green" | "blue"`) and you want the
 
 Handy for select-box options, discriminated-union test matrices, etc.
 
+`T` may hold only literal types, the `boolean` atomic (which stands for `true | false`), and `null`. An argument that carries anything else — `string`, `number`, a template literal type — is a compile error, so `reflect.literals<"a" | number>()` never compiles into a partial array.
+
+`never` is the union with no member, so `reflect.literals<never>()` emits `[]`. That matters when the argument is computed: `Exclude<Color, Color>` filtering everything away yields an empty array rather than breaking the build.
+
 <Tabs items={["TypeScript Source", "Compiled JavaScript"]}>
   <Tabs.Tab>
     <LocalSource


### PR DESCRIPTION
Solo issue-campaign cycle claim. This pull request owns the complete accepted cycle, which is one issue: #2377.

**Scope.** `typia.reflect.literals<never>()` fails to compile with `no constant literal type found.` instead of emitting `[]`.

**Status.** Empty claim; implementation and verification pending. The body is the historical intent statement — later CI fixes and Self-Review rounds land as formal `COMMENT` reviews on this thread.

**Release freeze.** Campaign branches never choose a release number or publish a package. Version bumps stay out of this pull request.
