### PR TITLE
feat(tags): ship next-major tag extensions

### DIFF
--- a/packages/interface/src/tags/Default.ts
+++ b/packages/interface/src/tags/Default.ts
@@ -11,9 +11,10 @@ import { TagBase } from "./TagBase";
  * which API documentation tools and code generators can use to show default
  * values or generate code that applies them.
  *
- * Only primitive literal types are supported: `boolean`, `bigint`, `number`,
- * and `string`. For complex defaults, consider using optional properties with
- * runtime default assignment.
+ * Primitive literals and readonly tuples of primitive literals are supported.
+ * Array defaults must be concrete tuples, normally captured with `as const`; an
+ * open array type such as `string[]` does not identify a value to emit. For
+ * object defaults, use optional properties with runtime default assignment.
  *
  * @author Jeongho Nam - https://github.com/samchon
  * @example
@@ -24,27 +25,37 @@ import { TagBase } from "./TagBase";
  *     enabled: (boolean & Default<true>) | undefined;
  *     // Default sort order
  *     sortOrder: (string & Default<"asc">) | undefined;
+ *     // Default selected columns
+ *     columns: (string[] & Default<readonly ["id", "name"]>) | undefined;
  *   }
  *
- * @template Value The default value literal (must be a primitive)
+ * @template Value The primitive or readonly tuple default value
  */
-export type Default<Value extends boolean | bigint | number | string> =
-  TagBase<{
-    target: Value extends boolean
+export type Default<Value extends DefaultAtomic | DefaultArray> = TagBase<{
+  target: Value extends DefaultArray
+    ? "array"
+    : Value extends boolean
       ? "boolean"
       : Value extends bigint
         ? "bigint"
         : Value extends number
           ? "number"
           : "string";
-    kind: "default";
-    value: Value;
-    exclusive: true;
-    schema: Value extends bigint
-      ? { default: Numeric<Value> }
-      : { default: Value };
-  }>;
+  kind: "default";
+  value: Value;
+  exclusive: true;
+  schema: { default: JsonDefault<Value> };
+}>;
 
 type Numeric<T extends bigint> = `${T}` extends `${infer N extends number}`
   ? N
   : never;
+
+type DefaultAtomic = boolean | bigint | number | string;
+type DefaultArray = readonly [] | readonly [DefaultAtomic, ...DefaultAtomic[]];
+
+type JsonDefault<Value> = Value extends bigint
+  ? Numeric<Value>
+  : Value extends DefaultArray
+    ? { [Key in keyof Value]: JsonDefault<Value[Key]> }
+    : Value;

--- a/packages/interface/src/tags/MaxLength.ts
+++ b/packages/interface/src/tags/MaxLength.ts
@@ -29,7 +29,7 @@ export type MaxLength<Value extends number> = TagBase<{
   target: "string";
   kind: "maxLength";
   value: Value;
-  validate: `$importInternal("_stringLength")($input) <= ${Value}`;
+  validate: `$importInternal("_stringLengthLte")($input, ${Value})`;
   exclusive: true;
   schema: {
     maxLength: Value;

--- a/packages/interface/src/tags/MinLength.ts
+++ b/packages/interface/src/tags/MinLength.ts
@@ -29,7 +29,7 @@ export type MinLength<Value extends number> = TagBase<{
   target: "string";
   kind: "minLength";
   value: Value;
-  validate: `${Value} <= $importInternal("_stringLength")($input)`;
+  validate: `$importInternal("_stringLengthGte")($input, ${Value})`;
   exclusive: true;
   schema: {
     minLength: Value;

--- a/packages/interface/src/tags/TagBase.ts
+++ b/packages/interface/src/tags/TagBase.ts
@@ -99,7 +99,7 @@ export namespace TagBase {
      *   `"5 <= $input"`; // For Minimum<5>
      *
      * @example
-     *   `"$importInternal(\"_stringLength\")($input) <= 10"`; // For MaxLength<10>
+     *   `"$importInternal(\"_stringLengthLte\")($input, 10)"`; // For MaxLength<10>
      */
     validate?: Validate;
 

--- a/packages/typia/native/cmd/ttsc-typia/dynamic_key_tags_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/dynamic_key_tags_transform_test.go
@@ -54,7 +54,7 @@ func TestDynamicKeyTagsTransform(t *testing.T) {
   }
   // The key is read into a local before it is tested, so its predicate is the
   // one place the emitted text can show the check exists at all.
-  if !strings.Contains(out, "RegExp(") || !strings.Contains(out, "_stringLength") {
+  if !strings.Contains(out, "RegExp(") || !strings.Contains(out, "_stringLengthGte") {
     t.Fatalf("emitted checker should test the dynamic key, not only its value:\n%s", out)
   }
   dynamicKeyTagsRunRuntimeCases(t, project, out)

--- a/packages/typia/native/cmd/ttsc-typia/template_literal_type_tags_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/template_literal_type_tags_transform_test.go
@@ -34,8 +34,9 @@ func TestTemplateLiteralTypeTagsTransform(t *testing.T) {
   if code != 0 {
     t.Fatalf("template literal tags transform failed: code=%d stderr=\n%s", code, errText)
   }
-  if !strings.Contains(out, `require("typia/lib/internal/_stringLength")`) ||
-    !strings.Contains(out, "._stringLength(input) <= 30") ||
+  if !strings.Contains(out, `require("typia/lib/internal/_stringLengthLte")`) ||
+    !strings.Contains(out, "._stringLengthLte(input, 30)") ||
+    !strings.Contains(out, `require("typia/lib/internal/_stringLengthGte")`) ||
     !strings.Contains(out, "RegExp(/^prefix(.*)postfix$/)") {
     t.Fatalf("emitted checker should combine the template pattern with its tags:\n%s", out)
   }

--- a/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/transform_helpers_test.go
@@ -155,6 +155,8 @@ func ttscTypiaTestRewriteCommonJS(t *testing.T, js string) string {
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_functionalTypeGuardErrorFactory")`, `require("./functional-error-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_accessExpressionAsString")`, `require("./access-expression-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_stringLength")`, `require("./string-length-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_stringLengthGte")`, `require("./string-length-stub.cjs")`)
+  runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_stringLengthLte")`, `require("./string-length-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyArray")`, `require("./json-stringify-array-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyProperty")`, `require("./json-stringify-property-stub.cjs")`)
   runtimeJS = strings.ReplaceAll(runtimeJS, `require("typia/lib/internal/_jsonStringifyElement")`, `require("./json-stringify-element-stub.cjs")`)
@@ -292,13 +294,25 @@ const ttscTypiaTestRandomStringStub = `module.exports._randomString = (props) =>
 };
 `
 
-// A double for packages/typia/src/internal/_stringLength.ts: the string
-// iterator walks code points, so a surrogate pair counts once, which is what
-// `MinLength` and `MaxLength` now mean.
+// Doubles for the string-length helpers. The string iterator walks code points,
+// so a surrogate pair counts once; the comparisons stop as soon as their
+// boundary determines the answer.
 const ttscTypiaTestStringLengthStub = `module.exports._stringLength = (value) => {
   let count = 0;
   for (const _ of value) ++count;
   return count;
+};
+module.exports._stringLengthGte = (value, length) => {
+  let count = 0;
+  if (length <= count) return true;
+  for (const _ of value) if (length <= ++count) return true;
+  return false;
+};
+module.exports._stringLengthLte = (value, length) => {
+  let count = 0;
+  if (!(count <= length)) return false;
+  for (const _ of value) if (!(++count <= length)) return false;
+  return true;
 };
 `
 

--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -331,10 +331,11 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
     // `$input.length` counts UTF-16 code units, while the `minLength` and
     // `maxLength` keywords these tags emit count characters, so one astral
     // character would measure 2 against a schema that measures 1.
-    // `_stringLength` first shipped in 13.1.19; see the doc comment above.
+    // The comparison helpers keep that code-point walk but stop when the
+    // declared boundary already determines the answer.
     return metadataCommentTagFactory_TagRecord{"string": {
-      {Name: "MinLength<" + props.Value + ">", Target: "string", Kind: "minLength", Value: value, Validate: props.Value + " <= $importInternal(\"_stringLength\")($input)", Exclusive: metadataCommentTagFactory_exclusive("minLength"), Schema: map[string]any{"minLength": value}},
-      {Name: "MaxLength<" + props.Value + ">", Target: "string", Kind: "maxLength", Value: value, Validate: "$importInternal(\"_stringLength\")($input) <= " + props.Value, Exclusive: metadataCommentTagFactory_exclusive("maxLength"), Schema: map[string]any{"maxLength": value}},
+      {Name: "MinLength<" + props.Value + ">", Target: "string", Kind: "minLength", Value: value, Validate: "$importInternal(\"_stringLengthGte\")($input, " + props.Value + ")", Exclusive: metadataCommentTagFactory_exclusive("minLength"), Schema: map[string]any{"minLength": value}},
+      {Name: "MaxLength<" + props.Value + ">", Target: "string", Kind: "maxLength", Value: value, Validate: "$importInternal(\"_stringLengthLte\")($input, " + props.Value + ")", Exclusive: metadataCommentTagFactory_exclusive("maxLength"), Schema: map[string]any{"maxLength": value}},
     }}
   },
   "minLength": func(props struct {
@@ -342,14 +343,14 @@ var metadataCommentTagFactory_PARSER = map[string]metadataCommentTagFactory_pars
     Value  string
   }) metadataCommentTagFactory_TagRecord {
     value := metadataCommentTagFactory_parse_number(props)
-    return metadataCommentTagFactory_TagRecord{"string": {{Name: "MinLength<" + props.Value + ">", Target: "string", Kind: "minLength", Value: value, Validate: props.Value + " <= $importInternal(\"_stringLength\")($input)", Exclusive: metadataCommentTagFactory_exclusive("minLength"), Schema: map[string]any{"minLength": value}}}}
+    return metadataCommentTagFactory_TagRecord{"string": {{Name: "MinLength<" + props.Value + ">", Target: "string", Kind: "minLength", Value: value, Validate: "$importInternal(\"_stringLengthGte\")($input, " + props.Value + ")", Exclusive: metadataCommentTagFactory_exclusive("minLength"), Schema: map[string]any{"minLength": value}}}}
   },
   "maxLength": func(props struct {
     Report func(msg string) any
     Value  string
   }) metadataCommentTagFactory_TagRecord {
     value := metadataCommentTagFactory_parse_number(props)
-    return metadataCommentTagFactory_TagRecord{"string": {{Name: "MaxLength<" + props.Value + ">", Target: "string", Kind: "maxLength", Value: value, Validate: "$importInternal(\"_stringLength\")($input) <= " + props.Value, Exclusive: metadataCommentTagFactory_exclusive("maxLength"), Schema: map[string]any{"maxLength": value}}}}
+    return metadataCommentTagFactory_TagRecord{"string": {{Name: "MaxLength<" + props.Value + ">", Target: "string", Kind: "maxLength", Value: value, Validate: "$importInternal(\"_stringLengthLte\")($input, " + props.Value + ")", Exclusive: metadataCommentTagFactory_exclusive("maxLength"), Schema: map[string]any{"maxLength": value}}}}
   },
 }
 

--- a/packages/typia/native/core/factories/MetadataCommentTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataCommentTagFactory.go
@@ -216,11 +216,12 @@ func (metadataCommentTagFactoryNamespace) Get(props struct {
 // The rule: a template may name only a helper that every `typia` inside the
 // caret range already ships. `isTypeInt8` and its siblings satisfy it --
 // `@typia/interface` 13.0.0 named them and `typia` 13.0.0 shipped them. The
-// four this file and `Type.ts` now name do not: `_stringLength`, `_isMultipleOf`
-// (both first published in 13.1.19), `_isTypeInt64Bigint`, and
-// `_isTypeUint64Bigint` (13.1.19). They are safe only because the release that
-// carries them is a major, where the caret cannot reach a `typia` that predates
-// them. A minor or patch release of this tree reopens #2330.
+// helpers this file and the tag declarations now name do not:
+// `_stringLengthGte`, `_stringLengthLte`, `_isMultipleOf`,
+// `_isTypeInt64Bigint`, and `_isTypeUint64Bigint`. They are safe only because
+// the release that carries them is a major, where the caret cannot reach a
+// `typia` that predates them. A minor or patch release of this tree reopens
+// #2330.
 //
 // Nothing here can enforce that; the release version is the maintainer's, and a
 // campaign pull request never assigns one. This comment is the record.

--- a/packages/typia/native/core/factories/MetadataTypeTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataTypeTagFactory.go
@@ -66,6 +66,20 @@ func (metadataTypeTagFactoryNamespace) Analyze(props struct {
     messages = append(messages, "the property "+property+" "+next.Message+".")
     return false
   }
+  failure := func() []schemametadata.IMetadataTypeTag {
+    if props.Errors != nil {
+      names := []string{props.Type}
+      for _, object := range props.Objects {
+        names = append(names, object.Name)
+      }
+      metadataTypeTagFactory_append_error(props.Errors, MetadataFactory_IError{
+        Name:     strings.Join(names, " & "),
+        Explore:  props.Explore,
+        Messages: messages,
+      })
+    }
+    return []schemametadata.IMetadataTypeTag{}
+  }
 
   filtered := []*schemametadata.MetadataObjectType{}
   for _, obj := range props.Objects {
@@ -140,6 +154,9 @@ func (metadataTypeTagFactoryNamespace) Analyze(props struct {
       filtered = append(filtered, obj)
     }
   }
+  if len(messages) != 0 {
+    return failure()
+  }
   if len(filtered) == 0 {
     return []schemametadata.IMetadataTypeTag{}
   }
@@ -194,18 +211,7 @@ func (metadataTypeTagFactoryNamespace) Analyze(props struct {
   })
 
   if len(messages) > 0 {
-    if props.Errors != nil {
-      names := []string{props.Type}
-      for _, object := range props.Objects {
-        names = append(names, object.Name)
-      }
-      metadataTypeTagFactory_append_error(props.Errors, MetadataFactory_IError{
-        Name:     strings.Join(names, " & "),
-        Explore:  props.Explore,
-        Messages: messages,
-      })
-    }
-    return []schemametadata.IMetadataTypeTag{}
+    return failure()
   }
   return output
 }
@@ -315,12 +321,13 @@ func metadataTypeTagFactory_validate_property(props struct {
       Message  string
     }{Property: property, Message: "must be a string literal type"})
   }
-  if props.Key == "value" && !((props.Value.Size() == 0 && props.Value.IsRequired() == false) ||
-    (props.Value.Size() == 1 && (len(props.Value.Objects) == 1 || len(props.Value.Constants) == 1))) {
-    return props.Report(struct {
-      Property *string
-      Message  string
-    }{Property: property, Message: "must be a literal type or undefined value"})
+  if props.Key == "value" {
+    if _, ok := metadataTypeTagFactory_get_value(props.Value); ok == false {
+      return props.Report(struct {
+        Property *string
+        Message  string
+      }{Property: property, Message: "must be a literal, literal tuple, object, or undefined type"})
+    }
   }
   if props.Key == "exclusive" {
     return metadataTypeTagFactory_get_exclusive(struct {
@@ -415,8 +422,8 @@ func metadataTypeTagFactory_create_metadata_type_tag(props struct {
   kind := fmt.Sprint(kindProperty.Value.Constants[0].Values[0].Value)
 
   var value any
-  if valueProperty := find("value"); valueProperty != nil && len(valueProperty.Value.Constants) != 0 && len(valueProperty.Value.Constants[0].Values) != 0 {
-    value = valueProperty.Value.Constants[0].Values[0].Value
+  if valueProperty := find("value"); valueProperty != nil {
+    value, _ = metadataTypeTagFactory_get_value(valueProperty.Value)
   }
   exclusive := metadataTypeTagFactory_get_exclusive(struct {
     Report func(struct {
@@ -488,6 +495,48 @@ func metadataTypeTagFactory_create_metadata_type_tag(props struct {
     Exclusive: exclusive,
     Schema:    schema,
   }
+}
+
+func metadataTypeTagFactory_get_value(metadata *schemametadata.MetadataSchema) (any, bool) {
+  if metadata == nil {
+    return nil, false
+  }
+  if metadata.Size() == 0 {
+    return nil, metadata.IsRequired() == false && metadata.Nullable == false
+  }
+  if metadata.Size() != 1 || metadata.Nullable {
+    return nil, false
+  }
+  if len(metadata.Constants) == 1 && len(metadata.Constants[0].Values) == 1 {
+    return metadata.Constants[0].Values[0].Value, true
+  }
+  if len(metadata.Arrays) != 0 || len(metadata.Atomics) != 0 || len(metadata.Natives) != 0 || len(metadata.Functions) != 0 {
+    return nil, false
+  }
+  if len(metadata.Tuples) == 1 {
+    tuple := metadata.Tuples[0].Type
+    if tuple.Recursive || tuple.IsRest() {
+      return nil, false
+    }
+    output := make([]any, 0, len(tuple.Elements))
+    for _, elem := range tuple.Elements {
+      if elem.IsRequired() == false {
+        return nil, false
+      }
+      value, ok := metadataTypeTagFactory_get_value(elem)
+      if ok == false {
+        return nil, false
+      }
+      output = append(output, value)
+    }
+    return output, true
+  }
+  if len(metadata.Objects) == 1 {
+    // Object-valued metadata predates tuple support. Its concrete value is
+    // carried by the tag's schema object rather than IMetadataTypeTag.Value.
+    return nil, true
+  }
+  return nil, false
 }
 
 func metadataTypeTagFactory_get_exclusive(props struct {

--- a/packages/typia/native/core/factories/MetadataTypeTagFactory.go
+++ b/packages/typia/native/core/factories/MetadataTypeTagFactory.go
@@ -520,14 +520,14 @@ func metadataTypeTagFactory_get_value(metadata *schemametadata.MetadataSchema) (
     }
     output := make([]any, 0, len(tuple.Elements))
     for _, elem := range tuple.Elements {
-      if elem.IsRequired() == false {
+      if elem.IsRequired() == false ||
+        elem.Nullable ||
+        elem.Size() != 1 ||
+        len(elem.Constants) != 1 ||
+        len(elem.Constants[0].Values) != 1 {
         return nil, false
       }
-      value, ok := metadataTypeTagFactory_get_value(elem)
-      if ok == false {
-        return nil, false
-      }
-      output = append(output, value)
+      output = append(output, elem.Constants[0].Values[0].Value)
     }
     return output, true
   }

--- a/packages/typia/native/core/factories/metadata_comment_tag_factory_string_length_helpers_test.go
+++ b/packages/typia/native/core/factories/metadata_comment_tag_factory_string_length_helpers_test.go
@@ -1,0 +1,55 @@
+package factories
+
+import (
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestMetadataCommentTagFactoryStringLengthHelpers verifies every JSDoc length
+// spelling emits the same short-circuiting predicates as the public type tags.
+//
+// The type-tag declarations and JSDoc parser are independent metadata sources.
+// Updating only one would preserve schema output while making runtime behavior
+// and helper imports depend on which spelling a user chose.
+//
+//  1. Parse @length and require both comparison helpers at the same boundary.
+//  2. Parse @minLength and @maxLength and require their corresponding helper.
+func TestMetadataCommentTagFactoryStringLengthHelpers(t *testing.T) {
+  parse := func(name string, value string) []schemametadata.IMetadataTypeTag {
+    t.Helper()
+    reports := []string{}
+    record := metadataCommentTagFactory_parse(struct {
+      Report func(msg string) any
+      Tag    schemametadata.IJsDocTagInfo
+    }{
+      Report: func(msg string) any {
+        reports = append(reports, msg)
+        return nil
+      },
+      Tag: schemametadata.IJsDocTagInfo{
+        Name: name,
+        Text: []schemametadata.IJsDocTagInfo_IText{{Text: value}},
+      },
+    })
+    if len(reports) != 0 {
+      t.Fatalf("@%s %s reported errors: %#v", name, value, reports)
+    }
+    return record["string"]
+  }
+
+  length := parse("length", "3")
+  if len(length) != 2 ||
+    length[0].Validate != `$importInternal("_stringLengthGte")($input, 3)` ||
+    length[1].Validate != `$importInternal("_stringLengthLte")($input, 3)` {
+    t.Fatalf("@length must emit both comparison helpers: %#v", length)
+  }
+  minimum := parse("minLength", "2")
+  if len(minimum) != 1 || minimum[0].Validate != `$importInternal("_stringLengthGte")($input, 2)` {
+    t.Fatalf("@minLength must emit the lower-bound helper: %#v", minimum)
+  }
+  maximum := parse("maxLength", "4")
+  if len(maximum) != 1 || maximum[0].Validate != `$importInternal("_stringLengthLte")($input, 4)` {
+    t.Fatalf("@maxLength must emit the upper-bound helper: %#v", maximum)
+  }
+}

--- a/packages/typia/native/core/factories/metadata_type_tag_factory_reports_all_invalid_candidates_test.go
+++ b/packages/typia/native/core/factories/metadata_type_tag_factory_reports_all_invalid_candidates_test.go
@@ -1,0 +1,73 @@
+package factories
+
+import (
+  "testing"
+
+  schemametadata "github.com/samchon/typia/packages/typia/native/core/schemas/metadata"
+)
+
+// TestMetadataTypeTagFactoryReportsAllInvalidCandidates verifies a rejected tag
+// still produces a transform diagnostic when no valid tag candidate accompanies
+// it.
+//
+// Analyze used to return as soon as its filtered candidate list was empty. That
+// discarded the messages collected while rejecting the candidates, so a lone
+// malformed tag silently became an ordinary phantom brand while the same tag
+// beside a valid one failed compilation.
+//
+//  1. Build one structurally recognizable tag with a non-literal value.
+//  2. Analyze it without a valid companion and require no emitted metadata tag.
+//  3. Require the collected validation message to reach the factory errors.
+func TestMetadataTypeTagFactoryReportsAllInvalidCandidates(t *testing.T) {
+  invalid := metadataTypeTagFactoryAllInvalidContainer("InvalidValue",
+    metadataTypeTagFactoryAllInvalidProperty("target", MetadataFactory.SoleLiteral("array")),
+    metadataTypeTagFactoryAllInvalidProperty("kind", MetadataFactory.SoleLiteral("default")),
+    metadataTypeTagFactoryAllInvalidProperty("value", func() *schemametadata.MetadataSchema {
+      metadata := schemametadata.MetadataSchema_initialize()
+      metadata.Atomics = append(metadata.Atomics, schemametadata.MetadataAtomic_create(schemametadata.MetadataAtomic{Type: "string"}))
+      return metadata
+    }()),
+  )
+  errors := []MetadataFactory_IError{}
+  tags := MetadataTypeTagFactory.Analyze(struct {
+    Errors  *[]MetadataFactory_IError
+    Type    string
+    Objects []*schemametadata.MetadataObjectType
+    Explore MetadataFactory_IExplore
+  }{
+    Errors:  &errors,
+    Type:    "array",
+    Objects: []*schemametadata.MetadataObjectType{invalid},
+  })
+  if len(tags) != 0 {
+    t.Fatalf("an invalid value must not produce a metadata tag: %#v", tags)
+  }
+  if len(errors) != 1 || len(errors[0].Messages) == 0 {
+    t.Fatalf("a lone invalid tag must retain its diagnostic: %#v", errors)
+  }
+}
+
+func metadataTypeTagFactoryAllInvalidProperty(key string, value *schemametadata.MetadataSchema) *schemametadata.MetadataProperty {
+  return schemametadata.MetadataProperty_create(schemametadata.MetadataProperty{
+    Key:   MetadataFactory.SoleLiteral(key),
+    Value: value,
+  })
+}
+
+func metadataTypeTagFactoryAllInvalidContainer(name string, properties ...*schemametadata.MetadataProperty) *schemametadata.MetadataObjectType {
+  tagValue := schemametadata.MetadataSchema_initialize()
+  tagValue.Required = false
+  tagValue.Optional = true
+  tagValue.Objects = append(tagValue.Objects, schemametadata.MetadataObject_create(schemametadata.MetadataObject{
+    Type: schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{
+      Name:       name + "Shape",
+      Properties: properties,
+    }),
+  }))
+  return schemametadata.MetadataObjectType_create(schemametadata.MetadataObjectType{
+    Name: name,
+    Properties: []*schemametadata.MetadataProperty{
+      metadataTypeTagFactoryAllInvalidProperty("typia.tag", tagValue),
+    },
+  })
+}

--- a/packages/typia/src/internal/_stringLengthGte.ts
+++ b/packages/typia/src/internal/_stringLengthGte.ts
@@ -1,0 +1,6 @@
+export const _stringLengthGte = (value: string, length: number): boolean => {
+  let count: number = 0;
+  if (length <= count) return true;
+  for (const _ch of value) if (length <= ++count) return true;
+  return false;
+};

--- a/packages/typia/src/internal/_stringLengthLte.ts
+++ b/packages/typia/src/internal/_stringLengthLte.ts
@@ -1,0 +1,6 @@
+export const _stringLengthLte = (value: string, length: number): boolean => {
+  let count: number = 0;
+  if (!(count <= length)) return false;
+  for (const _ch of value) if (!(++count <= length)) return false;
+  return true;
+};

--- a/tests/test-error/src/tag/error_tag_default_array_non_literal.ts
+++ b/tests/test-error/src/tag/error_tag_default_array_non_literal.ts
@@ -1,0 +1,6 @@
+import typia, { tags } from "typia";
+
+// This tuple fixes its length but leaves its element unspecified. Default
+// accepts the tuple shape so typia can issue the tag diagnostic at the
+// transformed call site, where every member must be a concrete literal.
+typia.json.schema<string[] & tags.Default<readonly [string]>>();

--- a/tests/test-interface/src/tags/test_default_array.ts
+++ b/tests/test-interface/src/tags/test_default_array.ts
@@ -1,0 +1,41 @@
+import { tags } from "@typia/interface";
+
+/**
+ * Verifies `Default` accepts concrete array tuples without widening its shared
+ * `TagBase` contract.
+ *
+ * The public type admits tuple shapes so the transformer can preserve literal
+ * values and report a focused diagnostic for a non-literal tuple member. An
+ * open array remains invalid because it does not describe one default value.
+ *
+ * 1. Accept readonly, mutable, empty, and bigint-containing tuples.
+ * 2. Preserve the array target and JSON-safe bigint schema value.
+ * 3. Reject open mutable and readonly array types at the generic boundary.
+ */
+export type DefaultArrayCases = [
+  tags.Default<typeof HEADERS>,
+  tags.Default<["id", "status"]>,
+  tags.Default<readonly []>,
+  tags.Default<readonly [1n, 2n]>,
+  Assert<IsEqual<BigintProps["target"], "array">>,
+  Assert<IsEqual<BigintProps["schema"], { default: readonly [1, 2] }>>,
+];
+
+const HEADERS = ["id", "status"] as const;
+
+type BigintProps = NonNullable<tags.Default<readonly [1n, 2n]>["typia.tag"]>;
+
+// @ts-expect-error an open array does not carry one concrete default value.
+export type MutableOpenArrayDefault = tags.Default<string[]>;
+
+// @ts-expect-error a readonly open array is not a literal tuple either.
+export type ReadonlyOpenArrayDefault = tags.Default<readonly string[]>;
+
+type Assert<T extends true> = T;
+
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_array_default.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_array_default.ts
@@ -1,0 +1,44 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { tags } from "typia";
+
+/**
+ * Verifies `Default` carries readonly literal tuples into array schemas.
+ *
+ * Array tags are intersections on the array wrapper, so a default tuple must
+ * coexist with `MinItems` and `UniqueItems` without becoming an element tag or
+ * losing its literal values during metadata extraction.
+ *
+ * 1. Emit the reported header-selection shape and assert all three annotations.
+ * 2. Preserve an empty tuple as an empty default rather than missing metadata.
+ * 3. Convert bigint tuple members to the JSON numeric values scalar defaults use.
+ */
+export const test_json_schema_array_default = (): void => {
+  const HEADERS = ["id", "status", "created_at"] as const;
+  type Header = (typeof HEADERS)[number];
+  type Selection = Array<Header> &
+    tags.Default<typeof HEADERS> &
+    tags.MinItems<1> &
+    tags.UniqueItems;
+
+  const selection: any = typia.json.schema<Selection>().schema;
+  TestValidator.equals("array default and constraints", pick(selection), {
+    default: [...HEADERS],
+    minItems: 1,
+    uniqueItems: true,
+  });
+
+  const empty: any = typia.json.schema<string[] & tags.Default<readonly []>>()
+    .schema;
+  TestValidator.equals("empty array default", empty.default, []);
+
+  const bigint: any = typia.json.schema<
+    number[] & tags.Default<readonly [1n, 2n]>
+  >().schema;
+  TestValidator.equals("bigint array default", bigint.default, [1, 2]);
+};
+
+const pick = (schema: any): object => ({
+  default: schema.default,
+  minItems: schema.minItems,
+  uniqueItems: schema.uniqueItems,
+});

--- a/tests/test-typia-schema/src/features/validate/test_validate_string_length_short_circuit.ts
+++ b/tests/test-typia-schema/src/features/validate/test_validate_string_length_short_circuit.ts
@@ -1,0 +1,110 @@
+import { TestValidator } from "@nestia/e2e";
+import { _stringLengthGte } from "typia/lib/internal/_stringLengthGte";
+import { _stringLengthLte } from "typia/lib/internal/_stringLengthLte";
+
+/**
+ * Verifies the string-length comparison helpers preserve exact code-point
+ * semantics while stopping once a boundary determines their result.
+ *
+ * The generated validators no longer compute a complete numeric length for
+ * `MinLength` and `MaxLength`. The replacement predicates must remain equal to
+ * comparing `[...value].length`, including zero, fractional, and Unicode cases,
+ * and their loops must not read beyond a decisive character.
+ *
+ * 1. Compare both helpers with a code-point-count oracle over boundary values.
+ * 2. Wrap the native string iterator and count reads made by decisive checks.
+ * 3. Require zero-bound checks to return without opening the iterator at all.
+ */
+export const test_validate_string_length_short_circuit = (): void => {
+  const values: string[] = [
+    "",
+    "a",
+    "\u{1f600}",
+    "a\u{1f600}",
+    "\u{1f1f0}\u{1f1f7}",
+    "\u{1f468}\u200d\u{1f469}\u200d\u{1f467}",
+  ];
+  const boundaries: number[] = [
+    -1,
+    0,
+    0.5,
+    1,
+    1.5,
+    2,
+    5,
+    Number.POSITIVE_INFINITY,
+    Number.NaN,
+  ];
+  for (const value of values)
+    for (const boundary of boundaries) {
+      const length: number = [...value].length;
+      const label: string = `${JSON.stringify(value)} against ${boundary}`;
+      TestValidator.equals(
+        `greater-than-or-equal ${label}`,
+        _stringLengthGte(value, boundary),
+        length >= boundary,
+      );
+      TestValidator.equals(
+        `less-than-or-equal ${label}`,
+        _stringLengthLte(value, boundary),
+        length <= boundary,
+      );
+    }
+
+  const descriptor: PropertyDescriptor = Object.getOwnPropertyDescriptor(
+    String.prototype,
+    Symbol.iterator,
+  )!;
+  const original: () => IterableIterator<string> = descriptor.value;
+  let reads: number = 0;
+  Object.defineProperty(String.prototype, Symbol.iterator, {
+    ...descriptor,
+    value: function (this: string): IterableIterator<string> {
+      const iterator: IterableIterator<string> = original.call(this);
+      return {
+        next: (): IteratorResult<string> => {
+          ++reads;
+          return iterator.next();
+        },
+        [Symbol.iterator](): IterableIterator<string> {
+          return this;
+        },
+      };
+    },
+  });
+  let minimumResult: boolean;
+  let minimumReads: number;
+  let maximumResult: boolean;
+  let maximumReads: number;
+  let zeroMinimumResult: boolean;
+  let zeroMinimumReads: number;
+  let negativeMaximumResult: boolean;
+  let negativeMaximumReads: number;
+  try {
+    reads = 0;
+    minimumResult = _stringLengthGte("abcdef", 2);
+    minimumReads = reads;
+
+    reads = 0;
+    maximumResult = _stringLengthLte("abcdef", 2);
+    maximumReads = reads;
+
+    reads = 0;
+    zeroMinimumResult = _stringLengthGte("abcdef", 0);
+    zeroMinimumReads = reads;
+
+    reads = 0;
+    negativeMaximumResult = _stringLengthLte("abcdef", -1);
+    negativeMaximumReads = reads;
+  } finally {
+    Object.defineProperty(String.prototype, Symbol.iterator, descriptor);
+  }
+  TestValidator.equals("minimum result", minimumResult!, true);
+  TestValidator.equals("minimum decisive reads", minimumReads!, 2);
+  TestValidator.equals("maximum result", maximumResult!, false);
+  TestValidator.equals("maximum decisive reads", maximumReads!, 3);
+  TestValidator.equals("zero minimum", zeroMinimumResult!, true);
+  TestValidator.equals("zero minimum reads", zeroMinimumReads!, 0);
+  TestValidator.equals("negative maximum", negativeMaximumResult!, false);
+  TestValidator.equals("negative maximum reads", negativeMaximumReads!, 0);
+};

--- a/website/src/content/docs/validators/tags.mdx
+++ b/website/src/content/docs/validators/tags.mdx
@@ -184,11 +184,13 @@ For `url`, DNS host labels may contain interior hyphen runs such as `example--ex
 | `tags.MaxItems<N>` | `arr.length <= N`              |
 | `tags.UniqueItems` | All elements pairwise distinct |
 
+`Default` accepts a readonly tuple as an array default. Capture the value with `as const`, then use its type on the array wrapper: `Header[] & tags.Default<typeof headers>`. The tuple is emitted in the schema's `default` field and can be combined with `MinItems`, `MaxItems`, and `UniqueItems`. An open type such as `string[]` describes many possible arrays rather than one default value, so typia rejects `tags.Default<string[]>`.
+
 #### Other useful tags
 
 | Tag                                         | What it does                                                    |
 | ------------------------------------------- | --------------------------------------------------------------- |
-| `tags.Default<V>`                           | Records a default value in JSON Schema output                   |
+| `tags.Default<V>`                           | Records a primitive or readonly tuple default in schema output |
 | `tags.Example<V>` / `tags.Examples<Record>` | Records example(s) in JSON Schema output                        |
 | `tags.Constant<V, {title, description}>`    | Single-value literal with metadata                              |
 | `tags.JsonSchemaPlugin<{...}>`              | Inject arbitrary `x-…` JSON Schema fields                       |


### PR DESCRIPTION
Rebases the prepared next-major tag work onto the new next branch. Adds concrete literal-tuple defaults and Unicode code-point short-circuit helpers, while preserving the corrected v14 tag diagnostics. Closes #2371. Closes #2372.