### PR TITLE
test(native): restore classify runtime stub

### DIFF
--- a/packages/typia/native/cmd/ttsc-typia/recursive_container_helper_index_transform_test.go
+++ b/packages/typia/native/cmd/ttsc-typia/recursive_container_helper_index_transform_test.go
@@ -77,6 +77,7 @@ func recursiveContainerHelperIndexRunRuntimeCases(t *testing.T, project string, 
     "_randomArray",
     "_randomNumber",
     "_randomPick",
+    "_throwTypeGuardError",
   } {
     js = strings.ReplaceAll(
       js,
@@ -201,4 +202,5 @@ module.exports._jsonStringifyString = (value) => JSON.stringify(value);
 module.exports._randomArray = () => [];
 module.exports._randomNumber = () => 1;
 module.exports._randomPick = (values) => values[0];
+module.exports._throwTypeGuardError = (props) => { throw Object.assign(new Error(props.expected), props); };
 `


### PR DESCRIPTION
Restores the one runtime shim required by the reduced recursive-container regression test. The product implementation passed; PR #2388 CI failed only because plain.classify still imports this helper.